### PR TITLE
submitAllRecords method should return BFTask.

### DIFF
--- a/Kinesis/AWSKinesisRecorder.m
+++ b/Kinesis/AWSKinesisRecorder.m
@@ -140,7 +140,7 @@ NSTimeInterval const AWSKinesisRecorderAgeLimitDefault = 0.0; // Keeps the data 
                     } else {
                         [self.cache removeObjectForKey:key];
                     }
-                    return nil;
+                    return task;
                 }]];
             } else {
                 AZLogError(@"Only AWSKinesisPutRecordInput should be in the queue. [%@]", [queuedObject class]);


### PR DESCRIPTION
The BFTask blocks in submitAllRecords requests return nil ,
and BFTask taskForCompletionOfAllTasks can not recognize error tasks.
So It seems that blocks in submitAllRecords should return task.

Please check it.
