### PR TITLE
Additional stability fixes

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -754,7 +754,13 @@
             self.connectionAgeTimer = nil;
         }
         [self.session close];
-    
+        
+        if ( self.webSocket) {
+            [self.toDecoderStream close];
+            [self.webSocket close];
+            self.webSocket = nil;
+        }
+
         //Set status
         self.mqttStatus = AWSIoTMQTTStatusDisconnected;
         

--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTSession.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTSession.m
@@ -138,12 +138,7 @@
 }
 
 -(void)disconnect {
-    if (timer != nil) {
-        [timer invalidate];
-        timer = nil;
-    }
     [self send:AWSMQTTMessage.disconnectMessage];
-
 }
 
 - (void)close {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 -  Removed the Timer invalidation from the disconnect logic as it needs to be called on the same thread that created the Timer.
-  closed toDecoderStream and WebSocket when the RunLoop is ended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
