### PR TITLE
Add ability to set keychain service and access group

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -203,6 +203,21 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
            identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager;
 
 /**
+ Initializer for credentials provider with enhanced authentication flow. This is the recommended method for first time Amazon Cognito developers. Will create an instance of `AWSEnhancedCognitoIdentityProvider`.
+ 
+ @param regionType The region in which your identity pool exists.
+ @param identityPoolId The identity pool id for this provider. Value is used to communicate with Amazon Cognito as well as namespace values stored in the keychain.
+ @param identityProviderManager An object that conforms to the `AWSIdentityProviderManager` protocol. It should return a valid `login` dictionary when requested. Can be nil if identity is unauthenticated.
+ @param keychainService A key whose value is a string indicating the keychain service to store credentials.
+ @param keychainAccessGroup A key whose value is a string indicating the keychaing access group to store credentials.
+ */
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+           identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager
+                   keychainService:(nullable NSString *)keychainService
+               keychainAccessGroup:(nullable NSString *)keychainAccessGroup;
+
+/**
  Initializer for credentials provider with pre-created `AWSCognitoCredentialsProviderHelper`. Use this method when using developer authenticated identities.
 
  @param regionType The region in which your identity pool exists.
@@ -210,6 +225,19 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
  */
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
                   identityProvider:(id<AWSCognitoCredentialsProviderHelper>)identityProvider;
+
+/**
+ Initializer for credentials provider with pre-created `AWSCognitoCredentialsProviderHelper`. Use this method when using developer authenticated identities.
+ 
+ @param regionType The region in which your identity pool exists.
+ @param identityPoolId The identity pool id for this provider. Value is used to communicate with Amazon Cognito as well as namespace values stored in the keychain.
+ @param keychainService A key whose value is a string indicating the keychain service to store credentials.
+ @param keychainAccessGroup A key whose value is a string indicating the keychaing access group to store credentials.
+ */
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+                   keychainService:(nullable NSString *)keychainService
+               keychainAccessGroup:(nullable NSString *)keychainAccessGroup;
 
 /**
  Initializer for credentials provider with pre-created `AWSCognitoCredentialsProviderHelper`. Only use this method if you need to set your IAM roles client side and use developer authenticated identities

--- a/AWSCore/Service/AWSInfo.m
+++ b/AWSCore/Service/AWSInfo.m
@@ -22,6 +22,8 @@ NSString *const AWSInfoDefault = @"Default";
 
 static NSString *const AWSInfoRoot = @"AWS";
 static NSString *const AWSInfoCredentialsProvider = @"CredentialsProvider";
+static NSString *const AWSInfoKeychainService = @"KeychainService";
+static NSString *const AWSInfoKeychainAccessGroup = @"KeychainAccessGroup";
 static NSString *const AWSInfoRegion = @"Region";
 static NSString *const AWSInfoUserAgent = @"UserAgent";
 static NSString *const AWSInfoCognitoIdentity = @"CognitoIdentity";
@@ -90,9 +92,13 @@ static NSString *const AWSInfoIdentityManager = @"IdentityManager";
         NSDictionary <NSString *, id> *defaultCredentialsProviderDictionary = [[[_rootInfoDictionary objectForKey:AWSInfoCredentialsProvider] objectForKey:AWSInfoCognitoIdentity] objectForKey:AWSInfoDefault];
         NSString *cognitoIdentityPoolID = [defaultCredentialsProviderDictionary objectForKey:AWSInfoCognitoIdentityPoolId];
         AWSRegionType cognitoIdentityRegion =  [[defaultCredentialsProviderDictionary objectForKey:AWSInfoRegion] aws_regionTypeValue];
+        NSString *keychainService = [defaultCredentialsProviderDictionary objectForKey:AWSInfoKeychainService];
+        NSString *keychainAccessGroup = [defaultCredentialsProviderDictionary objectForKey:AWSInfoKeychainAccessGroup];
         if (cognitoIdentityPoolID && cognitoIdentityRegion != AWSRegionUnknown) {
             _defaultCognitoCredentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:cognitoIdentityRegion
-                                                                                            identityPoolId:cognitoIdentityPoolID];
+                                                                                            identityPoolId:cognitoIdentityPoolID
+                                                                                           keychainService:keychainService
+                                                                                       keychainAccessGroup:keychainAccessGroup];
         }
         
         _defaultRegion = [[defaultInfoDictionary objectForKey:AWSInfoRegion] aws_regionTypeValue];


### PR DESCRIPTION
iOS allows to share data between "apps" / "apps and extensions", e.g. keychain data or files in folders.

AWS iOS SDK doesn't allow to share credentials between apps, but it can be easily achieved with keychain access groups.

This PR allows developers to set keychain service and access group to achieve sharing the same session between apps.