### PR TITLE
Fix issue where the SignIn storyboard is not found

### DIFF
--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -27,7 +27,6 @@
 #define DEFAULT_BACKGROUND_COLOR_BOTTOM [UIColor whiteColor]
 #define NAVIGATION_BAR_HEIGHT 64
 
-static NSString *const RESOURCES_BUNDLE = @"AWSAuthUI.bundle";
 static NSString *const SMALL_IMAGE_NAME = @"logo-aws-small";
 static NSString *const BIG_IMAGE_NAME = @"logo-aws-big";
 
@@ -379,7 +378,7 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
 
 + (UIImage *)getImageFromBundle:(NSString *)imageName {
     NSBundle *currentBundle = [NSBundle bundleForClass:[self class]];
-    NSURL *url = [[currentBundle resourceURL] URLByAppendingPathComponent:RESOURCES_BUNDLE];
+    NSURL *url = [currentBundle resourceURL];
     AWSDDLogDebug(@"URL: %@", url);
     
     NSBundle *assetsBundle = [NSBundle bundleWithURL:url];
@@ -396,7 +395,7 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
 
 + (UIStoryboard *)getUIStoryboardFromBundle:(NSString *)storyboardName {
     NSBundle *currentBundle = [NSBundle bundleForClass:[self class]];
-    NSURL *url = [[currentBundle resourceURL] URLByAppendingPathComponent:RESOURCES_BUNDLE];
+    NSURL *url = [currentBundle resourceURL];
     AWSDDLogDebug(@"URL: %@", url);
     
     NSBundle *resourcesBundle = [NSBundle bundleWithURL:url];


### PR DESCRIPTION
The previous code was looking for resources in a non-existent AWSAuthUI.bundle nested in the AWSAuthUI framework. This was causing an exception when the `[AWSSignInViewController getUIStoryboardFromBundle]` method was called. This change removes the call to append the AWSAuthUI.bundle to the path of the framework to load the storyboard and image resources.