### PR TITLE
Fix simulator startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,6 @@ commands:
             sdkName=aws-ios-sdk
             echo "export sdkName=$sdkName" >> $BASH_ENV
 
-            test_device_id=$(xcrun simctl create "circleci-test-device" "com.apple.CoreSimulator.SimDeviceType.iPhone-8" "com.apple.CoreSimulator.SimRuntime.iOS-12-1")
-            echo "export test_device_id='$test_device_id'" >> $BASH_ENV
-
-            # destinationspecifier for xcodebuild commands
-            destination="platform=iOS Simulator,id=$test_device_id"
-            echo "export destination='$destination'" >> $BASH_ENV
-
             release_bucket=${S3_RELEASE_BUCKET}
             echo "export release_bucket=$release_bucket" >> $BASH_ENV
 
@@ -149,7 +142,7 @@ commands:
       - run:
           name: install aws cli
           command: |
-            brew install awscli
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
       - run:
           name: configure aws profile
           command: |
@@ -161,7 +154,8 @@ commands:
     steps:
       - run:
           name: pre-start simulator
-          command: xcrun simctl boot ${test_device_id}
+          command: |
+            bash CircleciScripts/pre_start_simulator.sh
   skip_test_job:
     description: >-
       check if the test job can be skipped
@@ -434,6 +428,7 @@ jobs:
       - early_return_for_forked_prs
       - checkout
       - skip_test_job
+      - pre_start_simulator
       - restore_cache:
           key: build_result-{{ .Revision }}
       - run:
@@ -443,9 +438,6 @@ jobs:
           name: create credentials
           command: |
             echo ${IOS_TESTS_CREDENTIALS_JSON}  | base64 --decode  > AWSCoreTests/Resources/credentials.json
-      - run:
-          name: pre-start simulator
-          command: xcrun simctl boot ${test_device_id}
       - run :
           name: run integration tests
           command: |
@@ -479,7 +471,7 @@ jobs:
       - update_brew
       - run:
           name: install github-release
-          command: brew install github-release
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install github-release
       - run:
           name: release the tag
           command: |
@@ -497,11 +489,11 @@ jobs:
       - update_brew
       - run:
           name: install github-release
-          command: brew install github-release
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install github-release
       - run:
           name: install aws cli
           command: |
-            brew install awscli
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
       - run:
           name: download custom carthage
           command: |
@@ -610,6 +602,7 @@ jobs:
       - early_return_for_forked_prs
       - checkout
       - skip_test_job
+      - pre_start_simulator
       - run:
           name: Run Sample UI Test
           command: |

--- a/CircleciScripts/pre_start_simulator.sh
+++ b/CircleciScripts/pre_start_simulator.sh
@@ -1,0 +1,32 @@
+# Create sim if needed
+test_device_id=$( xcrun simctl list devices | grep "circleci-test-device" | sed 's/ *circleci-test-device *(//' | sed 's/).*//' )
+
+if [[ -z $test_device_id ]] ; then
+  echo "Creating test device"
+
+  # Get the most recent available runtime
+  runtime=$( xcrun simctl list runtimes iOS | sed 's/iOS //' | sort -h | tail -1 | sed 's/.* - //' | tr -d '[:space:]' )
+  echo "Runtime: '${runtime}'"
+
+  # Get the last alphabetical device (probably something in the iPhone X family, as of 2019-05-31)
+  devicetype=$( xcrun simctl list devicetypes iPhone | sort | tail -1 | sed 's/.*(//' | sed 's/).*//' | tr -d '[:space:]' )
+  echo "Device type: '${devicetype}'"
+
+  test_device_id=$( xcrun simctl create "circleci-test-device" "${devicetype}" "${runtime}" | tr -d '[:space:]' )
+fi
+
+echo "test_device_id: ${test_device_id}"
+echo "export test_device_id='$test_device_id'" >> $BASH_ENV
+
+# Boot sim if needed
+xcrun simctl list devices ${test_device_id} | grep -q Booted
+if [[ $? -eq 1 ]] ; then
+  echo "Booting ${test_device_id}"
+  xcrun simctl boot ${test_device_id}
+fi
+
+# destinationspecifier for xcodebuild commands
+destination="platform=iOS Simulator,id=${test_device_id}"
+echo "destination: ${destination}"
+echo "export destination='$destination'" >> $BASH_ENV
+


### PR DESCRIPTION
- Don't update brew on each install
- Dynamically derive simulator settings based on available runtimes & device
  types in current image
- Extract pre_start_simulator to standalone script

*Issue #, if available:*
N/A

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
