### PR TITLE
change release-sdk process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,22 @@ jobs:
       - store_artifacts:
           path: integration_test_result
 
+  release_tag:
+    # Specify the Xcode version to use
+    macos:
+      xcode: "10.1.0"
+    steps: 
+      - checkout
+      - run:
+          name: install github-release
+          command: brew install github-release                
+      - run:
+          name: release the tag
+          command: |
+            tagdescription=$(sed -n '/## '${CIRCLE_TAG}'/,/## [0-9]*\.[0-9]*\.[0-9]/p'  CHANGELOG.md | sed '1d' | sed '$d')
+            tagname="AWS SDK for iOS "${CIRCLE_TAG}
+            echo "$tagdescription" | github-release release -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME}  -t ${CIRCLE_TAG}  --name  "$tagname" -d -         
+
   release_carthage:
     # Specify the Xcode version to use
     macos:
@@ -113,12 +129,6 @@ jobs:
       - run:
           name: Create Carthage Archive
           command: bash CreateCarthageArchive.sh   
-      - run:
-          name: release the tag
-          command: |
-            tagdescription=$(sed -n '/## '${CIRCLE_TAG}'/,/## [0-9]*\.[0-9]*\.[0-9]/p'  CHANGELOG.md | sed '1d' | sed '$d')
-            tagname="AWS SDK for iOS "${CIRCLE_TAG}
-            github-release release -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME}  -t ${CIRCLE_TAG} -d "$tagdescription" -n "$tagname"         
       - run:
           name: upload file to git release 
           command: github-release upload -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME}  -t ${CIRCLE_TAG} -f aws-sdk-ios-carthage.framework.zip -n aws-sdk-ios-carthage.framework.zip
@@ -179,14 +189,14 @@ jobs:
           name: generate jazzy documents
           command: |
             currentversion=${CIRCLE_TAG}
-            bash ./Scripts/AWSMobileClientAPIRererence.sh $currentversion
+            bash ./Scripts/AWSMobileClientAPIReference.sh $currentversion
       - run:
           name: copy jazzy documents
           command: |
             git config --local user.name "AWS"
             git checkout  gh-pages
-            mkdir docs/reference/AWSMobileClient
-            cp -R docs/api/* docs/reference/AWSMobileClient
+            mkdir -p docs/reference/AWSMobileClient     
+            cp -R docs/api/* docs/reference/AWSMobileClient               
       - run:
           name: checkin jazzy documents
           command: |
@@ -274,7 +284,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
-      - release_carthage:
+      - release_tag:
           requires:
             - unittest  
             - integrationtest
@@ -283,10 +293,17 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
+      - release_carthage:
+          requires:
+            - release_tag  
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+.[0-9]+.[0-9]+$/
       - release_cocoapods:
           requires:
-            - unittest     
-            - integrationtest    
+            - release_tag       
           filters:
             branches:
               ignore: /.*/
@@ -294,8 +311,8 @@ workflows:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
       - release_appledoc:
           requires:
-            - unittest          
-            - integrationtest
+            - release_carthage          
+            - release_cocoapods
           filters:
             branches:
               ignore: /.*/

--- a/Scripts/AWSMobileClientAPIReference.sh
+++ b/Scripts/AWSMobileClientAPIReference.sh
@@ -1,0 +1,17 @@
+
+sdkversion=$1
+jazzy \
+  --clean \
+  --author AWS \
+  --author_url https://github.com/aws-amplify/aws-sdk-ios \
+  --github_url https://github.com/aws-amplify/aws-sdk-ios \
+  --module-version $sdkversion \
+  --framework-root AWSAuthSDK/ \
+  --exclude=AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift \
+  --xcodebuild-arguments -project,AWSAuthSDK/AWSAuthSDK.xcodeproj,-scheme,AWSMobileClient \
+  --module AWSMobileClient \
+  --min-acl public \
+  --root-url https://github.com/aws-amplify/aws-sdk-ios/docs/reference/AWSMobileClient \
+  --output docs/api
+
+open docs/api/index.html


### PR DESCRIPTION
1. change workflow of release-sdk so that only release-carthage and release-cocoapods are finished, can release-appdoc job be started

2. split release-tag job from release-carthage job

3. use pipeline to input release description to github-release command instead of using parameter so that special characters can be supported in release description
