### PR TITLE
Update AWSFacebookSingIn dependency. Initial solution for #1397

### DIFF
--- a/AWSFacebookSignIn.podspec
+++ b/AWSFacebookSignIn.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
                       :tag => s.version}
    s.requires_arc = true
    s.dependency 'AWSAuthCore', '2.9.4'
-   s.dependency 'FBSDKLoginKit', '~> 4.0'
-   s.dependency 'FBSDKCoreKit', '~> 4.0'
+   s.dependency 'FBSDKLoginKit', '<= 4.42'
+   s.dependency 'FBSDKCoreKit', '<= 4.42'
    s.source_files = 'AWSAuthSDK/Sources/AWSFacebookSignIn/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSFacebookSignIn/*.h'
    s.resource_bundle = {  'AWSFacebookSignIn' => 'AWSAuthSDK/Sources/AWSFacebookSignIn/Images.xcassets' }


### PR DESCRIPTION
*Issue:*
#1397 

*Description of changes:*
FBSDK ChangeLog for reference: https://github.com/facebook/facebook-objc-sdk/blob/master/CHANGELOG.md#4430
`[FBSDKLoginManager renewSystemCredentials]` was deleted immediately after deprecation. To ensure releases go through for next minor version introducing this change. Eventual solution is a breaking change requiring user to login. Will submit a separate PR for that.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
