### PR TITLE
Fix memory leaks in MQTT client

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -99,7 +99,7 @@
 /**
  An optional associated object (nil by default).
  */
-@property(nonatomic, strong) NSObject *associatedObject;
+@property(nonatomic, weak) NSObject *associatedObject;
 
 /**
  Initalizer with the Delegate object


### PR DESCRIPTION
IoT framework side of fixes needed to avoid memory leaks. Core changes will still be needed to fully eliminate leaking IoT objects, though.

After removing an `AWSIoTDataManager`, the `AWSIoTDataManager`, `AWSIoTMQTTClient`, `AWSURLSessionManager` and other related entities were leaked.

This fixes a retain cycle between the `AWSIoTMQTTClient` where it held a strong reference to the `associatedObject` the `AWSIoTDataManager` which was holding a strong reference to the `mqttClient`. This makes the `associatedObject` reference weak.

If an `AWSIoTDataManager` was disconnected before the `connectionAgeInSeconds` exceeded the `minimumConnectionTime` the `connectionAgeTimer` was never invalidated and held a strong reference to the `AWSIoTMQTTClient` (e.g. `self` passed to the timer on creation of the timer). This fixes the issue by issuing an `invalidate` to the timer on the correct thread in the event the user requests a disconnect before reaching the `minimumConnectionTime`.

The `reconnectTimer` was invalidated on whatever thread `disconnect` was called on rather than the `reconnectThread` causing a memory leak; this is fixed by having the `reconnectTimer` invalidated on the correct thread.

To fully fix IoT entities leaking #1203 has additional changes needed.