### PR TITLE
Fix SafariViewController compatibility issue.

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -40,6 +40,7 @@ NSString *const AWSCognitoAuthErrorDomain = @"com.amazon.cognito.AWSCognitoAuthE
 
 @property (nonatomic) BOOL useSFAuthenticationSession;
 @property (nonatomic) BOOL sfAuthenticationSessionAvailable;
+@property (nonatomic) BOOL isHandlingRedirection;
 
 @end
 
@@ -537,7 +538,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
  to its initializer. It is not invoked for any subsequent page loads in the same SFSafariViewController instance.
  */
 - (void)safariViewController:(SFSafariViewController *)controller didCompleteInitialLoad:(BOOL)didLoadSuccessfully {
-    if(!didLoadSuccessfully){
+    if(!didLoadSuccessfully && !self.isHandlingRedirection){
         NSError *error = [self getError:@"Loading page failed" code:AWSCognitoAuthClientErrorLoadingPageFailed];
         if(self.getSessionBlock){
             [self completeGetSession:nil error:error];
@@ -589,6 +590,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 }
     
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+    self.isHandlingRedirection = YES;
     return [self processURL:url];
 }
 
@@ -698,6 +700,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {
+    self.isHandlingRedirection = NO;
     NSError * error;
     NSDictionary *result = [NSJSONSerialization JSONObjectWithData:self.responseData options:kNilOptions error:&error];
     if(error){


### PR DESCRIPTION
safariViewController:didCompleteInitialLoad: will always return NO for didLoadSuccessfully when the webUI immediately calls the redirect url. (ie Facebook does this when user is already logged in.) This fix prevents the SFSafarVC error handling blocks getting called which will prevent with the oauth2/token success callback being called.

This behavior has been reported in the past by other when Google is used as Identity Provider: https://github.com/aws-amplify/aws-sdk-ios/issues/857