### PR TITLE
Fix compile issues when installing AWSS3 with Cocoapods 1.7+ with multiple project generation enabled

### DIFF
--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}'
-  s.private_header_files = 'AWSCore/XMLDictionary/**/*.h', 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h', 'AWSCore/Fabric/*.h', 'AWSCore/Mantle/extobjc/*.h', 'AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h'
+  s.private_header_files = 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h', 'AWSCore/Fabric/*.h', 'AWSCore/Mantle/extobjc/*.h', 'AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h'
 end

--- a/AWSCore/AWSCore.h
+++ b/AWSCore/AWSCore.h
@@ -50,6 +50,7 @@ FOUNDATION_EXPORT const unsigned char AWSCoreVersionString[] DEPRECATED_MSG_ATTR
 #import "AWSLogging.h"
 #import "AWSClientContext.h"
 #import "AWSSynchronizedMutableDictionary.h"
+#import "AWSXMLDictionary.h"
 #import "AWSSerialization.h"
 #import "AWSURLRequestSerialization.h"
 #import "AWSURLResponseSerialization.h"

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -19,7 +19,6 @@
 #import "AWSS3TransferUtilityDatabaseHelper.h"
 #import "AWSS3TransferUtilityTasks.h"
 
-#import <AWSCore/AWSXMLDictionary.h>
 #import <AWSCore/AWSFMDB.h>
 #import <AWSCore/AWSSynchronizedMutableDictionary.h>
 

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -16,10 +16,10 @@
 #import "AWSS3TransferUtility.h"
 #import "AWSS3PreSignedURL.h"
 #import "AWSS3Service.h"
-#import "AWSXMLDictionary.h"
 #import "AWSS3TransferUtilityDatabaseHelper.h"
 #import "AWSS3TransferUtilityTasks.h"
 
+#import <AWSCore/AWSXMLDictionary.h>
 #import <AWSCore/AWSFMDB.h>
 #import <AWSCore/AWSSynchronizedMutableDictionary.h>
 

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 		CE0D42A61C6A673E006B91B5 /* AWSModel.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D42181C6A673E006B91B5 /* AWSModel.m */; };
 		CE0D42A71C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = CE0D42191C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE0D42A81C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D421A1C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.m */; };
-		CE0D42A91C6A673E006B91B5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = CE0D421C1C6A673E006B91B5 /* AWSXMLDictionary.h */; };
+		CE0D42A91C6A673E006B91B5 /* AWSXMLDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = CE0D421C1C6A673E006B91B5 /* AWSXMLDictionary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE0D42AA1C6A673E006B91B5 /* AWSXMLDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D421D1C6A673E006B91B5 /* AWSXMLDictionary.m */; };
 		CE0D42AD1C6A673E006B91B5 /* AWSXMLWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = CE0D42211C6A673E006B91B5 /* AWSXMLWriter.h */; };
 		CE0D42AE1C6A673E006B91B5 /* AWSXMLWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D42221C6A673E006B91B5 /* AWSXMLWriter.m */; };
@@ -9921,6 +9921,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);


### PR DESCRIPTION
*Description of changes:*
Installing the AWSS3 SDK with Cocoapods 1.7+ with `generate_multiple_pod_projects` enabled caused the frameworks to fail compilation.

`AWSXMLDictionary` was being imported directly within the `AWSS3` project when it exists in `AWSCore`. Fixed this by exposing `AWSXMLDictionary` as a public header and importing the file directly from the `AWSCore` framework.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
