### PR TITLE
Swift 5/Xcode 10.2 compatibility

### DIFF
--- a/AWSDynamoDBTests/AWSDynamoDBObjectMapperSwiftTests.swift
+++ b/AWSDynamoDBTests/AWSDynamoDBObjectMapperSwiftTests.swift
@@ -84,7 +84,7 @@ class AWSDynamoDBObjectMapperSwiftTests: XCTestCase {
         let boolNumberArray:Array<AnyObject> = [true as AnyObject, false as AnyObject, NSNumber(value: true as Bool), NSNumber(value: false as Bool)]
         let nonBoolNumberArray:Array<AnyObject> = [20 as AnyObject, 500.34 as AnyObject, NSNumber(value: 34 as Int), NSNumber(value: 3 as Int8), NSNumber(value: 23.4 as Float)]
         let myboolClass = type(of: NSNumber(value: true as Bool))
-        let klass: AnyClass = object_getClass(NSNumber(value: true as Bool))
+        let klass: AnyClass = object_getClass(NSNumber(value: true as Bool))!
 
         for myNum in boolNumberArray {
             let result = myNum.isKind(of: myboolClass)

--- a/AWSIoTTests/AWSIoTDataManagerTests.swift
+++ b/AWSIoTTests/AWSIoTDataManagerTests.swift
@@ -45,7 +45,7 @@ class AWSIoTDataManagerTests: XCTestCase {
         lwt.qos = AWSIoTMQTTQoS.messageDeliveryAttemptedAtLeastOnce
 
         let mqttConfig = AWSIoTMQTTConfiguration.init(keepAliveTimeInterval: 30.0,
-                                                      baseReconnectTimeInterval: 1.0, minimumConnectionTimeInterval: 20, maximumReconnectTimeInterval: 8, runLoop: RunLoop.current , runLoopMode: RunLoopMode.defaultRunLoopMode.rawValue, autoResubscribe: true, lastWillAndTestament: lwt)
+                                                      baseReconnectTimeInterval: 1.0, minimumConnectionTimeInterval: 20, maximumReconnectTimeInterval: 8, runLoop: RunLoop.current , runLoopMode: RunLoop.Mode.default.rawValue, autoResubscribe: true, lastWillAndTestament: lwt)
 
         //Setup iOT Manager for Broker 1
         let iotConfigurationBroker1 = AWSServiceConfiguration(region: .USEast1 ,
@@ -1284,16 +1284,18 @@ class AWSIoTDataManagerTests: XCTestCase {
         }
         
         // Use the MQTT broker from the `endpoint1`
-        let iotDataManager: AWSIoTDataManager = AWSIoTDataManager(forKey: "iot-data-manager-broker-custom-auth")
+        let iotDataManager = AWSIoTDataManager(forKey: "iot-data-manager-broker-custom-auth")
         let uuid = UUID().uuidString
         
-        let connectedWS: Bool = iotDataManager.connectUsingWebSocket(withClientId: uuid,
-                                                                     cleanSession: true,
-                                                                     customAuthorizerName: AWSIoTDataManagerTests.customAuthorizerName!,
-                                                                     tokenKeyName: AWSIoTDataManagerTests.tokenKeyName!,
-                                                                     tokenValue: "Deny",
-                                                                     tokenSignature: "Deny",
-                                                                     statusCallback: mqttEventCallback)
+        let connectedWS = iotDataManager.connectUsingWebSocket(withClientId: uuid,
+                                                               cleanSession: true,
+                                                               customAuthorizerName: AWSIoTDataManagerTests.customAuthorizerName!,
+                                                               tokenKeyName: AWSIoTDataManagerTests.tokenKeyName!,
+                                                               tokenValue: "Deny",
+                                                               tokenSignature: "Deny",
+                                                               statusCallback: mqttEventCallback)
+
+        XCTAssert(connectedWS)
         print("Calling connect completed. Waiting for 30 seconds to see if the connection errors out.")
         
         wait(for:[hasConnectionError], timeout: 30)
@@ -1460,9 +1462,6 @@ class AWSIoTDataManagerTests: XCTestCase {
             connected = false
             let uuid = UUID().uuidString
             print("Calling Connect using Custom Auth.")
-            
-            let tokenValue: String? = "allow"
-            let tokenSignature: String? = tokenValue?.data(using: .utf8)?.base64EncodedString()
             
             connected = iotDataManager.connectUsingWebSocket(withClientId: uuid,
                                                              cleanSession: true,

--- a/AWSKinesisUnitTests/AWSGZIPTestHelper.h
+++ b/AWSKinesisUnitTests/AWSGZIPTestHelper.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface AWSGZIPTestHelper : NSObject
 
 @property (nonatomic, strong) id mockSerializer;
@@ -34,5 +36,7 @@
 - (void)stopMocking;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif /* AWSGZIPTestHelper_h */

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -13141,7 +13141,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -13165,7 +13165,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoArchivedMediaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -13290,7 +13290,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSS3Tests/AWSS3Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -13312,7 +13312,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSS3Tests/AWSS3Tests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -13341,7 +13341,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSTranscribeTests/AWSTranscribeTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -13369,7 +13369,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSTranscribeTests/AWSTranscribeTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -14225,7 +14225,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSComprehendTests/AWSComprehendTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -14252,7 +14252,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSComprehendTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSComprehendTests/AWSComprehendTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -14282,7 +14282,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSTranslateTests/AWSTranslateTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -14310,7 +14310,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSTranslateTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSTranslateTests/AWSTranslateTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -14337,7 +14337,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSRekognitionTests/AWSRekognitionTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -14363,7 +14363,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSRekognitionTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSRekognitionTests/AWSRekognitionTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
@@ -15280,7 +15280,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSDynamoDBTests/AWSDynamoDBTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Debug;
@@ -15300,7 +15300,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSDynamoDBTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSDynamoDBTests/AWSDynamoDBTests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Release;
@@ -15503,7 +15503,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSIoTTests/AWSIoTTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Debug;
@@ -15523,7 +15523,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSIoTTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSIoTTests/AWSIoTTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Release;
@@ -15873,7 +15873,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSS3Tests/AWSS3Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Debug;
@@ -15893,7 +15893,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSS3Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSS3Tests/AWSS3Tests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Release;
@@ -16312,7 +16312,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSAPIGatewayTests/AWSAPIGatewayTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Debug;
@@ -16332,7 +16332,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSAPIGatewayTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSAPIGatewayTests/AWSAPIGatewayTests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAllTestsHost.app/AWSAllTestsHost";
 			};
 			name = Release;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Misc. Updates
 
+* Ensured compatibility when building with Xcode 10.2
 * Model updates for the following services
   * Amazon DynamoDB
   * Amazon EC2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows SDK to build in Xcode 10.2.1.
- Update SWIFT_VERSION to 4.2 where applicable
- Add nullability specifiers to AWSGZIPTestHelper
- Fix deprecations & removing unused vars

**NOTE:** This change is not intended to update the `SWIFT_VERSION` of Swift-based modules (e.g., AWSMobileClient), only to ensure the projects build in Xcode 10.2.1, or in projects that themselves use Swift 5.

Tested the following configurations:
- [PASSED] Base project using Carthage, Xcode 10.1, Swift 4.2
- [PASSED] Base project using Carthage, Xcode 10.2.1, Swift 4.2
- [PASSED] Base project using Carthage, Xcode 10.2.1, Swift 5
- [PASSED] Base project using CocoaPods, Xcode 10.1, Swift 4.2
- [PASSED] Base project using CocoaPods, Xcode 10.2.1, Swift 4.2
- [PASSED] Base project using CocoaPods, Xcode 10.2.1, Swift 5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
