### PR TITLE
Fix for 'Could not find a storyboard named 'AWSUserPools'

### DIFF
--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/AWSUserPoolsUIOperations.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/AWSUserPoolsUIOperations.m
@@ -157,7 +157,7 @@ completionHandler:(nonnull void (^)(id _Nullable, NSError * _Nullable))completio
 
 + (UIStoryboard *)getUIStoryboardFromBundle:(NSString *)storyboardName {
     NSBundle *currentBundle = [NSBundle bundleForClass:[self class]];
-    NSURL *url = [[currentBundle resourceURL] URLByAppendingPathComponent:RESOURCES_BUNDLE];
+    NSURL *url = [currentBundle resourceURL];
     AWSDDLogDebug(@"URL: %@", url);
     
     NSBundle *resourcesBundle = [NSBundle bundleWithURL:url];


### PR DESCRIPTION
After applying patch #1013 successfully I encountered a similar issue for another storyboard:

When tapping on the 'Create new account' link or the 'Forgot your password?' link in the Sign In UI my test app crashes because the AWSUserPools storyboard was not found.

This patch solves the issue, the applied solution is similar to te patch #1013  