### PR TITLE
Added method to set the user pool at runtime

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -246,6 +246,17 @@ extension AWSMobileClient {
     internal var currentUser: AWSCognitoIdentityUser? {
         return self.userPoolClient?.currentUser()
     }
+
+
+    /// Set the current cognito user pool. This assumes you have registerd
+    /// a pool with `AWSCognitoIdentityUserPool`.
+    ///
+    /// - Parameter key: The key used to register the user pool
+    public func setUserPool(forKey key: String) {
+        let client = AWSCognitoIdentityUserPool(forKey: key)
+        self.userpoolOpsHelper.userpoolClient = client
+        client.delegate = self.userpoolOpsHelper
+    }
     
     /// Federates a social provider like Google, Facebook, Amazon or Twitter.
     /// If user is already signed in through the `signIn` method, it will return `AWSMobileClientError.federationProviderExists` error.


### PR DESCRIPTION
*Issue #, if available:*
 Related to #1592 

*Description of changes:*
As far as I can tell, there is currently no way to dynamically configure a user pool at runtime. Instead of using `awsconfiguration.json`, I'd like to be able to set the user pool during app setup. Our app will be pulling configuration options from a server based on a few parameters, so runtime configuration is a requirement.

An example of use:
```
let serviceConfig = AWSServiceConfiguration(
    region: .USEast1,
    credentialsProvider: nil
)
let poolConfig = AWSCognitoIdentityUserPoolConfiguration(clientId: "client_id_from_server",
                                                         clientSecret: "client_secret_from_server",
                                                         poolId: "pool_id_from_server",
                                                         shouldProvideCognitoValidationData: true,
                                                         pinpointAppId: nil)

AWSCognitoIdentityUserPool.register(with: serviceConfig,
                                    userPoolConfiguration: poolConfig,
                                    forKey: "some_key")
AWSMobileClient.sharedInstance().setUserPool(forKey: "some_key")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.