### PR TITLE
JWT token claims values not only strings

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -272,7 +272,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A NSDictionary of claims in this token.
  */
-@property (nonatomic, readonly) NSDictionary<NSString *, NSString*> * claims;
+@property (nonatomic, readonly) NSDictionary<NSString *, id> * claims;
 
 @end
 

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1477,7 +1477,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     return self;
 }
 
--(NSDictionary<NSString *, NSString*> *) claims {
+-(NSDictionary<NSString *, id> *) claims {
     NSDictionary * result = nil;
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){


### PR DESCRIPTION
When trying to get JWT values which are not Strings application written in Swift crashes.