### PR TITLE
circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,109 @@
+# iOS CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/ios-migrating-from-1-2/ for more details
+#
+version: 2
+jobs:
+
+
+  release_carthage:
+    # Specify the Xcode version to use
+    macos:
+      xcode: "10.0.0"
+
+    steps: 
+      - checkout
+      - run:
+          name: upgrade carthage
+          command: brew outdated carthage || brew upgrade carthage
+      - run:
+          name: install github-release
+          command: brew install github-release
+      - run:
+          name: Build Cathage
+          command: carthage build --no-skip-current
+
+      - run:
+          name: Create Cathage Archive
+          command: bash CreateCarthageArchive.sh   
+
+      - run:
+          name: release the tag
+          command: |
+            tagdescription=$(sed -n '/## '${CIRCLE_TAG}'/,/## [0-9]*\.[0-9]*\.[0-9]/p'  CHANGELOG.md | sed '1d' | sed '$d')
+            tagname="AWS SDK for iOS "${CIRCLE_TAG}
+            github-release release -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME}  -t ${CIRCLE_TAG} -d "$tagdescription" -n "$tagname"         
+      - run:
+          name: upload file to git release 
+          command: github-release upload -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME}  -t ${CIRCLE_TAG} -f aws-sdk-ios-carthage.framework.zip -n aws-sdk-ios-carthage.framework.zip
+
+  release_cocoapods:
+    # Specify the Xcode version to use
+    macos:
+      xcode: "10.0.0"
+    steps:
+      - checkout  
+      - run:
+          name: Release cocoapods
+          command : python3    cocoapods_release.py
+  release_appledoc:
+    # Specify the Xcode version to use
+    macos:
+      xcode: "10.0.0"
+    steps:
+      - checkout  
+ 
+      - run:
+          name: Install appledoc 
+          command: |
+            pwd
+            pushd $TMPDIR
+            git clone https://github.com/tomaz/appledoc
+            cd appledoc
+            bash install-appledoc.sh -t default
+            popd 
+            pwd
+
+      - run:
+          name: generate documents
+          command: bash ./Scripts/GenerateAppleDocs.sh
+
+      - run:
+          name: copy documents
+          command: |
+            git checkout  gh-pages
+            cp -R docs/html/*   docs/reference/
+
+      - run:
+          name: checkin documents
+          command: |
+            git add docs/reference
+            git commit -m "Update document via CircleCI"
+            git push -q https://${GITHUB_TOKEN}@github.com/aws/aws-sdk-ios.git  
+
+      
+
+
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs: 
+      - release_carthage:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+.[0-9]+.[0-9]+$/
+      - release_cocoapods:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+.[0-9]+.[0-9]+$/
+      - release_appledoc:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+.[0-9]+.[0-9]+$/

--- a/CreateCarthageArchive.sh
+++ b/CreateCarthageArchive.sh
@@ -1,0 +1,15 @@
+carthage archive | tee "carthageout.txt"
+frameworkfilename=$(cat carthageout.txt |  grep -o 'Created .*\.zip$'  | grep -o   '\S*\.zip$')
+
+if [ -z  "$frameworkfilename" ];then
+	echo "Cannot find framework zip file from output of carthage archive"
+	exit 1
+fi
+
+if [ ! -f "$frameworkfilename" ]; then
+	echo "$frameworkfilename is not present"
+	exit 1
+fi
+
+mv $frameworkfilename   aws-sdk-ios-carthage.framework.zip
+

--- a/cocoapods_release.py
+++ b/cocoapods_release.py
@@ -1,0 +1,87 @@
+from subprocess import Popen, PIPE
+import subprocess
+import os
+from datetime import datetime
+import time
+
+
+
+podpackages = [
+               'AWSCore.podspec',
+               'AWSAPIGateway.podspec',
+               'AWSAutoScaling.podspec',
+               'AWSCloudWatch.podspec',
+               'AWSCognito.podspec',
+               'AWSCognitoIdentityProvider.podspec',
+               'AWSCognitoSync.podspec',
+               'AWSCognitoAuth.podspec',
+               'AWSDynamoDB.podspec',
+               'AWSEC2.podspec',
+               'AWSElasticLoadBalancing.podspec',
+               'AWSIoT.podspec',
+               'AWSKinesis.podspec',
+               'AWSKinesisVideo.podspec',
+               'AWSKinesisVideoArchivedMedia.podspec',
+               'AWSKMS.podspec',
+               'AWSLambda.podspec',
+               'AWSLogs.podspec',
+               'AWSMachineLearning.podspec',
+               'AWSMobileAnalytics.podspec',
+               'AWSPinpoint.podspec',
+               'AWSS3.podspec',
+               'AWSSES.podspec',
+               'AWSSimpleDB.podspec',
+               'AWSSNS.podspec',
+               'AWSSQS.podspec',
+               'AWSLex.podspec',
+               'AWSPolly.podspec',
+               'AWSRekognition.podspec',
+               'AWSTranslate.podspec',
+               'AWSComprehend.podspec',
+               'AWSTranscribe.podspec',
+               
+               'AWSAuthCore.podspec',
+               'AWSUserPoolsSignIn.podspec',
+               'AWSFacebookSignIn.podspec',
+               'AWSGoogleSignIn.podspec',
+               'AWSAuthUI.podspec',
+               'AWSAuth.podspec',
+               
+               'AWSMobileClient.podspec',
+               
+               'AWSiOSSDKv2.podspec',
+
+               ]
+print (str(datetime.now()) + ': publishing cocoapods ...')
+for package in podpackages:
+    print (str(datetime.now())+': publishing ' + package + ' ...')
+    process = Popen(["pod", 'trunk','push',package,'--allow-warnings'], stdout= PIPE, stderr= PIPE)
+    wait_times = 0 ;
+    while True:
+        try:
+            (output, err) = process.communicate(timeout = 10)
+        except subprocess.TimeoutExpired:
+            wait_times = wait_times + 1;
+            #tell circleci I am still alive, don't kill me
+            if wait_times % 30 == 0 :
+                print(str(datetime.now())+ ": I am still alive")
+            if wait_times > 600 :
+                print(str(datetime.now())+ ": time out")
+                quit(1)
+
+            continue
+        break
+    exit_code = process.wait()
+    if exit_code != 0 :
+        if "Unable to accept duplicate entry for:" in str(output):
+            print (str(datetime.now()) +": " +  package +" is already published")
+        else:
+            print(output)
+            print(err,  exit_code  )
+            print(str(datetime.now()) + " Failed to publish " + package)
+            quit(exit_code);
+    print (str(datetime.now())+': published ' + package)
+
+
+
+

--- a/release_cocapod.py
+++ b/release_cocapod.py
@@ -1,0 +1,26 @@
+from subprocess import Popen, PIPE
+import os
+import sys
+import re
+
+if len(sys.argv) < 2:
+    print("parameter is missed")
+    quit(1)
+packages = sys.argv[1]
+packages = re.split("[, ,]", packages)
+for package in packages:
+    if package =='':  continue
+    print ('publishing ' + package + ' ...')
+    #   process = Popen(["pod", 'trunk','push',package,'--allow-warnings'], stdout=PIPE)
+    process = Popen(["pod", 'repo','push','https://github.com/sunchunqiang/mypod-specs',package,'--allow-warnings'], stdout=PIPE)
+    (output, err) = process.communicate()
+    exit_code = process.wait()
+    if exit_code != 0 :
+        if "Unable to accept duplicate entry for:" in str(output):
+            print (package +" is already published")
+        else:
+            print(output)
+            print(err,  exit_code  )
+            print("Failed to publish " + package)
+            quit(exit_code);
+


### PR DESCRIPTION
This change is to add configuration of circleci to the repository. 
It implements three jobs 
1. release carthage framework to release tag
2. release cocoapods
3. publish appdocs

after the PR is merged and the repository is configured in circleci. the three jobs will be triggered when there is a tag push. 

To configure the repositiory on circleci, we need 
1. follow the repositiory from circleci
2. set project environment variables for COCOAPODS_TRUNK_TOKEN and GITHUB_TOKEN
 


