### PR TITLE
Fix URL session having a 0 timeoutIntervalForResource when using a custom AWSS3TransferUtility

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -420,7 +420,7 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
         //Create the NS URL session
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:_sessionIdentifier];
         configuration.allowsCellularAccess = serviceConfiguration.allowsCellularAccess;
-        configuration.timeoutIntervalForResource = _transferUtilityConfiguration.timeoutIntervalForResource;
+        configuration.timeoutIntervalForResource = transferUtilityConfiguration.timeoutIntervalForResource;
         
         if(serviceConfiguration.timeoutIntervalForRequest > 0){
             configuration.timeoutIntervalForRequest = serviceConfiguration.timeoutIntervalForRequest;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

When registering a custom `AWSS3TransferUtility` with a custom set of `AWSS3TransferUtilityConfiguration`, the internal `NSURLSessionConfiguration` that is created has its `timeoutIntervalForResource` set to 0 instead of the incoming value as the `timeoutIntervalForResource` is pulled from the existing ivar, `_transferUtilityConfiguration`, which hasn't been initialized yet.

This can be reproduced with the following code:

```
let credentialProvider = AWSCognitoCredentialsProvider(regionType: YOUR-IDENTITY-POOL-REGION, identityPoolId: "YOUR-IDENTITY-POOL-ID")

let configuration = AWSServiceConfiguration(region: .USEast1, credentialsProvider: credentialProvider)

let transferUtilityConfig = AWSS3TransferUtilityConfiguration()
transferUtilityConfig.timeoutIntervalForResource = 15 * 60

AWSS3TransferUtility.register(with: configuration,
                              transferUtilityConfiguration: transferUtilityConfig,
                              forKey: "custom-transfer-utility")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
