### PR TITLE
Add check for malformed remaining length

### DIFF
--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTDecoder.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTDecoder.m
@@ -29,6 +29,8 @@
 
 @implementation AWSMQTTDecoder
 
+int maxLengthMultiplier = 128 * 128 * 128;
+
 - (id)initWithStream:(NSInputStream*)aStream
 {
     _status = AWSMQTTDecoderStatusInitializing;
@@ -53,7 +55,7 @@
 
 - (void)stream:(NSStream*)sender handleEvent:(NSStreamEvent)eventCode {
     AWSDDLogVerbose(@"%s [Line %d] EventCode:%lu, stream: %@, Thread: %@", __PRETTY_FUNCTION__, __LINE__, (unsigned long)eventCode, sender, [NSThread currentThread]);
-    int maxLengthMultiplier = 128 * 128 * 128;
+
     if(stream == nil)
         return;
     switch (eventCode) {

--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTDecoder.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTDecoder.m
@@ -53,7 +53,7 @@
 
 - (void)stream:(NSStream*)sender handleEvent:(NSStreamEvent)eventCode {
     AWSDDLogVerbose(@"%s [Line %d] EventCode:%lu, stream: %@, Thread: %@", __PRETTY_FUNCTION__, __LINE__, (unsigned long)eventCode, sender, [NSThread currentThread]);
-
+    int maxLengthMultiplier = 128 * 128 * 128;
     if(stream == nil)
         return;
     switch (eventCode) {
@@ -91,7 +91,7 @@
                 }
                 else {
                     lengthMultiplier *= 128;
-                    if (lengthMultiplier > 128 * 128 * 128){
+                    if (lengthMultiplier > maxLengthMultiplier){
                         AWSDDLogWarn(@"Malformed Remaining Length");
                         lengthMultiplier = 1;
                         length = 0;

--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTDecoder.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTDecoder.m
@@ -91,6 +91,12 @@
                 }
                 else {
                     lengthMultiplier *= 128;
+                    if (lengthMultiplier > 128 * 128 * 128){
+                        AWSDDLogWarn(@"Malformed Remaining Length");
+                        lengthMultiplier = 1;
+                        length = 0;
+                        break;
+                    }
                 }
             }
             if (_status == AWSMQTTDecoderStatusDecodingData) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.9.9
 
+### Bug Fixes
+
+* **AWS IoT**
+  * Added a check for the upper limit of `lengthMultiplier` used for calculation of remaning length of MQTT packets. See [PR #1595](https://github.com/aws-amplify/aws-sdk-ios/pull/1595), [issue #1398](https://github.com/aws-amplify/aws-sdk-ios/issues/1398).
+
 ### Misc. Updates
 
 * Model updates for the following services


### PR DESCRIPTION
*Issue #, if available:*
This is part of fix for https://github.com/aws-amplify/aws-sdk-ios/issues/1398

*Description of changes:*
Updating the algorithm to decode the remaining length of MQTT packet as per specification
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html#_Toc385349759

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
