### PR TITLE
fix to SFSafariViewController done button handler

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -677,9 +677,9 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
     dispatch_async(dispatch_get_main_queue(), ^{
         if(self.svc){
             [self.svc dismissViewControllerAnimated:NO completion:^{
+                dismissBlock();
                 //clean up vc
                 self.svc = nil;
-                dismissBlock();
             }];
         }else {
             dismissBlock();


### PR DESCRIPTION
Need to call the getSession completion block with an error when user hits the done.