### PR TITLE
Fixed S3 compatible endpoint signature issues

### DIFF
--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -150,25 +150,26 @@ NSString *const AWSSignatureV4Terminator = @"aws4_request";
 
 - (AWSTask *)interceptRequest:(NSMutableURLRequest *)request {
     [request addValue:request.URL.host forHTTPHeaderField:@"Host"];
+    
     return [[self.credentialsProvider credentials] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCredentials *> * _Nonnull task) {
         AWSCredentials *credentials = task.result;
         // clear authorization header if set
         [request setValue:nil forHTTPHeaderField:@"Authorization"];
 
         if (credentials) {
-            NSString *authorization;
-            NSArray *hostArray  = [[[request URL] host] componentsSeparatedByString:@"."];
-
             [request setValue:credentials.sessionKey forHTTPHeaderField:@"X-Amz-Security-Token"];
-            if ([hostArray firstObject] && [[hostArray firstObject] rangeOfString:@"s3"].location != NSNotFound) {
-                //If it is a S3 Request
+            
+            NSString *authorization;
+            
+            if (self.endpoint.serviceType == AWSServiceS3) {
+                // If it is a S3 Request
                 authorization = [self signS3RequestV4:request
-                                         credentials:credentials];
+                                          credentials:credentials];
             } else {
                 authorization = [self signRequestV4:request
-                                       credentials:credentials];
+                                        credentials:credentials];
             }
-
+            
             if (authorization) {
                 [request setValue:authorization forHTTPHeaderField:@"Authorization"];
             }


### PR DESCRIPTION
Now properly checking service type when generating authorization header.

I've tested support for DigitalOcean Spaces S3 compatible API.