### PR TITLE
[Cognito][S3] Fix imports from AWSCore

### DIFF
--- a/AWSCognito/AWSCognitoService.m
+++ b/AWSCognito/AWSCognitoService.m
@@ -30,8 +30,8 @@
 #import <AWSCore/AWSSynchronizedMutableDictionary.h>
 #import <AWSCore/AWSInfo.h>
 
-#import "FABKitProtocol.h"
-#import "Fabric+FABKits.h"
+#import <AWSCore/FABKitProtocol.h>
+#import <AWSCore/Fabric+FABKits.h>
 
 static NSString *const AWSInfoCognito = @"Cognito";
 NSString *const AWSCognitoSDKVersion = @"2.9.5";

--- a/AWSCognito/AWSCognitoService.m
+++ b/AWSCognito/AWSCognitoService.m
@@ -30,8 +30,8 @@
 #import <AWSCore/AWSSynchronizedMutableDictionary.h>
 #import <AWSCore/AWSInfo.h>
 
-#import <AWSCore/FABKitProtocol.h>
-#import <AWSCore/Fabric+FABKits.h>
+#import "FABKitProtocol.h"
+#import "Fabric+FABKits.h"
 
 static NSString *const AWSInfoCognito = @"Cognito";
 NSString *const AWSCognitoSDKVersion = @"2.9.5";

--- a/AWSCore/AWSCore.h
+++ b/AWSCore/AWSCore.h
@@ -58,6 +58,7 @@ FOUNDATION_EXPORT const unsigned char AWSCoreVersionString[] DEPRECATED_MSG_ATTR
 #import "AWSURLRequestRetryHandler.h"
 #import "AWSValidation.h"
 #import "AWSInfo.h"
+#import "AWSXMLDictionary.h"
 
 #import "AWSBolts.h"
 #import "AWSGZIP.h"

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -16,7 +16,7 @@
 #import "AWSS3TransferUtility.h"
 #import "AWSS3PreSignedURL.h"
 #import "AWSS3Service.h"
-#import "AWSXMLDictionary.h"
+#import <AWSCore/AWSXMLDictionary.h>
 #import "AWSS3TransferUtilityDatabaseHelper.h"
 #import "AWSS3TransferUtilityTasks.h"
 


### PR DESCRIPTION
Description of changes:
When trying to compile these dependencies as separate projects, I found that there were some headers from `AWSCore` that were being imported as local headers in in `AWSCognito` and `AWSS3` projects, instead of as part of `AWSCore`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.