### PR TITLE
Cast error to AWSMobileClientError when using `changePassword` API.

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -663,7 +663,7 @@ extension AWSMobileClient {
     public func changePassword(currentPassword: String, proposedPassword: String, completionHandler: @escaping ((Error?) -> Void)) {
         self.userpoolOpsHelper.currentActiveUser!.changePassword(currentPassword, proposedPassword: proposedPassword).continueWith { (task) -> Any? in
             if let error = task.error {
-                completionHandler(error)
+                completionHandler(self.getMobileError(for: error))
             } else if let _ = task.result {
                 completionHandler(nil)
             }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -670,6 +670,11 @@ class AWSMobileClientTests: XCTestCase {
         let changePasswordExpectation = expectation(description: "Change password should fail")
         AWSMobileClient.sharedInstance().changePassword(currentPassword: "WronPassword", proposedPassword: "NewPassword123!@") { (error) in
             XCTAssertNotNil(error)
+            guard let _ = error as? AWSMobileClientError else {
+                XCTFail("Error should be of type AWSMobileClientError")
+                changePasswordExpectation.fulfill()
+                return
+            }
             changePasswordExpectation.fulfill()
         }
         wait(for: [changePasswordExpectation], timeout: 5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # AWS Mobile SDK for iOS CHANGELOG
 
+## 2.9.4
+
+### Bug Fixes
+ 
+* **AWSMobileClient**
+  * Fixed issue where error was not correctly cast to `AWSMobileClientError` when using `changePassword` API. [issue #1246](https://github.com/aws-amplify/aws-sdk-ios/issues/1246)
+
 ## 2.9.3
 
 ### New Features


### PR DESCRIPTION
*Issue #, if available:*
#1246 

*Description of changes:*
- Cast error to AWSMobileClientError for `changePassword` API.
- Update test to check for type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
