### PR TITLE
Fix compile error on Swift.(This is a workaround)

### DIFF
--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -556,7 +556,7 @@ NSString *const emptyStringSha256 = @"e3b0c44298fc1c149afbf4c8996fb92427ae41e464
 
 @interface AWSS3ChunkedEncodingInputStream()
 
-@property (nonatomic, weak) id<NSStreamDelegate> delegate;
+@property (nonatomic, weak) id<NSStreamDelegate> streamDelegate;
 
 // original input stream
 @property (nonatomic, strong) NSInputStream *stream;
@@ -594,7 +594,7 @@ NSString *const emptyStringSha256 = @"e3b0c44298fc1c149afbf4c8996fb92427ae41e464
                     headerSignature:(NSString *)headerSignature {
     if (self = [super init]) {
         _stream = stream;
-        _delegate = self;
+        _streamDelegate = self;
         _date = [date copy];
         _scope = [scope copy];
         _kSigning = [kSigning copy];
@@ -720,9 +720,9 @@ NSString *const emptyStringSha256 = @"e3b0c44298fc1c149afbf4c8996fb92427ae41e464
 
 - (void)setDelegate:(id)delegate {
     if (delegate == nil) {
-        _delegate = self;
+        _streamDelegate = self;
     } else {
-        _delegate = delegate;
+        _streamDelegate = delegate;
     }
 }
 


### PR DESCRIPTION
I try to use AWS iOS SDK(v2) on Swift. (installed via CocoaPods).

```
pod 'AWSiOSSDKv2'
pod 'AWSCognitoSync'
```

But following compile error occur. 

```
/Users/FGtatsuro/workspace/xcode/cognito_sample/Pods/AWSiOSSDKv2/AWSCore/Authentication/AWSSignature.m:598:9: Use of undeclared identifier '_delegate'
```

I think this isn't the fault of AWS SDK, but swift compiler can't identify the name 'delegate' with underscore. (Other underscore variable(ex. _stream) can be identified...)
Thus, I need the workaround to use SDK on Swift.
