### PR TITLE
Fixes memory leaks in IoT

### DIFF
--- a/AWSCore/Networking/AWSNetworking.m
+++ b/AWSCore/Networking/AWSNetworking.m
@@ -86,6 +86,13 @@ NSString *const AWSNetworkingErrorDomain = @"com.amazonaws.AWSNetworkingErrorDom
 - (AWSTask *)sendRequest:(AWSNetworkingRequest *)request {
     return [self.networkManager dataTaskWithRequest:request];
 }
+
+- (void)dealloc {
+    // If this is being released, the network manager should be notified so it can invalidate
+    // its NSURLSession to avoid a memory leak.
+    [_networkManager invalidate];
+}
+
 @end
 
 #pragma mark - AWSNetworkingConfiguration

--- a/AWSCore/Networking/AWSURLSessionManager.h
+++ b/AWSCore/Networking/AWSURLSessionManager.h
@@ -24,4 +24,11 @@
 
 - (AWSTask *)dataTaskWithRequest:(AWSNetworkingRequest *)request;
 
+/**
+ Invalidates the underlying NSURLSession to avoid memory leaks.
+ 
+ @warning Before calling this method, make sure no method is running on this manager.
+ */
+- (void)invalidate;
+
 @end

--- a/AWSCore/Networking/AWSURLSessionManager.m
+++ b/AWSCore/Networking/AWSURLSessionManager.m
@@ -204,6 +204,11 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
     }];
 }
 
+- (void)invalidate {
+    // Invalidate the session so its strong reference to self is released.
+    [_session invalidateAndCancel];
+}
+
 #pragma mark - NSURLSessionTaskDelegate
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)sessionTask didCompleteWithError:(NSError *)error {

--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -99,7 +99,7 @@
 /**
  An optional associated object (nil by default).
  */
-@property(nonatomic, strong) NSObject *associatedObject;
+@property(nonatomic, weak) NSObject *associatedObject;
 
 /**
  Initalizer with the Delegate object


### PR DESCRIPTION
Similar to earlier PR with another memory leak fixed and target most recent SDK version.

After removing an `AWSIoTDataManager`, the `AWSIoTDataManager`, `AWSIoTMQTTClient`, `AWSURLSessionManager` and other related entities were leaked.

This fixes a retain cycle between the `AWSIoTMQTTClient` where it held a strong reference to the `associatedObject` the `AWSIoTDataManager` which was holding a strong reference to the `mqttClient`. This makes the `associatedObject` reference weak.

If an `AWSIoTDataManager` was disconnected before the `connectionAgeInSeconds` exceeded the `minimumConnectionTime` the `connectionAgeTimer` was never invalidated and held a strong reference to the `AWSIoTMQTTClient` (e.g. `self` passed to the timer on creation of the timer). This fixes the issue by issuing an `invalidate` to the timer on the correct thread in the event the user requests a disconnect before reaching the `minimumConnectionTime`.

The `AWSURLSessionManager` creates and passes `self` to an `NSURLSession` but never invalidated the session to release the strong reference to `self`. `AWSNetworking` could be released but the `AWSURLSessionManager` leaked being held by the `NSURLSession`. This is fixed by having the `AWSNetworking` let the `AWSURLSessionManager` know it needs to invalidate the session when it is being released, as none of them should be needed after the `AWSNetworking` creating them is released.

The `reconnectTimer` was invalidated on whatever thread `disconnect` was called on rather than the `reconnectThread` causing a memory leak; this is fixed by having the `reconnectTimer` invalidated on the correct thread.