### PR TITLE
Use Xcode 10.2.1 for ui tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ jobs:
   run_ui_test:
     # Specify the Xcode version to use
     macos:
-      xcode: "10.1.0"
+      xcode: "10.2.1"
     steps:
       - set_environment_variables
       - override_test_job


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Samples now use Swift 5, so they must be run with Xcode 10.2 or greater. See https://circleci.com/gh/aws-amplify/aws-sdk-ios/6429 for failing test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
