### PR TITLE
Fix retain cycle between NSURLSession and AWSURLSessionManager

### DIFF
--- a/AWSCore/Networking/AWSNetworking.m
+++ b/AWSCore/Networking/AWSNetworking.m
@@ -83,6 +83,10 @@ NSString *const AWSNetworkingErrorDomain = @"com.amazonaws.AWSNetworkingErrorDom
     return self;
 }
 
+- (void)dealloc {
+    [self.networkManager finishTasksAndInvalidate];
+}
+
 - (AWSTask *)sendRequest:(AWSNetworkingRequest *)request {
     return [self.networkManager dataTaskWithRequest:request];
 }

--- a/AWSCore/Networking/AWSURLSessionManager.h
+++ b/AWSCore/Networking/AWSURLSessionManager.h
@@ -24,4 +24,6 @@
 
 - (AWSTask *)dataTaskWithRequest:(AWSNetworkingRequest *)request;
 
+- (void)finishTasksAndInvalidate;
+
 @end

--- a/AWSCore/Networking/AWSURLSessionManager.m
+++ b/AWSCore/Networking/AWSURLSessionManager.m
@@ -135,6 +135,10 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
     return delegate.taskCompletionSource.task;
 }
 
+- (void)finishTasksAndInvalidate {
+    [self.session finishTasksAndInvalidate];
+};
+
 - (void)taskWithDelegate:(AWSURLSessionManagerDelegate *)delegate {
     if (delegate.downloadingFileURL) delegate.shouldWriteToFile = YES;
     delegate.responseData = nil;


### PR DESCRIPTION
*Description of changes:*

`NSURLSession` strongly references its `delegate`. The session releases the delegate only once it is invalidated or the application exits (See https://developer.apple.com/documentation/foundation/nsurlsession/1411530-delegate?language=objc)
`AWSURLSessionManager` strongly references the `NSURLSession` it is itself a delegate to, this way creating a retain cycle.

This change adds a `finishTasksAndInvalidate` method to `AWSURLSessionManager` that is forwarded to the `NSURLSession` so that the retain cycle will eventually be broken. It is called when the `AWSURLSessionManager` will no longer be used by the `AWSNetworking` instance that created it.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.