### PR TITLE
add swift functions for TOTP MFA for the mobile client

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -239,7 +239,7 @@ extension AWSMobileClient {
         return UserPoolOperationsHandler.sharedInstance
     }
     
-    internal var userPoolClient: AWSCognitoIdentityUserPool? {
+    public var userPoolClient: AWSCognitoIdentityUserPool? {
         return self.userpoolOpsHelper.userpoolClient
     }
     

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift
@@ -178,7 +178,7 @@ public struct ForgotPasswordResult {
     public let forgotPasswordState: ForgotPasswordState
     public let codeDeliveryDetails: UserCodeDeliveryDetails?
     
-    internal init(forgotPasswordState: ForgotPasswordState, codeDeliveryDetails: UserCodeDeliveryDetails?) {
+    public init(forgotPasswordState: ForgotPasswordState, codeDeliveryDetails: UserCodeDeliveryDetails?) {
         self.forgotPasswordState = forgotPasswordState
         self.codeDeliveryDetails = codeDeliveryDetails
     }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileResults.swift
@@ -157,6 +157,7 @@ extension AWSMobileClient {
 /// Indicates sign in state of the user in the sign in process.
 public enum SignInState: String {
     case unknown = "UNKNOWN"
+    case totpMFASetupRequired = "MFAS_CAN_SETUP"
     case smsMFA = "CONFIRMATION_CODE"
     case passwordVerifier = "PASSWORD_VERIFIER"
     case customChallenge = "CUSTOM_CHALLENGE"

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -29,6 +29,10 @@ protocol UserPoolAuthHelperlCallbacks {
     
     func didCompleteNewPasswordStepWithError(_ error: Error?)
     
+    func getSoftwareMfaSetupDetails(_ softwareMfaSetupInput: AWSCognitoIdentitySoftwareMfaSetupRequiredInput, softwareMfaSetupRequiredCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentitySoftwareMfaSetupRequiredDetails>)
+    
+    func didCompleteMfaSetupStepWithError(_ error: Error?)
+    
     func getCode(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput, mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>)
     
     func didCompleteMultifactorAuthenticationStepWithError(_ error: Error?)
@@ -53,6 +57,9 @@ internal class UserPoolOperationsHandler: NSObject, AWSCognitoIdentityInteractiv
     internal var mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>?
     
     internal var currentSignInHandlerCallback: ((SignInResult?, Error?) -> Void)?
+    
+    internal var softwareMfaSetupInput: AWSCognitoIdentitySoftwareMfaSetupRequiredInput?
+    internal var mfaSetupCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentitySoftwareMfaSetupRequiredDetails>?
     
     var authHelperDelegate: UserPoolAuthHelperlCallbacks?
     
@@ -80,6 +87,10 @@ internal class UserPoolOperationsHandler: NSObject, AWSCognitoIdentityInteractiv
     
     internal func setAuthHelperDelegate(authHelperDelegate: UserPoolAuthHelperlCallbacks) {
         self.authHelperDelegate = authHelperDelegate
+    }
+    
+    internal func startSoftwareMfaSetupRequired() -> AWSCognitoIdentitySoftwareMfaSetupRequired {
+        return self
     }
 }
 
@@ -115,5 +126,16 @@ extension UserPoolOperationsHandler: AWSCognitoIdentityMultiFactorAuthentication
     
     public func didCompleteMultifactorAuthenticationStepWithError(_ error: Error?) {
         self.authHelperDelegate?.didCompleteMultifactorAuthenticationStepWithError(error)
+    }
+}
+
+extension UserPoolOperationsHandler: AWSCognitoIdentitySoftwareMfaSetupRequired {
+    func getSoftwareMfaSetupDetails(_ softwareMfaSetupInput: AWSCognitoIdentitySoftwareMfaSetupRequiredInput, softwareMfaSetupRequiredCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentitySoftwareMfaSetupRequiredDetails>) {
+        self.softwareMfaSetupInput = softwareMfaSetupInput
+        self.authHelperDelegate?.getSoftwareMfaSetupDetails(softwareMfaSetupInput, softwareMfaSetupRequiredCompletionSource: softwareMfaSetupRequiredCompletionSource)
+    }
+    
+    func didCompleteMfaSetupStepWithError(_ error: Error?) {
+        self.authHelperDelegate?.didCompleteMfaSetupStepWithError(error)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
No issue #, just added functionality as I needed it and adding it to the repo. I'll add details here about things that I've addressed.

*Description of changes:*

### Prelim
When using AWS Cognito MFA, I went to use TOTP MFA. When setting up my app, the pod produced a crash due to MFA setup steps not completing.

Specifically, the`if` in line 381 in `AWSCognitoIdentityUser.m` fails, resulting in an error

_failing `if`_:
```
if ([self.pool.delegate respondsToSelector:@selector(startSoftwareMfaSetupRequired)])
```
_error produced_:
```
[AWSTask taskWithError:[NSError errorWithDomain:AWSCognitoIdentityProviderErrorDomain code:AWSCognitoIdentityProviderClientErrorInvalidAuthenticationDelegate userInfo:@{NSLocalizedDescriptionKey: @"startSoftwareMfaSetupRequired not implemented by authentication delegate"}]]
```

As a result, a crash occurs during the force unwrap in `AWSMobileClientExtensions.swift` of `let message = (error as NSError).userInfo["message"] as! String` since there's no userInfo entry for `message`.
```
internal func getMobileError(for error: Error) -> Error {
    if error._domain == AWSCognitoIdentityProviderErrorDomain {
        let message = (error as NSError).userInfo["message"] as! String
        let type = (error as NSError).userInfo["__type"] as! String
        let mobileError = AWSMobileClient.ErrorMappingHelper(errorCode: type, message: message, error: error as NSError)
        return mobileError
    }
    return error
}
```

### Fixes
I fixed the crash by implementing the required functionality to get TOTP MFA working properly. (I did not address the mismatch between the error and `getMobileError` function). As a result of responding to `startSoftwareMfaSetupRequired`, the first if clause on line 381 of `AWSCognitoIdentityUser.m` succeeds and I avoid the error altogether.

The bulk of this PR is replicating the pattern used throughout the swift mobile client for TOTP MFA handling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.