### PR TITLE
Change the xcode version for release carthage job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   release_carthage:
     # Specify the Xcode version to use
     macos:
-      xcode: "10.0.0"
+      xcode: "9.2.0"
 
     steps: 
       - checkout

--- a/CreateCarthageArchive.sh
+++ b/CreateCarthageArchive.sh
@@ -1,6 +1,6 @@
-# carthage archive | tee "carthageout.txt"
-frameworkfilename=$(carthage archive |  grep -o 'Created .*\.zip$'  | grep -o   '\S*\.zip$')
-
+carthage archive | tee "carthageout.txt"
+ls *.zip
+frameworkfilename=$(cat carthageout.txt |  grep -o 'Created .*\.zip$'  | grep -o   '\S*\.zip$')
 if [ -z  "$frameworkfilename" ];then
 	echo "Cannot find framework zip file from output of carthage archive"
 	exit 1


### PR DESCRIPTION
Change the xcode version from 10.0.0 to 9.2.0 for release carthage job to fix the carthage build timeout issue