### PR TITLE
add restore method for AWSS3TransferManager

### DIFF
--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -1,2588 +1,10624 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		38627E3F19253F5500EF30EF /* AWSCognitoIdentityServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 38627E3E19253F5500EF30EF /* AWSCognitoIdentityServiceTests.m */; };
-		388CA0A21926CA3800AF5A50 /* AWSCognitoCredentialsProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 388CA0A11926CA3800AF5A50 /* AWSCognitoCredentialsProviderTests.m */; };
-		38D2089419C2A67D0024D82A /* AWSIdentityProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 38D2089319C2A67D0024D82A /* AWSIdentityProvider.m */; };
-		6F8CA45C05144354BEC9C638 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F3A0CE70F1DF4EEE8E04D464 /* libPods.a */; };
-		BD1861BF19A41395003C8E42 /* ec2-input.json in Resources */ = {isa = PBXBuildFile; fileRef = BD1861BD19A41395003C8E42 /* ec2-input.json */; };
-		BD1861C019A41395003C8E42 /* ec2-output.json in Resources */ = {isa = PBXBuildFile; fileRef = BD1861BE19A41395003C8E42 /* ec2-output.json */; };
-		BD19ED05188F15EB001F5B98 /* AWSS3Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = BD19ED04188F15EB001F5B98 /* AWSS3Tests.m */; };
-		BD324C66194BA556003369D0 /* ec2-2014-06-15.json in Resources */ = {isa = PBXBuildFile; fileRef = CE896C84194A8619000DBB3C /* ec2-2014-06-15.json */; };
-		BD9CC214193CFF0700780456 /* AWSMobileAnalyticsERSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BD9CC213193CFF0700780456 /* AWSMobileAnalyticsERSTests.m */; };
-		BDBA90BA18EE43B6004EE131 /* AWSValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F35218DB716B00F8C75F /* AWSValidation.m */; };
-		BDBA90BB18EE43BA004EE131 /* AWSURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F35018DB716B00F8C75F /* AWSURLResponseSerialization.m */; };
-		BDBA90BC18EE43BE004EE131 /* AWSURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F34E18DB716B00F8C75F /* AWSURLRequestSerialization.m */; };
-		BDBA90BD18EE43C0004EE131 /* AWSURLRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F34C18DB716B00F8C75F /* AWSURLRequestRetryHandler.m */; };
-		BDBA90C018EE43C8004EE131 /* AWSNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F34518DB716B00F8C75F /* AWSNetworking.m */; };
-		BDBA90C118EE43D3004EE131 /* AWSCredentialsProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F33F18DB716B00F8C75F /* AWSCredentialsProvider.m */; };
-		BDBA90C218EE43FF004EE131 /* AWSSignature.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F34118DB716B00F8C75F /* AWSSignature.m */; };
-		BDBA90C318EE441F004EE131 /* AWSService.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F35918DB716B00F8C75F /* AWSService.m */; };
-		BDBA90C518EE4427004EE131 /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = CE55F35F18DB716B00F8C75F /* AWSXMLWriter.m */; };
-		BDC8315F1919725000A01D20 /* AWSS3TransferManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDC8315E1919725000A01D20 /* AWSS3TransferManagerTests.m */; };
-		BDD11DEF193FA13600AF60E1 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83E71857AA3100907C25 /* XCTest.framework */; };
-		BDD11DF0193FA13600AF60E1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83D91857AA3100907C25 /* Foundation.framework */; };
-		BDD11DF1193FA13600AF60E1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE31486C187B59220068883B /* UIKit.framework */; };
-		BDD11DF7193FA13600AF60E1 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BDD11DF5193FA13600AF60E1 /* InfoPlist.strings */; };
-		BDD11E00193FA19B00AF60E1 /* libAWSiOSSDKv2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83D61857AA3100907C25 /* libAWSiOSSDKv2.a */; };
-		BDD11E01193FA1B700AF60E1 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD39A0A193E646C00C712BD /* libz.dylib */; };
-		BDD11E05193FA23200AF60E1 /* AIAmazonInsightsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E04193FA23200AF60E1 /* AIAmazonInsightsTests.m */; };
-		BDD11E08193FA24E00AF60E1 /* AIIntegrationTestBase.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E07193FA24E00AF60E1 /* AIIntegrationTestBase.m */; };
-		BDD11E0A193FA33E00AF60E1 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD11E09193FA33E00AF60E1 /* SenTestingKit.framework */; };
-		BDD11E0D193FA39400AF60E1 /* AmazonInsightsSDKTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E0C193FA39400AF60E1 /* AmazonInsightsSDKTests.m */; };
-		BDD11E0F193FA40300AF60E1 /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD11E0E193FA40300AF60E1 /* OCHamcrestIOS.framework */; };
-		BDD11E11193FA41F00AF60E1 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD11E10193FA41F00AF60E1 /* libOCMock.a */; };
-		BDD11E14193FA4DD00AF60E1 /* AIInsightsContextBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E13193FA4DD00AF60E1 /* AIInsightsContextBuilder.m */; };
-		BDD11E18193FA51A00AF60E1 /* AITestConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E17193FA51A00AF60E1 /* AITestConfiguration.m */; };
-		BDD11E1B193FA55700AF60E1 /* AITestHttpClient.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E1A193FA55700AF60E1 /* AITestHttpClient.m */; };
-		BDD11E1F193FA5A400AF60E1 /* TestConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E1E193FA5A400AF60E1 /* TestConnectivity.m */; };
-		BDD11E25193FA5E600AF60E1 /* NSObject+TTTSwizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E22193FA5E600AF60E1 /* NSObject+TTTSwizzling.m */; };
-		BDD11E26193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E24193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.m */; };
-		BDD11E29193FA61300AF60E1 /* TestInsightsContext.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E28193FA61300AF60E1 /* TestInsightsContext.m */; };
-		BDD11E2F193FA67100AF60E1 /* BlockingInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E2C193FA67100AF60E1 /* BlockingInterceptor.m */; };
-		BDD11E30193FA67100AF60E1 /* TestEventObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD11E2E193FA67100AF60E1 /* TestEventObserver.m */; };
-		BDD11E32193FA70C00AF60E1 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD11E31193FA70C00AF60E1 /* SystemConfiguration.framework */; };
-		BDD11E33193FA78000AF60E1 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EFEAC89419295311005FEDE4 /* libsqlite3.dylib */; };
-		BDD196CD198AFF2200CC94A2 /* json-input.json in Resources */ = {isa = PBXBuildFile; fileRef = BDD196C8198AFF2200CC94A2 /* json-input.json */; };
-		BDD196CE198AFF2200CC94A2 /* query-input.json in Resources */ = {isa = PBXBuildFile; fileRef = BDD196C9198AFF2200CC94A2 /* query-input.json */; };
-		BDD196D0198AFF2200CC94A2 /* rest-xml-input.json in Resources */ = {isa = PBXBuildFile; fileRef = BDD196CB198AFF2200CC94A2 /* rest-xml-input.json */; };
-		BDD196D7198AFF2C00CC94A2 /* json-output.json in Resources */ = {isa = PBXBuildFile; fileRef = BDD196D2198AFF2C00CC94A2 /* json-output.json */; };
-		BDD196D8198AFF2C00CC94A2 /* query-output.json in Resources */ = {isa = PBXBuildFile; fileRef = BDD196D3198AFF2C00CC94A2 /* query-output.json */; };
-		BDD196DA198AFF2C00CC94A2 /* rest-xml-output.json in Resources */ = {isa = PBXBuildFile; fileRef = BDD196D5198AFF2C00CC94A2 /* rest-xml-output.json */; };
-		BDD39A0E193E652100C712BD /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD39A0A193E646C00C712BD /* libz.dylib */; };
-		BDD39A11193E8D4500C712BD /* AWSAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD39A10193E8D4500C712BD /* AWSAnalyticsTests.m */; };
-		BDD77705193FBF6000F04070 /* (null) in Sources */ = {isa = PBXBuildFile; };
-		BDD77719193FDADE00F04070 /* AIConfigurationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77714193FDADE00F04070 /* AIConfigurationIntegrationTests.m */; };
-		BDD7771A193FDADE00F04070 /* AIDeliveryIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77716193FDADE00F04070 /* AIDeliveryIntegrationTests.m */; };
-		BDD7771B193FDADE00F04070 /* AISessionIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77718193FDADE00F04070 /* AISessionIntegrationTests.m */; };
-		BDD77722193FDB2800F04070 /* AIDefaultInsightsOptionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7771D193FDB2800F04070 /* AIDefaultInsightsOptionsTests.m */; };
-		BDD77723193FDB2800F04070 /* AIDelayedBlockTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7771F193FDB2800F04070 /* AIDelayedBlockTests.m */; };
-		BDD77724193FDB2800F04070 /* AICountDownLatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77721193FDB2800F04070 /* AICountDownLatchTests.m */; };
-		BDD77729193FDB6B00F04070 /* AIHttpCachingConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77728193FDB6B00F04070 /* AIHttpCachingConfigurationTests.m */; };
-		BDD77737193FDB9400F04070 /* AIDefaultRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7772C193FDB9400F04070 /* AIDefaultRequestTests.m */; };
-		BDD77738193FDB9400F04070 /* AISDKInfoInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7772E193FDB9400F04070 /* AISDKInfoInterceptorTests.m */; };
-		BDD7773A193FDB9400F04070 /* AIClientContextInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77732193FDB9400F04070 /* AIClientContextInterceptorTests.m */; };
-		BDD7773C193FDB9400F04070 /* AIInstanceIdInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77736193FDB9400F04070 /* AIInstanceIdInterceptorTests.m */; };
-		BDD77740193FDBC800F04070 /* AIStringUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7773F193FDBC800F04070 /* AIStringUtilsTests.m */; };
-		BDD77744193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77743193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.m */; };
-		BDD7774C193FDBF300F04070 /* AIBufferedReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77747193FDBF300F04070 /* AIBufferedReaderTests.m */; };
-		BDD7774D193FDBF300F04070 /* AIEncryptedReaderWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77749193FDBF300F04070 /* AIEncryptedReaderWriterTests.m */; };
-		BDD77758193FDC0C00F04070 /* AIFileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77751193FDC0C00F04070 /* AIFileTests.m */; };
-		BDD77759193FDC0C00F04070 /* AIDefaultFileManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77753193FDC0C00F04070 /* AIDefaultFileManagerTests.m */; };
-		BDD7775A193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77755193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.m */; };
-		BDD7775B193FDC0C00F04070 /* AIIOSPreferencesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77757193FDC0C00F04070 /* AIIOSPreferencesTests.m */; };
-		BDD7775E193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7775D193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.m */; };
-		BDD77762193FDD0500F04070 /* AZIOSClientContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77761193FDD0500F04070 /* AZIOSClientContextTests.m */; };
-		BDD7777F193FDD3B00F04070 /* AIMonetizationEventBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7777E193FDD3B00F04070 /* AIMonetizationEventBuilderTests.m */; };
-		BDD7778D193FDD5200F04070 /* AIFileEventStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77782193FDD5200F04070 /* AIFileEventStoreTests.m */; };
-		BDD7778E193FDD5200F04070 /* AIDefaultDeliveryClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77784193FDD5200F04070 /* AIDefaultDeliveryClientTests.m */; };
-		BDD77790193FDD5200F04070 /* AIConnectivityPolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77788193FDD5200F04070 /* AIConnectivityPolicyTests.m */; };
-		BDD77791193FDD5200F04070 /* AISubmissionTimePolicyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7778A193FDD5200F04070 /* AISubmissionTimePolicyTests.m */; };
-		BDD77792193FDD5200F04070 /* AIERSRequestBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7778C193FDD5200F04070 /* AIERSRequestBuilderTests.m */; };
-		BDD77796193FDD6E00F04070 /* AIDateUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77795193FDD6E00F04070 /* AIDateUtilTests.m */; };
-		BDD7779E193FDD9000F04070 /* AIEventClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD77799193FDD9000F04070 /* AIEventClientTests.m */; };
-		BDD7779F193FDD9000F04070 /* AIDefaultEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7779B193FDD9000F04070 /* AIDefaultEventTests.m */; };
-		BDD777A0193FDD9000F04070 /* AIEventContraintDecoratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD7779D193FDD9000F04070 /* AIEventContraintDecoratorTests.m */; };
-		BDD777AE193FDDA800F04070 /* AISessionClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD777A3193FDDA800F04070 /* AISessionClientTests.m */; };
-		BDD777AF193FDDA800F04070 /* AISessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD777A5193FDDA800F04070 /* AISessionTests.m */; };
-		BDD777B0193FDDA800F04070 /* AIPausedSessionStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD777A7193FDDA800F04070 /* AIPausedSessionStateTests.m */; };
-		BDD777B1193FDDA800F04070 /* AIActiveSessionStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD777A9193FDDA800F04070 /* AIActiveSessionStateTests.m */; };
-		BDD777B2193FDDA800F04070 /* AIInactiveSessionStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD777AB193FDDA800F04070 /* AIInactiveSessionStateTests.m */; };
-		BDD777B3193FDDA800F04070 /* AISessionStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BDD777AD193FDDA800F04070 /* AISessionStoreTests.m */; };
-		BDDC42671942A1100039664B /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CE31486A187B58090068883B /* credentials.json */; };
-		CE0986161922A7470006EA67 /* sts-2011-06-15.json in Resources */ = {isa = PBXBuildFile; fileRef = CE0986121922A7470006EA67 /* sts-2011-06-15.json */; };
-		CE0D85D718D37EC000D41F8A /* AWSSQSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D85D618D37EC000D41F8A /* AWSSQSTests.m */; };
-		CE0D85D918D385DA00D41F8A /* AWSSNSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D85D818D385DA00D41F8A /* AWSSNSTests.m */; };
-		CE0D85DB18D38AAB00D41F8A /* AWSSimpleDBTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D85DA18D38AAB00D41F8A /* AWSSimpleDBTests.m */; };
-		CE0D85DD18D38FCA00D41F8A /* AWSSESTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D85DC18D38FCA00D41F8A /* AWSSESTests.m */; };
-		CE0EFAE7193D2939002A896B /* AWSSTS.m in Sources */ = {isa = PBXBuildFile; fileRef = CE09860E1922A7470006EA67 /* AWSSTS.m */; };
-		CE0EFAE8193D2939002A896B /* AWSSTSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0986101922A7470006EA67 /* AWSSTSModel.m */; };
-		CE160B2119774315001ABF94 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CE160B2019774315001ABF94 /* AWSTestUtility.m */; };
-		CE16EEE119916C5100A318A3 /* AWSCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = CE16EEDA19916C5100A318A3 /* AWSCategory.m */; };
-		CE16EEE219916C5100A318A3 /* AWSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = CE16EEDC19916C5100A318A3 /* AWSLogging.m */; };
-		CE16EEE319916C5100A318A3 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE16EEDE19916C5100A318A3 /* AWSModel.m */; };
-		CE16EEE419916C5100A318A3 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = CE16EEE019916C5100A318A3 /* AWSSynchronizedMutableDictionary.m */; };
-		CE16EEEA19916C8400A318A3 /* AWSURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CE16EEE819916C8400A318A3 /* AWSURLSessionManager.m */; };
-		CE1C9DE51936CE38007B6F33 /* AWSClockSkewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE1C9DE41936CE38007B6F33 /* AWSClockSkewTests.m */; };
-		CE23E60C19BF7CD60036EDC0 /* AWSS3PreSignedURL.m in Sources */ = {isa = PBXBuildFile; fileRef = CE23E60B19BF7CD60036EDC0 /* AWSS3PreSignedURL.m */; };
-		CE2C174718D0D8CF003FE9AA /* AWSSTSTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE2C174618D0D8CF003FE9AA /* AWSSTSTests.m */; };
-		CE314853187B577A0068883B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83E71857AA3100907C25 /* XCTest.framework */; };
-		CE314854187B577A0068883B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83D91857AA3100907C25 /* Foundation.framework */; };
-		CE31485B187B577A0068883B /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE314859187B577A0068883B /* InfoPlist.strings */; };
-		CE314867187B57F50068883B /* AWSDynamoDBTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE314864187B57F50068883B /* AWSDynamoDBTests.m */; };
-		CE314868187B57F50068883B /* AWSCoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE314865187B57F50068883B /* AWSCoreTests.m */; };
-		CE31486B187B58090068883B /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CE31486A187B58090068883B /* credentials.json */; };
-		CE31486D187B59220068883B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE31486C187B59220068883B /* UIKit.framework */; };
-		CE372B7318DA874000D2CFD2 /* AWSAutoScaling.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B1618DA874000D2CFD2 /* AWSAutoScaling.m */; };
-		CE372B7418DA874000D2CFD2 /* AWSAutoScalingModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B1818DA874000D2CFD2 /* AWSAutoScalingModel.m */; };
-		CE372B7518DA874000D2CFD2 /* AWSCloudWatch.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B1D18DA874000D2CFD2 /* AWSCloudWatch.m */; };
-		CE372B7618DA874000D2CFD2 /* AWSCloudWatchModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B1F18DA874000D2CFD2 /* AWSCloudWatchModel.m */; };
-		CE372B7718DA874000D2CFD2 /* AWSDynamoDB.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B2518DA874000D2CFD2 /* AWSDynamoDB.m */; };
-		CE372B7818DA874000D2CFD2 /* AWSDynamoDBModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B2718DA874000D2CFD2 /* AWSDynamoDBModel.m */; };
-		CE372B7918DA874000D2CFD2 /* AWSEC2.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B2D18DA874000D2CFD2 /* AWSEC2.m */; };
-		CE372B7A18DA874000D2CFD2 /* AWSEC2Model.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B2F18DA874000D2CFD2 /* AWSEC2Model.m */; };
-		CE372B7B18DA874000D2CFD2 /* AWSElasticLoadBalancing.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B3518DA874000D2CFD2 /* AWSElasticLoadBalancing.m */; };
-		CE372B7C18DA874000D2CFD2 /* AWSElasticLoadBalancingModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B3718DA874000D2CFD2 /* AWSElasticLoadBalancingModel.m */; };
-		CE372B7D18DA874000D2CFD2 /* AWSKinesis.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B3D18DA874000D2CFD2 /* AWSKinesis.m */; };
-		CE372B7E18DA874000D2CFD2 /* AWSKinesisModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B3F18DA874000D2CFD2 /* AWSKinesisModel.m */; };
-		CE372B7F18DA874000D2CFD2 /* AWSS3.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B4518DA874000D2CFD2 /* AWSS3.m */; };
-		CE372B8018DA874000D2CFD2 /* AWSS3Model.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B4718DA874000D2CFD2 /* AWSS3Model.m */; };
-		CE372B8118DA874000D2CFD2 /* AWSSES.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B4D18DA874000D2CFD2 /* AWSSES.m */; };
-		CE372B8218DA874000D2CFD2 /* AWSSESModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B4F18DA874000D2CFD2 /* AWSSESModel.m */; };
-		CE372B8318DA874000D2CFD2 /* AWSSimpleDB.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B5518DA874000D2CFD2 /* AWSSimpleDB.m */; };
-		CE372B8418DA874000D2CFD2 /* AWSSimpleDBModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B5718DA874000D2CFD2 /* AWSSimpleDBModel.m */; };
-		CE372B8518DA874000D2CFD2 /* AWSSNS.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B5D18DA874000D2CFD2 /* AWSSNS.m */; };
-		CE372B8618DA874000D2CFD2 /* AWSSNSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B5F18DA874000D2CFD2 /* AWSSNSModel.m */; };
-		CE372B8718DA874000D2CFD2 /* AWSSQS.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B6518DA874000D2CFD2 /* AWSSQS.m */; };
-		CE372B8818DA874000D2CFD2 /* AWSSQSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE372B6718DA874000D2CFD2 /* AWSSQSModel.m */; };
-		CE3F4D3919BFCE5A000C1A6C /* AWSS3PreSignedURLBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE3F4D3819BFCE5A000C1A6C /* AWSS3PreSignedURLBuilderTests.m */; };
-		CE4AB8D919085CFB00E0600E /* AWSSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CE4AB8D819085CFB00E0600E /* AWSSerialization.m */; };
-		CE5312B41922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = CE5312B31922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.m */; };
-		CE55F37718DB7FCC00F8C75F /* autoscaling-2011-01-01.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B1A18DA874000D2CFD2 /* autoscaling-2011-01-01.json */; };
-		CE55F37818DB7FCC00F8C75F /* monitoring-2010-08-01.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B2218DA874000D2CFD2 /* monitoring-2010-08-01.json */; };
-		CE55F37918DB7FCC00F8C75F /* dynamodb-2012-08-10.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B2A18DA874000D2CFD2 /* dynamodb-2012-08-10.json */; };
-		CE55F37B18DB7FCC00F8C75F /* elasticloadbalancing-2012-06-01.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B3A18DA874000D2CFD2 /* elasticloadbalancing-2012-06-01.json */; };
-		CE55F37C18DB7FCC00F8C75F /* kinesis-2013-12-02.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B4218DA874000D2CFD2 /* kinesis-2013-12-02.json */; };
-		CE55F37D18DB7FCC00F8C75F /* s3-2006-03-01.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B4918DA874000D2CFD2 /* s3-2006-03-01.json */; };
-		CE55F37E18DB7FCC00F8C75F /* email-2010-12-01.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B5118DA874000D2CFD2 /* email-2010-12-01.json */; };
-		CE55F37F18DB7FCC00F8C75F /* sdb-2009-04-15.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B5918DA874000D2CFD2 /* sdb-2009-04-15.json */; };
-		CE55F38018DB7FCC00F8C75F /* sns-2010-03-31.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B6118DA874000D2CFD2 /* sns-2010-03-31.json */; };
-		CE55F38118DB7FCC00F8C75F /* sqs-2012-11-05.json in Resources */ = {isa = PBXBuildFile; fileRef = CE372B6918DA874000D2CFD2 /* sqs-2012-11-05.json */; };
-		CE5D83DA1857AA3100907C25 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83D91857AA3100907C25 /* Foundation.framework */; };
-		CE7635B919BFA034005FD5D0 /* AWSCognitoIdentity.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7635B319BFA034005FD5D0 /* AWSCognitoIdentity.m */; };
-		CE7635BA19BFA034005FD5D0 /* AWSCognitoIdentityModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7635B519BFA034005FD5D0 /* AWSCognitoIdentityModel.m */; };
-		CE7635BB19BFA03C005FD5D0 /* cib-2014-06-30.json in Resources */ = {isa = PBXBuildFile; fileRef = CE7635B819BFA034005FD5D0 /* cib-2014-06-30.json */; };
-		CE7635BC19BFA03C005FD5D0 /* cib-2014-06-30.json in Resources */ = {isa = PBXBuildFile; fileRef = CE7635B819BFA034005FD5D0 /* cib-2014-06-30.json */; };
-		CE7635C519BFA050005FD5D0 /* AWSMobileAnalyticsERS.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7635BF19BFA050005FD5D0 /* AWSMobileAnalyticsERS.m */; };
-		CE7635C619BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7635C119BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.m */; };
-		CE7635C719BFA055005FD5D0 /* mobileanalytics-2014-06-30.json in Resources */ = {isa = PBXBuildFile; fileRef = CE7635C419BFA050005FD5D0 /* mobileanalytics-2014-06-30.json */; };
-		CE7635C819BFA056005FD5D0 /* mobileanalytics-2014-06-30.json in Resources */ = {isa = PBXBuildFile; fileRef = CE7635C419BFA050005FD5D0 /* mobileanalytics-2014-06-30.json */; };
-		CE8FEAA318D3B18600EC90A6 /* AWSElasticLoadBalancingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8FEAA218D3B18600EC90A6 /* AWSElasticLoadBalancingTests.m */; };
-		CE8FEAA618D3B62100EC90A6 /* AWSCloudWatchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8FEAA518D3B62100EC90A6 /* AWSCloudWatchTests.m */; };
-		CE8FEAA818D3B84E00EC90A6 /* AWSAutoScalingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8FEAA718D3B84E00EC90A6 /* AWSAutoScalingTests.m */; };
-		CE91D2BF18D3C03B000390D2 /* AWSKinesisTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE91D2BE18D3C03B000390D2 /* AWSKinesisTests.m */; };
-		CEB2A4A418D782F80007AAF4 /* AWSEC2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB2A4A318D782F80007AAF4 /* AWSEC2Tests.m */; };
-		CEBA14CD1921AC2F008C596A /* AWSDynamoDBObjectMapperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBA14CC1921AC2F008C596A /* AWSDynamoDBObjectMapperTests.m */; };
-		CED514051954B83B00D693F7 /* AWSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = CED514041954B83B00D693F7 /* AWSClientContext.m */; };
-		CED6C36618EE3EC800A56FB2 /* AWSS3TransferManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CED6C36518EE3EC800A56FB2 /* AWSS3TransferManager.m */; };
-		CEE68C17193FB11A00259EFF /* AWSKinesisRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CEE68C16193FB11A00259EFF /* AWSKinesisRecorder.m */; };
-		CEE68C191940000500259EFF /* AWSKinesisRecorderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CEE68C181940000500259EFF /* AWSKinesisRecorderTests.m */; };
-		EA2AF80C195E206B007DDDD4 /* AWSMobileAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF764195E206B007DDDD4 /* AWSMobileAnalytics.m */; };
-		EA2AF80D195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF767195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.m */; };
-		EA2AF80E195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF76B195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.m */; };
-		EA2AF80F195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF76D195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.m */; };
-		EA2AF810195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF76E195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.m */; };
-		EA2AF811195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF76F195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.m */; };
-		EA2AF812195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF770195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.m */; };
-		EA2AF813195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF771195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.m */; };
-		EA2AF814195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF772195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.m */; };
-		EA2AF815195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF774195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.m */; };
-		EA2AF816195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF775195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.m */; };
-		EA2AF817195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF777195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.m */; };
-		EA2AF818195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF778195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.m */; };
-		EA2AF819195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF779195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.m */; };
-		EA2AF81A195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF77A195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.m */; };
-		EA2AF81B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF77B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.m */; };
-		EA2AF81C195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF77C195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.m */; };
-		EA2AF81D195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF77D195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.m */; };
-		EA2AF81E195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF77E195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.m */; };
-		EA2AF81F195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF77F195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.m */; };
-		EA2AF820195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF781195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.m */; };
-		EA2AF821195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF782195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.m */; };
-		EA2AF822195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF784195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.m */; };
-		EA2AF823195E206B007DDDD4 /* AWSMobileAnalyticsWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF785195E206B007DDDD4 /* AWSMobileAnalyticsWriter.m */; };
-		EA2AF824195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF787195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.m */; };
-		EA2AF825195E206B007DDDD4 /* AWSMobileAnalyticsFile.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF788195E206B007DDDD4 /* AWSMobileAnalyticsFile.m */; };
-		EA2AF826195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF789195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.m */; };
-		EA2AF827195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF78A195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.m */; };
-		EA2AF828195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF78B195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.m */; };
-		EA2AF829195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF78C195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.m */; };
-		EA2AF82B195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF78F195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.m */; };
-		EA2AF82C195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF790195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.m */; };
-		EA2AF82D195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF791195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.m */; };
-		EA2AF82E195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF792195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.m */; };
-		EA2AF82F195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF794195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.m */; };
-		EA2AF830195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF795195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.m */; };
-		EA2AF831195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF796195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.m */; };
-		EA2AF832195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF797195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.m */; };
-		EA2AF833195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF798195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.m */; };
-		EA2AF834195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF799195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.m */; };
-		EA2AF835195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF79B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.m */; };
-		EA2AF836195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF79D195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.m */; };
-		EA2AF837195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF79E195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.m */; };
-		EA2AF838195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF7FB195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.m */; };
-		EA2AF839195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF7FC195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.m */; };
-		EA2AF83A195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF7FD195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.m */; };
-		EA2AF83B195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF7FF195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.m */; };
-		EA2AF83C195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF800195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.m */; };
-		EA2AF83D195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF801195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.m */; };
-		EA2AF83E195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF802195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.m */; };
-		EA2AF83F195E206B007DDDD4 /* AWSMobileAnalyticsSession.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF803195E206B007DDDD4 /* AWSMobileAnalyticsSession.m */; };
-		EA2AF840195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.m in Sources */ = {isa = PBXBuildFile; fileRef = EA2AF804195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.m */; };
-		EFEAC89619295448005FEDE4 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = EFEAC89419295311005FEDE4 /* libsqlite3.dylib */; };
-		EFEAC897192954B2005FEDE4 /* libAWSiOSSDKv2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5D83D61857AA3100907C25 /* libAWSiOSSDKv2.a */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		BDD11DFB193FA13600AF60E1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE5D83CE1857AA3100907C25 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CE5D83D51857AA3100907C25;
-			remoteInfo = AWSiOSSDK;
-		};
-		CE1F781418B6A1C100EE588B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = CE5D83CE1857AA3100907C25 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CE5D83D51857AA3100907C25;
-			remoteInfo = AWSiOSSDK;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		CE5D83D41857AA3100907C25 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
-/* Begin PBXFileReference section */
-		38627E3E19253F5500EF30EF /* AWSCognitoIdentityServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSCognitoIdentityServiceTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		388CA0A11926CA3800AF5A50 /* AWSCognitoCredentialsProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSCognitoCredentialsProviderTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		38D2089219C2A67D0024D82A /* AWSIdentityProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSIdentityProvider.h; sourceTree = "<group>"; };
-		38D2089319C2A67D0024D82A /* AWSIdentityProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSIdentityProvider.m; sourceTree = "<group>"; };
-		AAF85B9700504764BCD966E3 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
-		BD1861BD19A41395003C8E42 /* ec2-input.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ec2-input.json"; sourceTree = "<group>"; };
-		BD1861BE19A41395003C8E42 /* ec2-output.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ec2-output.json"; sourceTree = "<group>"; };
-		BD19ED04188F15EB001F5B98 /* AWSS3Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSS3Tests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BD9CC213193CFF0700780456 /* AWSMobileAnalyticsERSTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsERSTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDC8315E1919725000A01D20 /* AWSS3TransferManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSS3TransferManagerTests.m; sourceTree = "<group>"; };
-		BDD11DEE193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSiOSSDKv2AnalyticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BDD11DF4193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AWSiOSSDKv2AnalyticsTests-Info.plist"; sourceTree = "<group>"; };
-		BDD11DF6193FA13600AF60E1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		BDD11DFA193FA13600AF60E1 /* AWSiOSSDKAnalyticsTests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSiOSSDKAnalyticsTests-Prefix.pch"; sourceTree = "<group>"; };
-		BDD11E03193FA23200AF60E1 /* AIAmazonInsightsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIAmazonInsightsTests.h; sourceTree = "<group>"; };
-		BDD11E04193FA23200AF60E1 /* AIAmazonInsightsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIAmazonInsightsTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD11E06193FA24E00AF60E1 /* AIIntegrationTestBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AIIntegrationTestBase.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E07193FA24E00AF60E1 /* AIIntegrationTestBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIIntegrationTestBase.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD11E09193FA33E00AF60E1 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
-		BDD11E0B193FA39400AF60E1 /* AmazonInsightsSDKTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AmazonInsightsSDKTests.h; sourceTree = "<group>"; };
-		BDD11E0C193FA39400AF60E1 /* AmazonInsightsSDKTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AmazonInsightsSDKTests.m; sourceTree = "<group>"; };
-		BDD11E0E193FA40300AF60E1 /* OCHamcrestIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCHamcrestIOS.framework; path = AWSiOSSDKAnalyticsTests/Frameworks/OCHamcrestIOS.framework; sourceTree = "<group>"; };
-		BDD11E10193FA41F00AF60E1 /* libOCMock.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libOCMock.a; path = AWSiOSSDKAnalyticsTests/usr/lib/libOCMock.a; sourceTree = "<group>"; };
-		BDD11E12193FA4DD00AF60E1 /* AIInsightsContextBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AIInsightsContextBuilder.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E13193FA4DD00AF60E1 /* AIInsightsContextBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIInsightsContextBuilder.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD11E16193FA51A00AF60E1 /* AITestConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AITestConfiguration.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E17193FA51A00AF60E1 /* AITestConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AITestConfiguration.m; sourceTree = "<group>"; };
-		BDD11E19193FA55700AF60E1 /* AITestHttpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AITestHttpClient.h; sourceTree = "<group>"; };
-		BDD11E1A193FA55700AF60E1 /* AITestHttpClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AITestHttpClient.m; sourceTree = "<group>"; };
-		BDD11E1D193FA5A400AF60E1 /* TestConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = TestConnectivity.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E1E193FA5A400AF60E1 /* TestConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestConnectivity.m; sourceTree = "<group>"; };
-		BDD11E20193FA5AC00AF60E1 /* TestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = TestConstants.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E21193FA5E600AF60E1 /* NSObject+TTTSwizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+TTTSwizzling.h"; sourceTree = "<group>"; };
-		BDD11E22193FA5E600AF60E1 /* NSObject+TTTSwizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+TTTSwizzling.m"; sourceTree = "<group>"; };
-		BDD11E23193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSLocale+TTTOverrideLocale.h"; sourceTree = "<group>"; };
-		BDD11E24193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+TTTOverrideLocale.m"; sourceTree = "<group>"; };
-		BDD11E27193FA61300AF60E1 /* TestInsightsContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = TestInsightsContext.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E28193FA61300AF60E1 /* TestInsightsContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = TestInsightsContext.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD11E2A193FA67100AF60E1 /* AIInternalInterfaces.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AIInternalInterfaces.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E2B193FA67100AF60E1 /* BlockingInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = BlockingInterceptor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E2C193FA67100AF60E1 /* BlockingInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlockingInterceptor.m; sourceTree = "<group>"; };
-		BDD11E2D193FA67100AF60E1 /* TestEventObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = TestEventObserver.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD11E2E193FA67100AF60E1 /* TestEventObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = TestEventObserver.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD11E31193FA70C00AF60E1 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		BDD196C8198AFF2200CC94A2 /* json-input.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "json-input.json"; sourceTree = "<group>"; };
-		BDD196C9198AFF2200CC94A2 /* query-input.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "query-input.json"; sourceTree = "<group>"; };
-		BDD196CB198AFF2200CC94A2 /* rest-xml-input.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "rest-xml-input.json"; sourceTree = "<group>"; };
-		BDD196D2198AFF2C00CC94A2 /* json-output.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "json-output.json"; sourceTree = "<group>"; };
-		BDD196D3198AFF2C00CC94A2 /* query-output.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "query-output.json"; sourceTree = "<group>"; };
-		BDD196D5198AFF2C00CC94A2 /* rest-xml-output.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "rest-xml-output.json"; sourceTree = "<group>"; };
-		BDD39A0A193E646C00C712BD /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
-		BDD39A10193E8D4500C712BD /* AWSAnalyticsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSAnalyticsTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77713193FDADE00F04070 /* AIConfigurationIntegrationTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIConfigurationIntegrationTests.h; sourceTree = "<group>"; };
-		BDD77714193FDADE00F04070 /* AIConfigurationIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIConfigurationIntegrationTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77715193FDADE00F04070 /* AIDeliveryIntegrationTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDeliveryIntegrationTests.h; sourceTree = "<group>"; };
-		BDD77716193FDADE00F04070 /* AIDeliveryIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIDeliveryIntegrationTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77717193FDADE00F04070 /* AISessionIntegrationTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AISessionIntegrationTests.h; sourceTree = "<group>"; };
-		BDD77718193FDADE00F04070 /* AISessionIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AISessionIntegrationTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD7771C193FDB2800F04070 /* AIDefaultInsightsOptionsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDefaultInsightsOptionsTests.h; sourceTree = "<group>"; };
-		BDD7771D193FDB2800F04070 /* AIDefaultInsightsOptionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIDefaultInsightsOptionsTests.m; sourceTree = "<group>"; };
-		BDD7771E193FDB2800F04070 /* AIDelayedBlockTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDelayedBlockTests.h; sourceTree = "<group>"; };
-		BDD7771F193FDB2800F04070 /* AIDelayedBlockTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIDelayedBlockTests.m; sourceTree = "<group>"; };
-		BDD77720193FDB2800F04070 /* AICountDownLatchTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AICountDownLatchTests.h; sourceTree = "<group>"; };
-		BDD77721193FDB2800F04070 /* AICountDownLatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AICountDownLatchTests.m; sourceTree = "<group>"; };
-		BDD77727193FDB6B00F04070 /* AIHttpCachingConfigurationTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIHttpCachingConfigurationTests.h; sourceTree = "<group>"; };
-		BDD77728193FDB6B00F04070 /* AIHttpCachingConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIHttpCachingConfigurationTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD7772B193FDB9400F04070 /* AIDefaultRequestTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDefaultRequestTests.h; sourceTree = "<group>"; };
-		BDD7772C193FDB9400F04070 /* AIDefaultRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIDefaultRequestTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD7772D193FDB9400F04070 /* AISDKInfoInterceptorTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AISDKInfoInterceptorTests.h; sourceTree = "<group>"; };
-		BDD7772E193FDB9400F04070 /* AISDKInfoInterceptorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AISDKInfoInterceptorTests.m; sourceTree = "<group>"; };
-		BDD77731193FDB9400F04070 /* AIClientContextInterceptorTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIClientContextInterceptorTests.h; sourceTree = "<group>"; };
-		BDD77732193FDB9400F04070 /* AIClientContextInterceptorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIClientContextInterceptorTests.m; sourceTree = "<group>"; };
-		BDD77735193FDB9400F04070 /* AIInstanceIdInterceptorTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIInstanceIdInterceptorTests.h; sourceTree = "<group>"; };
-		BDD77736193FDB9400F04070 /* AIInstanceIdInterceptorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIInstanceIdInterceptorTests.m; sourceTree = "<group>"; };
-		BDD7773E193FDBC800F04070 /* AIStringUtilsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIStringUtilsTests.h; sourceTree = "<group>"; };
-		BDD7773F193FDBC800F04070 /* AIStringUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIStringUtilsTests.m; sourceTree = "<group>"; };
-		BDD77742193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIPrefsUniqueIdServiceTests.h; sourceTree = "<group>"; };
-		BDD77743193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIPrefsUniqueIdServiceTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77746193FDBF300F04070 /* AIBufferedReaderTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIBufferedReaderTests.h; sourceTree = "<group>"; };
-		BDD77747193FDBF300F04070 /* AIBufferedReaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIBufferedReaderTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77748193FDBF300F04070 /* AIEncryptedReaderWriterTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIEncryptedReaderWriterTests.h; sourceTree = "<group>"; };
-		BDD77749193FDBF300F04070 /* AIEncryptedReaderWriterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIEncryptedReaderWriterTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77750193FDC0C00F04070 /* AIFileTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFileTests.h; sourceTree = "<group>"; };
-		BDD77751193FDC0C00F04070 /* AIFileTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFileTests.m; sourceTree = "<group>"; };
-		BDD77752193FDC0C00F04070 /* AIDefaultFileManagerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDefaultFileManagerTests.h; sourceTree = "<group>"; };
-		BDD77753193FDC0C00F04070 /* AIDefaultFileManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIDefaultFileManagerTests.m; sourceTree = "<group>"; };
-		BDD77754193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AIIOSLifeCycleManagerTests.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD77755193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIIOSLifeCycleManagerTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77756193FDC0C00F04070 /* AIIOSPreferencesTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIIOSPreferencesTests.h; sourceTree = "<group>"; };
-		BDD77757193FDC0C00F04070 /* AIIOSPreferencesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIIOSPreferencesTests.m; sourceTree = "<group>"; };
-		BDD7775C193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLRequest+NSURLRequestSSLY.h"; sourceTree = "<group>"; };
-		BDD7775D193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLRequest+NSURLRequestSSLY.m"; sourceTree = "<group>"; };
-		BDD77760193FDD0500F04070 /* AZIOSClientContextTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AZIOSClientContextTests.h; sourceTree = "<group>"; };
-		BDD77761193FDD0500F04070 /* AZIOSClientContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AZIOSClientContextTests.m; sourceTree = "<group>"; };
-		BDD7777D193FDD3B00F04070 /* AIMonetizationEventBuilderTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIMonetizationEventBuilderTests.h; sourceTree = "<group>"; };
-		BDD7777E193FDD3B00F04070 /* AIMonetizationEventBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIMonetizationEventBuilderTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77781193FDD5200F04070 /* AIFileEventStoreTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFileEventStoreTests.h; sourceTree = "<group>"; };
-		BDD77782193FDD5200F04070 /* AIFileEventStoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIFileEventStoreTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77783193FDD5200F04070 /* AIDefaultDeliveryClientTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDefaultDeliveryClientTests.h; sourceTree = "<group>"; };
-		BDD77784193FDD5200F04070 /* AIDefaultDeliveryClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIDefaultDeliveryClientTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77787193FDD5200F04070 /* AIConnectivityPolicyTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIConnectivityPolicyTests.h; sourceTree = "<group>"; };
-		BDD77788193FDD5200F04070 /* AIConnectivityPolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIConnectivityPolicyTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77789193FDD5200F04070 /* AISubmissionTimePolicyTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AISubmissionTimePolicyTests.h; sourceTree = "<group>"; };
-		BDD7778A193FDD5200F04070 /* AISubmissionTimePolicyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AISubmissionTimePolicyTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD7778B193FDD5200F04070 /* AIERSRequestBuilderTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AIERSRequestBuilderTests.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD7778C193FDD5200F04070 /* AIERSRequestBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIERSRequestBuilderTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD77794193FDD6E00F04070 /* AIDateUtilTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIDateUtilTests.h; sourceTree = "<group>"; };
-		BDD77795193FDD6E00F04070 /* AIDateUtilTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIDateUtilTests.m; sourceTree = "<group>"; };
-		BDD77798193FDD9000F04070 /* AIEventClientTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIEventClientTests.h; sourceTree = "<group>"; };
-		BDD77799193FDD9000F04070 /* AIEventClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIEventClientTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD7779A193FDD9000F04070 /* AIDefaultEventTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AIDefaultEventTests.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		BDD7779B193FDD9000F04070 /* AIDefaultEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIDefaultEventTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD7779C193FDD9000F04070 /* AIEventContraintDecoratorTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIEventContraintDecoratorTests.h; sourceTree = "<group>"; };
-		BDD7779D193FDD9000F04070 /* AIEventContraintDecoratorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIEventContraintDecoratorTests.m; sourceTree = "<group>"; };
-		BDD777A2193FDDA800F04070 /* AISessionClientTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AISessionClientTests.h; sourceTree = "<group>"; };
-		BDD777A3193FDDA800F04070 /* AISessionClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AISessionClientTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD777A4193FDDA800F04070 /* AISessionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AISessionTests.h; sourceTree = "<group>"; };
-		BDD777A5193FDDA800F04070 /* AISessionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AISessionTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD777A6193FDDA800F04070 /* AIPausedSessionStateTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIPausedSessionStateTests.h; sourceTree = "<group>"; };
-		BDD777A7193FDDA800F04070 /* AIPausedSessionStateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIPausedSessionStateTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD777A8193FDDA800F04070 /* AIActiveSessionStateTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIActiveSessionStateTests.h; sourceTree = "<group>"; };
-		BDD777A9193FDDA800F04070 /* AIActiveSessionStateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIActiveSessionStateTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD777AA193FDDA800F04070 /* AIInactiveSessionStateTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIInactiveSessionStateTests.h; sourceTree = "<group>"; };
-		BDD777AB193FDDA800F04070 /* AIInactiveSessionStateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AIInactiveSessionStateTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		BDD777AC193FDDA800F04070 /* AISessionStoreTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AISessionStoreTests.h; sourceTree = "<group>"; };
-		BDD777AD193FDDA800F04070 /* AISessionStoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AISessionStoreTests.m; sourceTree = "<group>"; };
-		CE09860D1922A7470006EA67 /* AWSSTS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSSTS.h; sourceTree = "<group>"; };
-		CE09860E1922A7470006EA67 /* AWSSTS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSTS.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE09860F1922A7470006EA67 /* AWSSTSModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSSTSModel.h; sourceTree = "<group>"; };
-		CE0986101922A7470006EA67 /* AWSSTSModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSTSModel.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE0986121922A7470006EA67 /* sts-2011-06-15.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "sts-2011-06-15.json"; sourceTree = "<group>"; };
-		CE0986131922A7470006EA67 /* STS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STS.h; sourceTree = "<group>"; };
-		CE0D85D618D37EC000D41F8A /* AWSSQSTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSQSTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE0D85D818D385DA00D41F8A /* AWSSNSTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSNSTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE0D85DA18D38AAB00D41F8A /* AWSSimpleDBTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSimpleDBTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE0D85DC18D38FCA00D41F8A /* AWSSESTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSESTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE160B2019774315001ABF94 /* AWSTestUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSTestUtility.m; sourceTree = "<group>"; };
-		CE160B2219774365001ABF94 /* AWSTestUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSTestUtility.h; sourceTree = "<group>"; };
-		CE16EED919916C5100A318A3 /* AWSCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCategory.h; sourceTree = "<group>"; };
-		CE16EEDA19916C5100A318A3 /* AWSCategory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSCategory.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE16EEDB19916C5100A318A3 /* AWSLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSLogging.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE16EEDC19916C5100A318A3 /* AWSLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSLogging.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE16EEDD19916C5100A318A3 /* AWSModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSModel.h; sourceTree = "<group>"; };
-		CE16EEDE19916C5100A318A3 /* AWSModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSModel.m; sourceTree = "<group>"; };
-		CE16EEDF19916C5100A318A3 /* AWSSynchronizedMutableDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSSynchronizedMutableDictionary.h; sourceTree = "<group>"; };
-		CE16EEE019916C5100A318A3 /* AWSSynchronizedMutableDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSynchronizedMutableDictionary.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE16EEE719916C8400A318A3 /* AWSURLSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSURLSessionManager.h; sourceTree = "<group>"; };
-		CE16EEE819916C8400A318A3 /* AWSURLSessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSURLSessionManager.m; sourceTree = "<group>"; };
-		CE1C9DE41936CE38007B6F33 /* AWSClockSkewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSClockSkewTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE23E60A19BF7CD00036EDC0 /* AWSS3PreSignedURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSS3PreSignedURL.h; sourceTree = "<group>"; };
-		CE23E60B19BF7CD60036EDC0 /* AWSS3PreSignedURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSS3PreSignedURL.m; sourceTree = "<group>"; };
-		CE2C174618D0D8CF003FE9AA /* AWSSTSTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSTSTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE314852187B577A0068883B /* AWSiOSSDKv2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSiOSSDKv2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		CE314858187B577A0068883B /* AWSiOSSDKv2Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "AWSiOSSDKv2Tests-Info.plist"; sourceTree = "<group>"; };
-		CE31485A187B577A0068883B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		CE31485E187B577A0068883B /* AWSiOSSDKv2Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "AWSiOSSDKv2Tests-Prefix.pch"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE314864187B57F50068883B /* AWSDynamoDBTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSDynamoDBTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE314865187B57F50068883B /* AWSCoreTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSCoreTests.m; sourceTree = "<group>"; };
-		CE31486A187B58090068883B /* credentials.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = credentials.json; sourceTree = "<group>"; };
-		CE31486C187B59220068883B /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		CE372B1418DA874000D2CFD2 /* AutoScaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AutoScaling.h; path = AutoScaling/AutoScaling.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE372B1518DA874000D2CFD2 /* AWSAutoScaling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSAutoScaling.h; path = AutoScaling/AWSAutoScaling.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE372B1618DA874000D2CFD2 /* AWSAutoScaling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSAutoScaling.m; path = AutoScaling/AWSAutoScaling.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B1718DA874000D2CFD2 /* AWSAutoScalingModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSAutoScalingModel.h; path = AutoScaling/AWSAutoScalingModel.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE372B1818DA874000D2CFD2 /* AWSAutoScalingModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSAutoScalingModel.m; path = AutoScaling/AWSAutoScalingModel.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B1A18DA874000D2CFD2 /* autoscaling-2011-01-01.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "autoscaling-2011-01-01.json"; path = "AutoScaling/Resources/autoscaling-2011-01-01.json"; sourceTree = SOURCE_ROOT; };
-		CE372B1C18DA874000D2CFD2 /* AWSCloudWatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSCloudWatch.h; path = CloudWatch/AWSCloudWatch.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE372B1D18DA874000D2CFD2 /* AWSCloudWatch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSCloudWatch.m; path = CloudWatch/AWSCloudWatch.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B1E18DA874000D2CFD2 /* AWSCloudWatchModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSCloudWatchModel.h; path = CloudWatch/AWSCloudWatchModel.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE372B1F18DA874000D2CFD2 /* AWSCloudWatchModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSCloudWatchModel.m; path = CloudWatch/AWSCloudWatchModel.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B2018DA874000D2CFD2 /* CloudWatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CloudWatch.h; path = CloudWatch/CloudWatch.h; sourceTree = SOURCE_ROOT; };
-		CE372B2218DA874000D2CFD2 /* monitoring-2010-08-01.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "monitoring-2010-08-01.json"; path = "CloudWatch/Resources/monitoring-2010-08-01.json"; sourceTree = SOURCE_ROOT; };
-		CE372B2418DA874000D2CFD2 /* AWSDynamoDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSDynamoDB.h; path = DynamoDB/AWSDynamoDB.h; sourceTree = SOURCE_ROOT; };
-		CE372B2518DA874000D2CFD2 /* AWSDynamoDB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSDynamoDB.m; path = DynamoDB/AWSDynamoDB.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B2618DA874000D2CFD2 /* AWSDynamoDBModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSDynamoDBModel.h; path = DynamoDB/AWSDynamoDBModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B2718DA874000D2CFD2 /* AWSDynamoDBModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSDynamoDBModel.m; path = DynamoDB/AWSDynamoDBModel.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B2818DA874000D2CFD2 /* DynamoDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamoDB.h; path = DynamoDB/DynamoDB.h; sourceTree = SOURCE_ROOT; };
-		CE372B2A18DA874000D2CFD2 /* dynamodb-2012-08-10.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "dynamodb-2012-08-10.json"; path = "DynamoDB/Resources/dynamodb-2012-08-10.json"; sourceTree = SOURCE_ROOT; };
-		CE372B2C18DA874000D2CFD2 /* AWSEC2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSEC2.h; path = EC2/AWSEC2.h; sourceTree = SOURCE_ROOT; };
-		CE372B2D18DA874000D2CFD2 /* AWSEC2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSEC2.m; path = EC2/AWSEC2.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B2E18DA874000D2CFD2 /* AWSEC2Model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSEC2Model.h; path = EC2/AWSEC2Model.h; sourceTree = SOURCE_ROOT; };
-		CE372B2F18DA874000D2CFD2 /* AWSEC2Model.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSEC2Model.m; path = EC2/AWSEC2Model.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B3018DA874000D2CFD2 /* EC2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EC2.h; path = EC2/EC2.h; sourceTree = SOURCE_ROOT; };
-		CE372B3418DA874000D2CFD2 /* AWSElasticLoadBalancing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSElasticLoadBalancing.h; path = ElasticLoadBalancing/AWSElasticLoadBalancing.h; sourceTree = SOURCE_ROOT; };
-		CE372B3518DA874000D2CFD2 /* AWSElasticLoadBalancing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSElasticLoadBalancing.m; path = ElasticLoadBalancing/AWSElasticLoadBalancing.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B3618DA874000D2CFD2 /* AWSElasticLoadBalancingModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSElasticLoadBalancingModel.h; path = ElasticLoadBalancing/AWSElasticLoadBalancingModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B3718DA874000D2CFD2 /* AWSElasticLoadBalancingModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSElasticLoadBalancingModel.m; path = ElasticLoadBalancing/AWSElasticLoadBalancingModel.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B3818DA874000D2CFD2 /* ElasticLoadBalancing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ElasticLoadBalancing.h; path = ElasticLoadBalancing/ElasticLoadBalancing.h; sourceTree = SOURCE_ROOT; };
-		CE372B3A18DA874000D2CFD2 /* elasticloadbalancing-2012-06-01.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "elasticloadbalancing-2012-06-01.json"; path = "ElasticLoadBalancing/Resources/elasticloadbalancing-2012-06-01.json"; sourceTree = SOURCE_ROOT; };
-		CE372B3C18DA874000D2CFD2 /* AWSKinesis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSKinesis.h; path = Kinesis/AWSKinesis.h; sourceTree = SOURCE_ROOT; };
-		CE372B3D18DA874000D2CFD2 /* AWSKinesis.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSKinesis.m; path = Kinesis/AWSKinesis.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B3E18DA874000D2CFD2 /* AWSKinesisModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSKinesisModel.h; path = Kinesis/AWSKinesisModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B3F18DA874000D2CFD2 /* AWSKinesisModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSKinesisModel.m; path = Kinesis/AWSKinesisModel.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B4018DA874000D2CFD2 /* Kinesis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Kinesis.h; path = Kinesis/Kinesis.h; sourceTree = SOURCE_ROOT; };
-		CE372B4218DA874000D2CFD2 /* kinesis-2013-12-02.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "kinesis-2013-12-02.json"; path = "Kinesis/Resources/kinesis-2013-12-02.json"; sourceTree = SOURCE_ROOT; };
-		CE372B4418DA874000D2CFD2 /* AWSS3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSS3.h; path = S3/AWSS3.h; sourceTree = SOURCE_ROOT; };
-		CE372B4518DA874000D2CFD2 /* AWSS3.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSS3.m; path = S3/AWSS3.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B4618DA874000D2CFD2 /* AWSS3Model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSS3Model.h; path = S3/AWSS3Model.h; sourceTree = SOURCE_ROOT; };
-		CE372B4718DA874000D2CFD2 /* AWSS3Model.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSS3Model.m; path = S3/AWSS3Model.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B4918DA874000D2CFD2 /* s3-2006-03-01.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "s3-2006-03-01.json"; path = "S3/Resources/s3-2006-03-01.json"; sourceTree = SOURCE_ROOT; };
-		CE372B4A18DA874000D2CFD2 /* S3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = S3.h; path = S3/S3.h; sourceTree = SOURCE_ROOT; };
-		CE372B4C18DA874000D2CFD2 /* AWSSES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSES.h; path = SES/AWSSES.h; sourceTree = SOURCE_ROOT; };
-		CE372B4D18DA874000D2CFD2 /* AWSSES.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSSES.m; path = SES/AWSSES.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B4E18DA874000D2CFD2 /* AWSSESModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSESModel.h; path = SES/AWSSESModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B4F18DA874000D2CFD2 /* AWSSESModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSSESModel.m; path = SES/AWSSESModel.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B5118DA874000D2CFD2 /* email-2010-12-01.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "email-2010-12-01.json"; path = "SES/Resources/email-2010-12-01.json"; sourceTree = SOURCE_ROOT; };
-		CE372B5218DA874000D2CFD2 /* SES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SES.h; path = SES/SES.h; sourceTree = SOURCE_ROOT; };
-		CE372B5418DA874000D2CFD2 /* AWSSimpleDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSimpleDB.h; path = SimpleDB/AWSSimpleDB.h; sourceTree = SOURCE_ROOT; };
-		CE372B5518DA874000D2CFD2 /* AWSSimpleDB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSSimpleDB.m; path = SimpleDB/AWSSimpleDB.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B5618DA874000D2CFD2 /* AWSSimpleDBModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSimpleDBModel.h; path = SimpleDB/AWSSimpleDBModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B5718DA874000D2CFD2 /* AWSSimpleDBModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSSimpleDBModel.m; path = SimpleDB/AWSSimpleDBModel.m; sourceTree = SOURCE_ROOT; };
-		CE372B5918DA874000D2CFD2 /* sdb-2009-04-15.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "sdb-2009-04-15.json"; path = "SimpleDB/Resources/sdb-2009-04-15.json"; sourceTree = SOURCE_ROOT; };
-		CE372B5A18DA874000D2CFD2 /* SimpleDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SimpleDB.h; path = SimpleDB/SimpleDB.h; sourceTree = SOURCE_ROOT; };
-		CE372B5C18DA874000D2CFD2 /* AWSSNS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSNS.h; path = SNS/AWSSNS.h; sourceTree = SOURCE_ROOT; };
-		CE372B5D18DA874000D2CFD2 /* AWSSNS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSSNS.m; path = SNS/AWSSNS.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B5E18DA874000D2CFD2 /* AWSSNSModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSNSModel.h; path = SNS/AWSSNSModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B5F18DA874000D2CFD2 /* AWSSNSModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSSNSModel.m; path = SNS/AWSSNSModel.m; sourceTree = SOURCE_ROOT; };
-		CE372B6118DA874000D2CFD2 /* sns-2010-03-31.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "sns-2010-03-31.json"; path = "SNS/Resources/sns-2010-03-31.json"; sourceTree = SOURCE_ROOT; };
-		CE372B6218DA874000D2CFD2 /* SNS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SNS.h; path = SNS/SNS.h; sourceTree = SOURCE_ROOT; };
-		CE372B6418DA874000D2CFD2 /* AWSSQS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSQS.h; path = SQS/AWSSQS.h; sourceTree = SOURCE_ROOT; };
-		CE372B6518DA874000D2CFD2 /* AWSSQS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSSQS.m; path = SQS/AWSSQS.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE372B6618DA874000D2CFD2 /* AWSSQSModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSQSModel.h; path = SQS/AWSSQSModel.h; sourceTree = SOURCE_ROOT; };
-		CE372B6718DA874000D2CFD2 /* AWSSQSModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSSQSModel.m; path = SQS/AWSSQSModel.m; sourceTree = SOURCE_ROOT; };
-		CE372B6918DA874000D2CFD2 /* sqs-2012-11-05.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "sqs-2012-11-05.json"; path = "SQS/Resources/sqs-2012-11-05.json"; sourceTree = SOURCE_ROOT; };
-		CE372B6A18DA874000D2CFD2 /* SQS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SQS.h; path = SQS/SQS.h; sourceTree = SOURCE_ROOT; };
-		CE3F4D3819BFCE5A000C1A6C /* AWSS3PreSignedURLBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSS3PreSignedURLBuilderTests.m; sourceTree = "<group>"; };
-		CE4AB8D719085CFB00E0600E /* AWSSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSSerialization.h; sourceTree = "<group>"; };
-		CE4AB8D819085CFB00E0600E /* AWSSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSSerialization.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE5312B21922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDynamoDBObjectMapper.h; sourceTree = "<group>"; };
-		CE5312B31922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDynamoDBObjectMapper.m; sourceTree = "<group>"; };
-		CE55F33E18DB716B00F8C75F /* AWSCredentialsProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSCredentialsProvider.h; path = AWSCore/Authentication/AWSCredentialsProvider.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE55F33F18DB716B00F8C75F /* AWSCredentialsProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSCredentialsProvider.m; path = AWSCore/Authentication/AWSCredentialsProvider.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE55F34018DB716B00F8C75F /* AWSSignature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSSignature.h; path = AWSCore/Authentication/AWSSignature.h; sourceTree = SOURCE_ROOT; };
-		CE55F34118DB716B00F8C75F /* AWSSignature.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSSignature.m; path = AWSCore/Authentication/AWSSignature.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE55F34218DB716B00F8C75F /* AWSCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSCore.h; path = AWSCore/AWSCore.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE55F34418DB716B00F8C75F /* AWSNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = AWSNetworking.h; path = AWSCore/Networking/AWSNetworking.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		CE55F34518DB716B00F8C75F /* AWSNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSNetworking.m; path = AWSCore/Networking/AWSNetworking.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE55F34B18DB716B00F8C75F /* AWSURLRequestRetryHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestRetryHandler.h; path = AWSCore/Serialization/AWSURLRequestRetryHandler.h; sourceTree = SOURCE_ROOT; };
-		CE55F34C18DB716B00F8C75F /* AWSURLRequestRetryHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSURLRequestRetryHandler.m; path = AWSCore/Serialization/AWSURLRequestRetryHandler.m; sourceTree = SOURCE_ROOT; };
-		CE55F34D18DB716B00F8C75F /* AWSURLRequestSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSURLRequestSerialization.h; path = AWSCore/Serialization/AWSURLRequestSerialization.h; sourceTree = SOURCE_ROOT; };
-		CE55F34E18DB716B00F8C75F /* AWSURLRequestSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSURLRequestSerialization.m; path = AWSCore/Serialization/AWSURLRequestSerialization.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE55F34F18DB716B00F8C75F /* AWSURLResponseSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSURLResponseSerialization.h; path = AWSCore/Serialization/AWSURLResponseSerialization.h; sourceTree = SOURCE_ROOT; };
-		CE55F35018DB716B00F8C75F /* AWSURLResponseSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSURLResponseSerialization.m; path = AWSCore/Serialization/AWSURLResponseSerialization.m; sourceTree = SOURCE_ROOT; };
-		CE55F35118DB716B00F8C75F /* AWSValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSValidation.h; path = AWSCore/Serialization/AWSValidation.h; sourceTree = SOURCE_ROOT; };
-		CE55F35218DB716B00F8C75F /* AWSValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSValidation.m; path = AWSCore/Serialization/AWSValidation.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE55F35818DB716B00F8C75F /* AWSService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSService.h; path = AWSCore/Service/AWSService.h; sourceTree = SOURCE_ROOT; };
-		CE55F35918DB716B00F8C75F /* AWSService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = AWSService.m; path = AWSCore/Service/AWSService.m; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE55F35E18DB716B00F8C75F /* AWSXMLWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AWSXMLWriter.h; path = AWSCore/XMLWriter/AWSXMLWriter.h; sourceTree = SOURCE_ROOT; };
-		CE55F35F18DB716B00F8C75F /* AWSXMLWriter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSXMLWriter.m; path = AWSCore/XMLWriter/AWSXMLWriter.m; sourceTree = SOURCE_ROOT; };
-		CE571E2D1937D1F00027826E /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		CE5D83D61857AA3100907C25 /* libAWSiOSSDKv2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAWSiOSSDKv2.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		CE5D83D91857AA3100907C25 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		CE5D83DD1857AA3100907C25 /* AWSiOSSDKv2-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSiOSSDKv2-Prefix.pch"; sourceTree = "<group>"; };
-		CE5D83E71857AA3100907C25 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		CE7635B219BFA034005FD5D0 /* AWSCognitoIdentity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCognitoIdentity.h; sourceTree = "<group>"; };
-		CE7635B319BFA034005FD5D0 /* AWSCognitoIdentity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSCognitoIdentity.m; sourceTree = "<group>"; };
-		CE7635B419BFA034005FD5D0 /* AWSCognitoIdentityModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCognitoIdentityModel.h; sourceTree = "<group>"; };
-		CE7635B519BFA034005FD5D0 /* AWSCognitoIdentityModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSCognitoIdentityModel.m; sourceTree = "<group>"; };
-		CE7635B619BFA034005FD5D0 /* CognitoIdentity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CognitoIdentity.h; sourceTree = "<group>"; };
-		CE7635B819BFA034005FD5D0 /* cib-2014-06-30.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "cib-2014-06-30.json"; sourceTree = "<group>"; };
-		CE7635BE19BFA050005FD5D0 /* AWSMobileAnalyticsERS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsERS.h; sourceTree = "<group>"; };
-		CE7635BF19BFA050005FD5D0 /* AWSMobileAnalyticsERS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsERS.m; sourceTree = "<group>"; };
-		CE7635C019BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsERSModel.h; sourceTree = "<group>"; };
-		CE7635C119BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsERSModel.m; sourceTree = "<group>"; };
-		CE7635C219BFA050005FD5D0 /* MobileAnalyticsERS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MobileAnalyticsERS.h; sourceTree = "<group>"; };
-		CE7635C419BFA050005FD5D0 /* mobileanalytics-2014-06-30.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "mobileanalytics-2014-06-30.json"; sourceTree = "<group>"; };
-		CE896C84194A8619000DBB3C /* ec2-2014-06-15.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ec2-2014-06-15.json"; sourceTree = "<group>"; };
-		CE8FEAA218D3B18600EC90A6 /* AWSElasticLoadBalancingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSElasticLoadBalancingTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE8FEAA518D3B62100EC90A6 /* AWSCloudWatchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSCloudWatchTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE8FEAA718D3B84E00EC90A6 /* AWSAutoScalingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSAutoScalingTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CE91D2BE18D3C03B000390D2 /* AWSKinesisTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSKinesisTests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CEB2A4A318D782F80007AAF4 /* AWSEC2Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSEC2Tests.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CEBA14CC1921AC2F008C596A /* AWSDynamoDBObjectMapperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDynamoDBObjectMapperTests.m; sourceTree = "<group>"; };
-		CED514031954B83B00D693F7 /* AWSClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSClientContext.h; sourceTree = "<group>"; };
-		CED514041954B83B00D693F7 /* AWSClientContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSClientContext.m; sourceTree = "<group>"; };
-		CED6C36418EE3EC800A56FB2 /* AWSS3TransferManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSS3TransferManager.h; sourceTree = "<group>"; };
-		CED6C36518EE3EC800A56FB2 /* AWSS3TransferManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSS3TransferManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CEE68C15193FB11A00259EFF /* AWSKinesisRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSKinesisRecorder.h; sourceTree = "<group>"; };
-		CEE68C16193FB11A00259EFF /* AWSKinesisRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSKinesisRecorder.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		CEE68C181940000500259EFF /* AWSKinesisRecorderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSKinesisRecorderTests.m; sourceTree = "<group>"; };
-		EA2AF764195E206B007DDDD4 /* AWSMobileAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalytics.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF766195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsConfiguration.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF767195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsConfiguration.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF769195E206B007DDDD4 /* AWSMobileAnalyticsClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsClientContext.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF76A195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsIOSClientContext.h; sourceTree = "<group>"; };
-		EA2AF76B195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsIOSClientContext.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF76D195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsCountDownLatch.m; sourceTree = "<group>"; };
-		EA2AF76E195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultContext.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF76F195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsDefaultOptions.m; sourceTree = "<group>"; };
-		EA2AF770195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsDelayedBlock.m; sourceTree = "<group>"; };
-		EA2AF771195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsJSONSerializer.m; sourceTree = "<group>"; };
-		EA2AF772195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsSerializerFactory.m; sourceTree = "<group>"; };
-		EA2AF774195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsConfigurationKeys.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF775195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsHttpCachingConfiguration.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF777195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsClientContextInterceptor.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF778195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultHttpClient.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF779195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsDefaultInterceptor.m; sourceTree = "<group>"; };
-		EA2AF77A195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultRequest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF77B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultResponse.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF77C195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsInstanceIdInterceptor.m; sourceTree = "<group>"; };
-		EA2AF77D195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsLogInterceptor.m; sourceTree = "<group>"; };
-		EA2AF77E195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsRequestTimingInterceptor.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF77F195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsSDKInfoInterceptor.m; sourceTree = "<group>"; };
-		EA2AF781195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsPrefsUniqueIdService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF782195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsRandomUUIDGenerator.m; sourceTree = "<group>"; };
-		EA2AF784195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsBufferedReader.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF785195E206B007DDDD4 /* AWSMobileAnalyticsWriter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsWriter.m; sourceTree = "<group>"; };
-		EA2AF787195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultFileManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF788195E206B007DDDD4 /* AWSMobileAnalyticsFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsFile.m; sourceTree = "<group>"; };
-		EA2AF789195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsIOSConnectivity.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF78A195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsIOSLifeCycleManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF78B195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsIOSPreferences.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF78C195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsIOSSystem.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF78F195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsDateUtils.m; sourceTree = "<group>"; };
-		EA2AF790195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsErrorUtils.m; sourceTree = "<group>"; };
-		EA2AF791195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsSDKInfo.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF792195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsStringUtils.m; sourceTree = "<group>"; };
-		EA2AF794195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsConnectivityPolicy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF795195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultDeliveryClient.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF796195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDeliveryPolicyFactory.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF797195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsERSRequestBuilder.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF798195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsFileEventStore.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF799195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsSubmissionTimePolicy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF79B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsDefaultEvent.m; sourceTree = "<group>"; };
-		EA2AF79C195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultEventClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF79D195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultEventClient.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF79E195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsEventConstraintDecorator.m; sourceTree = "<group>"; };
-		EA2AF7A0195E206B007DDDD4 /* AWSMobileAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalytics.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7A1195E206B007DDDD4 /* AWSMobileAnalyticsEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsEvent.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7A2195E206B007DDDD4 /* AWSMobileAnalyticsEventClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsEventClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7A3195E206B007DDDD4 /* AWSMobileAnalyticsOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsOptions.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7A4195E206B007DDDD4 /* MobileAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MobileAnalytics.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7A6195E206B007DDDD4 /* AWSMobileAnalyticsConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsConstants.h; sourceTree = "<group>"; };
-		EA2AF7A7195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsCountDownLatch.h; sourceTree = "<group>"; };
-		EA2AF7A8195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultContext.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7A9195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsDefaultOptions.h; sourceTree = "<group>"; };
-		EA2AF7AA195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsDelayedBlock.h; sourceTree = "<group>"; };
-		EA2AF7AB195E206B007DDDD4 /* AWSMobileAnalyticsContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsContext.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7AC195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsJSONSerializer.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7AD195E206B007DDDD4 /* AWSMobileAnalyticsSerializable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsSerializable.h; sourceTree = "<group>"; };
-		EA2AF7AE195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsSerializerFactory.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B0195E206B007DDDD4 /* AWSMobileAnalyticsConfiguring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsConfiguring.h; sourceTree = "<group>"; };
-		EA2AF7B1195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsConfigurationKeys.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B2195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsHttpCachingConfiguration.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B4195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsClientContextInterceptor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B5195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultHttpClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B6195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultInterceptor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B7195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultRequest.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B8195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultResponse.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7B9195E206B007DDDD4 /* AWSMobileAnalyticsHttpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsHttpClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7BA195E206B007DDDD4 /* AWSMobileAnalyticsHttpConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsHttpConstants.h; sourceTree = "<group>"; };
-		EA2AF7BB195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsInstanceIdInterceptor.h; sourceTree = "<group>"; };
-		EA2AF7BC195E206B007DDDD4 /* AWSMobileAnalyticsInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsInterceptor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7BD195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsLogInterceptor.h; sourceTree = "<group>"; };
-		EA2AF7BE195E206B007DDDD4 /* AWSMobileAnalyticsRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsRequest.h; sourceTree = "<group>"; };
-		EA2AF7BF195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsRequestTimingInterceptor.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7C0195E206B007DDDD4 /* AWSMobileAnalyticsResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsResponse.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7C1195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsSDKInfoInterceptor.h; sourceTree = "<group>"; };
-		EA2AF7C3195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsPrefsUniqueIdService.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7C4195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsRandomUUIDGenerator.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7C5195E206B007DDDD4 /* AWSMobileAnalyticsUniqueIdGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsUniqueIdGenerator.h; sourceTree = "<group>"; };
-		EA2AF7C6195E206B007DDDD4 /* AWSMobileAnalyticsUniqueIdService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsUniqueIdService.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7C8195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsBufferedReader.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7C9195E206B007DDDD4 /* AWSMobileAnalyticsWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsWriter.h; sourceTree = "<group>"; };
-		EA2AF7CB195E206B007DDDD4 /* AWSMobileAnalyticsConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsConnectivity.h; sourceTree = "<group>"; };
-		EA2AF7CC195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultFileManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7CD195E206B007DDDD4 /* AWSMobileAnalyticsFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsFile.h; sourceTree = "<group>"; };
-		EA2AF7CE195E206B007DDDD4 /* AWSMobileAnalyticsFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsFileManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7CF195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsIOSConnectivity.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7D0195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsIOSLifeCycleManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7D1195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsIOSPreferences.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7D2195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsIOSSystem.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7D3195E206B007DDDD4 /* AWSMobileAnalyticsLifeCycleManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsLifeCycleManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7D4195E206B007DDDD4 /* AWSMobileAnalyticsPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsPreferences.h; sourceTree = "<group>"; };
-		EA2AF7D5195E206B007DDDD4 /* AWSMobileAnalyticsSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsSystem.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7D8195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsDateUtils.h; sourceTree = "<group>"; };
-		EA2AF7D9195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsErrorUtils.h; sourceTree = "<group>"; };
-		EA2AF7DA195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsSDKInfo.h; sourceTree = "<group>"; };
-		EA2AF7DB195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsStringUtils.h; sourceTree = "<group>"; };
-		EA2AF7DD195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsConnectivityPolicy.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7DE195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultDeliveryClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7DF195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDeliveryClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E0195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsDeliveryPolicy.h; sourceTree = "<group>"; };
-		EA2AF7E1195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDeliveryPolicyFactory.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E2195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsERSRequestBuilder.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E3195E206B007DDDD4 /* AWSMobileAnalyticsEventStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsEventStore.h; sourceTree = "<group>"; };
-		EA2AF7E4195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsFileEventStore.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E5195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsSubmissionTimePolicy.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E7195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultEvent.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E8195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsEventConstraintDecorator.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7E9195E206B007DDDD4 /* AWSMobileAnalyticsEventObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsEventObserver.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7EA195E206B007DDDD4 /* AWSMobileAnalyticsInternalEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsInternalEvent.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7EB195E206B007DDDD4 /* AWSMobileAnalyticsInternalEventClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsInternalEventClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7ED195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsAppleMonetizationEventBuilder.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7EE195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsMonetizationEventBuilder.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7EF195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsVirtualMonetizationEventBuilder.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F1195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsActiveSessionState.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F2195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient+SessionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "AWSMobileAnalyticsDefaultSessionClient+SessionState.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F3195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsDefaultSessionClient.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F4195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsInactiveSessionState.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F5195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsPausedSessionState.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F6195E206B007DDDD4 /* AWSMobileAnalyticsSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsSession.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7F7195E206B007DDDD4 /* AWSMobileAnalyticsSessionClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsSessionClient.h; sourceTree = "<group>"; };
-		EA2AF7F8195E206B007DDDD4 /* AWSMobileAnalyticsSessionClientState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSMobileAnalyticsSessionClientState.h; sourceTree = "<group>"; };
-		EA2AF7F9195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AWSMobileAnalyticsSessionStore.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		EA2AF7FB195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsAppleMonetizationEventBuilder.m; sourceTree = "<group>"; };
-		EA2AF7FC195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsMonetizationEventBuilder.m; sourceTree = "<group>"; };
-		EA2AF7FD195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsVirtualMonetizationEventBuilder.m; sourceTree = "<group>"; };
-		EA2AF7FF195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsActiveSessionState.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF800195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsDefaultSessionClient.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF801195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsInactiveSessionState.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF802195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsPausedSessionState.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF803195E206B007DDDD4 /* AWSMobileAnalyticsSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AWSMobileAnalyticsSession.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		EA2AF804195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSMobileAnalyticsSessionStore.m; sourceTree = "<group>"; };
-		EAC25F5E195E4A4500675156 /* AWSServiceEnum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSServiceEnum.h; sourceTree = "<group>"; };
-		EADE666419539C4100313444 /* GenerateAppleDocs.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = GenerateAppleDocs.sh; path = Scripts/GenerateAppleDocs.sh; sourceTree = "<group>"; };
-		EFEAC89419295311005FEDE4 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
-		F3A0CE70F1DF4EEE8E04D464 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		BDD11DEB193FA13600AF60E1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDD11E33193FA78000AF60E1 /* libsqlite3.dylib in Frameworks */,
-				BDD11E32193FA70C00AF60E1 /* SystemConfiguration.framework in Frameworks */,
-				BDD11E11193FA41F00AF60E1 /* libOCMock.a in Frameworks */,
-				BDD11E0F193FA40300AF60E1 /* OCHamcrestIOS.framework in Frameworks */,
-				BDD11E0A193FA33E00AF60E1 /* SenTestingKit.framework in Frameworks */,
-				BDD11E01193FA1B700AF60E1 /* libz.dylib in Frameworks */,
-				BDD11E00193FA19B00AF60E1 /* libAWSiOSSDKv2.a in Frameworks */,
-				BDD11DEF193FA13600AF60E1 /* XCTest.framework in Frameworks */,
-				BDD11DF1193FA13600AF60E1 /* UIKit.framework in Frameworks */,
-				BDD11DF0193FA13600AF60E1 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CE31484F187B577A0068883B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDD39A0E193E652100C712BD /* libz.dylib in Frameworks */,
-				EFEAC897192954B2005FEDE4 /* libAWSiOSSDKv2.a in Frameworks */,
-				EFEAC89619295448005FEDE4 /* libsqlite3.dylib in Frameworks */,
-				CE31486D187B59220068883B /* UIKit.framework in Frameworks */,
-				CE314853187B577A0068883B /* XCTest.framework in Frameworks */,
-				CE314854187B577A0068883B /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CE5D83D31857AA3100907C25 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CE5D83DA1857AA3100907C25 /* Foundation.framework in Frameworks */,
-				6F8CA45C05144354BEC9C638 /* libPods.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		BDD11DF2193FA13600AF60E1 /* AWSiOSSDKAnalyticsTests */ = {
-			isa = PBXGroup;
-			children = (
-				BDD777A1193FDD9C00F04070 /* session */,
-				BDD77797193FDD7F00F04070 /* event */,
-				BDD77793193FDD6300F04070 /* util */,
-				BDD77780193FDD4500F04070 /* delivery */,
-				BDD7777C193FDD2E00F04070 /* monetization */,
-				BDD7775C193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.h */,
-				BDD7775D193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.m */,
-				BDD77725193FDB4E00F04070 /* AZCommon */,
-				BDD11E15193FA50600AF60E1 /* core */,
-				BDD11E0B193FA39400AF60E1 /* AmazonInsightsSDKTests.h */,
-				BDD11E0C193FA39400AF60E1 /* AmazonInsightsSDKTests.m */,
-				BDD11E12193FA4DD00AF60E1 /* AIInsightsContextBuilder.h */,
-				BDD11E13193FA4DD00AF60E1 /* AIInsightsContextBuilder.m */,
-				BDD11E19193FA55700AF60E1 /* AITestHttpClient.h */,
-				BDD11E1A193FA55700AF60E1 /* AITestHttpClient.m */,
-				BDD11E02193FA1EE00AF60E1 /* integration */,
-				BDD11DF3193FA13600AF60E1 /* Supporting Files */,
-			);
-			path = AWSiOSSDKAnalyticsTests;
-			sourceTree = "<group>";
-		};
-		BDD11DF3193FA13600AF60E1 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				BDD11DF4193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests-Info.plist */,
-				BDD11DF5193FA13600AF60E1 /* InfoPlist.strings */,
-				BDD11DFA193FA13600AF60E1 /* AWSiOSSDKAnalyticsTests-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		BDD11E02193FA1EE00AF60E1 /* integration */ = {
-			isa = PBXGroup;
-			children = (
-				BDD11E1C193FA58200AF60E1 /* util */,
-				BDD11E06193FA24E00AF60E1 /* AIIntegrationTestBase.h */,
-				BDD11E07193FA24E00AF60E1 /* AIIntegrationTestBase.m */,
-				BDD11E03193FA23200AF60E1 /* AIAmazonInsightsTests.h */,
-				BDD11E04193FA23200AF60E1 /* AIAmazonInsightsTests.m */,
-				BDD77713193FDADE00F04070 /* AIConfigurationIntegrationTests.h */,
-				BDD77714193FDADE00F04070 /* AIConfigurationIntegrationTests.m */,
-				BDD77715193FDADE00F04070 /* AIDeliveryIntegrationTests.h */,
-				BDD77716193FDADE00F04070 /* AIDeliveryIntegrationTests.m */,
-				BDD77717193FDADE00F04070 /* AISessionIntegrationTests.h */,
-				BDD77718193FDADE00F04070 /* AISessionIntegrationTests.m */,
-			);
-			name = integration;
-			sourceTree = "<group>";
-		};
-		BDD11E15193FA50600AF60E1 /* core */ = {
-			isa = PBXGroup;
-			children = (
-				BDD7774F193FDBFF00F04070 /* system */,
-				BDD77745193FDBE800F04070 /* io */,
-				BDD77741193FDBD500F04070 /* id */,
-				BDD7773D193FDBAC00F04070 /* utils */,
-				BDD7772A193FDB8600F04070 /* http */,
-				BDD77726193FDB5D00F04070 /* configuration */,
-				BDD11E16193FA51A00AF60E1 /* AITestConfiguration.h */,
-				BDD11E17193FA51A00AF60E1 /* AITestConfiguration.m */,
-				BDD7771C193FDB2800F04070 /* AIDefaultInsightsOptionsTests.h */,
-				BDD7771D193FDB2800F04070 /* AIDefaultInsightsOptionsTests.m */,
-				BDD7771E193FDB2800F04070 /* AIDelayedBlockTests.h */,
-				BDD7771F193FDB2800F04070 /* AIDelayedBlockTests.m */,
-				BDD77720193FDB2800F04070 /* AICountDownLatchTests.h */,
-				BDD77721193FDB2800F04070 /* AICountDownLatchTests.m */,
-			);
-			name = core;
-			sourceTree = "<group>";
-		};
-		BDD11E1C193FA58200AF60E1 /* util */ = {
-			isa = PBXGroup;
-			children = (
-				BDD11E21193FA5E600AF60E1 /* NSObject+TTTSwizzling.h */,
-				BDD11E22193FA5E600AF60E1 /* NSObject+TTTSwizzling.m */,
-				BDD11E23193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.h */,
-				BDD11E24193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.m */,
-				BDD11E1D193FA5A400AF60E1 /* TestConnectivity.h */,
-				BDD11E1E193FA5A400AF60E1 /* TestConnectivity.m */,
-				BDD11E27193FA61300AF60E1 /* TestInsightsContext.h */,
-				BDD11E28193FA61300AF60E1 /* TestInsightsContext.m */,
-				BDD11E20193FA5AC00AF60E1 /* TestConstants.h */,
-				BDD11E2A193FA67100AF60E1 /* AIInternalInterfaces.h */,
-				BDD11E2B193FA67100AF60E1 /* BlockingInterceptor.h */,
-				BDD11E2C193FA67100AF60E1 /* BlockingInterceptor.m */,
-				BDD11E2D193FA67100AF60E1 /* TestEventObserver.h */,
-				BDD11E2E193FA67100AF60E1 /* TestEventObserver.m */,
-			);
-			name = util;
-			sourceTree = "<group>";
-		};
-		BDD77725193FDB4E00F04070 /* AZCommon */ = {
-			isa = PBXGroup;
-			children = (
-				BDD7775F193FDCF600F04070 /* ClientContext */,
-			);
-			name = AZCommon;
-			sourceTree = "<group>";
-		};
-		BDD77726193FDB5D00F04070 /* configuration */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77727193FDB6B00F04070 /* AIHttpCachingConfigurationTests.h */,
-				BDD77728193FDB6B00F04070 /* AIHttpCachingConfigurationTests.m */,
-			);
-			name = configuration;
-			sourceTree = "<group>";
-		};
-		BDD7772A193FDB8600F04070 /* http */ = {
-			isa = PBXGroup;
-			children = (
-				BDD7772B193FDB9400F04070 /* AIDefaultRequestTests.h */,
-				BDD7772C193FDB9400F04070 /* AIDefaultRequestTests.m */,
-				BDD7772D193FDB9400F04070 /* AISDKInfoInterceptorTests.h */,
-				BDD7772E193FDB9400F04070 /* AISDKInfoInterceptorTests.m */,
-				BDD77731193FDB9400F04070 /* AIClientContextInterceptorTests.h */,
-				BDD77732193FDB9400F04070 /* AIClientContextInterceptorTests.m */,
-				BDD77735193FDB9400F04070 /* AIInstanceIdInterceptorTests.h */,
-				BDD77736193FDB9400F04070 /* AIInstanceIdInterceptorTests.m */,
-			);
-			name = http;
-			sourceTree = "<group>";
-		};
-		BDD7773D193FDBAC00F04070 /* utils */ = {
-			isa = PBXGroup;
-			children = (
-				BDD7773E193FDBC800F04070 /* AIStringUtilsTests.h */,
-				BDD7773F193FDBC800F04070 /* AIStringUtilsTests.m */,
-			);
-			name = utils;
-			sourceTree = "<group>";
-		};
-		BDD77741193FDBD500F04070 /* id */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77742193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.h */,
-				BDD77743193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.m */,
-			);
-			name = id;
-			sourceTree = "<group>";
-		};
-		BDD77745193FDBE800F04070 /* io */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77746193FDBF300F04070 /* AIBufferedReaderTests.h */,
-				BDD77747193FDBF300F04070 /* AIBufferedReaderTests.m */,
-				BDD77748193FDBF300F04070 /* AIEncryptedReaderWriterTests.h */,
-				BDD77749193FDBF300F04070 /* AIEncryptedReaderWriterTests.m */,
-			);
-			name = io;
-			sourceTree = "<group>";
-		};
-		BDD7774F193FDBFF00F04070 /* system */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77750193FDC0C00F04070 /* AIFileTests.h */,
-				BDD77751193FDC0C00F04070 /* AIFileTests.m */,
-				BDD77752193FDC0C00F04070 /* AIDefaultFileManagerTests.h */,
-				BDD77753193FDC0C00F04070 /* AIDefaultFileManagerTests.m */,
-				BDD77754193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.h */,
-				BDD77755193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.m */,
-				BDD77756193FDC0C00F04070 /* AIIOSPreferencesTests.h */,
-				BDD77757193FDC0C00F04070 /* AIIOSPreferencesTests.m */,
-			);
-			name = system;
-			sourceTree = "<group>";
-		};
-		BDD7775F193FDCF600F04070 /* ClientContext */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77760193FDD0500F04070 /* AZIOSClientContextTests.h */,
-				BDD77761193FDD0500F04070 /* AZIOSClientContextTests.m */,
-			);
-			name = ClientContext;
-			sourceTree = "<group>";
-		};
-		BDD7777C193FDD2E00F04070 /* monetization */ = {
-			isa = PBXGroup;
-			children = (
-				BDD7777D193FDD3B00F04070 /* AIMonetizationEventBuilderTests.h */,
-				BDD7777E193FDD3B00F04070 /* AIMonetizationEventBuilderTests.m */,
-			);
-			name = monetization;
-			sourceTree = "<group>";
-		};
-		BDD77780193FDD4500F04070 /* delivery */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77781193FDD5200F04070 /* AIFileEventStoreTests.h */,
-				BDD77782193FDD5200F04070 /* AIFileEventStoreTests.m */,
-				BDD77783193FDD5200F04070 /* AIDefaultDeliveryClientTests.h */,
-				BDD77784193FDD5200F04070 /* AIDefaultDeliveryClientTests.m */,
-				BDD77787193FDD5200F04070 /* AIConnectivityPolicyTests.h */,
-				BDD77788193FDD5200F04070 /* AIConnectivityPolicyTests.m */,
-				BDD77789193FDD5200F04070 /* AISubmissionTimePolicyTests.h */,
-				BDD7778A193FDD5200F04070 /* AISubmissionTimePolicyTests.m */,
-				BDD7778B193FDD5200F04070 /* AIERSRequestBuilderTests.h */,
-				BDD7778C193FDD5200F04070 /* AIERSRequestBuilderTests.m */,
-			);
-			name = delivery;
-			sourceTree = "<group>";
-		};
-		BDD77793193FDD6300F04070 /* util */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77794193FDD6E00F04070 /* AIDateUtilTests.h */,
-				BDD77795193FDD6E00F04070 /* AIDateUtilTests.m */,
-			);
-			name = util;
-			sourceTree = "<group>";
-		};
-		BDD77797193FDD7F00F04070 /* event */ = {
-			isa = PBXGroup;
-			children = (
-				BDD77798193FDD9000F04070 /* AIEventClientTests.h */,
-				BDD77799193FDD9000F04070 /* AIEventClientTests.m */,
-				BDD7779A193FDD9000F04070 /* AIDefaultEventTests.h */,
-				BDD7779B193FDD9000F04070 /* AIDefaultEventTests.m */,
-				BDD7779C193FDD9000F04070 /* AIEventContraintDecoratorTests.h */,
-				BDD7779D193FDD9000F04070 /* AIEventContraintDecoratorTests.m */,
-			);
-			name = event;
-			sourceTree = "<group>";
-		};
-		BDD777A1193FDD9C00F04070 /* session */ = {
-			isa = PBXGroup;
-			children = (
-				BDD777A2193FDDA800F04070 /* AISessionClientTests.h */,
-				BDD777A3193FDDA800F04070 /* AISessionClientTests.m */,
-				BDD777A4193FDDA800F04070 /* AISessionTests.h */,
-				BDD777A5193FDDA800F04070 /* AISessionTests.m */,
-				BDD777A6193FDDA800F04070 /* AIPausedSessionStateTests.h */,
-				BDD777A7193FDDA800F04070 /* AIPausedSessionStateTests.m */,
-				BDD777A8193FDDA800F04070 /* AIActiveSessionStateTests.h */,
-				BDD777A9193FDDA800F04070 /* AIActiveSessionStateTests.m */,
-				BDD777AA193FDDA800F04070 /* AIInactiveSessionStateTests.h */,
-				BDD777AB193FDDA800F04070 /* AIInactiveSessionStateTests.m */,
-				BDD777AC193FDDA800F04070 /* AISessionStoreTests.h */,
-				BDD777AD193FDDA800F04070 /* AISessionStoreTests.m */,
-			);
-			name = session;
-			sourceTree = "<group>";
-		};
-		CE09860C1922A7470006EA67 /* STS */ = {
-			isa = PBXGroup;
-			children = (
-				CE0986131922A7470006EA67 /* STS.h */,
-				CE09860D1922A7470006EA67 /* AWSSTS.h */,
-				CE09860E1922A7470006EA67 /* AWSSTS.m */,
-				CE09860F1922A7470006EA67 /* AWSSTSModel.h */,
-				CE0986101922A7470006EA67 /* AWSSTSModel.m */,
-				CE0986111922A7470006EA67 /* Resources */,
-			);
-			path = STS;
-			sourceTree = "<group>";
-		};
-		CE0986111922A7470006EA67 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE0986121922A7470006EA67 /* sts-2011-06-15.json */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		CE16EED819916C5100A318A3 /* Utility */ = {
-			isa = PBXGroup;
-			children = (
-				CE16EED919916C5100A318A3 /* AWSCategory.h */,
-				CE16EEDA19916C5100A318A3 /* AWSCategory.m */,
-				CE16EEDB19916C5100A318A3 /* AWSLogging.h */,
-				CE16EEDC19916C5100A318A3 /* AWSLogging.m */,
-				CE16EEDD19916C5100A318A3 /* AWSModel.h */,
-				CE16EEDE19916C5100A318A3 /* AWSModel.m */,
-				CE16EEDF19916C5100A318A3 /* AWSSynchronizedMutableDictionary.h */,
-				CE16EEE019916C5100A318A3 /* AWSSynchronizedMutableDictionary.m */,
-			);
-			path = Utility;
-			sourceTree = "<group>";
-		};
-		CE314856187B577A0068883B /* AWSiOSSDKTests */ = {
-			isa = PBXGroup;
-			children = (
-				BDD39A10193E8D4500C712BD /* AWSAnalyticsTests.m */,
-				CE8FEAA718D3B84E00EC90A6 /* AWSAutoScalingTests.m */,
-				CE1C9DE41936CE38007B6F33 /* AWSClockSkewTests.m */,
-				CE8FEAA518D3B62100EC90A6 /* AWSCloudWatchTests.m */,
-				388CA0A11926CA3800AF5A50 /* AWSCognitoCredentialsProviderTests.m */,
-				38627E3E19253F5500EF30EF /* AWSCognitoIdentityServiceTests.m */,
-				CE314865187B57F50068883B /* AWSCoreTests.m */,
-				CEBA14CC1921AC2F008C596A /* AWSDynamoDBObjectMapperTests.m */,
-				CE314864187B57F50068883B /* AWSDynamoDBTests.m */,
-				CEB2A4A318D782F80007AAF4 /* AWSEC2Tests.m */,
-				CE8FEAA218D3B18600EC90A6 /* AWSElasticLoadBalancingTests.m */,
-				CEE68C181940000500259EFF /* AWSKinesisRecorderTests.m */,
-				CE91D2BE18D3C03B000390D2 /* AWSKinesisTests.m */,
-				BD9CC213193CFF0700780456 /* AWSMobileAnalyticsERSTests.m */,
-				CE3F4D3819BFCE5A000C1A6C /* AWSS3PreSignedURLBuilderTests.m */,
-				BD19ED04188F15EB001F5B98 /* AWSS3Tests.m */,
-				BDC8315E1919725000A01D20 /* AWSS3TransferManagerTests.m */,
-				CE0D85DC18D38FCA00D41F8A /* AWSSESTests.m */,
-				CE0D85DA18D38AAB00D41F8A /* AWSSimpleDBTests.m */,
-				CE0D85D818D385DA00D41F8A /* AWSSNSTests.m */,
-				CE0D85D618D37EC000D41F8A /* AWSSQSTests.m */,
-				CE2C174618D0D8CF003FE9AA /* AWSSTSTests.m */,
-				CE160B2219774365001ABF94 /* AWSTestUtility.h */,
-				CE160B2019774315001ABF94 /* AWSTestUtility.m */,
-				CE314857187B577A0068883B /* Supporting Files */,
-			);
-			path = AWSiOSSDKTests;
-			sourceTree = "<group>";
-		};
-		CE314857187B577A0068883B /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				CE31485E187B577A0068883B /* AWSiOSSDKv2Tests-Prefix.pch */,
-				BD1861BD19A41395003C8E42 /* ec2-input.json */,
-				BD1861BE19A41395003C8E42 /* ec2-output.json */,
-				BDD196D2198AFF2C00CC94A2 /* json-output.json */,
-				BDD196D3198AFF2C00CC94A2 /* query-output.json */,
-				BDD196D5198AFF2C00CC94A2 /* rest-xml-output.json */,
-				BDD196C8198AFF2200CC94A2 /* json-input.json */,
-				BDD196C9198AFF2200CC94A2 /* query-input.json */,
-				BDD196CB198AFF2200CC94A2 /* rest-xml-input.json */,
-				CE31486A187B58090068883B /* credentials.json */,
-				CE314858187B577A0068883B /* AWSiOSSDKv2Tests-Info.plist */,
-				CE314859187B577A0068883B /* InfoPlist.strings */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		CE372B1318DA874000D2CFD2 /* AutoScaling */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B1418DA874000D2CFD2 /* AutoScaling.h */,
-				CE372B1518DA874000D2CFD2 /* AWSAutoScaling.h */,
-				CE372B1618DA874000D2CFD2 /* AWSAutoScaling.m */,
-				CE372B1718DA874000D2CFD2 /* AWSAutoScalingModel.h */,
-				CE372B1818DA874000D2CFD2 /* AWSAutoScalingModel.m */,
-				CE372B1918DA874000D2CFD2 /* Resources */,
-			);
-			path = AutoScaling;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B1918DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B1A18DA874000D2CFD2 /* autoscaling-2011-01-01.json */,
-			);
-			name = Resources;
-			path = AutoScaling/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B1B18DA874000D2CFD2 /* CloudWatch */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B2018DA874000D2CFD2 /* CloudWatch.h */,
-				CE372B1C18DA874000D2CFD2 /* AWSCloudWatch.h */,
-				CE372B1D18DA874000D2CFD2 /* AWSCloudWatch.m */,
-				CE372B1E18DA874000D2CFD2 /* AWSCloudWatchModel.h */,
-				CE372B1F18DA874000D2CFD2 /* AWSCloudWatchModel.m */,
-				CE372B2118DA874000D2CFD2 /* Resources */,
-			);
-			path = CloudWatch;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B2118DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B2218DA874000D2CFD2 /* monitoring-2010-08-01.json */,
-			);
-			name = Resources;
-			path = CloudWatch/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B2318DA874000D2CFD2 /* DynamoDB */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B2818DA874000D2CFD2 /* DynamoDB.h */,
-				CE372B2418DA874000D2CFD2 /* AWSDynamoDB.h */,
-				CE372B2518DA874000D2CFD2 /* AWSDynamoDB.m */,
-				CE372B2618DA874000D2CFD2 /* AWSDynamoDBModel.h */,
-				CE372B2718DA874000D2CFD2 /* AWSDynamoDBModel.m */,
-				CE5312B21922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.h */,
-				CE5312B31922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.m */,
-				CE372B2918DA874000D2CFD2 /* Resources */,
-			);
-			path = DynamoDB;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B2918DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B2A18DA874000D2CFD2 /* dynamodb-2012-08-10.json */,
-			);
-			name = Resources;
-			path = DynamoDB/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B2B18DA874000D2CFD2 /* EC2 */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B3018DA874000D2CFD2 /* EC2.h */,
-				CE372B2C18DA874000D2CFD2 /* AWSEC2.h */,
-				CE372B2D18DA874000D2CFD2 /* AWSEC2.m */,
-				CE372B2E18DA874000D2CFD2 /* AWSEC2Model.h */,
-				CE372B2F18DA874000D2CFD2 /* AWSEC2Model.m */,
-				CE372B3118DA874000D2CFD2 /* Resources */,
-			);
-			path = EC2;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B3118DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE896C84194A8619000DBB3C /* ec2-2014-06-15.json */,
-			);
-			name = Resources;
-			path = EC2/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B3318DA874000D2CFD2 /* ElasticLoadBalancing */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B3818DA874000D2CFD2 /* ElasticLoadBalancing.h */,
-				CE372B3418DA874000D2CFD2 /* AWSElasticLoadBalancing.h */,
-				CE372B3518DA874000D2CFD2 /* AWSElasticLoadBalancing.m */,
-				CE372B3618DA874000D2CFD2 /* AWSElasticLoadBalancingModel.h */,
-				CE372B3718DA874000D2CFD2 /* AWSElasticLoadBalancingModel.m */,
-				CE372B3918DA874000D2CFD2 /* Resources */,
-			);
-			path = ElasticLoadBalancing;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B3918DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B3A18DA874000D2CFD2 /* elasticloadbalancing-2012-06-01.json */,
-			);
-			name = Resources;
-			path = ElasticLoadBalancing/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B3B18DA874000D2CFD2 /* Kinesis */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B4018DA874000D2CFD2 /* Kinesis.h */,
-				CE372B3C18DA874000D2CFD2 /* AWSKinesis.h */,
-				CE372B3D18DA874000D2CFD2 /* AWSKinesis.m */,
-				CE372B3E18DA874000D2CFD2 /* AWSKinesisModel.h */,
-				CE372B3F18DA874000D2CFD2 /* AWSKinesisModel.m */,
-				CEE68C15193FB11A00259EFF /* AWSKinesisRecorder.h */,
-				CEE68C16193FB11A00259EFF /* AWSKinesisRecorder.m */,
-				CE372B4118DA874000D2CFD2 /* Resources */,
-			);
-			path = Kinesis;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B4118DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B4218DA874000D2CFD2 /* kinesis-2013-12-02.json */,
-			);
-			name = Resources;
-			path = Kinesis/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B4318DA874000D2CFD2 /* S3 */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B4A18DA874000D2CFD2 /* S3.h */,
-				CE372B4418DA874000D2CFD2 /* AWSS3.h */,
-				CE372B4518DA874000D2CFD2 /* AWSS3.m */,
-				CE372B4618DA874000D2CFD2 /* AWSS3Model.h */,
-				CE372B4718DA874000D2CFD2 /* AWSS3Model.m */,
-				CE23E60A19BF7CD00036EDC0 /* AWSS3PreSignedURL.h */,
-				CE23E60B19BF7CD60036EDC0 /* AWSS3PreSignedURL.m */,
-				CED6C36418EE3EC800A56FB2 /* AWSS3TransferManager.h */,
-				CED6C36518EE3EC800A56FB2 /* AWSS3TransferManager.m */,
-				CE372B4818DA874000D2CFD2 /* Resources */,
-			);
-			path = S3;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B4818DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B4918DA874000D2CFD2 /* s3-2006-03-01.json */,
-			);
-			name = Resources;
-			path = S3/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B4B18DA874000D2CFD2 /* SES */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B5218DA874000D2CFD2 /* SES.h */,
-				CE372B4C18DA874000D2CFD2 /* AWSSES.h */,
-				CE372B4D18DA874000D2CFD2 /* AWSSES.m */,
-				CE372B4E18DA874000D2CFD2 /* AWSSESModel.h */,
-				CE372B4F18DA874000D2CFD2 /* AWSSESModel.m */,
-				CE372B5018DA874000D2CFD2 /* Resources */,
-			);
-			path = SES;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B5018DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B5118DA874000D2CFD2 /* email-2010-12-01.json */,
-			);
-			name = Resources;
-			path = SES/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B5318DA874000D2CFD2 /* SimpleDB */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B5A18DA874000D2CFD2 /* SimpleDB.h */,
-				CE372B5418DA874000D2CFD2 /* AWSSimpleDB.h */,
-				CE372B5518DA874000D2CFD2 /* AWSSimpleDB.m */,
-				CE372B5618DA874000D2CFD2 /* AWSSimpleDBModel.h */,
-				CE372B5718DA874000D2CFD2 /* AWSSimpleDBModel.m */,
-				CE372B5818DA874000D2CFD2 /* Resources */,
-			);
-			path = SimpleDB;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B5818DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B5918DA874000D2CFD2 /* sdb-2009-04-15.json */,
-			);
-			name = Resources;
-			path = SimpleDB/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B5B18DA874000D2CFD2 /* SNS */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B6218DA874000D2CFD2 /* SNS.h */,
-				CE372B5C18DA874000D2CFD2 /* AWSSNS.h */,
-				CE372B5D18DA874000D2CFD2 /* AWSSNS.m */,
-				CE372B5E18DA874000D2CFD2 /* AWSSNSModel.h */,
-				CE372B5F18DA874000D2CFD2 /* AWSSNSModel.m */,
-				CE372B6018DA874000D2CFD2 /* Resources */,
-			);
-			path = SNS;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B6018DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B6118DA874000D2CFD2 /* sns-2010-03-31.json */,
-			);
-			name = Resources;
-			path = SNS/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B6318DA874000D2CFD2 /* SQS */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B6A18DA874000D2CFD2 /* SQS.h */,
-				CE372B6418DA874000D2CFD2 /* AWSSQS.h */,
-				CE372B6518DA874000D2CFD2 /* AWSSQS.m */,
-				CE372B6618DA874000D2CFD2 /* AWSSQSModel.h */,
-				CE372B6718DA874000D2CFD2 /* AWSSQSModel.m */,
-				CE372B6818DA874000D2CFD2 /* Resources */,
-			);
-			path = SQS;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE372B6818DA874000D2CFD2 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE372B6918DA874000D2CFD2 /* sqs-2012-11-05.json */,
-			);
-			name = Resources;
-			path = SQS/Resources;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE55F33C18DB716B00F8C75F /* AWSCore */ = {
-			isa = PBXGroup;
-			children = (
-				CE55F34218DB716B00F8C75F /* AWSCore.h */,
-				CE55F33D18DB716B00F8C75F /* Authentication */,
-				CE7635B119BFA034005FD5D0 /* CognitoIdentity */,
-				EA2AF763195E206B007DDDD4 /* MobileAnalytics */,
-				CE7635BD19BFA050005FD5D0 /* MobileAnalyticsERS */,
-				CE55F34318DB716B00F8C75F /* Networking */,
-				CE55F34618DB716B00F8C75F /* Serialization */,
-				CE55F35718DB716B00F8C75F /* Service */,
-				CE09860C1922A7470006EA67 /* STS */,
-				CE16EED819916C5100A318A3 /* Utility */,
-				CE55F35D18DB716B00F8C75F /* XMLWriter */,
-			);
-			path = AWSCore;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE55F33D18DB716B00F8C75F /* Authentication */ = {
-			isa = PBXGroup;
-			children = (
-				38D2089219C2A67D0024D82A /* AWSIdentityProvider.h */,
-				38D2089319C2A67D0024D82A /* AWSIdentityProvider.m */,
-				CE55F33E18DB716B00F8C75F /* AWSCredentialsProvider.h */,
-				CE55F33F18DB716B00F8C75F /* AWSCredentialsProvider.m */,
-				CE55F34018DB716B00F8C75F /* AWSSignature.h */,
-				CE55F34118DB716B00F8C75F /* AWSSignature.m */,
-			);
-			name = Authentication;
-			path = AWSCore/Authentication;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE55F34318DB716B00F8C75F /* Networking */ = {
-			isa = PBXGroup;
-			children = (
-				CE55F34418DB716B00F8C75F /* AWSNetworking.h */,
-				CE55F34518DB716B00F8C75F /* AWSNetworking.m */,
-				CE16EEE719916C8400A318A3 /* AWSURLSessionManager.h */,
-				CE16EEE819916C8400A318A3 /* AWSURLSessionManager.m */,
-			);
-			name = Networking;
-			path = AWSCore/Networking;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE55F34618DB716B00F8C75F /* Serialization */ = {
-			isa = PBXGroup;
-			children = (
-				CE4AB8D719085CFB00E0600E /* AWSSerialization.h */,
-				CE4AB8D819085CFB00E0600E /* AWSSerialization.m */,
-				CE55F34B18DB716B00F8C75F /* AWSURLRequestRetryHandler.h */,
-				CE55F34C18DB716B00F8C75F /* AWSURLRequestRetryHandler.m */,
-				CE55F34D18DB716B00F8C75F /* AWSURLRequestSerialization.h */,
-				CE55F34E18DB716B00F8C75F /* AWSURLRequestSerialization.m */,
-				CE55F34F18DB716B00F8C75F /* AWSURLResponseSerialization.h */,
-				CE55F35018DB716B00F8C75F /* AWSURLResponseSerialization.m */,
-				CE55F35118DB716B00F8C75F /* AWSValidation.h */,
-				CE55F35218DB716B00F8C75F /* AWSValidation.m */,
-			);
-			name = Serialization;
-			path = AWSCore/Serialization;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE55F35718DB716B00F8C75F /* Service */ = {
-			isa = PBXGroup;
-			children = (
-				EAC25F5E195E4A4500675156 /* AWSServiceEnum.h */,
-				CED514031954B83B00D693F7 /* AWSClientContext.h */,
-				CED514041954B83B00D693F7 /* AWSClientContext.m */,
-				CE55F35818DB716B00F8C75F /* AWSService.h */,
-				CE55F35918DB716B00F8C75F /* AWSService.m */,
-			);
-			name = Service;
-			path = AWSCore/Service;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE55F35D18DB716B00F8C75F /* XMLWriter */ = {
-			isa = PBXGroup;
-			children = (
-				CE55F35E18DB716B00F8C75F /* AWSXMLWriter.h */,
-				CE55F35F18DB716B00F8C75F /* AWSXMLWriter.m */,
-			);
-			name = XMLWriter;
-			path = AWSCore/XMLWriter;
-			sourceTree = SOURCE_ROOT;
-		};
-		CE5D83CD1857AA3100907C25 = {
-			isa = PBXGroup;
-			children = (
-				CE55F33C18DB716B00F8C75F /* AWSCore */,
-				CE372B1318DA874000D2CFD2 /* AutoScaling */,
-				CE372B1B18DA874000D2CFD2 /* CloudWatch */,
-				CE372B2318DA874000D2CFD2 /* DynamoDB */,
-				CE372B2B18DA874000D2CFD2 /* EC2 */,
-				CE372B3318DA874000D2CFD2 /* ElasticLoadBalancing */,
-				CE372B3B18DA874000D2CFD2 /* Kinesis */,
-				CE372B4318DA874000D2CFD2 /* S3 */,
-				CE372B4B18DA874000D2CFD2 /* SES */,
-				CE372B5318DA874000D2CFD2 /* SimpleDB */,
-				CE372B5B18DA874000D2CFD2 /* SNS */,
-				CE372B6318DA874000D2CFD2 /* SQS */,
-				CE5D83DC1857AA3100907C25 /* Supporting Files */,
-				CE314856187B577A0068883B /* AWSiOSSDKTests */,
-				BDD11DF2193FA13600AF60E1 /* AWSiOSSDKAnalyticsTests */,
-				CE5D83D81857AA3100907C25 /* Frameworks */,
-				CE5D83D71857AA3100907C25 /* Products */,
-				AAF85B9700504764BCD966E3 /* Pods.xcconfig */,
-			);
-			sourceTree = "<group>";
-		};
-		CE5D83D71857AA3100907C25 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				CE5D83D61857AA3100907C25 /* libAWSiOSSDKv2.a */,
-				CE314852187B577A0068883B /* AWSiOSSDKv2Tests.xctest */,
-				BDD11DEE193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		CE5D83D81857AA3100907C25 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				CE5D83D91857AA3100907C25 /* Foundation.framework */,
-				BDD11E10193FA41F00AF60E1 /* libOCMock.a */,
-				F3A0CE70F1DF4EEE8E04D464 /* libPods.a */,
-				EFEAC89419295311005FEDE4 /* libsqlite3.dylib */,
-				BDD39A0A193E646C00C712BD /* libz.dylib */,
-				BDD11E0E193FA40300AF60E1 /* OCHamcrestIOS.framework */,
-				BDD11E09193FA33E00AF60E1 /* SenTestingKit.framework */,
-				BDD11E31193FA70C00AF60E1 /* SystemConfiguration.framework */,
-				CE31486C187B59220068883B /* UIKit.framework */,
-				CE5D83E71857AA3100907C25 /* XCTest.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		CE5D83DC1857AA3100907C25 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				EADE666419539C4100313444 /* GenerateAppleDocs.sh */,
-				CE571E2D1937D1F00027826E /* Podfile */,
-				CE5D83DD1857AA3100907C25 /* AWSiOSSDKv2-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = SOURCE_ROOT;
-		};
-		CE7635B119BFA034005FD5D0 /* CognitoIdentity */ = {
-			isa = PBXGroup;
-			children = (
-				CE7635B619BFA034005FD5D0 /* CognitoIdentity.h */,
-				CE7635B219BFA034005FD5D0 /* AWSCognitoIdentity.h */,
-				CE7635B319BFA034005FD5D0 /* AWSCognitoIdentity.m */,
-				CE7635B419BFA034005FD5D0 /* AWSCognitoIdentityModel.h */,
-				CE7635B519BFA034005FD5D0 /* AWSCognitoIdentityModel.m */,
-				CE7635B719BFA034005FD5D0 /* Resources */,
-			);
-			path = CognitoIdentity;
-			sourceTree = "<group>";
-		};
-		CE7635B719BFA034005FD5D0 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE7635B819BFA034005FD5D0 /* cib-2014-06-30.json */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		CE7635BD19BFA050005FD5D0 /* MobileAnalyticsERS */ = {
-			isa = PBXGroup;
-			children = (
-				CE7635C219BFA050005FD5D0 /* MobileAnalyticsERS.h */,
-				CE7635BE19BFA050005FD5D0 /* AWSMobileAnalyticsERS.h */,
-				CE7635BF19BFA050005FD5D0 /* AWSMobileAnalyticsERS.m */,
-				CE7635C019BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.h */,
-				CE7635C119BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.m */,
-				CE7635C319BFA050005FD5D0 /* Resources */,
-			);
-			path = MobileAnalyticsERS;
-			sourceTree = "<group>";
-		};
-		CE7635C319BFA050005FD5D0 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				CE7635C419BFA050005FD5D0 /* mobileanalytics-2014-06-30.json */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		EA2AF763195E206B007DDDD4 /* MobileAnalytics */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF764195E206B007DDDD4 /* AWSMobileAnalytics.m */,
-				EA2AF765195E206B007DDDD4 /* AZCommon */,
-				EA2AF76C195E206B007DDDD4 /* core */,
-				EA2AF793195E206B007DDDD4 /* delivery */,
-				EA2AF79A195E206B007DDDD4 /* event */,
-				EA2AF79F195E206B007DDDD4 /* include */,
-				EA2AF7FA195E206B007DDDD4 /* monetization */,
-				EA2AF7FE195E206B007DDDD4 /* session */,
-			);
-			path = MobileAnalytics;
-			sourceTree = "<group>";
-		};
-		EA2AF765195E206B007DDDD4 /* AZCommon */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF766195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.h */,
-				EA2AF767195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.m */,
-				EA2AF768195E206B007DDDD4 /* ClientContext */,
-			);
-			path = AZCommon;
-			sourceTree = "<group>";
-		};
-		EA2AF768195E206B007DDDD4 /* ClientContext */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF769195E206B007DDDD4 /* AWSMobileAnalyticsClientContext.h */,
-				EA2AF76A195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.h */,
-				EA2AF76B195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.m */,
-			);
-			path = ClientContext;
-			sourceTree = "<group>";
-		};
-		EA2AF76C195E206B007DDDD4 /* core */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF76D195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.m */,
-				EA2AF76E195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.m */,
-				EA2AF76F195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.m */,
-				EA2AF770195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.m */,
-				EA2AF771195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.m */,
-				EA2AF772195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.m */,
-				EA2AF773195E206B007DDDD4 /* configuration */,
-				EA2AF776195E206B007DDDD4 /* http */,
-				EA2AF780195E206B007DDDD4 /* id */,
-				EA2AF783195E206B007DDDD4 /* io */,
-				EA2AF786195E206B007DDDD4 /* system */,
-				EA2AF78D195E206B007DDDD4 /* util */,
-			);
-			path = core;
-			sourceTree = "<group>";
-		};
-		EA2AF773195E206B007DDDD4 /* configuration */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF774195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.m */,
-				EA2AF775195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.m */,
-			);
-			path = configuration;
-			sourceTree = "<group>";
-		};
-		EA2AF776195E206B007DDDD4 /* http */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF777195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.m */,
-				EA2AF778195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.m */,
-				EA2AF779195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.m */,
-				EA2AF77A195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.m */,
-				EA2AF77B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.m */,
-				EA2AF77C195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.m */,
-				EA2AF77D195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.m */,
-				EA2AF77E195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.m */,
-				EA2AF77F195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.m */,
-			);
-			path = http;
-			sourceTree = "<group>";
-		};
-		EA2AF780195E206B007DDDD4 /* id */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF781195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.m */,
-				EA2AF782195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.m */,
-			);
-			path = id;
-			sourceTree = "<group>";
-		};
-		EA2AF783195E206B007DDDD4 /* io */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF784195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.m */,
-				EA2AF785195E206B007DDDD4 /* AWSMobileAnalyticsWriter.m */,
-			);
-			path = io;
-			sourceTree = "<group>";
-		};
-		EA2AF786195E206B007DDDD4 /* system */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF787195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.m */,
-				EA2AF788195E206B007DDDD4 /* AWSMobileAnalyticsFile.m */,
-				EA2AF789195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.m */,
-				EA2AF78A195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.m */,
-				EA2AF78B195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.m */,
-				EA2AF78C195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.m */,
-			);
-			path = system;
-			sourceTree = "<group>";
-		};
-		EA2AF78D195E206B007DDDD4 /* util */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF78F195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.m */,
-				EA2AF790195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.m */,
-				EA2AF791195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.m */,
-				EA2AF792195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.m */,
-			);
-			path = util;
-			sourceTree = "<group>";
-		};
-		EA2AF793195E206B007DDDD4 /* delivery */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF794195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.m */,
-				EA2AF795195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.m */,
-				EA2AF796195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.m */,
-				EA2AF797195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.m */,
-				EA2AF798195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.m */,
-				EA2AF799195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.m */,
-			);
-			path = delivery;
-			sourceTree = "<group>";
-		};
-		EA2AF79A195E206B007DDDD4 /* event */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF79B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.m */,
-				EA2AF79C195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.h */,
-				EA2AF79D195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.m */,
-				EA2AF79E195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.m */,
-			);
-			path = event;
-			sourceTree = "<group>";
-		};
-		EA2AF79F195E206B007DDDD4 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7A0195E206B007DDDD4 /* AWSMobileAnalytics.h */,
-				EA2AF7A1195E206B007DDDD4 /* AWSMobileAnalyticsEvent.h */,
-				EA2AF7A2195E206B007DDDD4 /* AWSMobileAnalyticsEventClient.h */,
-				EA2AF7A3195E206B007DDDD4 /* AWSMobileAnalyticsOptions.h */,
-				EA2AF7A4195E206B007DDDD4 /* MobileAnalytics.h */,
-				EA2AF7A5195E206B007DDDD4 /* core */,
-				EA2AF7DC195E206B007DDDD4 /* delivery */,
-				EA2AF7E6195E206B007DDDD4 /* event */,
-				EA2AF7EC195E206B007DDDD4 /* monetization */,
-				EA2AF7F0195E206B007DDDD4 /* session */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		EA2AF7A5195E206B007DDDD4 /* core */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7A6195E206B007DDDD4 /* AWSMobileAnalyticsConstants.h */,
-				EA2AF7A7195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.h */,
-				EA2AF7A8195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.h */,
-				EA2AF7A9195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.h */,
-				EA2AF7AA195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.h */,
-				EA2AF7AB195E206B007DDDD4 /* AWSMobileAnalyticsContext.h */,
-				EA2AF7AC195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.h */,
-				EA2AF7AD195E206B007DDDD4 /* AWSMobileAnalyticsSerializable.h */,
-				EA2AF7AE195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.h */,
-				EA2AF7AF195E206B007DDDD4 /* configuration */,
-				EA2AF7B3195E206B007DDDD4 /* http */,
-				EA2AF7C2195E206B007DDDD4 /* id */,
-				EA2AF7C7195E206B007DDDD4 /* io */,
-				EA2AF7CA195E206B007DDDD4 /* system */,
-				EA2AF7D6195E206B007DDDD4 /* util */,
-			);
-			path = core;
-			sourceTree = "<group>";
-		};
-		EA2AF7AF195E206B007DDDD4 /* configuration */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7B0195E206B007DDDD4 /* AWSMobileAnalyticsConfiguring.h */,
-				EA2AF7B1195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.h */,
-				EA2AF7B2195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.h */,
-			);
-			path = configuration;
-			sourceTree = "<group>";
-		};
-		EA2AF7B3195E206B007DDDD4 /* http */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7B4195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.h */,
-				EA2AF7B5195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.h */,
-				EA2AF7B6195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.h */,
-				EA2AF7B7195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.h */,
-				EA2AF7B8195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.h */,
-				EA2AF7B9195E206B007DDDD4 /* AWSMobileAnalyticsHttpClient.h */,
-				EA2AF7BA195E206B007DDDD4 /* AWSMobileAnalyticsHttpConstants.h */,
-				EA2AF7BB195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.h */,
-				EA2AF7BC195E206B007DDDD4 /* AWSMobileAnalyticsInterceptor.h */,
-				EA2AF7BD195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.h */,
-				EA2AF7BE195E206B007DDDD4 /* AWSMobileAnalyticsRequest.h */,
-				EA2AF7BF195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.h */,
-				EA2AF7C0195E206B007DDDD4 /* AWSMobileAnalyticsResponse.h */,
-				EA2AF7C1195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.h */,
-			);
-			path = http;
-			sourceTree = "<group>";
-		};
-		EA2AF7C2195E206B007DDDD4 /* id */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7C3195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.h */,
-				EA2AF7C4195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.h */,
-				EA2AF7C5195E206B007DDDD4 /* AWSMobileAnalyticsUniqueIdGenerator.h */,
-				EA2AF7C6195E206B007DDDD4 /* AWSMobileAnalyticsUniqueIdService.h */,
-			);
-			path = id;
-			sourceTree = "<group>";
-		};
-		EA2AF7C7195E206B007DDDD4 /* io */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7C8195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.h */,
-				EA2AF7C9195E206B007DDDD4 /* AWSMobileAnalyticsWriter.h */,
-			);
-			path = io;
-			sourceTree = "<group>";
-		};
-		EA2AF7CA195E206B007DDDD4 /* system */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7CB195E206B007DDDD4 /* AWSMobileAnalyticsConnectivity.h */,
-				EA2AF7CC195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.h */,
-				EA2AF7CD195E206B007DDDD4 /* AWSMobileAnalyticsFile.h */,
-				EA2AF7CE195E206B007DDDD4 /* AWSMobileAnalyticsFileManager.h */,
-				EA2AF7CF195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.h */,
-				EA2AF7D0195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.h */,
-				EA2AF7D1195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.h */,
-				EA2AF7D2195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.h */,
-				EA2AF7D3195E206B007DDDD4 /* AWSMobileAnalyticsLifeCycleManager.h */,
-				EA2AF7D4195E206B007DDDD4 /* AWSMobileAnalyticsPreferences.h */,
-				EA2AF7D5195E206B007DDDD4 /* AWSMobileAnalyticsSystem.h */,
-			);
-			path = system;
-			sourceTree = "<group>";
-		};
-		EA2AF7D6195E206B007DDDD4 /* util */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7D8195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.h */,
-				EA2AF7D9195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.h */,
-				EA2AF7DA195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.h */,
-				EA2AF7DB195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.h */,
-			);
-			path = util;
-			sourceTree = "<group>";
-		};
-		EA2AF7DC195E206B007DDDD4 /* delivery */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7DD195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.h */,
-				EA2AF7DE195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.h */,
-				EA2AF7DF195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryClient.h */,
-				EA2AF7E0195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicy.h */,
-				EA2AF7E1195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.h */,
-				EA2AF7E2195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.h */,
-				EA2AF7E3195E206B007DDDD4 /* AWSMobileAnalyticsEventStore.h */,
-				EA2AF7E4195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.h */,
-				EA2AF7E5195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.h */,
-			);
-			path = delivery;
-			sourceTree = "<group>";
-		};
-		EA2AF7E6195E206B007DDDD4 /* event */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7E7195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.h */,
-				EA2AF7E8195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.h */,
-				EA2AF7E9195E206B007DDDD4 /* AWSMobileAnalyticsEventObserver.h */,
-				EA2AF7EA195E206B007DDDD4 /* AWSMobileAnalyticsInternalEvent.h */,
-				EA2AF7EB195E206B007DDDD4 /* AWSMobileAnalyticsInternalEventClient.h */,
-			);
-			path = event;
-			sourceTree = "<group>";
-		};
-		EA2AF7EC195E206B007DDDD4 /* monetization */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7ED195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.h */,
-				EA2AF7EE195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.h */,
-				EA2AF7EF195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.h */,
-			);
-			path = monetization;
-			sourceTree = "<group>";
-		};
-		EA2AF7F0195E206B007DDDD4 /* session */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7F1195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.h */,
-				EA2AF7F2195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient+SessionState.h */,
-				EA2AF7F3195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.h */,
-				EA2AF7F4195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.h */,
-				EA2AF7F5195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.h */,
-				EA2AF7F6195E206B007DDDD4 /* AWSMobileAnalyticsSession.h */,
-				EA2AF7F7195E206B007DDDD4 /* AWSMobileAnalyticsSessionClient.h */,
-				EA2AF7F8195E206B007DDDD4 /* AWSMobileAnalyticsSessionClientState.h */,
-				EA2AF7F9195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.h */,
-			);
-			path = session;
-			sourceTree = "<group>";
-		};
-		EA2AF7FA195E206B007DDDD4 /* monetization */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7FB195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.m */,
-				EA2AF7FC195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.m */,
-				EA2AF7FD195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.m */,
-			);
-			path = monetization;
-			sourceTree = "<group>";
-		};
-		EA2AF7FE195E206B007DDDD4 /* session */ = {
-			isa = PBXGroup;
-			children = (
-				EA2AF7FF195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.m */,
-				EA2AF800195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.m */,
-				EA2AF801195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.m */,
-				EA2AF802195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.m */,
-				EA2AF803195E206B007DDDD4 /* AWSMobileAnalyticsSession.m */,
-				EA2AF804195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.m */,
-			);
-			path = session;
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXLegacyTarget section */
-		EADE665F1953997D00313444 /* Documentation */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "$(ACTION)";
-			buildConfigurationList = EADE66621953997D00313444 /* Build configuration list for PBXLegacyTarget "Documentation" */;
-			buildPhases = (
-			);
-			buildToolPath = Scripts/GenerateAppleDocs.sh;
-			buildWorkingDirectory = "";
-			dependencies = (
-			);
-			name = Documentation;
-			passBuildSettingsInEnvironment = 1;
-			productName = Documentation;
-		};
-/* End PBXLegacyTarget section */
-
-/* Begin PBXNativeTarget section */
-		BDD11DED193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BDD11DFF193FA13600AF60E1 /* Build configuration list for PBXNativeTarget "AWSiOSSDKv2AnalyticsTests" */;
-			buildPhases = (
-				BDD11DEA193FA13600AF60E1 /* Sources */,
-				BDD11DEB193FA13600AF60E1 /* Frameworks */,
-				BDD11DEC193FA13600AF60E1 /* Resources */,
-				BDD77712193FC6B100F04070 /* ShellScript */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BDD11DFC193FA13600AF60E1 /* PBXTargetDependency */,
-			);
-			name = AWSiOSSDKv2AnalyticsTests;
-			productName = AWSiOSSDKAnalyticsTests;
-			productReference = BDD11DEE193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		CE314851187B577A0068883B /* AWSiOSSDKv2Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CE314861187B577A0068883B /* Build configuration list for PBXNativeTarget "AWSiOSSDKv2Tests" */;
-			buildPhases = (
-				CE31484E187B577A0068883B /* Sources */,
-				CE31484F187B577A0068883B /* Frameworks */,
-				CE314850187B577A0068883B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				CE1F781518B6A1C100EE588B /* PBXTargetDependency */,
-			);
-			name = AWSiOSSDKv2Tests;
-			productName = AWSiOSSDKTests;
-			productReference = CE314852187B577A0068883B /* AWSiOSSDKv2Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		CE5D83D51857AA3100907C25 /* AWSiOSSDKv2 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CE5D83F91857AA3100907C25 /* Build configuration list for PBXNativeTarget "AWSiOSSDKv2" */;
-			buildPhases = (
-				6E52D05EBCB24E1CA70E6F9A /* Check Pods Manifest.lock */,
-				CE5D83D21857AA3100907C25 /* Sources */,
-				CE5D83D31857AA3100907C25 /* Frameworks */,
-				CE5D83D41857AA3100907C25 /* CopyFiles */,
-				AAE1414ED6C74E3CAF6A84AB /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = AWSiOSSDKv2;
-			productName = AWSiOSSDK;
-			productReference = CE5D83D61857AA3100907C25 /* libAWSiOSSDKv2.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		CE5D83CE1857AA3100907C25 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastTestingUpgradeCheck = 0600;
-				LastUpgradeCheck = 0600;
-				ORGANIZATIONNAME = "Amazon Web Services";
-				TargetAttributes = {
-					BDD11DED193FA13600AF60E1 = {
-						TestTargetID = CE5D83D51857AA3100907C25;
-					};
-					CE314851187B577A0068883B = {
-						TestTargetID = CE5D83D51857AA3100907C25;
-					};
-				};
-			};
-			buildConfigurationList = CE5D83D11857AA3100907C25 /* Build configuration list for PBXProject "AWSiOSSDKv2" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = CE5D83CD1857AA3100907C25;
-			productRefGroup = CE5D83D71857AA3100907C25 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				CE5D83D51857AA3100907C25 /* AWSiOSSDKv2 */,
-				CE314851187B577A0068883B /* AWSiOSSDKv2Tests */,
-				BDD11DED193FA13600AF60E1 /* AWSiOSSDKv2AnalyticsTests */,
-				EADE665F1953997D00313444 /* Documentation */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		BDD11DEC193FA13600AF60E1 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDDC42671942A1100039664B /* credentials.json in Resources */,
-				CE7635BB19BFA03C005FD5D0 /* cib-2014-06-30.json in Resources */,
-				CE7635C819BFA056005FD5D0 /* mobileanalytics-2014-06-30.json in Resources */,
-				BDD11DF7193FA13600AF60E1 /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CE314850187B577A0068883B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CE55F37718DB7FCC00F8C75F /* autoscaling-2011-01-01.json in Resources */,
-				CE55F37818DB7FCC00F8C75F /* monitoring-2010-08-01.json in Resources */,
-				BDD196D0198AFF2200CC94A2 /* rest-xml-input.json in Resources */,
-				CE7635C719BFA055005FD5D0 /* mobileanalytics-2014-06-30.json in Resources */,
-				CE55F37918DB7FCC00F8C75F /* dynamodb-2012-08-10.json in Resources */,
-				BD324C66194BA556003369D0 /* ec2-2014-06-15.json in Resources */,
-				BDD196D8198AFF2C00CC94A2 /* query-output.json in Resources */,
-				BD1861C019A41395003C8E42 /* ec2-output.json in Resources */,
-				CE55F37B18DB7FCC00F8C75F /* elasticloadbalancing-2012-06-01.json in Resources */,
-				BDD196CE198AFF2200CC94A2 /* query-input.json in Resources */,
-				CE55F37C18DB7FCC00F8C75F /* kinesis-2013-12-02.json in Resources */,
-				CE0986161922A7470006EA67 /* sts-2011-06-15.json in Resources */,
-				CE55F37D18DB7FCC00F8C75F /* s3-2006-03-01.json in Resources */,
-				CE55F37E18DB7FCC00F8C75F /* email-2010-12-01.json in Resources */,
-				CE55F37F18DB7FCC00F8C75F /* sdb-2009-04-15.json in Resources */,
-				CE55F38018DB7FCC00F8C75F /* sns-2010-03-31.json in Resources */,
-				CE55F38118DB7FCC00F8C75F /* sqs-2012-11-05.json in Resources */,
-				BD1861BF19A41395003C8E42 /* ec2-input.json in Resources */,
-				CE31486B187B58090068883B /* credentials.json in Resources */,
-				CE7635BC19BFA03C005FD5D0 /* cib-2014-06-30.json in Resources */,
-				BDD196CD198AFF2200CC94A2 /* json-input.json in Resources */,
-				BDD196D7198AFF2C00CC94A2 /* json-output.json in Resources */,
-				BDD196DA198AFF2C00CC94A2 /* rest-xml-output.json in Resources */,
-				CE31485B187B577A0068883B /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		6E52D05EBCB24E1CA70E6F9A /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		AAE1414ED6C74E3CAF6A84AB /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BDD77712193FC6B100F04070 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"";
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		BDD11DEA193FA13600AF60E1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDD777A0193FDD9000F04070 /* AIEventContraintDecoratorTests.m in Sources */,
-				BDD77729193FDB6B00F04070 /* AIHttpCachingConfigurationTests.m in Sources */,
-				BDD77724193FDB2800F04070 /* AICountDownLatchTests.m in Sources */,
-				BDD7773A193FDB9400F04070 /* AIClientContextInterceptorTests.m in Sources */,
-				BDD11E25193FA5E600AF60E1 /* NSObject+TTTSwizzling.m in Sources */,
-				BDD777B2193FDDA800F04070 /* AIInactiveSessionStateTests.m in Sources */,
-				BDD7775B193FDC0C00F04070 /* AIIOSPreferencesTests.m in Sources */,
-				BDD77762193FDD0500F04070 /* AZIOSClientContextTests.m in Sources */,
-				BDD77722193FDB2800F04070 /* AIDefaultInsightsOptionsTests.m in Sources */,
-				BDD7775E193FDCDC00F04070 /* NSURLRequest+NSURLRequestSSLY.m in Sources */,
-				BDD777AE193FDDA800F04070 /* AISessionClientTests.m in Sources */,
-				BDD77792193FDD5200F04070 /* AIERSRequestBuilderTests.m in Sources */,
-				BDD11E30193FA67100AF60E1 /* TestEventObserver.m in Sources */,
-				BDD7775A193FDC0C00F04070 /* AIIOSLifeCycleManagerTests.m in Sources */,
-				BDD11E18193FA51A00AF60E1 /* AITestConfiguration.m in Sources */,
-				BDD7778D193FDD5200F04070 /* AIFileEventStoreTests.m in Sources */,
-				BDD7779E193FDD9000F04070 /* AIEventClientTests.m in Sources */,
-				BDD11E08193FA24E00AF60E1 /* AIIntegrationTestBase.m in Sources */,
-				BDD77719193FDADE00F04070 /* AIConfigurationIntegrationTests.m in Sources */,
-				BDD7774C193FDBF300F04070 /* AIBufferedReaderTests.m in Sources */,
-				BDD77738193FDB9400F04070 /* AISDKInfoInterceptorTests.m in Sources */,
-				BDD11E26193FA5E600AF60E1 /* NSLocale+TTTOverrideLocale.m in Sources */,
-				BDD77791193FDD5200F04070 /* AISubmissionTimePolicyTests.m in Sources */,
-				BDD7778E193FDD5200F04070 /* AIDefaultDeliveryClientTests.m in Sources */,
-				BDD11E2F193FA67100AF60E1 /* BlockingInterceptor.m in Sources */,
-				BDD77758193FDC0C00F04070 /* AIFileTests.m in Sources */,
-				BDD11E05193FA23200AF60E1 /* AIAmazonInsightsTests.m in Sources */,
-				BDD11E14193FA4DD00AF60E1 /* AIInsightsContextBuilder.m in Sources */,
-				BDD11E1F193FA5A400AF60E1 /* TestConnectivity.m in Sources */,
-				BDD7779F193FDD9000F04070 /* AIDefaultEventTests.m in Sources */,
-				BDD777B0193FDDA800F04070 /* AIPausedSessionStateTests.m in Sources */,
-				BDD77759193FDC0C00F04070 /* AIDefaultFileManagerTests.m in Sources */,
-				BDD7771B193FDADE00F04070 /* AISessionIntegrationTests.m in Sources */,
-				BDD7777F193FDD3B00F04070 /* AIMonetizationEventBuilderTests.m in Sources */,
-				BDD77796193FDD6E00F04070 /* AIDateUtilTests.m in Sources */,
-				BDD11E1B193FA55700AF60E1 /* AITestHttpClient.m in Sources */,
-				BDD11E0D193FA39400AF60E1 /* AmazonInsightsSDKTests.m in Sources */,
-				BDD7771A193FDADE00F04070 /* AIDeliveryIntegrationTests.m in Sources */,
-				BDD77737193FDB9400F04070 /* AIDefaultRequestTests.m in Sources */,
-				BDD7773C193FDB9400F04070 /* AIInstanceIdInterceptorTests.m in Sources */,
-				BDD7774D193FDBF300F04070 /* AIEncryptedReaderWriterTests.m in Sources */,
-				BDD77790193FDD5200F04070 /* AIConnectivityPolicyTests.m in Sources */,
-				BDD777AF193FDDA800F04070 /* AISessionTests.m in Sources */,
-				BDD777B1193FDDA800F04070 /* AIActiveSessionStateTests.m in Sources */,
-				BDD777B3193FDDA800F04070 /* AISessionStoreTests.m in Sources */,
-				BDD11E29193FA61300AF60E1 /* TestInsightsContext.m in Sources */,
-				BDD77740193FDBC800F04070 /* AIStringUtilsTests.m in Sources */,
-				BDD77723193FDB2800F04070 /* AIDelayedBlockTests.m in Sources */,
-				BDD77744193FDBDF00F04070 /* AIPrefsUniqueIdServiceTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CE31484E187B577A0068883B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CE8FEAA618D3B62100EC90A6 /* AWSCloudWatchTests.m in Sources */,
-				388CA0A21926CA3800AF5A50 /* AWSCognitoCredentialsProviderTests.m in Sources */,
-				CE91D2BF18D3C03B000390D2 /* AWSKinesisTests.m in Sources */,
-				BD19ED05188F15EB001F5B98 /* AWSS3Tests.m in Sources */,
-				CE2C174718D0D8CF003FE9AA /* AWSSTSTests.m in Sources */,
-				CE160B2119774315001ABF94 /* AWSTestUtility.m in Sources */,
-				CE314867187B57F50068883B /* AWSDynamoDBTests.m in Sources */,
-				CE8FEAA818D3B84E00EC90A6 /* AWSAutoScalingTests.m in Sources */,
-				CE1C9DE51936CE38007B6F33 /* AWSClockSkewTests.m in Sources */,
-				CEE68C191940000500259EFF /* AWSKinesisRecorderTests.m in Sources */,
-				CE0D85DB18D38AAB00D41F8A /* AWSSimpleDBTests.m in Sources */,
-				CEBA14CD1921AC2F008C596A /* AWSDynamoDBObjectMapperTests.m in Sources */,
-				CEB2A4A418D782F80007AAF4 /* AWSEC2Tests.m in Sources */,
-				BDD39A11193E8D4500C712BD /* AWSAnalyticsTests.m in Sources */,
-				BDC8315F1919725000A01D20 /* AWSS3TransferManagerTests.m in Sources */,
-				BD9CC214193CFF0700780456 /* AWSMobileAnalyticsERSTests.m in Sources */,
-				38627E3F19253F5500EF30EF /* AWSCognitoIdentityServiceTests.m in Sources */,
-				CE8FEAA318D3B18600EC90A6 /* AWSElasticLoadBalancingTests.m in Sources */,
-				CE314868187B57F50068883B /* AWSCoreTests.m in Sources */,
-				CE0D85DD18D38FCA00D41F8A /* AWSSESTests.m in Sources */,
-				CE0D85D918D385DA00D41F8A /* AWSSNSTests.m in Sources */,
-				CE3F4D3919BFCE5A000C1A6C /* AWSS3PreSignedURLBuilderTests.m in Sources */,
-				CE0D85D718D37EC000D41F8A /* AWSSQSTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CE5D83D21857AA3100907C25 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CE0EFAE7193D2939002A896B /* AWSSTS.m in Sources */,
-				CE0EFAE8193D2939002A896B /* AWSSTSModel.m in Sources */,
-				EA2AF82C195E206B007DDDD4 /* AWSMobileAnalyticsErrorUtils.m in Sources */,
-				38D2089419C2A67D0024D82A /* AWSIdentityProvider.m in Sources */,
-				CE372B7918DA874000D2CFD2 /* AWSEC2.m in Sources */,
-				CE372B7618DA874000D2CFD2 /* AWSCloudWatchModel.m in Sources */,
-				EA2AF81C195E206B007DDDD4 /* AWSMobileAnalyticsInstanceIdInterceptor.m in Sources */,
-				CE372B8018DA874000D2CFD2 /* AWSS3Model.m in Sources */,
-				CE372B8718DA874000D2CFD2 /* AWSSQS.m in Sources */,
-				CE372B8118DA874000D2CFD2 /* AWSSES.m in Sources */,
-				BDBA90BC18EE43BE004EE131 /* AWSURLRequestSerialization.m in Sources */,
-				EA2AF831195E206B007DDDD4 /* AWSMobileAnalyticsDeliveryPolicyFactory.m in Sources */,
-				EA2AF810195E206B007DDDD4 /* AWSMobileAnalyticsDefaultContext.m in Sources */,
-				EA2AF833195E206B007DDDD4 /* AWSMobileAnalyticsFileEventStore.m in Sources */,
-				EA2AF80F195E206B007DDDD4 /* AWSMobileAnalyticsCountDownLatch.m in Sources */,
-				CE372B7D18DA874000D2CFD2 /* AWSKinesis.m in Sources */,
-				EA2AF830195E206B007DDDD4 /* AWSMobileAnalyticsDefaultDeliveryClient.m in Sources */,
-				EA2AF828195E206B007DDDD4 /* AWSMobileAnalyticsIOSPreferences.m in Sources */,
-				CE16EEE219916C5100A318A3 /* AWSLogging.m in Sources */,
-				CE7635B919BFA034005FD5D0 /* AWSCognitoIdentity.m in Sources */,
-				EA2AF83D195E206B007DDDD4 /* AWSMobileAnalyticsInactiveSessionState.m in Sources */,
-				CE372B7718DA874000D2CFD2 /* AWSDynamoDB.m in Sources */,
-				EA2AF829195E206B007DDDD4 /* AWSMobileAnalyticsIOSSystem.m in Sources */,
-				EA2AF81E195E206B007DDDD4 /* AWSMobileAnalyticsRequestTimingInterceptor.m in Sources */,
-				EA2AF822195E206B007DDDD4 /* AWSMobileAnalyticsBufferedReader.m in Sources */,
-				EA2AF834195E206B007DDDD4 /* AWSMobileAnalyticsSubmissionTimePolicy.m in Sources */,
-				BDBA90BD18EE43C0004EE131 /* AWSURLRequestRetryHandler.m in Sources */,
-				EA2AF80D195E206B007DDDD4 /* AWSMobileAnalyticsConfiguration.m in Sources */,
-				EA2AF83B195E206B007DDDD4 /* AWSMobileAnalyticsActiveSessionState.m in Sources */,
-				CE372B7318DA874000D2CFD2 /* AWSAutoScaling.m in Sources */,
-				CE372B8418DA874000D2CFD2 /* AWSSimpleDBModel.m in Sources */,
-				EA2AF81A195E206B007DDDD4 /* AWSMobileAnalyticsDefaultRequest.m in Sources */,
-				EA2AF811195E206B007DDDD4 /* AWSMobileAnalyticsDefaultOptions.m in Sources */,
-				EA2AF840195E206B007DDDD4 /* AWSMobileAnalyticsSessionStore.m in Sources */,
-				BDBA90C518EE4427004EE131 /* AWSXMLWriter.m in Sources */,
-				EA2AF824195E206B007DDDD4 /* AWSMobileAnalyticsDefaultFileManager.m in Sources */,
-				EA2AF81F195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfoInterceptor.m in Sources */,
-				EA2AF812195E206B007DDDD4 /* AWSMobileAnalyticsDelayedBlock.m in Sources */,
-				EA2AF820195E206B007DDDD4 /* AWSMobileAnalyticsPrefsUniqueIdService.m in Sources */,
-				EA2AF82D195E206B007DDDD4 /* AWSMobileAnalyticsSDKInfo.m in Sources */,
-				EA2AF82E195E206B007DDDD4 /* AWSMobileAnalyticsStringUtils.m in Sources */,
-				CE372B7C18DA874000D2CFD2 /* AWSElasticLoadBalancingModel.m in Sources */,
-				CE372B8518DA874000D2CFD2 /* AWSSNS.m in Sources */,
-				EA2AF80C195E206B007DDDD4 /* AWSMobileAnalytics.m in Sources */,
-				EA2AF818195E206B007DDDD4 /* AWSMobileAnalyticsDefaultHttpClient.m in Sources */,
-				CE7635BA19BFA034005FD5D0 /* AWSCognitoIdentityModel.m in Sources */,
-				CE16EEE319916C5100A318A3 /* AWSModel.m in Sources */,
-				BDBA90BB18EE43BA004EE131 /* AWSURLResponseSerialization.m in Sources */,
-				EA2AF82F195E206B007DDDD4 /* AWSMobileAnalyticsConnectivityPolicy.m in Sources */,
-				CE372B8618DA874000D2CFD2 /* AWSSNSModel.m in Sources */,
-				EA2AF814195E206B007DDDD4 /* AWSMobileAnalyticsSerializerFactory.m in Sources */,
-				CE372B7E18DA874000D2CFD2 /* AWSKinesisModel.m in Sources */,
-				CE372B7A18DA874000D2CFD2 /* AWSEC2Model.m in Sources */,
-				EA2AF83A195E206B007DDDD4 /* AWSMobileAnalyticsVirtualMonetizationEventBuilder.m in Sources */,
-				EA2AF827195E206B007DDDD4 /* AWSMobileAnalyticsIOSLifeCycleManager.m in Sources */,
-				EA2AF819195E206B007DDDD4 /* AWSMobileAnalyticsDefaultInterceptor.m in Sources */,
-				BDBA90C018EE43C8004EE131 /* AWSNetworking.m in Sources */,
-				CE16EEE119916C5100A318A3 /* AWSCategory.m in Sources */,
-				BDD77705193FBF6000F04070 /* (null) in Sources */,
-				EA2AF835195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEvent.m in Sources */,
-				EA2AF813195E206B007DDDD4 /* AWSMobileAnalyticsJSONSerializer.m in Sources */,
-				BDBA90C218EE43FF004EE131 /* AWSSignature.m in Sources */,
-				CE16EEE419916C5100A318A3 /* AWSSynchronizedMutableDictionary.m in Sources */,
-				EA2AF83E195E206B007DDDD4 /* AWSMobileAnalyticsPausedSessionState.m in Sources */,
-				CE7635C519BFA050005FD5D0 /* AWSMobileAnalyticsERS.m in Sources */,
-				BDBA90C318EE441F004EE131 /* AWSService.m in Sources */,
-				CE5312B41922DFFA005DAFA3 /* AWSDynamoDBObjectMapper.m in Sources */,
-				CE372B8218DA874000D2CFD2 /* AWSSESModel.m in Sources */,
-				EA2AF815195E206B007DDDD4 /* AWSMobileAnalyticsConfigurationKeys.m in Sources */,
-				EA2AF826195E206B007DDDD4 /* AWSMobileAnalyticsIOSConnectivity.m in Sources */,
-				CE372B7518DA874000D2CFD2 /* AWSCloudWatch.m in Sources */,
-				CED6C36618EE3EC800A56FB2 /* AWSS3TransferManager.m in Sources */,
-				CED514051954B83B00D693F7 /* AWSClientContext.m in Sources */,
-				EA2AF832195E206B007DDDD4 /* AWSMobileAnalyticsERSRequestBuilder.m in Sources */,
-				CE372B8818DA874000D2CFD2 /* AWSSQSModel.m in Sources */,
-				EA2AF81D195E206B007DDDD4 /* AWSMobileAnalyticsLogInterceptor.m in Sources */,
-				EA2AF817195E206B007DDDD4 /* AWSMobileAnalyticsClientContextInterceptor.m in Sources */,
-				EA2AF837195E206B007DDDD4 /* AWSMobileAnalyticsEventConstraintDecorator.m in Sources */,
-				BDBA90BA18EE43B6004EE131 /* AWSValidation.m in Sources */,
-				CE372B7B18DA874000D2CFD2 /* AWSElasticLoadBalancing.m in Sources */,
-				EA2AF80E195E206B007DDDD4 /* AWSMobileAnalyticsIOSClientContext.m in Sources */,
-				CE372B7818DA874000D2CFD2 /* AWSDynamoDBModel.m in Sources */,
-				EA2AF839195E206B007DDDD4 /* AWSMobileAnalyticsMonetizationEventBuilder.m in Sources */,
-				EA2AF81B195E206B007DDDD4 /* AWSMobileAnalyticsDefaultResponse.m in Sources */,
-				EA2AF82B195E206B007DDDD4 /* AWSMobileAnalyticsDateUtils.m in Sources */,
-				CEE68C17193FB11A00259EFF /* AWSKinesisRecorder.m in Sources */,
-				EA2AF838195E206B007DDDD4 /* AWSMobileAnalyticsAppleMonetizationEventBuilder.m in Sources */,
-				EA2AF821195E206B007DDDD4 /* AWSMobileAnalyticsRandomUUIDGenerator.m in Sources */,
-				CE4AB8D919085CFB00E0600E /* AWSSerialization.m in Sources */,
-				CE16EEEA19916C8400A318A3 /* AWSURLSessionManager.m in Sources */,
-				BDBA90C118EE43D3004EE131 /* AWSCredentialsProvider.m in Sources */,
-				EA2AF83C195E206B007DDDD4 /* AWSMobileAnalyticsDefaultSessionClient.m in Sources */,
-				EA2AF816195E206B007DDDD4 /* AWSMobileAnalyticsHttpCachingConfiguration.m in Sources */,
-				CE372B8318DA874000D2CFD2 /* AWSSimpleDB.m in Sources */,
-				EA2AF836195E206B007DDDD4 /* AWSMobileAnalyticsDefaultEventClient.m in Sources */,
-				CE372B7F18DA874000D2CFD2 /* AWSS3.m in Sources */,
-				CE23E60C19BF7CD60036EDC0 /* AWSS3PreSignedURL.m in Sources */,
-				EA2AF825195E206B007DDDD4 /* AWSMobileAnalyticsFile.m in Sources */,
-				EA2AF823195E206B007DDDD4 /* AWSMobileAnalyticsWriter.m in Sources */,
-				CE7635C619BFA050005FD5D0 /* AWSMobileAnalyticsERSModel.m in Sources */,
-				EA2AF83F195E206B007DDDD4 /* AWSMobileAnalyticsSession.m in Sources */,
-				CE372B7418DA874000D2CFD2 /* AWSAutoScalingModel.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		BDD11DFC193FA13600AF60E1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CE5D83D51857AA3100907C25 /* AWSiOSSDKv2 */;
-			targetProxy = BDD11DFB193FA13600AF60E1 /* PBXContainerItemProxy */;
-		};
-		CE1F781518B6A1C100EE588B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = CE5D83D51857AA3100907C25 /* AWSiOSSDKv2 */;
-			targetProxy = CE1F781418B6A1C100EE588B /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		BDD11DF5193FA13600AF60E1 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				BDD11DF6193FA13600AF60E1 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		CE314859187B577A0068883B /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				CE31485A187B577A0068883B /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
-/* Begin XCBuildConfiguration section */
-		BDD11DFD193FA13600AF60E1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/Frameworks",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AWSiOSSDKv2-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"\"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/include\"",
-					"${SRCROOT}/Pods/Headers/**",
-				);
-				INFOPLIST_FILE = "AWSiOSSDKAnalyticsTests/AWSiOSSDKv2AnalyticsTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/usr/lib",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-					"-force_load",
-					"\"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/lib/libOCMock.a\"",
-				);
-				PRODUCT_NAME = AWSiOSSDKv2AnalyticsTests;
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Debug;
-		};
-		BDD11DFE193FA13600AF60E1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/Frameworks",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AWSiOSSDKv2-Prefix.pch";
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"\"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/include\"",
-					"${SRCROOT}/Pods/Headers/**",
-				);
-				INFOPLIST_FILE = "AWSiOSSDKAnalyticsTests/AWSiOSSDKv2AnalyticsTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/usr/lib",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-					"-force_load",
-					"\"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/lib/libOCMock.a\"",
-				);
-				PRODUCT_NAME = AWSiOSSDKv2AnalyticsTests;
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Release;
-		};
-		CE314862187B577A0068883B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AWSiOSSDKTests/AWSiOSSDKv2Tests-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"${SRCROOT}/Pods/Headers/**",
-				);
-				INFOPLIST_FILE = "AWSiOSSDKTests/AWSiOSSDKv2Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_NAME = AWSiOSSDKv2Tests;
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Debug;
-		};
-		CE314863187B577A0068883B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AWSiOSSDKTests/AWSiOSSDKv2Tests-Prefix.pch";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"${SRCROOT}/Pods/Headers/**",
-				);
-				INFOPLIST_FILE = "AWSiOSSDKTests/AWSiOSSDKv2Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_NAME = AWSiOSSDKv2Tests;
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = Release;
-		};
-		CE5D83F71857AA3100907C25 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_MODULES_AUTOLINK = NO;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		CE5D83F81857AA3100907C25 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_MODULES_AUTOLINK = NO;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		CE5D83FA1857AA3100907C25 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = AAF85B9700504764BCD966E3 /* Pods.xcconfig */;
-			buildSettings = {
-				DSTROOT = /tmp/AWSiOSSDK.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AWSiOSSDKv2-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = AWSiOSSDKv2;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		CE5D83FB1857AA3100907C25 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = AAF85B9700504764BCD966E3 /* Pods.xcconfig */;
-			buildSettings = {
-				DSTROOT = /tmp/AWSiOSSDK.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AWSiOSSDKv2-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = AWSiOSSDKv2;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		EADE66601953997D00313444 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEBUGGING_SYMBOLS = YES;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				OTHER_CFLAGS = "";
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Debug;
-		};
-		EADE66611953997D00313444 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				OTHER_CFLAGS = "";
-				OTHER_LDFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		BDD11DFF193FA13600AF60E1 /* Build configuration list for PBXNativeTarget "AWSiOSSDKv2AnalyticsTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BDD11DFD193FA13600AF60E1 /* Debug */,
-				BDD11DFE193FA13600AF60E1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CE314861187B577A0068883B /* Build configuration list for PBXNativeTarget "AWSiOSSDKv2Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CE314862187B577A0068883B /* Debug */,
-				CE314863187B577A0068883B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CE5D83D11857AA3100907C25 /* Build configuration list for PBXProject "AWSiOSSDKv2" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CE5D83F71857AA3100907C25 /* Debug */,
-				CE5D83F81857AA3100907C25 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CE5D83F91857AA3100907C25 /* Build configuration list for PBXNativeTarget "AWSiOSSDKv2" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CE5D83FA1857AA3100907C25 /* Debug */,
-				CE5D83FB1857AA3100907C25 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		EADE66621953997D00313444 /* Build configuration list for PBXLegacyTarget "Documentation" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EADE66601953997D00313444 /* Debug */,
-				EADE66611953997D00313444 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = CE5D83CE1857AA3100907C25 /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>08CE328CA793D64CEAC80787</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>D479C31380205F2701CF047A</string>
+				<string>961B98E1A4FE127C89540439</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>38627E3E19253F5500EF30EF</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSCognitoIdentityServiceTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>38627E3F19253F5500EF30EF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>38627E3E19253F5500EF30EF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>388CA0A11926CA3800AF5A50</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSCognitoCredentialsProviderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>388CA0A21926CA3800AF5A50</key>
+		<dict>
+			<key>fileRef</key>
+			<string>388CA0A11926CA3800AF5A50</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>38D2089219C2A67D0024D82A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSIdentityProvider.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>38D2089319C2A67D0024D82A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSIdentityProvider.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>38D2089419C2A67D0024D82A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>38D2089319C2A67D0024D82A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>6E52D05EBCB24E1CA70E6F9A</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>6F8CA45C05144354BEC9C638</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F3A0CE70F1DF4EEE8E04D464</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>961B98E1A4FE127C89540439</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods/Pods.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AAE1414ED6C74E3CAF6A84AB</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>BD1861BD19A41395003C8E42</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>ec2-input.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BD1861BE19A41395003C8E42</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>ec2-output.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BD1861BF19A41395003C8E42</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BD1861BD19A41395003C8E42</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BD1861C019A41395003C8E42</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BD1861BE19A41395003C8E42</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BD19ED04188F15EB001F5B98</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSS3Tests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BD19ED05188F15EB001F5B98</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BD19ED04188F15EB001F5B98</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BD324C66194BA556003369D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE896C84194A8619000DBB3C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BD9CC213193CFF0700780456</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERSTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BD9CC214193CFF0700780456</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BD9CC213193CFF0700780456</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90BA18EE43B6004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F35218DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90BB18EE43BA004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F35018DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90BC18EE43BE004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F34E18DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90BD18EE43C0004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F34C18DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90C018EE43C8004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F34518DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90C118EE43D3004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F33F18DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90C218EE43FF004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F34118DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90C318EE441F004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F35918DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDBA90C518EE4427004EE131</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE55F35F18DB716B00F8C75F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDC8315E1919725000A01D20</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSS3TransferManagerTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDC8315F1919725000A01D20</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDC8315E1919725000A01D20</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11DEA193FA13600AF60E1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>BDD777A0193FDD9000F04070</string>
+				<string>BDD77729193FDB6B00F04070</string>
+				<string>BDD77724193FDB2800F04070</string>
+				<string>BDD7773A193FDB9400F04070</string>
+				<string>BDD11E25193FA5E600AF60E1</string>
+				<string>BDD777B2193FDDA800F04070</string>
+				<string>BDD7775B193FDC0C00F04070</string>
+				<string>BDD77762193FDD0500F04070</string>
+				<string>BDD77722193FDB2800F04070</string>
+				<string>BDD7775E193FDCDC00F04070</string>
+				<string>BDD777AE193FDDA800F04070</string>
+				<string>BDD77792193FDD5200F04070</string>
+				<string>BDD11E30193FA67100AF60E1</string>
+				<string>BDD7775A193FDC0C00F04070</string>
+				<string>BDD11E18193FA51A00AF60E1</string>
+				<string>BDD7778D193FDD5200F04070</string>
+				<string>BDD7779E193FDD9000F04070</string>
+				<string>BDD11E08193FA24E00AF60E1</string>
+				<string>BDD77719193FDADE00F04070</string>
+				<string>BDD7774C193FDBF300F04070</string>
+				<string>BDD77738193FDB9400F04070</string>
+				<string>BDD11E26193FA5E600AF60E1</string>
+				<string>BDD77791193FDD5200F04070</string>
+				<string>BDD7778E193FDD5200F04070</string>
+				<string>BDD11E2F193FA67100AF60E1</string>
+				<string>BDD77758193FDC0C00F04070</string>
+				<string>BDD11E05193FA23200AF60E1</string>
+				<string>BDD11E14193FA4DD00AF60E1</string>
+				<string>BDD11E1F193FA5A400AF60E1</string>
+				<string>BDD7779F193FDD9000F04070</string>
+				<string>BDD777B0193FDDA800F04070</string>
+				<string>BDD77759193FDC0C00F04070</string>
+				<string>BDD7771B193FDADE00F04070</string>
+				<string>BDD7777F193FDD3B00F04070</string>
+				<string>BDD77796193FDD6E00F04070</string>
+				<string>BDD11E1B193FA55700AF60E1</string>
+				<string>BDD11E0D193FA39400AF60E1</string>
+				<string>BDD7771A193FDADE00F04070</string>
+				<string>BDD77737193FDB9400F04070</string>
+				<string>BDD7773C193FDB9400F04070</string>
+				<string>BDD7774D193FDBF300F04070</string>
+				<string>BDD77790193FDD5200F04070</string>
+				<string>BDD777AF193FDDA800F04070</string>
+				<string>BDD777B1193FDDA800F04070</string>
+				<string>BDD777B3193FDDA800F04070</string>
+				<string>BDD11E29193FA61300AF60E1</string>
+				<string>BDD77740193FDBC800F04070</string>
+				<string>BDD77723193FDB2800F04070</string>
+				<string>BDD77744193FDBDF00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>BDD11DEB193FA13600AF60E1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>BDD11E33193FA78000AF60E1</string>
+				<string>BDD11E32193FA70C00AF60E1</string>
+				<string>BDD11E11193FA41F00AF60E1</string>
+				<string>BDD11E0F193FA40300AF60E1</string>
+				<string>BDD11E0A193FA33E00AF60E1</string>
+				<string>BDD11E01193FA1B700AF60E1</string>
+				<string>BDD11E00193FA19B00AF60E1</string>
+				<string>BDD11DEF193FA13600AF60E1</string>
+				<string>BDD11DF1193FA13600AF60E1</string>
+				<string>BDD11DF0193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>BDD11DEC193FA13600AF60E1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>BDDC42671942A1100039664B</string>
+				<string>CE7635BB19BFA03C005FD5D0</string>
+				<string>CE7635C819BFA056005FD5D0</string>
+				<string>BDD11DF7193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>BDD11DED193FA13600AF60E1</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>BDD11DFF193FA13600AF60E1</string>
+			<key>buildPhases</key>
+			<array>
+				<string>BDD11DEA193FA13600AF60E1</string>
+				<string>BDD11DEB193FA13600AF60E1</string>
+				<string>BDD11DEC193FA13600AF60E1</string>
+				<string>BDD77712193FC6B100F04070</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>BDD11DFC193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>AWSiOSSDKv2AnalyticsTests</string>
+			<key>productName</key>
+			<string>AWSiOSSDKAnalyticsTests</string>
+			<key>productReference</key>
+			<string>BDD11DEE193FA13600AF60E1</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>BDD11DEE193FA13600AF60E1</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>AWSiOSSDKv2AnalyticsTests.xctest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>BDD11DEF193FA13600AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83E71857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11DF0193FA13600AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83D91857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11DF1193FA13600AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE31486C187B59220068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11DF2193FA13600AF60E1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD777A1193FDD9C00F04070</string>
+				<string>BDD77797193FDD7F00F04070</string>
+				<string>BDD77793193FDD6300F04070</string>
+				<string>BDD77780193FDD4500F04070</string>
+				<string>BDD7777C193FDD2E00F04070</string>
+				<string>BDD7775C193FDCDC00F04070</string>
+				<string>BDD7775D193FDCDC00F04070</string>
+				<string>BDD77725193FDB4E00F04070</string>
+				<string>BDD11E15193FA50600AF60E1</string>
+				<string>BDD11E0B193FA39400AF60E1</string>
+				<string>BDD11E0C193FA39400AF60E1</string>
+				<string>BDD11E12193FA4DD00AF60E1</string>
+				<string>BDD11E13193FA4DD00AF60E1</string>
+				<string>BDD11E19193FA55700AF60E1</string>
+				<string>BDD11E1A193FA55700AF60E1</string>
+				<string>BDD11E02193FA1EE00AF60E1</string>
+				<string>BDD11DF3193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AWSiOSSDKAnalyticsTests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11DF3193FA13600AF60E1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD11DF4193FA13600AF60E1</string>
+				<string>BDD11DF5193FA13600AF60E1</string>
+				<string>BDD11DFA193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11DF4193FA13600AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>AWSiOSSDKv2AnalyticsTests-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11DF5193FA13600AF60E1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD11DF6193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11DF6193FA13600AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11DF7193FA13600AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11DF5193FA13600AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11DFA193FA13600AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSiOSSDKAnalyticsTests-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11DFB193FA13600AF60E1</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>CE5D83CE1857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>CE5D83D51857AA3100907C25</string>
+			<key>remoteInfo</key>
+			<string>AWSiOSSDK</string>
+		</dict>
+		<key>BDD11DFC193FA13600AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>CE5D83D51857AA3100907C25</string>
+			<key>targetProxy</key>
+			<string>BDD11DFB193FA13600AF60E1</string>
+		</dict>
+		<key>BDD11DFD193FA13600AF60E1</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/Frameworks</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AWSiOSSDKv2-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>HEADER_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include</string>
+					<string>"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/include"</string>
+					<string>${SRCROOT}/Pods/Headers/**</string>
+				</array>
+				<key>INFOPLIST_FILE</key>
+				<string>AWSiOSSDKAnalyticsTests/AWSiOSSDKv2AnalyticsTests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>LIBRARY_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/usr/lib</string>
+				</array>
+				<key>OTHER_LDFLAGS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>-ObjC</string>
+					<string>-force_load</string>
+					<string>"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/lib/libOCMock.a"</string>
+				</array>
+				<key>PRODUCT_NAME</key>
+				<string>AWSiOSSDKv2AnalyticsTests</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>xctest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>BDD11DFE193FA13600AF60E1</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/Frameworks</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AWSiOSSDKv2-Prefix.pch</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>HEADER_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include</string>
+					<string>"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/include"</string>
+					<string>${SRCROOT}/Pods/Headers/**</string>
+				</array>
+				<key>INFOPLIST_FILE</key>
+				<string>AWSiOSSDKAnalyticsTests/AWSiOSSDKv2AnalyticsTests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>LIBRARY_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>$(PROJECT_DIR)/AWSiOSSDKAnalyticsTests/usr/lib</string>
+				</array>
+				<key>OTHER_LDFLAGS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>-ObjC</string>
+					<string>-force_load</string>
+					<string>"${SRCROOT}/AWSiOSSDKAnalyticsTests/usr/lib/libOCMock.a"</string>
+				</array>
+				<key>PRODUCT_NAME</key>
+				<string>AWSiOSSDKv2AnalyticsTests</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>xctest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>BDD11DFF193FA13600AF60E1</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>BDD11DFD193FA13600AF60E1</string>
+				<string>BDD11DFE193FA13600AF60E1</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>BDD11E00193FA19B00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83D61857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E01193FA1B700AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD39A0A193E646C00C712BD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E02193FA1EE00AF60E1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD11E1C193FA58200AF60E1</string>
+				<string>BDD11E06193FA24E00AF60E1</string>
+				<string>BDD11E07193FA24E00AF60E1</string>
+				<string>BDD11E03193FA23200AF60E1</string>
+				<string>BDD11E04193FA23200AF60E1</string>
+				<string>BDD77713193FDADE00F04070</string>
+				<string>BDD77714193FDADE00F04070</string>
+				<string>BDD77715193FDADE00F04070</string>
+				<string>BDD77716193FDADE00F04070</string>
+				<string>BDD77717193FDADE00F04070</string>
+				<string>BDD77718193FDADE00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>integration</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E03193FA23200AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIAmazonInsightsTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E04193FA23200AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIAmazonInsightsTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD11E05193FA23200AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E04193FA23200AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E06193FA24E00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIIntegrationTestBase.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E07193FA24E00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIIntegrationTestBase.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD11E08193FA24E00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E07193FA24E00AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E09193FA33E00AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>SenTestingKit.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/SenTestingKit.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>BDD11E0A193FA33E00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E09193FA33E00AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E0B193FA39400AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AmazonInsightsSDKTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E0C193FA39400AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AmazonInsightsSDKTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E0D193FA39400AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E0C193FA39400AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E0E193FA40300AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>OCHamcrestIOS.framework</string>
+			<key>path</key>
+			<string>AWSiOSSDKAnalyticsTests/Frameworks/OCHamcrestIOS.framework</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E0F193FA40300AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E0E193FA40300AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E10193FA41F00AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>archive.ar</string>
+			<key>name</key>
+			<string>libOCMock.a</string>
+			<key>path</key>
+			<string>AWSiOSSDKAnalyticsTests/usr/lib/libOCMock.a</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E11193FA41F00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E10193FA41F00AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E12193FA4DD00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIInsightsContextBuilder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E13193FA4DD00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIInsightsContextBuilder.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD11E14193FA4DD00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E13193FA4DD00AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E15193FA50600AF60E1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD7774F193FDBFF00F04070</string>
+				<string>BDD77745193FDBE800F04070</string>
+				<string>BDD77741193FDBD500F04070</string>
+				<string>BDD7773D193FDBAC00F04070</string>
+				<string>BDD7772A193FDB8600F04070</string>
+				<string>BDD77726193FDB5D00F04070</string>
+				<string>BDD11E16193FA51A00AF60E1</string>
+				<string>BDD11E17193FA51A00AF60E1</string>
+				<string>BDD7771C193FDB2800F04070</string>
+				<string>BDD7771D193FDB2800F04070</string>
+				<string>BDD7771E193FDB2800F04070</string>
+				<string>BDD7771F193FDB2800F04070</string>
+				<string>BDD77720193FDB2800F04070</string>
+				<string>BDD77721193FDB2800F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>core</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E16193FA51A00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AITestConfiguration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E17193FA51A00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AITestConfiguration.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E18193FA51A00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E17193FA51A00AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E19193FA55700AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AITestHttpClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E1A193FA55700AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AITestHttpClient.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E1B193FA55700AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E1A193FA55700AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E1C193FA58200AF60E1</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD11E21193FA5E600AF60E1</string>
+				<string>BDD11E22193FA5E600AF60E1</string>
+				<string>BDD11E23193FA5E600AF60E1</string>
+				<string>BDD11E24193FA5E600AF60E1</string>
+				<string>BDD11E1D193FA5A400AF60E1</string>
+				<string>BDD11E1E193FA5A400AF60E1</string>
+				<string>BDD11E27193FA61300AF60E1</string>
+				<string>BDD11E28193FA61300AF60E1</string>
+				<string>BDD11E20193FA5AC00AF60E1</string>
+				<string>BDD11E2A193FA67100AF60E1</string>
+				<string>BDD11E2B193FA67100AF60E1</string>
+				<string>BDD11E2C193FA67100AF60E1</string>
+				<string>BDD11E2D193FA67100AF60E1</string>
+				<string>BDD11E2E193FA67100AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>util</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E1D193FA5A400AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>TestConnectivity.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E1E193FA5A400AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TestConnectivity.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E1F193FA5A400AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E1E193FA5A400AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E20193FA5AC00AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>TestConstants.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E21193FA5E600AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>NSObject+TTTSwizzling.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E22193FA5E600AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSObject+TTTSwizzling.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E23193FA5E600AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>NSLocale+TTTOverrideLocale.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E24193FA5E600AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSLocale+TTTOverrideLocale.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E25193FA5E600AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E22193FA5E600AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E26193FA5E600AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E24193FA5E600AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E27193FA61300AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>TestInsightsContext.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E28193FA61300AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>TestInsightsContext.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD11E29193FA61300AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E28193FA61300AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E2A193FA67100AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIInternalInterfaces.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E2B193FA67100AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>BlockingInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E2C193FA67100AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>BlockingInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD11E2D193FA67100AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>TestEventObserver.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD11E2E193FA67100AF60E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>TestEventObserver.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD11E2F193FA67100AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E2C193FA67100AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E30193FA67100AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E2E193FA67100AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E31193FA70C00AF60E1</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>SystemConfiguration.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/SystemConfiguration.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>BDD11E32193FA70C00AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD11E31193FA70C00AF60E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD11E33193FA78000AF60E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EFEAC89419295311005FEDE4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD196C8198AFF2200CC94A2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>json-input.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD196C9198AFF2200CC94A2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>query-input.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD196CB198AFF2200CC94A2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>rest-xml-input.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD196CD198AFF2200CC94A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD196C8198AFF2200CC94A2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD196CE198AFF2200CC94A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD196C9198AFF2200CC94A2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD196D0198AFF2200CC94A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD196CB198AFF2200CC94A2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD196D2198AFF2C00CC94A2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>json-output.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD196D3198AFF2C00CC94A2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>query-output.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD196D5198AFF2C00CC94A2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>rest-xml-output.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD196D7198AFF2C00CC94A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD196D2198AFF2C00CC94A2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD196D8198AFF2C00CC94A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD196D3198AFF2C00CC94A2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD196DA198AFF2C00CC94A2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD196D5198AFF2C00CC94A2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD39A0A193E646C00C712BD</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>compiled.mach-o.dylib</string>
+			<key>name</key>
+			<string>libz.dylib</string>
+			<key>path</key>
+			<string>usr/lib/libz.dylib</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>BDD39A0E193E652100C712BD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD39A0A193E646C00C712BD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD39A10193E8D4500C712BD</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSAnalyticsTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD39A11193E8D4500C712BD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD39A10193E8D4500C712BD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77705193FBF6000F04070</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77712193FC6B100F04070</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string># Run the unit tests in this test bundle.
+"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests"</string>
+		</dict>
+		<key>BDD77713193FDADE00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIConfigurationIntegrationTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77714193FDADE00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIConfigurationIntegrationTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77715193FDADE00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDeliveryIntegrationTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77716193FDADE00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIDeliveryIntegrationTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77717193FDADE00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AISessionIntegrationTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77718193FDADE00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AISessionIntegrationTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77719193FDADE00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77714193FDADE00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7771A193FDADE00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77716193FDADE00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7771B193FDADE00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77718193FDADE00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7771C193FDB2800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDefaultInsightsOptionsTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7771D193FDB2800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIDefaultInsightsOptionsTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7771E193FDB2800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDelayedBlockTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7771F193FDB2800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIDelayedBlockTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77720193FDB2800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AICountDownLatchTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77721193FDB2800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AICountDownLatchTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77722193FDB2800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7771D193FDB2800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77723193FDB2800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7771F193FDB2800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77724193FDB2800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77721193FDB2800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77725193FDB4E00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD7775F193FDCF600F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>AZCommon</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77726193FDB5D00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77727193FDB6B00F04070</string>
+				<string>BDD77728193FDB6B00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>configuration</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77727193FDB6B00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIHttpCachingConfigurationTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77728193FDB6B00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIHttpCachingConfigurationTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77729193FDB6B00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77728193FDB6B00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7772A193FDB8600F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD7772B193FDB9400F04070</string>
+				<string>BDD7772C193FDB9400F04070</string>
+				<string>BDD7772D193FDB9400F04070</string>
+				<string>BDD7772E193FDB9400F04070</string>
+				<string>BDD77731193FDB9400F04070</string>
+				<string>BDD77732193FDB9400F04070</string>
+				<string>BDD77735193FDB9400F04070</string>
+				<string>BDD77736193FDB9400F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>http</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7772B193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDefaultRequestTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7772C193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIDefaultRequestTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7772D193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AISDKInfoInterceptorTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7772E193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AISDKInfoInterceptorTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77731193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIClientContextInterceptorTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77732193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIClientContextInterceptorTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77735193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIInstanceIdInterceptorTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77736193FDB9400F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIInstanceIdInterceptorTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77737193FDB9400F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7772C193FDB9400F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77738193FDB9400F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7772E193FDB9400F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7773A193FDB9400F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77732193FDB9400F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7773C193FDB9400F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77736193FDB9400F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7773D193FDBAC00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD7773E193FDBC800F04070</string>
+				<string>BDD7773F193FDBC800F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>utils</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7773E193FDBC800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIStringUtilsTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7773F193FDBC800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIStringUtilsTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77740193FDBC800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7773F193FDBC800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77741193FDBD500F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77742193FDBDF00F04070</string>
+				<string>BDD77743193FDBDF00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>id</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77742193FDBDF00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIPrefsUniqueIdServiceTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77743193FDBDF00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIPrefsUniqueIdServiceTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77744193FDBDF00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77743193FDBDF00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77745193FDBE800F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77746193FDBF300F04070</string>
+				<string>BDD77747193FDBF300F04070</string>
+				<string>BDD77748193FDBF300F04070</string>
+				<string>BDD77749193FDBF300F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>io</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77746193FDBF300F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIBufferedReaderTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77747193FDBF300F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIBufferedReaderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77748193FDBF300F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIEncryptedReaderWriterTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77749193FDBF300F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIEncryptedReaderWriterTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7774C193FDBF300F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77747193FDBF300F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7774D193FDBF300F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77749193FDBF300F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7774F193FDBFF00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77750193FDC0C00F04070</string>
+				<string>BDD77751193FDC0C00F04070</string>
+				<string>BDD77752193FDC0C00F04070</string>
+				<string>BDD77753193FDC0C00F04070</string>
+				<string>BDD77754193FDC0C00F04070</string>
+				<string>BDD77755193FDC0C00F04070</string>
+				<string>BDD77756193FDC0C00F04070</string>
+				<string>BDD77757193FDC0C00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>system</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77750193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIFileTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77751193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIFileTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77752193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDefaultFileManagerTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77753193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIDefaultFileManagerTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77754193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIIOSLifeCycleManagerTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD77755193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIIOSLifeCycleManagerTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77756193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIIOSPreferencesTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77757193FDC0C00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIIOSPreferencesTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77758193FDC0C00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77751193FDC0C00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77759193FDC0C00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77753193FDC0C00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7775A193FDC0C00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77755193FDC0C00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7775B193FDC0C00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77757193FDC0C00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7775C193FDCDC00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>NSURLRequest+NSURLRequestSSLY.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7775D193FDCDC00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSURLRequest+NSURLRequestSSLY.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7775E193FDCDC00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7775D193FDCDC00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7775F193FDCF600F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77760193FDD0500F04070</string>
+				<string>BDD77761193FDD0500F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>ClientContext</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77760193FDD0500F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AZIOSClientContextTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77761193FDD0500F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AZIOSClientContextTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77762193FDD0500F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77761193FDD0500F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7777C193FDD2E00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD7777D193FDD3B00F04070</string>
+				<string>BDD7777E193FDD3B00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>monetization</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7777D193FDD3B00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIMonetizationEventBuilderTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7777E193FDD3B00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIMonetizationEventBuilderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7777F193FDD3B00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7777E193FDD3B00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77780193FDD4500F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77781193FDD5200F04070</string>
+				<string>BDD77782193FDD5200F04070</string>
+				<string>BDD77783193FDD5200F04070</string>
+				<string>BDD77784193FDD5200F04070</string>
+				<string>BDD77787193FDD5200F04070</string>
+				<string>BDD77788193FDD5200F04070</string>
+				<string>BDD77789193FDD5200F04070</string>
+				<string>BDD7778A193FDD5200F04070</string>
+				<string>BDD7778B193FDD5200F04070</string>
+				<string>BDD7778C193FDD5200F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>delivery</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77781193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIFileEventStoreTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77782193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIFileEventStoreTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77783193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDefaultDeliveryClientTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77784193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIDefaultDeliveryClientTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77787193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIConnectivityPolicyTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77788193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIConnectivityPolicyTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD77789193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AISubmissionTimePolicyTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7778A193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AISubmissionTimePolicyTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7778B193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIERSRequestBuilderTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD7778C193FDD5200F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIERSRequestBuilderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7778D193FDD5200F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77782193FDD5200F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7778E193FDD5200F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77784193FDD5200F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77790193FDD5200F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77788193FDD5200F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77791193FDD5200F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7778A193FDD5200F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77792193FDD5200F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7778C193FDD5200F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77793193FDD6300F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77794193FDD6E00F04070</string>
+				<string>BDD77795193FDD6E00F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>util</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77794193FDD6E00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIDateUtilTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77795193FDD6E00F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIDateUtilTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77796193FDD6E00F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77795193FDD6E00F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD77797193FDD7F00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD77798193FDD9000F04070</string>
+				<string>BDD77799193FDD9000F04070</string>
+				<string>BDD7779A193FDD9000F04070</string>
+				<string>BDD7779B193FDD9000F04070</string>
+				<string>BDD7779C193FDD9000F04070</string>
+				<string>BDD7779D193FDD9000F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>event</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77798193FDD9000F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIEventClientTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD77799193FDD9000F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIEventClientTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7779A193FDD9000F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIDefaultEventTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>BDD7779B193FDD9000F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIDefaultEventTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD7779C193FDD9000F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIEventContraintDecoratorTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7779D193FDD9000F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AIEventContraintDecoratorTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD7779E193FDD9000F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD77799193FDD9000F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD7779F193FDD9000F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7779B193FDD9000F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777A0193FDD9000F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD7779D193FDD9000F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777A1193FDD9C00F04070</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD777A2193FDDA800F04070</string>
+				<string>BDD777A3193FDDA800F04070</string>
+				<string>BDD777A4193FDDA800F04070</string>
+				<string>BDD777A5193FDDA800F04070</string>
+				<string>BDD777A6193FDDA800F04070</string>
+				<string>BDD777A7193FDDA800F04070</string>
+				<string>BDD777A8193FDDA800F04070</string>
+				<string>BDD777A9193FDDA800F04070</string>
+				<string>BDD777AA193FDDA800F04070</string>
+				<string>BDD777AB193FDDA800F04070</string>
+				<string>BDD777AC193FDDA800F04070</string>
+				<string>BDD777AD193FDDA800F04070</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>session</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777A2193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AISessionClientTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777A3193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AISessionClientTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD777A4193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AISessionTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777A5193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AISessionTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD777A6193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIPausedSessionStateTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777A7193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIPausedSessionStateTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD777A8193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIActiveSessionStateTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777A9193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIActiveSessionStateTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD777AA193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AIInactiveSessionStateTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777AB193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AIInactiveSessionStateTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>BDD777AC193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AISessionStoreTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777AD193FDDA800F04070</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AISessionStoreTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BDD777AE193FDDA800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD777A3193FDDA800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777AF193FDDA800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD777A5193FDDA800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777B0193FDDA800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD777A7193FDDA800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777B1193FDDA800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD777A9193FDDA800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777B2193FDDA800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD777AB193FDDA800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDD777B3193FDDA800F04070</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDD777AD193FDDA800F04070</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BDDC42671942A1100039664B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE31486A187B58090068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE09860C1922A7470006EA67</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE0986131922A7470006EA67</string>
+				<string>CE09860D1922A7470006EA67</string>
+				<string>CE09860E1922A7470006EA67</string>
+				<string>CE09860F1922A7470006EA67</string>
+				<string>CE0986101922A7470006EA67</string>
+				<string>CE0986111922A7470006EA67</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>STS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE09860D1922A7470006EA67</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSSTS.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE09860E1922A7470006EA67</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSTS.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE09860F1922A7470006EA67</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSSTSModel.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE0986101922A7470006EA67</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSTSModel.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE0986111922A7470006EA67</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE0986121922A7470006EA67</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Resources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE0986121922A7470006EA67</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>sts-2011-06-15.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE0986131922A7470006EA67</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>STS.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE0986161922A7470006EA67</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE0986121922A7470006EA67</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE0D85D618D37EC000D41F8A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSQSTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE0D85D718D37EC000D41F8A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE0D85D618D37EC000D41F8A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE0D85D818D385DA00D41F8A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSNSTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE0D85D918D385DA00D41F8A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE0D85D818D385DA00D41F8A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE0D85DA18D38AAB00D41F8A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSimpleDBTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE0D85DB18D38AAB00D41F8A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE0D85DA18D38AAB00D41F8A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE0D85DC18D38FCA00D41F8A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSESTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE0D85DD18D38FCA00D41F8A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE0D85DC18D38FCA00D41F8A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE0EFAE7193D2939002A896B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE09860E1922A7470006EA67</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE0EFAE8193D2939002A896B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE0986101922A7470006EA67</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE160B2019774315001ABF94</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSTestUtility.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE160B2119774315001ABF94</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE160B2019774315001ABF94</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE160B2219774365001ABF94</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSTestUtility.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EED819916C5100A318A3</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE16EED919916C5100A318A3</string>
+				<string>CE16EEDA19916C5100A318A3</string>
+				<string>CE16EEDB19916C5100A318A3</string>
+				<string>CE16EEDC19916C5100A318A3</string>
+				<string>CE16EEDD19916C5100A318A3</string>
+				<string>CE16EEDE19916C5100A318A3</string>
+				<string>CE16EEDF19916C5100A318A3</string>
+				<string>CE16EEE019916C5100A318A3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Utility</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EED919916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSCategory.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EEDA19916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSCategory.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE16EEDB19916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSLogging.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE16EEDC19916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSLogging.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE16EEDD19916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSModel.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EEDE19916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSModel.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EEDF19916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSSynchronizedMutableDictionary.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EEE019916C5100A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSynchronizedMutableDictionary.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE16EEE119916C5100A318A3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE16EEDA19916C5100A318A3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE16EEE219916C5100A318A3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE16EEDC19916C5100A318A3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE16EEE319916C5100A318A3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE16EEDE19916C5100A318A3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE16EEE419916C5100A318A3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE16EEE019916C5100A318A3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE16EEE719916C8400A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSURLSessionManager.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EEE819916C8400A318A3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSURLSessionManager.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE16EEEA19916C8400A318A3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE16EEE819916C8400A318A3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE1C9DE41936CE38007B6F33</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSClockSkewTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE1C9DE51936CE38007B6F33</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE1C9DE41936CE38007B6F33</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE1F781418B6A1C100EE588B</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>CE5D83CE1857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>CE5D83D51857AA3100907C25</string>
+			<key>remoteInfo</key>
+			<string>AWSiOSSDK</string>
+		</dict>
+		<key>CE1F781518B6A1C100EE588B</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>CE5D83D51857AA3100907C25</string>
+			<key>targetProxy</key>
+			<string>CE1F781418B6A1C100EE588B</string>
+		</dict>
+		<key>CE23E60A19BF7CD00036EDC0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSS3PreSignedURL.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE23E60B19BF7CD60036EDC0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSS3PreSignedURL.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE23E60C19BF7CD60036EDC0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE23E60B19BF7CD60036EDC0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE2C174618D0D8CF003FE9AA</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSTSTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE2C174718D0D8CF003FE9AA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE2C174618D0D8CF003FE9AA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE31484E187B577A0068883B</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>CE8FEAA618D3B62100EC90A6</string>
+				<string>388CA0A21926CA3800AF5A50</string>
+				<string>CE91D2BF18D3C03B000390D2</string>
+				<string>BD19ED05188F15EB001F5B98</string>
+				<string>CE2C174718D0D8CF003FE9AA</string>
+				<string>CE160B2119774315001ABF94</string>
+				<string>CE314867187B57F50068883B</string>
+				<string>CE8FEAA818D3B84E00EC90A6</string>
+				<string>CE1C9DE51936CE38007B6F33</string>
+				<string>CEE68C191940000500259EFF</string>
+				<string>CE0D85DB18D38AAB00D41F8A</string>
+				<string>CEBA14CD1921AC2F008C596A</string>
+				<string>CEB2A4A418D782F80007AAF4</string>
+				<string>BDD39A11193E8D4500C712BD</string>
+				<string>BDC8315F1919725000A01D20</string>
+				<string>BD9CC214193CFF0700780456</string>
+				<string>38627E3F19253F5500EF30EF</string>
+				<string>CE8FEAA318D3B18600EC90A6</string>
+				<string>CE314868187B57F50068883B</string>
+				<string>CE0D85DD18D38FCA00D41F8A</string>
+				<string>CE0D85D918D385DA00D41F8A</string>
+				<string>CE3F4D3919BFCE5A000C1A6C</string>
+				<string>CE0D85D718D37EC000D41F8A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CE31484F187B577A0068883B</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>BDD39A0E193E652100C712BD</string>
+				<string>EFEAC897192954B2005FEDE4</string>
+				<string>EFEAC89619295448005FEDE4</string>
+				<string>CE31486D187B59220068883B</string>
+				<string>CE314853187B577A0068883B</string>
+				<string>CE314854187B577A0068883B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CE314850187B577A0068883B</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>CE55F37718DB7FCC00F8C75F</string>
+				<string>CE55F37818DB7FCC00F8C75F</string>
+				<string>BDD196D0198AFF2200CC94A2</string>
+				<string>CE7635C719BFA055005FD5D0</string>
+				<string>CE55F37918DB7FCC00F8C75F</string>
+				<string>BD324C66194BA556003369D0</string>
+				<string>BDD196D8198AFF2C00CC94A2</string>
+				<string>BD1861C019A41395003C8E42</string>
+				<string>CE55F37B18DB7FCC00F8C75F</string>
+				<string>BDD196CE198AFF2200CC94A2</string>
+				<string>CE55F37C18DB7FCC00F8C75F</string>
+				<string>CE0986161922A7470006EA67</string>
+				<string>CE55F37D18DB7FCC00F8C75F</string>
+				<string>CE55F37E18DB7FCC00F8C75F</string>
+				<string>CE55F37F18DB7FCC00F8C75F</string>
+				<string>CE55F38018DB7FCC00F8C75F</string>
+				<string>CE55F38118DB7FCC00F8C75F</string>
+				<string>BD1861BF19A41395003C8E42</string>
+				<string>CE31486B187B58090068883B</string>
+				<string>CE7635BC19BFA03C005FD5D0</string>
+				<string>BDD196CD198AFF2200CC94A2</string>
+				<string>BDD196D7198AFF2C00CC94A2</string>
+				<string>BDD196DA198AFF2C00CC94A2</string>
+				<string>CE31485B187B577A0068883B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CE314851187B577A0068883B</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>CE314861187B577A0068883B</string>
+			<key>buildPhases</key>
+			<array>
+				<string>CE31484E187B577A0068883B</string>
+				<string>CE31484F187B577A0068883B</string>
+				<string>CE314850187B577A0068883B</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>CE1F781518B6A1C100EE588B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>AWSiOSSDKv2Tests</string>
+			<key>productName</key>
+			<string>AWSiOSSDKTests</string>
+			<key>productReference</key>
+			<string>CE314852187B577A0068883B</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>CE314852187B577A0068883B</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>AWSiOSSDKv2Tests.xctest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>CE314853187B577A0068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83E71857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE314854187B577A0068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83D91857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE314856187B577A0068883B</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BDD39A10193E8D4500C712BD</string>
+				<string>CE8FEAA718D3B84E00EC90A6</string>
+				<string>CE1C9DE41936CE38007B6F33</string>
+				<string>CE8FEAA518D3B62100EC90A6</string>
+				<string>388CA0A11926CA3800AF5A50</string>
+				<string>38627E3E19253F5500EF30EF</string>
+				<string>CE314865187B57F50068883B</string>
+				<string>CEBA14CC1921AC2F008C596A</string>
+				<string>CE314864187B57F50068883B</string>
+				<string>CEB2A4A318D782F80007AAF4</string>
+				<string>CE8FEAA218D3B18600EC90A6</string>
+				<string>CEE68C181940000500259EFF</string>
+				<string>CE91D2BE18D3C03B000390D2</string>
+				<string>BD9CC213193CFF0700780456</string>
+				<string>CE3F4D3819BFCE5A000C1A6C</string>
+				<string>BD19ED04188F15EB001F5B98</string>
+				<string>BDC8315E1919725000A01D20</string>
+				<string>CE0D85DC18D38FCA00D41F8A</string>
+				<string>CE0D85DA18D38AAB00D41F8A</string>
+				<string>CE0D85D818D385DA00D41F8A</string>
+				<string>CE0D85D618D37EC000D41F8A</string>
+				<string>CE2C174618D0D8CF003FE9AA</string>
+				<string>CE160B2219774365001ABF94</string>
+				<string>CE160B2019774315001ABF94</string>
+				<string>CE314857187B577A0068883B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AWSiOSSDKTests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE314857187B577A0068883B</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE31485E187B577A0068883B</string>
+				<string>BD1861BD19A41395003C8E42</string>
+				<string>BD1861BE19A41395003C8E42</string>
+				<string>BDD196D2198AFF2C00CC94A2</string>
+				<string>BDD196D3198AFF2C00CC94A2</string>
+				<string>BDD196D5198AFF2C00CC94A2</string>
+				<string>BDD196C8198AFF2200CC94A2</string>
+				<string>BDD196C9198AFF2200CC94A2</string>
+				<string>BDD196CB198AFF2200CC94A2</string>
+				<string>CE31486A187B58090068883B</string>
+				<string>CE314858187B577A0068883B</string>
+				<string>CE314859187B577A0068883B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE314858187B577A0068883B</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>AWSiOSSDKv2Tests-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE314859187B577A0068883B</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE31485A187B577A0068883B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE31485A187B577A0068883B</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE31485B187B577A0068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE314859187B577A0068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE31485E187B577A0068883B</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSiOSSDKv2Tests-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE314861187B577A0068883B</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>CE314862187B577A0068883B</string>
+				<string>CE314863187B577A0068883B</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>CE314862187B577A0068883B</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AWSiOSSDKTests/AWSiOSSDKv2Tests-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>HEADER_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include</string>
+					<string>${SRCROOT}/Pods/Headers/**</string>
+				</array>
+				<key>INFOPLIST_FILE</key>
+				<string>AWSiOSSDKTests/AWSiOSSDKv2Tests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>OTHER_LDFLAGS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>-ObjC</string>
+				</array>
+				<key>PRODUCT_NAME</key>
+				<string>AWSiOSSDKv2Tests</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>xctest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>CE314863187B577A0068883B</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AWSiOSSDKTests/AWSiOSSDKv2Tests-Prefix.pch</string>
+				<key>HEADER_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include</string>
+					<string>${SRCROOT}/Pods/Headers/**</string>
+				</array>
+				<key>INFOPLIST_FILE</key>
+				<string>AWSiOSSDKTests/AWSiOSSDKv2Tests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>OTHER_LDFLAGS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>-ObjC</string>
+				</array>
+				<key>PRODUCT_NAME</key>
+				<string>AWSiOSSDKv2Tests</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>xctest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>CE314864187B57F50068883B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSDynamoDBTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE314865187B57F50068883B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSCoreTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE314867187B57F50068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE314864187B57F50068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE314868187B57F50068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE314865187B57F50068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE31486A187B58090068883B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>credentials.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE31486B187B58090068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE31486A187B58090068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE31486C187B59220068883B</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>UIKit.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/UIKit.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>CE31486D187B59220068883B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE31486C187B59220068883B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B1318DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B1418DA874000D2CFD2</string>
+				<string>CE372B1518DA874000D2CFD2</string>
+				<string>CE372B1618DA874000D2CFD2</string>
+				<string>CE372B1718DA874000D2CFD2</string>
+				<string>CE372B1818DA874000D2CFD2</string>
+				<string>CE372B1918DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AutoScaling</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B1418DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AutoScaling.h</string>
+			<key>path</key>
+			<string>AutoScaling/AutoScaling.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE372B1518DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSAutoScaling.h</string>
+			<key>path</key>
+			<string>AutoScaling/AWSAutoScaling.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE372B1618DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSAutoScaling.m</string>
+			<key>path</key>
+			<string>AutoScaling/AWSAutoScaling.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B1718DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSAutoScalingModel.h</string>
+			<key>path</key>
+			<string>AutoScaling/AWSAutoScalingModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE372B1818DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSAutoScalingModel.m</string>
+			<key>path</key>
+			<string>AutoScaling/AWSAutoScalingModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B1918DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B1A18DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>AutoScaling/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B1A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>autoscaling-2011-01-01.json</string>
+			<key>path</key>
+			<string>AutoScaling/Resources/autoscaling-2011-01-01.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B1B18DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B2018DA874000D2CFD2</string>
+				<string>CE372B1C18DA874000D2CFD2</string>
+				<string>CE372B1D18DA874000D2CFD2</string>
+				<string>CE372B1E18DA874000D2CFD2</string>
+				<string>CE372B1F18DA874000D2CFD2</string>
+				<string>CE372B2118DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>CloudWatch</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B1C18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCloudWatch.h</string>
+			<key>path</key>
+			<string>CloudWatch/AWSCloudWatch.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE372B1D18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCloudWatch.m</string>
+			<key>path</key>
+			<string>CloudWatch/AWSCloudWatch.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B1E18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCloudWatchModel.h</string>
+			<key>path</key>
+			<string>CloudWatch/AWSCloudWatchModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE372B1F18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCloudWatchModel.m</string>
+			<key>path</key>
+			<string>CloudWatch/AWSCloudWatchModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B2018DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>CloudWatch.h</string>
+			<key>path</key>
+			<string>CloudWatch/CloudWatch.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2118DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B2218DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>CloudWatch/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2218DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>monitoring-2010-08-01.json</string>
+			<key>path</key>
+			<string>CloudWatch/Resources/monitoring-2010-08-01.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2318DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B2818DA874000D2CFD2</string>
+				<string>CE372B2418DA874000D2CFD2</string>
+				<string>CE372B2518DA874000D2CFD2</string>
+				<string>CE372B2618DA874000D2CFD2</string>
+				<string>CE372B2718DA874000D2CFD2</string>
+				<string>CE5312B21922DFFA005DAFA3</string>
+				<string>CE5312B31922DFFA005DAFA3</string>
+				<string>CE372B2918DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>DynamoDB</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2418DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSDynamoDB.h</string>
+			<key>path</key>
+			<string>DynamoDB/AWSDynamoDB.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2518DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSDynamoDB.m</string>
+			<key>path</key>
+			<string>DynamoDB/AWSDynamoDB.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B2618DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSDynamoDBModel.h</string>
+			<key>path</key>
+			<string>DynamoDB/AWSDynamoDBModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2718DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSDynamoDBModel.m</string>
+			<key>path</key>
+			<string>DynamoDB/AWSDynamoDBModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B2818DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>DynamoDB.h</string>
+			<key>path</key>
+			<string>DynamoDB/DynamoDB.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2918DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B2A18DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>DynamoDB/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>dynamodb-2012-08-10.json</string>
+			<key>path</key>
+			<string>DynamoDB/Resources/dynamodb-2012-08-10.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2B18DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B3018DA874000D2CFD2</string>
+				<string>CE372B2C18DA874000D2CFD2</string>
+				<string>CE372B2D18DA874000D2CFD2</string>
+				<string>CE372B2E18DA874000D2CFD2</string>
+				<string>CE372B2F18DA874000D2CFD2</string>
+				<string>CE372B3118DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>EC2</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2C18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSEC2.h</string>
+			<key>path</key>
+			<string>EC2/AWSEC2.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2D18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSEC2.m</string>
+			<key>path</key>
+			<string>EC2/AWSEC2.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B2E18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSEC2Model.h</string>
+			<key>path</key>
+			<string>EC2/AWSEC2Model.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B2F18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSEC2Model.m</string>
+			<key>path</key>
+			<string>EC2/AWSEC2Model.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B3018DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EC2.h</string>
+			<key>path</key>
+			<string>EC2/EC2.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3118DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE896C84194A8619000DBB3C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>EC2/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3318DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B3818DA874000D2CFD2</string>
+				<string>CE372B3418DA874000D2CFD2</string>
+				<string>CE372B3518DA874000D2CFD2</string>
+				<string>CE372B3618DA874000D2CFD2</string>
+				<string>CE372B3718DA874000D2CFD2</string>
+				<string>CE372B3918DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3418DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSElasticLoadBalancing.h</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/AWSElasticLoadBalancing.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3518DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSElasticLoadBalancing.m</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/AWSElasticLoadBalancing.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B3618DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSElasticLoadBalancingModel.h</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/AWSElasticLoadBalancingModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3718DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSElasticLoadBalancingModel.m</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/AWSElasticLoadBalancingModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B3818DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>ElasticLoadBalancing.h</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/ElasticLoadBalancing.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3918DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B3A18DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>elasticloadbalancing-2012-06-01.json</string>
+			<key>path</key>
+			<string>ElasticLoadBalancing/Resources/elasticloadbalancing-2012-06-01.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3B18DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B4018DA874000D2CFD2</string>
+				<string>CE372B3C18DA874000D2CFD2</string>
+				<string>CE372B3D18DA874000D2CFD2</string>
+				<string>CE372B3E18DA874000D2CFD2</string>
+				<string>CE372B3F18DA874000D2CFD2</string>
+				<string>CEE68C15193FB11A00259EFF</string>
+				<string>CEE68C16193FB11A00259EFF</string>
+				<string>CE372B4118DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Kinesis</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3C18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSKinesis.h</string>
+			<key>path</key>
+			<string>Kinesis/AWSKinesis.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3D18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSKinesis.m</string>
+			<key>path</key>
+			<string>Kinesis/AWSKinesis.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B3E18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSKinesisModel.h</string>
+			<key>path</key>
+			<string>Kinesis/AWSKinesisModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B3F18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSKinesisModel.m</string>
+			<key>path</key>
+			<string>Kinesis/AWSKinesisModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B4018DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Kinesis.h</string>
+			<key>path</key>
+			<string>Kinesis/Kinesis.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4118DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B4218DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>Kinesis/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4218DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>kinesis-2013-12-02.json</string>
+			<key>path</key>
+			<string>Kinesis/Resources/kinesis-2013-12-02.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4318DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B4A18DA874000D2CFD2</string>
+				<string>CE372B4418DA874000D2CFD2</string>
+				<string>CE372B4518DA874000D2CFD2</string>
+				<string>CE372B4618DA874000D2CFD2</string>
+				<string>CE372B4718DA874000D2CFD2</string>
+				<string>CE23E60A19BF7CD00036EDC0</string>
+				<string>CE23E60B19BF7CD60036EDC0</string>
+				<string>CED6C36418EE3EC800A56FB2</string>
+				<string>CED6C36518EE3EC800A56FB2</string>
+				<string>CE372B4818DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>S3</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4418DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSS3.h</string>
+			<key>path</key>
+			<string>S3/AWSS3.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4518DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSS3.m</string>
+			<key>path</key>
+			<string>S3/AWSS3.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B4618DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSS3Model.h</string>
+			<key>path</key>
+			<string>S3/AWSS3Model.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4718DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSS3Model.m</string>
+			<key>path</key>
+			<string>S3/AWSS3Model.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B4818DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B4918DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>S3/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4918DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>s3-2006-03-01.json</string>
+			<key>path</key>
+			<string>S3/Resources/s3-2006-03-01.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>S3.h</string>
+			<key>path</key>
+			<string>S3/S3.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4B18DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B5218DA874000D2CFD2</string>
+				<string>CE372B4C18DA874000D2CFD2</string>
+				<string>CE372B4D18DA874000D2CFD2</string>
+				<string>CE372B4E18DA874000D2CFD2</string>
+				<string>CE372B4F18DA874000D2CFD2</string>
+				<string>CE372B5018DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>SES</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4C18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSES.h</string>
+			<key>path</key>
+			<string>SES/AWSSES.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4D18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSSES.m</string>
+			<key>path</key>
+			<string>SES/AWSSES.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B4E18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSESModel.h</string>
+			<key>path</key>
+			<string>SES/AWSSESModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B4F18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSSESModel.m</string>
+			<key>path</key>
+			<string>SES/AWSSESModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B5018DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B5118DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>SES/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5118DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>email-2010-12-01.json</string>
+			<key>path</key>
+			<string>SES/Resources/email-2010-12-01.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5218DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SES.h</string>
+			<key>path</key>
+			<string>SES/SES.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5318DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B5A18DA874000D2CFD2</string>
+				<string>CE372B5418DA874000D2CFD2</string>
+				<string>CE372B5518DA874000D2CFD2</string>
+				<string>CE372B5618DA874000D2CFD2</string>
+				<string>CE372B5718DA874000D2CFD2</string>
+				<string>CE372B5818DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>SimpleDB</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5418DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSimpleDB.h</string>
+			<key>path</key>
+			<string>SimpleDB/AWSSimpleDB.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5518DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSSimpleDB.m</string>
+			<key>path</key>
+			<string>SimpleDB/AWSSimpleDB.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B5618DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSimpleDBModel.h</string>
+			<key>path</key>
+			<string>SimpleDB/AWSSimpleDBModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5718DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AWSSimpleDBModel.m</string>
+			<key>path</key>
+			<string>SimpleDB/AWSSimpleDBModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5818DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B5918DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>SimpleDB/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5918DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>sdb-2009-04-15.json</string>
+			<key>path</key>
+			<string>SimpleDB/Resources/sdb-2009-04-15.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SimpleDB.h</string>
+			<key>path</key>
+			<string>SimpleDB/SimpleDB.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5B18DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B6218DA874000D2CFD2</string>
+				<string>CE372B5C18DA874000D2CFD2</string>
+				<string>CE372B5D18DA874000D2CFD2</string>
+				<string>CE372B5E18DA874000D2CFD2</string>
+				<string>CE372B5F18DA874000D2CFD2</string>
+				<string>CE372B6018DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>SNS</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5C18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSNS.h</string>
+			<key>path</key>
+			<string>SNS/AWSSNS.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5D18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSSNS.m</string>
+			<key>path</key>
+			<string>SNS/AWSSNS.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B5E18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSNSModel.h</string>
+			<key>path</key>
+			<string>SNS/AWSSNSModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B5F18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AWSSNSModel.m</string>
+			<key>path</key>
+			<string>SNS/AWSSNSModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6018DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B6118DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>SNS/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6118DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>sns-2010-03-31.json</string>
+			<key>path</key>
+			<string>SNS/Resources/sns-2010-03-31.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6218DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SNS.h</string>
+			<key>path</key>
+			<string>SNS/SNS.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6318DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B6A18DA874000D2CFD2</string>
+				<string>CE372B6418DA874000D2CFD2</string>
+				<string>CE372B6518DA874000D2CFD2</string>
+				<string>CE372B6618DA874000D2CFD2</string>
+				<string>CE372B6718DA874000D2CFD2</string>
+				<string>CE372B6818DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>SQS</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6418DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSQS.h</string>
+			<key>path</key>
+			<string>SQS/AWSSQS.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6518DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSSQS.m</string>
+			<key>path</key>
+			<string>SQS/AWSSQS.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE372B6618DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSQSModel.h</string>
+			<key>path</key>
+			<string>SQS/AWSSQSModel.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6718DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AWSSQSModel.m</string>
+			<key>path</key>
+			<string>SQS/AWSSQSModel.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6818DA874000D2CFD2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE372B6918DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Resources</string>
+			<key>path</key>
+			<string>SQS/Resources</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6918DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>name</key>
+			<string>sqs-2012-11-05.json</string>
+			<key>path</key>
+			<string>SQS/Resources/sqs-2012-11-05.json</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B6A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SQS.h</string>
+			<key>path</key>
+			<string>SQS/SQS.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE372B7318DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B1618DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7418DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B1818DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7518DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B1D18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7618DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B1F18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7718DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B2518DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7818DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B2718DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7918DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B2D18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7A18DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B2F18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7B18DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B3518DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7C18DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B3718DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7D18DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B3D18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7E18DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B3F18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B7F18DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B4518DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8018DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B4718DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8118DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B4D18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8218DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B4F18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8318DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B5518DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8418DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B5718DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8518DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B5D18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8618DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B5F18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8718DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B6518DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE372B8818DA874000D2CFD2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B6718DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE3F4D3819BFCE5A000C1A6C</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSS3PreSignedURLBuilderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE3F4D3919BFCE5A000C1A6C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE3F4D3819BFCE5A000C1A6C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE4AB8D719085CFB00E0600E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSSerialization.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE4AB8D819085CFB00E0600E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSSerialization.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE4AB8D919085CFB00E0600E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE4AB8D819085CFB00E0600E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE5312B21922DFFA005DAFA3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSDynamoDBObjectMapper.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE5312B31922DFFA005DAFA3</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSDynamoDBObjectMapper.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE5312B41922DFFA005DAFA3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5312B31922DFFA005DAFA3</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F33C18DB716B00F8C75F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE55F34218DB716B00F8C75F</string>
+				<string>CE55F33D18DB716B00F8C75F</string>
+				<string>CE7635B119BFA034005FD5D0</string>
+				<string>EA2AF763195E206B007DDDD4</string>
+				<string>CE7635BD19BFA050005FD5D0</string>
+				<string>CE55F34318DB716B00F8C75F</string>
+				<string>CE55F34618DB716B00F8C75F</string>
+				<string>CE55F35718DB716B00F8C75F</string>
+				<string>CE09860C1922A7470006EA67</string>
+				<string>CE16EED819916C5100A318A3</string>
+				<string>CE55F35D18DB716B00F8C75F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AWSCore</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F33D18DB716B00F8C75F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>38D2089219C2A67D0024D82A</string>
+				<string>38D2089319C2A67D0024D82A</string>
+				<string>CE55F33E18DB716B00F8C75F</string>
+				<string>CE55F33F18DB716B00F8C75F</string>
+				<string>CE55F34018DB716B00F8C75F</string>
+				<string>CE55F34118DB716B00F8C75F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Authentication</string>
+			<key>path</key>
+			<string>AWSCore/Authentication</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F33E18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCredentialsProvider.h</string>
+			<key>path</key>
+			<string>AWSCore/Authentication/AWSCredentialsProvider.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE55F33F18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCredentialsProvider.m</string>
+			<key>path</key>
+			<string>AWSCore/Authentication/AWSCredentialsProvider.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE55F34018DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSSignature.h</string>
+			<key>path</key>
+			<string>AWSCore/Authentication/AWSSignature.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F34118DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSSignature.m</string>
+			<key>path</key>
+			<string>AWSCore/Authentication/AWSSignature.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE55F34218DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSCore.h</string>
+			<key>path</key>
+			<string>AWSCore/AWSCore.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE55F34318DB716B00F8C75F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE55F34418DB716B00F8C75F</string>
+				<string>CE55F34518DB716B00F8C75F</string>
+				<string>CE16EEE719916C8400A318A3</string>
+				<string>CE16EEE819916C8400A318A3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Networking</string>
+			<key>path</key>
+			<string>AWSCore/Networking</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F34418DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSNetworking.h</string>
+			<key>path</key>
+			<string>AWSCore/Networking/AWSNetworking.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>CE55F34518DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSNetworking.m</string>
+			<key>path</key>
+			<string>AWSCore/Networking/AWSNetworking.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE55F34618DB716B00F8C75F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE4AB8D719085CFB00E0600E</string>
+				<string>CE4AB8D819085CFB00E0600E</string>
+				<string>CE55F34B18DB716B00F8C75F</string>
+				<string>CE55F34C18DB716B00F8C75F</string>
+				<string>CE55F34D18DB716B00F8C75F</string>
+				<string>CE55F34E18DB716B00F8C75F</string>
+				<string>CE55F34F18DB716B00F8C75F</string>
+				<string>CE55F35018DB716B00F8C75F</string>
+				<string>CE55F35118DB716B00F8C75F</string>
+				<string>CE55F35218DB716B00F8C75F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Serialization</string>
+			<key>path</key>
+			<string>AWSCore/Serialization</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F34B18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSURLRequestRetryHandler.h</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSURLRequestRetryHandler.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F34C18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AWSURLRequestRetryHandler.m</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSURLRequestRetryHandler.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F34D18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSURLRequestSerialization.h</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSURLRequestSerialization.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F34E18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSURLRequestSerialization.m</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSURLRequestSerialization.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE55F34F18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSURLResponseSerialization.h</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSURLResponseSerialization.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35018DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AWSURLResponseSerialization.m</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSURLResponseSerialization.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35118DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSValidation.h</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSValidation.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35218DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSValidation.m</string>
+			<key>path</key>
+			<string>AWSCore/Serialization/AWSValidation.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE55F35718DB716B00F8C75F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EAC25F5E195E4A4500675156</string>
+				<string>CED514031954B83B00D693F7</string>
+				<string>CED514041954B83B00D693F7</string>
+				<string>CE55F35818DB716B00F8C75F</string>
+				<string>CE55F35918DB716B00F8C75F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Service</string>
+			<key>path</key>
+			<string>AWSCore/Service</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35818DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSService.h</string>
+			<key>path</key>
+			<string>AWSCore/Service/AWSService.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35918DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>name</key>
+			<string>AWSService.m</string>
+			<key>path</key>
+			<string>AWSCore/Service/AWSService.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE55F35D18DB716B00F8C75F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE55F35E18DB716B00F8C75F</string>
+				<string>CE55F35F18DB716B00F8C75F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>XMLWriter</string>
+			<key>path</key>
+			<string>AWSCore/XMLWriter</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35E18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>AWSXMLWriter.h</string>
+			<key>path</key>
+			<string>AWSCore/XMLWriter/AWSXMLWriter.h</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F35F18DB716B00F8C75F</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>AWSXMLWriter.m</string>
+			<key>path</key>
+			<string>AWSCore/XMLWriter/AWSXMLWriter.m</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE55F37718DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B1A18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37818DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B2218DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37918DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B2A18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37B18DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B3A18DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37C18DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B4218DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37D18DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B4918DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37E18DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B5118DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F37F18DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B5918DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F38018DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B6118DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE55F38118DB7FCC00F8C75F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE372B6918DA874000D2CFD2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE571E2D1937D1F00027826E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Podfile</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.ruby</string>
+		</dict>
+		<key>CE5D83CD1857AA3100907C25</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE55F33C18DB716B00F8C75F</string>
+				<string>CE372B1318DA874000D2CFD2</string>
+				<string>CE372B1B18DA874000D2CFD2</string>
+				<string>CE372B2318DA874000D2CFD2</string>
+				<string>CE372B2B18DA874000D2CFD2</string>
+				<string>CE372B3318DA874000D2CFD2</string>
+				<string>CE372B3B18DA874000D2CFD2</string>
+				<string>CE372B4318DA874000D2CFD2</string>
+				<string>CE372B4B18DA874000D2CFD2</string>
+				<string>CE372B5318DA874000D2CFD2</string>
+				<string>CE372B5B18DA874000D2CFD2</string>
+				<string>CE372B6318DA874000D2CFD2</string>
+				<string>CE5D83DC1857AA3100907C25</string>
+				<string>CE314856187B577A0068883B</string>
+				<string>BDD11DF2193FA13600AF60E1</string>
+				<string>CE5D83D81857AA3100907C25</string>
+				<string>CE5D83D71857AA3100907C25</string>
+				<string>08CE328CA793D64CEAC80787</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE5D83CE1857AA3100907C25</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastTestingUpgradeCheck</key>
+				<string>0600</string>
+				<key>LastUpgradeCheck</key>
+				<string>0600</string>
+				<key>ORGANIZATIONNAME</key>
+				<string>Amazon Web Services</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>BDD11DED193FA13600AF60E1</key>
+					<dict>
+						<key>TestTargetID</key>
+						<string>CE5D83D51857AA3100907C25</string>
+					</dict>
+					<key>CE314851187B577A0068883B</key>
+					<dict>
+						<key>TestTargetID</key>
+						<string>CE5D83D51857AA3100907C25</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>CE5D83D11857AA3100907C25</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>CE5D83CD1857AA3100907C25</string>
+			<key>productRefGroup</key>
+			<string>CE5D83D71857AA3100907C25</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>CE5D83D51857AA3100907C25</string>
+				<string>CE314851187B577A0068883B</string>
+				<string>BDD11DED193FA13600AF60E1</string>
+				<string>EADE665F1953997D00313444</string>
+			</array>
+		</dict>
+		<key>CE5D83D11857AA3100907C25</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>CE5D83F71857AA3100907C25</string>
+				<string>CE5D83F81857AA3100907C25</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>CE5D83D21857AA3100907C25</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>CE0EFAE7193D2939002A896B</string>
+				<string>CE0EFAE8193D2939002A896B</string>
+				<string>EA2AF82C195E206B007DDDD4</string>
+				<string>38D2089419C2A67D0024D82A</string>
+				<string>CE372B7918DA874000D2CFD2</string>
+				<string>CE372B7618DA874000D2CFD2</string>
+				<string>EA2AF81C195E206B007DDDD4</string>
+				<string>CE372B8018DA874000D2CFD2</string>
+				<string>CE372B8718DA874000D2CFD2</string>
+				<string>CE372B8118DA874000D2CFD2</string>
+				<string>BDBA90BC18EE43BE004EE131</string>
+				<string>EA2AF831195E206B007DDDD4</string>
+				<string>EA2AF810195E206B007DDDD4</string>
+				<string>EA2AF833195E206B007DDDD4</string>
+				<string>EA2AF80F195E206B007DDDD4</string>
+				<string>CE372B7D18DA874000D2CFD2</string>
+				<string>EA2AF830195E206B007DDDD4</string>
+				<string>EA2AF828195E206B007DDDD4</string>
+				<string>CE16EEE219916C5100A318A3</string>
+				<string>CE7635B919BFA034005FD5D0</string>
+				<string>EA2AF83D195E206B007DDDD4</string>
+				<string>CE372B7718DA874000D2CFD2</string>
+				<string>EA2AF829195E206B007DDDD4</string>
+				<string>EA2AF81E195E206B007DDDD4</string>
+				<string>EA2AF822195E206B007DDDD4</string>
+				<string>EA2AF834195E206B007DDDD4</string>
+				<string>BDBA90BD18EE43C0004EE131</string>
+				<string>EA2AF80D195E206B007DDDD4</string>
+				<string>EA2AF83B195E206B007DDDD4</string>
+				<string>CE372B7318DA874000D2CFD2</string>
+				<string>CE372B8418DA874000D2CFD2</string>
+				<string>EA2AF81A195E206B007DDDD4</string>
+				<string>EA2AF811195E206B007DDDD4</string>
+				<string>EA2AF840195E206B007DDDD4</string>
+				<string>BDBA90C518EE4427004EE131</string>
+				<string>EA2AF824195E206B007DDDD4</string>
+				<string>EA2AF81F195E206B007DDDD4</string>
+				<string>EA2AF812195E206B007DDDD4</string>
+				<string>EA2AF820195E206B007DDDD4</string>
+				<string>EA2AF82D195E206B007DDDD4</string>
+				<string>EA2AF82E195E206B007DDDD4</string>
+				<string>CE372B7C18DA874000D2CFD2</string>
+				<string>CE372B8518DA874000D2CFD2</string>
+				<string>EA2AF80C195E206B007DDDD4</string>
+				<string>EA2AF818195E206B007DDDD4</string>
+				<string>CE7635BA19BFA034005FD5D0</string>
+				<string>CE16EEE319916C5100A318A3</string>
+				<string>BDBA90BB18EE43BA004EE131</string>
+				<string>EA2AF82F195E206B007DDDD4</string>
+				<string>CE372B8618DA874000D2CFD2</string>
+				<string>EA2AF814195E206B007DDDD4</string>
+				<string>CE372B7E18DA874000D2CFD2</string>
+				<string>CE372B7A18DA874000D2CFD2</string>
+				<string>EA2AF83A195E206B007DDDD4</string>
+				<string>EA2AF827195E206B007DDDD4</string>
+				<string>EA2AF819195E206B007DDDD4</string>
+				<string>BDBA90C018EE43C8004EE131</string>
+				<string>CE16EEE119916C5100A318A3</string>
+				<string>BDD77705193FBF6000F04070</string>
+				<string>EA2AF835195E206B007DDDD4</string>
+				<string>EA2AF813195E206B007DDDD4</string>
+				<string>BDBA90C218EE43FF004EE131</string>
+				<string>CE16EEE419916C5100A318A3</string>
+				<string>EA2AF83E195E206B007DDDD4</string>
+				<string>CE7635C519BFA050005FD5D0</string>
+				<string>BDBA90C318EE441F004EE131</string>
+				<string>CE5312B41922DFFA005DAFA3</string>
+				<string>CE372B8218DA874000D2CFD2</string>
+				<string>EA2AF815195E206B007DDDD4</string>
+				<string>EA2AF826195E206B007DDDD4</string>
+				<string>CE372B7518DA874000D2CFD2</string>
+				<string>CED6C36618EE3EC800A56FB2</string>
+				<string>CED514051954B83B00D693F7</string>
+				<string>EA2AF832195E206B007DDDD4</string>
+				<string>CE372B8818DA874000D2CFD2</string>
+				<string>EA2AF81D195E206B007DDDD4</string>
+				<string>EA2AF817195E206B007DDDD4</string>
+				<string>EA2AF837195E206B007DDDD4</string>
+				<string>BDBA90BA18EE43B6004EE131</string>
+				<string>CE372B7B18DA874000D2CFD2</string>
+				<string>EA2AF80E195E206B007DDDD4</string>
+				<string>CE372B7818DA874000D2CFD2</string>
+				<string>EA2AF839195E206B007DDDD4</string>
+				<string>EA2AF81B195E206B007DDDD4</string>
+				<string>EA2AF82B195E206B007DDDD4</string>
+				<string>CEE68C17193FB11A00259EFF</string>
+				<string>EA2AF838195E206B007DDDD4</string>
+				<string>EA2AF821195E206B007DDDD4</string>
+				<string>CE4AB8D919085CFB00E0600E</string>
+				<string>CE16EEEA19916C8400A318A3</string>
+				<string>BDBA90C118EE43D3004EE131</string>
+				<string>EA2AF83C195E206B007DDDD4</string>
+				<string>EA2AF816195E206B007DDDD4</string>
+				<string>CE372B8318DA874000D2CFD2</string>
+				<string>EA2AF836195E206B007DDDD4</string>
+				<string>CE372B7F18DA874000D2CFD2</string>
+				<string>CE23E60C19BF7CD60036EDC0</string>
+				<string>EA2AF825195E206B007DDDD4</string>
+				<string>EA2AF823195E206B007DDDD4</string>
+				<string>CE7635C619BFA050005FD5D0</string>
+				<string>EA2AF83F195E206B007DDDD4</string>
+				<string>CE372B7418DA874000D2CFD2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CE5D83D31857AA3100907C25</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>CE5D83DA1857AA3100907C25</string>
+				<string>6F8CA45C05144354BEC9C638</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CE5D83D41857AA3100907C25</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>dstPath</key>
+			<string>include/$(PRODUCT_NAME)</string>
+			<key>dstSubfolderSpec</key>
+			<string>16</string>
+			<key>files</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXCopyFilesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>CE5D83D51857AA3100907C25</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>CE5D83F91857AA3100907C25</string>
+			<key>buildPhases</key>
+			<array>
+				<string>6E52D05EBCB24E1CA70E6F9A</string>
+				<string>CE5D83D21857AA3100907C25</string>
+				<string>CE5D83D31857AA3100907C25</string>
+				<string>CE5D83D41857AA3100907C25</string>
+				<string>AAE1414ED6C74E3CAF6A84AB</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>AWSiOSSDKv2</string>
+			<key>productName</key>
+			<string>AWSiOSSDK</string>
+			<key>productReference</key>
+			<string>CE5D83D61857AA3100907C25</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>CE5D83D61857AA3100907C25</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libAWSiOSSDKv2.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>CE5D83D71857AA3100907C25</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE5D83D61857AA3100907C25</string>
+				<string>CE314852187B577A0068883B</string>
+				<string>BDD11DEE193FA13600AF60E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE5D83D81857AA3100907C25</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE5D83D91857AA3100907C25</string>
+				<string>BDD11E10193FA41F00AF60E1</string>
+				<string>F3A0CE70F1DF4EEE8E04D464</string>
+				<string>EFEAC89419295311005FEDE4</string>
+				<string>BDD39A0A193E646C00C712BD</string>
+				<string>BDD11E0E193FA40300AF60E1</string>
+				<string>BDD11E09193FA33E00AF60E1</string>
+				<string>BDD11E31193FA70C00AF60E1</string>
+				<string>CE31486C187B59220068883B</string>
+				<string>CE5D83E71857AA3100907C25</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE5D83D91857AA3100907C25</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>CE5D83DA1857AA3100907C25</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83D91857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE5D83DC1857AA3100907C25</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EADE666419539C4100313444</string>
+				<string>CE571E2D1937D1F00027826E</string>
+				<string>CE5D83DD1857AA3100907C25</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>CE5D83DD1857AA3100907C25</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSiOSSDKv2-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE5D83E71857AA3100907C25</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>XCTest.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/XCTest.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>CE5D83F71857AA3100907C25</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_MODULES_AUTOLINK</key>
+				<string>NO</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>CE5D83F81857AA3100907C25</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_MODULES_AUTOLINK</key>
+				<string>NO</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>CE5D83F91857AA3100907C25</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>CE5D83FA1857AA3100907C25</string>
+				<string>CE5D83FB1857AA3100907C25</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>CE5D83FA1857AA3100907C25</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>D479C31380205F2701CF047A</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>DSTROOT</key>
+				<string>/tmp/AWSiOSSDK.dst</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AWSiOSSDKv2-Prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>OTHER_LDFLAGS</key>
+				<string>-ObjC</string>
+				<key>PRODUCT_NAME</key>
+				<string>AWSiOSSDKv2</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>CE5D83FB1857AA3100907C25</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>961B98E1A4FE127C89540439</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>DSTROOT</key>
+				<string>/tmp/AWSiOSSDK.dst</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>AWSiOSSDKv2-Prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>OTHER_LDFLAGS</key>
+				<string>-ObjC</string>
+				<key>PRODUCT_NAME</key>
+				<string>AWSiOSSDKv2</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>CE7635B119BFA034005FD5D0</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE7635B619BFA034005FD5D0</string>
+				<string>CE7635B219BFA034005FD5D0</string>
+				<string>CE7635B319BFA034005FD5D0</string>
+				<string>CE7635B419BFA034005FD5D0</string>
+				<string>CE7635B519BFA034005FD5D0</string>
+				<string>CE7635B719BFA034005FD5D0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>CognitoIdentity</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B219BFA034005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSCognitoIdentity.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B319BFA034005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSCognitoIdentity.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B419BFA034005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSCognitoIdentityModel.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B519BFA034005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSCognitoIdentityModel.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B619BFA034005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CognitoIdentity.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B719BFA034005FD5D0</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE7635B819BFA034005FD5D0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Resources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B819BFA034005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>cib-2014-06-30.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635B919BFA034005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635B319BFA034005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635BA19BFA034005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635B519BFA034005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635BB19BFA03C005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635B819BFA034005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635BC19BFA03C005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635B819BFA034005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635BD19BFA050005FD5D0</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE7635C219BFA050005FD5D0</string>
+				<string>CE7635BE19BFA050005FD5D0</string>
+				<string>CE7635BF19BFA050005FD5D0</string>
+				<string>CE7635C019BFA050005FD5D0</string>
+				<string>CE7635C119BFA050005FD5D0</string>
+				<string>CE7635C319BFA050005FD5D0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>MobileAnalyticsERS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635BE19BFA050005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERS.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635BF19BFA050005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERS.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635C019BFA050005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERSModel.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635C119BFA050005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERSModel.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635C219BFA050005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>MobileAnalyticsERS.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635C319BFA050005FD5D0</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CE7635C419BFA050005FD5D0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Resources</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635C419BFA050005FD5D0</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>mobileanalytics-2014-06-30.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE7635C519BFA050005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635BF19BFA050005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635C619BFA050005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635C119BFA050005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635C719BFA055005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635C419BFA050005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE7635C819BFA056005FD5D0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE7635C419BFA050005FD5D0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE896C84194A8619000DBB3C</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.json</string>
+			<key>path</key>
+			<string>ec2-2014-06-15.json</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CE8FEAA218D3B18600EC90A6</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSElasticLoadBalancingTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE8FEAA318D3B18600EC90A6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE8FEAA218D3B18600EC90A6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE8FEAA518D3B62100EC90A6</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSCloudWatchTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE8FEAA618D3B62100EC90A6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE8FEAA518D3B62100EC90A6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE8FEAA718D3B84E00EC90A6</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSAutoScalingTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE8FEAA818D3B84E00EC90A6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE8FEAA718D3B84E00EC90A6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CE91D2BE18D3C03B000390D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSKinesisTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CE91D2BF18D3C03B000390D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE91D2BE18D3C03B000390D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CEB2A4A318D782F80007AAF4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSEC2Tests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CEB2A4A418D782F80007AAF4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CEB2A4A318D782F80007AAF4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CEBA14CC1921AC2F008C596A</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSDynamoDBObjectMapperTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CEBA14CD1921AC2F008C596A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CEBA14CC1921AC2F008C596A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CED514031954B83B00D693F7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSClientContext.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CED514041954B83B00D693F7</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSClientContext.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CED514051954B83B00D693F7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CED514041954B83B00D693F7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CED6C36418EE3EC800A56FB2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSS3TransferManager.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CED6C36518EE3EC800A56FB2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSS3TransferManager.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CED6C36618EE3EC800A56FB2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CED6C36518EE3EC800A56FB2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CEE68C15193FB11A00259EFF</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSKinesisRecorder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CEE68C16193FB11A00259EFF</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSKinesisRecorder.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>CEE68C17193FB11A00259EFF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CEE68C16193FB11A00259EFF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CEE68C181940000500259EFF</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSKinesisRecorderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CEE68C191940000500259EFF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CEE68C181940000500259EFF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>D479C31380205F2701CF047A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods/Pods.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF763195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF764195E206B007DDDD4</string>
+				<string>EA2AF765195E206B007DDDD4</string>
+				<string>EA2AF76C195E206B007DDDD4</string>
+				<string>EA2AF793195E206B007DDDD4</string>
+				<string>EA2AF79A195E206B007DDDD4</string>
+				<string>EA2AF79F195E206B007DDDD4</string>
+				<string>EA2AF7FA195E206B007DDDD4</string>
+				<string>EA2AF7FE195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>MobileAnalytics</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF764195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalytics.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF765195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF766195E206B007DDDD4</string>
+				<string>EA2AF767195E206B007DDDD4</string>
+				<string>EA2AF768195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>AZCommon</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF766195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConfiguration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF767195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConfiguration.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF768195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF769195E206B007DDDD4</string>
+				<string>EA2AF76A195E206B007DDDD4</string>
+				<string>EA2AF76B195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ClientContext</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF769195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsClientContext.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF76A195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSClientContext.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF76B195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSClientContext.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF76C195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF76D195E206B007DDDD4</string>
+				<string>EA2AF76E195E206B007DDDD4</string>
+				<string>EA2AF76F195E206B007DDDD4</string>
+				<string>EA2AF770195E206B007DDDD4</string>
+				<string>EA2AF771195E206B007DDDD4</string>
+				<string>EA2AF772195E206B007DDDD4</string>
+				<string>EA2AF773195E206B007DDDD4</string>
+				<string>EA2AF776195E206B007DDDD4</string>
+				<string>EA2AF780195E206B007DDDD4</string>
+				<string>EA2AF783195E206B007DDDD4</string>
+				<string>EA2AF786195E206B007DDDD4</string>
+				<string>EA2AF78D195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>core</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF76D195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsCountDownLatch.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF76E195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultContext.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF76F195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultOptions.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF770195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDelayedBlock.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF771195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsJSONSerializer.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF772195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSerializerFactory.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF773195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF774195E206B007DDDD4</string>
+				<string>EA2AF775195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>configuration</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF774195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConfigurationKeys.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF775195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsHttpCachingConfiguration.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF776195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF777195E206B007DDDD4</string>
+				<string>EA2AF778195E206B007DDDD4</string>
+				<string>EA2AF779195E206B007DDDD4</string>
+				<string>EA2AF77A195E206B007DDDD4</string>
+				<string>EA2AF77B195E206B007DDDD4</string>
+				<string>EA2AF77C195E206B007DDDD4</string>
+				<string>EA2AF77D195E206B007DDDD4</string>
+				<string>EA2AF77E195E206B007DDDD4</string>
+				<string>EA2AF77F195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>http</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF777195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsClientContextInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF778195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultHttpClient.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF779195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF77A195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultRequest.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF77B195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultResponse.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF77C195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInstanceIdInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF77D195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsLogInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF77E195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsRequestTimingInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF77F195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSDKInfoInterceptor.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF780195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF781195E206B007DDDD4</string>
+				<string>EA2AF782195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>id</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF781195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsPrefsUniqueIdService.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF782195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsRandomUUIDGenerator.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF783195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF784195E206B007DDDD4</string>
+				<string>EA2AF785195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>io</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF784195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsBufferedReader.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF785195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsWriter.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF786195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF787195E206B007DDDD4</string>
+				<string>EA2AF788195E206B007DDDD4</string>
+				<string>EA2AF789195E206B007DDDD4</string>
+				<string>EA2AF78A195E206B007DDDD4</string>
+				<string>EA2AF78B195E206B007DDDD4</string>
+				<string>EA2AF78C195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>system</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF787195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultFileManager.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF788195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsFile.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF789195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSConnectivity.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF78A195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSLifeCycleManager.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF78B195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSPreferences.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF78C195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSSystem.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF78D195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF78F195E206B007DDDD4</string>
+				<string>EA2AF790195E206B007DDDD4</string>
+				<string>EA2AF791195E206B007DDDD4</string>
+				<string>EA2AF792195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>util</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF78F195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDateUtils.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF790195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsErrorUtils.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF791195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSDKInfo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF792195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsStringUtils.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF793195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF794195E206B007DDDD4</string>
+				<string>EA2AF795195E206B007DDDD4</string>
+				<string>EA2AF796195E206B007DDDD4</string>
+				<string>EA2AF797195E206B007DDDD4</string>
+				<string>EA2AF798195E206B007DDDD4</string>
+				<string>EA2AF799195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>delivery</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF794195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConnectivityPolicy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF795195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultDeliveryClient.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF796195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDeliveryPolicyFactory.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF797195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERSRequestBuilder.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF798195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsFileEventStore.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF799195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSubmissionTimePolicy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF79A195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF79B195E206B007DDDD4</string>
+				<string>EA2AF79C195E206B007DDDD4</string>
+				<string>EA2AF79D195E206B007DDDD4</string>
+				<string>EA2AF79E195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>event</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF79B195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultEvent.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF79C195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultEventClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF79D195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultEventClient.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF79E195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsEventConstraintDecorator.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF79F195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7A0195E206B007DDDD4</string>
+				<string>EA2AF7A1195E206B007DDDD4</string>
+				<string>EA2AF7A2195E206B007DDDD4</string>
+				<string>EA2AF7A3195E206B007DDDD4</string>
+				<string>EA2AF7A4195E206B007DDDD4</string>
+				<string>EA2AF7A5195E206B007DDDD4</string>
+				<string>EA2AF7DC195E206B007DDDD4</string>
+				<string>EA2AF7E6195E206B007DDDD4</string>
+				<string>EA2AF7EC195E206B007DDDD4</string>
+				<string>EA2AF7F0195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>include</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7A0195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalytics.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7A1195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsEvent.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7A2195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsEventClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7A3195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsOptions.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7A4195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>MobileAnalytics.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7A5195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7A6195E206B007DDDD4</string>
+				<string>EA2AF7A7195E206B007DDDD4</string>
+				<string>EA2AF7A8195E206B007DDDD4</string>
+				<string>EA2AF7A9195E206B007DDDD4</string>
+				<string>EA2AF7AA195E206B007DDDD4</string>
+				<string>EA2AF7AB195E206B007DDDD4</string>
+				<string>EA2AF7AC195E206B007DDDD4</string>
+				<string>EA2AF7AD195E206B007DDDD4</string>
+				<string>EA2AF7AE195E206B007DDDD4</string>
+				<string>EA2AF7AF195E206B007DDDD4</string>
+				<string>EA2AF7B3195E206B007DDDD4</string>
+				<string>EA2AF7C2195E206B007DDDD4</string>
+				<string>EA2AF7C7195E206B007DDDD4</string>
+				<string>EA2AF7CA195E206B007DDDD4</string>
+				<string>EA2AF7D6195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>core</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7A6195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConstants.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7A7195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsCountDownLatch.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7A8195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultContext.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7A9195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultOptions.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7AA195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDelayedBlock.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7AB195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsContext.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7AC195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsJSONSerializer.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7AD195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSerializable.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7AE195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSerializerFactory.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7AF195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7B0195E206B007DDDD4</string>
+				<string>EA2AF7B1195E206B007DDDD4</string>
+				<string>EA2AF7B2195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>configuration</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7B0195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConfiguring.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7B1195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConfigurationKeys.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B2195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsHttpCachingConfiguration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B3195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7B4195E206B007DDDD4</string>
+				<string>EA2AF7B5195E206B007DDDD4</string>
+				<string>EA2AF7B6195E206B007DDDD4</string>
+				<string>EA2AF7B7195E206B007DDDD4</string>
+				<string>EA2AF7B8195E206B007DDDD4</string>
+				<string>EA2AF7B9195E206B007DDDD4</string>
+				<string>EA2AF7BA195E206B007DDDD4</string>
+				<string>EA2AF7BB195E206B007DDDD4</string>
+				<string>EA2AF7BC195E206B007DDDD4</string>
+				<string>EA2AF7BD195E206B007DDDD4</string>
+				<string>EA2AF7BE195E206B007DDDD4</string>
+				<string>EA2AF7BF195E206B007DDDD4</string>
+				<string>EA2AF7C0195E206B007DDDD4</string>
+				<string>EA2AF7C1195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>http</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7B4195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsClientContextInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B5195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultHttpClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B6195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B7195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultRequest.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B8195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultResponse.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7B9195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsHttpClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7BA195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsHttpConstants.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7BB195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInstanceIdInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7BC195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7BD195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsLogInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7BE195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsRequest.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7BF195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsRequestTimingInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7C0195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsResponse.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7C1195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSDKInfoInterceptor.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7C2195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7C3195E206B007DDDD4</string>
+				<string>EA2AF7C4195E206B007DDDD4</string>
+				<string>EA2AF7C5195E206B007DDDD4</string>
+				<string>EA2AF7C6195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>id</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7C3195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsPrefsUniqueIdService.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7C4195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsRandomUUIDGenerator.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7C5195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsUniqueIdGenerator.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7C6195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsUniqueIdService.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7C7195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7C8195E206B007DDDD4</string>
+				<string>EA2AF7C9195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>io</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7C8195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsBufferedReader.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7C9195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsWriter.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7CA195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7CB195E206B007DDDD4</string>
+				<string>EA2AF7CC195E206B007DDDD4</string>
+				<string>EA2AF7CD195E206B007DDDD4</string>
+				<string>EA2AF7CE195E206B007DDDD4</string>
+				<string>EA2AF7CF195E206B007DDDD4</string>
+				<string>EA2AF7D0195E206B007DDDD4</string>
+				<string>EA2AF7D1195E206B007DDDD4</string>
+				<string>EA2AF7D2195E206B007DDDD4</string>
+				<string>EA2AF7D3195E206B007DDDD4</string>
+				<string>EA2AF7D4195E206B007DDDD4</string>
+				<string>EA2AF7D5195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>system</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7CB195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConnectivity.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7CC195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultFileManager.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7CD195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsFile.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7CE195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsFileManager.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7CF195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSConnectivity.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7D0195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSLifeCycleManager.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7D1195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSPreferences.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7D2195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsIOSSystem.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7D3195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsLifeCycleManager.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7D4195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsPreferences.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7D5195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSystem.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7D6195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7D8195E206B007DDDD4</string>
+				<string>EA2AF7D9195E206B007DDDD4</string>
+				<string>EA2AF7DA195E206B007DDDD4</string>
+				<string>EA2AF7DB195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>util</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7D8195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDateUtils.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7D9195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsErrorUtils.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7DA195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSDKInfo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7DB195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsStringUtils.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7DC195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7DD195E206B007DDDD4</string>
+				<string>EA2AF7DE195E206B007DDDD4</string>
+				<string>EA2AF7DF195E206B007DDDD4</string>
+				<string>EA2AF7E0195E206B007DDDD4</string>
+				<string>EA2AF7E1195E206B007DDDD4</string>
+				<string>EA2AF7E2195E206B007DDDD4</string>
+				<string>EA2AF7E3195E206B007DDDD4</string>
+				<string>EA2AF7E4195E206B007DDDD4</string>
+				<string>EA2AF7E5195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>delivery</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7DD195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsConnectivityPolicy.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7DE195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultDeliveryClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7DF195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDeliveryClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E0195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDeliveryPolicy.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7E1195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDeliveryPolicyFactory.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E2195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsERSRequestBuilder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E3195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsEventStore.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7E4195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsFileEventStore.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E5195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSubmissionTimePolicy.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E6195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7E7195E206B007DDDD4</string>
+				<string>EA2AF7E8195E206B007DDDD4</string>
+				<string>EA2AF7E9195E206B007DDDD4</string>
+				<string>EA2AF7EA195E206B007DDDD4</string>
+				<string>EA2AF7EB195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>event</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7E7195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultEvent.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E8195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsEventConstraintDecorator.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7E9195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsEventObserver.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7EA195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInternalEvent.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7EB195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInternalEventClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7EC195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7ED195E206B007DDDD4</string>
+				<string>EA2AF7EE195E206B007DDDD4</string>
+				<string>EA2AF7EF195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>monetization</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7ED195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsAppleMonetizationEventBuilder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7EE195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsMonetizationEventBuilder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7EF195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsVirtualMonetizationEventBuilder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F0195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7F1195E206B007DDDD4</string>
+				<string>EA2AF7F2195E206B007DDDD4</string>
+				<string>EA2AF7F3195E206B007DDDD4</string>
+				<string>EA2AF7F4195E206B007DDDD4</string>
+				<string>EA2AF7F5195E206B007DDDD4</string>
+				<string>EA2AF7F6195E206B007DDDD4</string>
+				<string>EA2AF7F7195E206B007DDDD4</string>
+				<string>EA2AF7F8195E206B007DDDD4</string>
+				<string>EA2AF7F9195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>session</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7F1195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsActiveSessionState.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F2195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultSessionClient+SessionState.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F3195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultSessionClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F4195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInactiveSessionState.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F5195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsPausedSessionState.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F6195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSession.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7F7195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSessionClient.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7F8195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSessionClientState.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7F9195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSessionStore.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objcpp</string>
+		</dict>
+		<key>EA2AF7FA195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7FB195E206B007DDDD4</string>
+				<string>EA2AF7FC195E206B007DDDD4</string>
+				<string>EA2AF7FD195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>monetization</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7FB195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsAppleMonetizationEventBuilder.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7FC195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsMonetizationEventBuilder.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7FD195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsVirtualMonetizationEventBuilder.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7FE195E206B007DDDD4</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>EA2AF7FF195E206B007DDDD4</string>
+				<string>EA2AF800195E206B007DDDD4</string>
+				<string>EA2AF801195E206B007DDDD4</string>
+				<string>EA2AF802195E206B007DDDD4</string>
+				<string>EA2AF803195E206B007DDDD4</string>
+				<string>EA2AF804195E206B007DDDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>session</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF7FF195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsActiveSessionState.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF800195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsDefaultSessionClient.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF801195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsInactiveSessionState.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF802195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsPausedSessionState.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF803195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>lineEnding</key>
+			<string>0</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSession.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.objc</string>
+		</dict>
+		<key>EA2AF804195E206B007DDDD4</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AWSMobileAnalyticsSessionStore.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EA2AF80C195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF764195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF80D195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF767195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF80E195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF76B195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF80F195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF76D195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF810195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF76E195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF811195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF76F195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF812195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF770195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF813195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF771195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF814195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF772195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF815195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF774195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF816195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF775195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF817195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF777195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF818195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF778195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF819195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF779195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF81A195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF77A195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF81B195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF77B195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF81C195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF77C195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF81D195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF77D195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF81E195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF77E195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF81F195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF77F195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF820195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF781195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF821195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF782195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF822195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF784195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF823195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF785195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF824195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF787195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF825195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF788195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF826195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF789195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF827195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF78A195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF828195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF78B195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF829195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF78C195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF82B195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF78F195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF82C195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF790195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF82D195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF791195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF82E195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF792195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF82F195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF794195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF830195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF795195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF831195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF796195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF832195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF797195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF833195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF798195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF834195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF799195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF835195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF79B195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF836195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF79D195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF837195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF79E195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF838195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF7FB195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF839195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF7FC195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF83A195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF7FD195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF83B195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF7FF195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF83C195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF800195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF83D195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF801195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF83E195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF802195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF83F195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF803195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EA2AF840195E206B007DDDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EA2AF804195E206B007DDDD4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EAC25F5E195E4A4500675156</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AWSServiceEnum.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EADE665F1953997D00313444</key>
+		<dict>
+			<key>buildArgumentsString</key>
+			<string>$(ACTION)</string>
+			<key>buildConfigurationList</key>
+			<string>EADE66621953997D00313444</string>
+			<key>buildPhases</key>
+			<array/>
+			<key>buildToolPath</key>
+			<string>Scripts/GenerateAppleDocs.sh</string>
+			<key>buildWorkingDirectory</key>
+			<string></string>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXLegacyTarget</string>
+			<key>name</key>
+			<string>Documentation</string>
+			<key>passBuildSettingsInEnvironment</key>
+			<string>1</string>
+			<key>productName</key>
+			<string>Documentation</string>
+		</dict>
+		<key>EADE66601953997D00313444</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>DEBUGGING_SYMBOLS</key>
+				<string>YES</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>OTHER_CFLAGS</key>
+				<string></string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>EADE66611953997D00313444</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>OTHER_CFLAGS</key>
+				<string></string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>EADE66621953997D00313444</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>EADE66601953997D00313444</string>
+				<string>EADE66611953997D00313444</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>EADE666419539C4100313444</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>name</key>
+			<string>GenerateAppleDocs.sh</string>
+			<key>path</key>
+			<string>Scripts/GenerateAppleDocs.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EFEAC89419295311005FEDE4</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>compiled.mach-o.dylib</string>
+			<key>name</key>
+			<string>libsqlite3.dylib</string>
+			<key>path</key>
+			<string>usr/lib/libsqlite3.dylib</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>EFEAC89619295448005FEDE4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EFEAC89419295311005FEDE4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EFEAC897192954B2005FEDE4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CE5D83D61857AA3100907C25</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>F3A0CE70F1DF4EEE8E04D464</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>CE5D83CE1857AA3100907C25</string>
+</dict>
+</plist>

--- a/S3/AWSS3TransferManager.h
+++ b/S3/AWSS3TransferManager.h
@@ -104,6 +104,13 @@ typedef void (^AWSS3TransferManagerResumeAllBlock) (AWSRequest *request);
 - (BFTask *)resumeAll:(AWSS3TransferManagerResumeAllBlock)block;
 
 /**
+ *  Get All upload and download requests
+ *
+ *  @return AWSRequest.
+ */
+- (NSArray *)allRequests;
+
+/**
  *  Clears the local cache.
  *
  *  @return BFTask.

--- a/S3/AWSS3TransferManager.m
+++ b/S3/AWSS3TransferManager.m
@@ -628,6 +628,26 @@ NSTimeInterval const AWSS3TransferManagerAgeLimitDefault = 0.0; // Keeps the dat
     }];
 }
 
+-(NSArray *)allRequests
+{
+    NSMutableArray *keys = [NSMutableArray new];
+    [self.cache.diskCache enumerateObjectsWithBlock:^(TMDiskCache *cache, NSString *key, id<NSCoding> object, NSURL *fileURL) {
+        [keys addObject:key];
+    }];
+    
+    NSMutableArray *results = [NSMutableArray new];
+    for (NSString *key in keys) {
+        id cachedObject = [self.cache objectForKey:key];
+        if (![cachedObject isKindOfClass:[AWSRequest class]]) {
+            continue;
+        }
+        
+        [results addObject:cachedObject];
+    }
+    
+    return results;
+}
+
 - (BFTask *)clearCache {
     BFTaskCompletionSource *taskCompletionSource = [BFTaskCompletionSource new];
     [self.cache removeAllObjects:^(TMCache *cache) {


### PR DESCRIPTION
-resumeAll method in AWSS3TransferManager is not suitable for most of cases.

For example, 
I want to restore all the requests from the disk cache and leave them paused
and let user to choose some of them to resume.

So I add the -restore method.
