### PR TITLE
Try to map the signIn errors using the existing getMobileError helper…

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -401,7 +401,7 @@ extension AWSMobileClient {
         } else {
             user!.getSession(username, password: password, validationData: validationAttributes).continueWith { (task) -> Any? in
                 if let error = task.error {
-                    self.userpoolOpsHelper.currentSignInHandlerCallback?(nil, error)
+                    self.userpoolOpsHelper.currentSignInHandlerCallback?(nil, self.getMobileError(for: error))
                     self.userpoolOpsHelper.currentSignInHandlerCallback = nil
                 } else if let result = task.result {
                     self.internalCredentialsProvider?.clearCredentials()


### PR DESCRIPTION
When an error occurs in a signIn request, the SDK tries to map the error using getMobileError helper function improving the error handling for the developers.