### PR TITLE
Add support for new CocoaPods 1.7.x `:generate_multiple_pod_projects` feature

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -16,12 +16,12 @@
 #import "AWSS3TransferUtility.h"
 #import "AWSS3PreSignedURL.h"
 #import "AWSS3Service.h"
-#import "AWSXMLDictionary.h"
 #import "AWSS3TransferUtilityDatabaseHelper.h"
 #import "AWSS3TransferUtilityTasks.h"
 
 #import <AWSCore/AWSFMDB.h>
 #import <AWSCore/AWSSynchronizedMutableDictionary.h>
+#import <AWSCore/AWSXMLDictionary.h>
 
 #include <stdio.h>
 


### PR DESCRIPTION
Only change required was to properly include `AWSCore` headers using:

    #import <AWSCore/...>

instead of:

    #import "..."

*NOTE* Only AWSS3 SDK has been updated.