### PR TITLE
Return error in `submitRecordsForStream:...` when `putRecord:` errors

### DIFF
--- a/AWSKinesis/AWSFirehoseRecorder.m
+++ b/AWSKinesis/AWSFirehoseRecorder.m
@@ -181,8 +181,8 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 
             if (task.error && [stopErrorDomains containsObject:task.error.domain]) {
                 *stop = YES;
-                return [AWSTask taskWithError:task.error];
             }
+            return [AWSTask taskWithError:task.error];
         }
         if (task.result) {
             AWSFirehosePutRecordBatchOutput *putRecordBatchOutput = task.result;


### PR DESCRIPTION
This matches the behavior of `AWSKinesisRecorder.m` and will save other souls from hours of wondering why `continueWith:` is never called.