### PR TITLE
Fail multipart upload if the temp file is missing

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1495,18 +1495,20 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
               getPresignedURLRequest:nil URLRequest: urlRequest];
         [ urlRequest setValue:[self.configuration.userAgent stringByAppendingString:@" MultiPart"] forHTTPHeaderField:@"User-Agent"];
         NSURLSessionUploadTask *nsURLUploadTask = nil;
+        NSString *exceptionReason = @"";
         @try {
             nsURLUploadTask  = [self->_session uploadTaskWithRequest:urlRequest
                                                             fromFile:[NSURL fileURLWithPath:subTask.file]];
         }
         @catch (NSException *exception) {
             AWSDDLogDebug(@"Exception in upload task %@", exception.debugDescription);
+            exceptionReason = [exception.reason copy];
             nsURLUploadTask = nil;
         }
         if (nsURLUploadTask == nil) {
             NSString *errorMessage = [NSString stringWithFormat:@"Exception from upload task."];
-            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errorMessage
-                                                                 forKey:@"Message"];
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:
+                                      errorMessage, @"Message", exceptionReason, @"Reason", nil];
             error = [NSError errorWithDomain:AWSS3TransferUtilityErrorDomain
                                         code:AWSS3TransferUtilityErrorUnknown
                                     userInfo:userInfo];

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1458,10 +1458,10 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
                    startTransfer: (BOOL) startTransfer
        internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAddSubTaskTo
 {
+    __block NSError *error = nil;
     //Create a temporary part file if required.
     if (!(subTask.file || [subTask.file isEqualToString:@""]) || ![[NSFileManager defaultManager] fileExistsAtPath:subTask.file]) {
         //Create a temporary file for this part.
-        NSError *error = nil;
         NSString * partFileName = [self createTemporaryFileForPart:transferUtilityMultiPartUploadTask.file partNumber:[subTask.partNumber integerValue] dataLength:subTask.totalBytesExpectedToSend error:&error];
         if (partFileName == nil)  {
             //Unable to create partFile. Send back error object to indicate that createUploadSubtask failed.
@@ -1494,8 +1494,25 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
         [self filterAndAssignHeaders:transferUtilityMultiPartUploadTask.expression.requestHeaders
               getPresignedURLRequest:nil URLRequest: urlRequest];
         [ urlRequest setValue:[self.configuration.userAgent stringByAppendingString:@" MultiPart"] forHTTPHeaderField:@"User-Agent"];
-        NSURLSessionUploadTask *nsURLUploadTask = [self->_session uploadTaskWithRequest:urlRequest
-                                                                         fromFile:[NSURL fileURLWithPath:subTask.file]];
+        NSURLSessionUploadTask *nsURLUploadTask = nil;
+        @try {
+            nsURLUploadTask  = [self->_session uploadTaskWithRequest:urlRequest
+                                                            fromFile:[NSURL fileURLWithPath:subTask.file]];
+        }
+        @catch (NSException *exception) {
+            AWSDDLogDebug(@"Exception in upload task %@", exception.debugDescription);
+            nsURLUploadTask = nil;
+        }
+        if (nsURLUploadTask == nil) {
+            NSString *errorMessage = [NSString stringWithFormat:@"Exception from upload task."];
+            NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errorMessage
+                                                                 forKey:@"Message"];
+            error = [NSError errorWithDomain:AWSS3TransferUtilityErrorDomain
+                                        code:AWSS3TransferUtilityErrorUnknown
+                                    userInfo:userInfo];
+            return nil;
+            
+        }
         //Create subtask to track this upload
         subTask.sessionTask = nsURLUploadTask;
         subTask.taskIdentifier = nsURLUploadTask.taskIdentifier;
@@ -1523,7 +1540,7 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
        
         return nil;
     }] waitUntilFinished];
-    return nil;
+    return error;
 }
 
 -(void) retryUploadSubTask: (AWSS3TransferUtilityMultiPartUploadTask *) transferUtilityMultiPartUploadTask

--- a/AWSS3Tests/AWSS3TransferUtilityTests.swift
+++ b/AWSS3Tests/AWSS3TransferUtilityTests.swift
@@ -2545,7 +2545,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         XCTAssertEqual(transferUtility?.getDownloadTasks().result!.count, 0)
         XCTAssertEqual(transferUtility?.getMultiPartUploadTasks().result!.count, 0)
         XCTAssertEqual(transferUtility?.getAllTasks().result!.count, 3)
-
+        
         wait(for:[uploadsCompleted],  timeout: 60)
         
         //upload 3 more files using multipart

--- a/AWSS3Tests/AWSS3TransferUtilityTests.swift
+++ b/AWSS3Tests/AWSS3TransferUtilityTests.swift
@@ -2530,7 +2530,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...3 {
             transferUtility?.uploadData(
                 testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods-royji",
+                bucket: "ios-v2-s3.periods",
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: uploadExpression,
@@ -2552,7 +2552,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 4...6 {
             transferUtility?.uploadUsingMultiPart(
                 data: testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods-royji",
+                bucket: "ios-v2-s3.periods",
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: multiPartUploadExpression,
@@ -2573,7 +2573,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...6 {
             let url = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("file\(i)")
             transferUtility?.download(to: url!,
-                                 bucket: "ios-v2-s3.periods-royji",
+                                 bucket: "ios-v2-s3.periods",
                                     key: "testFileForGetTasks\(i).txt",
                 expression: downloadExpression,
                 completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in

--- a/AWSS3Tests/AWSS3TransferUtilityTests.swift
+++ b/AWSS3Tests/AWSS3TransferUtilityTests.swift
@@ -2530,7 +2530,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...3 {
             transferUtility?.uploadData(
                 testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods",
+                bucket: "ios-v2-s3.periods-royji",
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: uploadExpression,
@@ -2545,14 +2545,14 @@ class AWSS3TransferUtilityTests: XCTestCase {
         XCTAssertEqual(transferUtility?.getDownloadTasks().result!.count, 0)
         XCTAssertEqual(transferUtility?.getMultiPartUploadTasks().result!.count, 0)
         XCTAssertEqual(transferUtility?.getAllTasks().result!.count, 3)
-        
+
         wait(for:[uploadsCompleted],  timeout: 60)
         
         //upload 3 more files using multipart
         for i in 4...6 {
             transferUtility?.uploadUsingMultiPart(
                 data: testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods",
+                bucket: "ios-v2-s3.periods-royji",
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: multiPartUploadExpression,
@@ -2573,7 +2573,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...6 {
             let url = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("file\(i)")
             transferUtility?.download(to: url!,
-                                 bucket: "ios-v2-s3.periods",
+                                 bucket: "ios-v2-s3.periods-royji",
                                     key: "testFileForGetTasks\(i).txt",
                 expression: downloadExpression,
                 completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in

--- a/AWSS3UnitTests/AWSS3TransferUtilityUnitTests.m
+++ b/AWSS3UnitTests/AWSS3TransferUtilityUnitTests.m
@@ -64,6 +64,9 @@ static id urlSession = nil;
     OCMStub([mockNetworking sendRequest:[OCMArg isKindOfClass:[AWSNetworkingRequest class]]]).andReturn(errorTask);
 }
 
+/**
+ Test the successfull execution of multipart data upload.
+ **/
 - (void)testMultiPartDataUpload {
     NSString *key = @"testMultiPartDataUpload";
     NSData *uploadData = [@"1234343454" dataUsingEncoding:NSUTF8StringEncoding];
@@ -105,6 +108,11 @@ static id urlSession = nil;
     [AWSS3TransferUtility removeS3TransferUtilityForKey:key];
 }
 
+/**
+ Test the situation where NSURLSession throws an exception in multipart upload.
+ This should return an error back to the caller. One possible scenario of this
+ usecase is when temporary file used for upload got deleted by OS.
+ **/
 - (void)testMultiPartDataUploadWithURLSessionException {
     NSString *key = @"testMultiPartDataUploadException";
     NSData *uploadData = [@"1234343454" dataUsingEncoding:NSUTF8StringEncoding];

--- a/AWSS3UnitTests/AWSS3TransferUtilityUnitTests.m
+++ b/AWSS3UnitTests/AWSS3TransferUtilityUnitTests.m
@@ -1,0 +1,151 @@
+//
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "OCMock.h"
+#import "AWSTestUtility.h"
+#import "AWSS3Service.h"
+#import "AWSS3TransferUtility.h"
+#import "AWSS3PreSignedUrl.h"
+
+static id mockNetworking = nil;
+static id awss3client = nil;
+static id awss3PresignedUrlBuilder = nil;
+static id urlSession = nil;
+@class MockUploadTask;
+
+@interface MockUploadTask: NSObject
+
+@property (readonly) NSUInteger taskIdentifier;
+
+@end
+
+@implementation MockUploadTask
+
+- (NSUInteger)getTaskIdentifier {
+    return 1;
+}
+
+- (void)resume {
+}
+
+- (void)cancel {
+}
+
+@end
+
+@interface AWSS3TransferUtilityUnitTests : XCTestCase
+
+@end
+
+@implementation AWSS3TransferUtilityUnitTests
+
+- (void)setUp {
+    [super setUp];
+    [AWSTestUtility setupFakeCognitoCredentialsProvider];
+    
+    awss3client = OCMClassMock([AWSS3 class]);
+    mockNetworking = OCMClassMock([AWSNetworking class]);
+    awss3PresignedUrlBuilder = OCMClassMock([AWSS3PreSignedURLBuilder class]);
+    urlSession = OCMClassMock([NSURLSession class]);
+    AWSTask *errorTask = [AWSTask taskWithError:[NSError errorWithDomain:@"OCMockExpectedNetworkingError" code:8848 userInfo:nil]];
+    OCMStub([mockNetworking sendRequest:[OCMArg isKindOfClass:[AWSNetworkingRequest class]]]).andReturn(errorTask);
+}
+
+- (void)testMultiPartDataUpload {
+    NSString *key = @"testMultiPartDataUpload";
+    NSData *uploadData = [@"1234343454" dataUsingEncoding:NSUTF8StringEncoding];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSS3TransferUtility registerS3TransferUtilityWithConfiguration:configuration forKey:key];
+    AWSS3TransferUtility *transferUtility = [AWSS3TransferUtility S3TransferUtilityForKey:key];
+    
+    [awss3client setValue:mockNetworking forKey:@"networking"];
+    [transferUtility setValue:awss3client forKey:@"s3"];
+    [transferUtility setValue:awss3PresignedUrlBuilder forKey:@"preSignedURLBuilder"];
+    [transferUtility setValue:urlSession forKey:@"session"];
+    
+    AWSS3CreateMultipartUploadOutput *output = [AWSS3CreateMultipartUploadOutput new];
+    output.uploadId = @"uploadID";
+    AWSTask *createMultipartUploadResultTask = [AWSTask taskWithResult:output];
+    OCMStub([awss3client createMultipartUpload:[OCMArg isKindOfClass:[AWSS3CreateMultipartUploadRequest class]]]).andReturn(createMultipartUploadResultTask);
+    
+    NSURL *preSignedURL = [NSURL URLWithString:@"http://asd.com/"];
+    AWSTask *getPreSignedURLResultTask = [AWSTask taskWithResult:preSignedURL];
+    OCMStub([awss3PresignedUrlBuilder getPreSignedURL:[OCMArg isKindOfClass:[AWSS3GetPreSignedURLRequest class]]]).andReturn(getPreSignedURLResultTask);
+    
+    MockUploadTask *uploadTask = [[MockUploadTask alloc] init];
+    OCMStub([urlSession uploadTaskWithRequest:[OCMArg isKindOfClass:[NSURLRequest class]]
+                                     fromFile:[OCMArg isKindOfClass:[NSURL class]]]).andReturn(uploadTask);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    [[[transferUtility uploadDataUsingMultiPart:uploadData
+                                         bucket:@"unittestBucket"
+                                            key:@"unittestKey.txt"
+                                    contentType:@"text/plain"
+                                     expression:[AWSS3TransferUtilityMultiPartUploadExpression new]
+                              completionHandler:nil]
+      continueWithBlock:^id (AWSTask *task) {
+          XCTAssertNil(task.error);
+          XCTAssertNotNil(task);
+          dispatch_semaphore_signal(semaphore);
+          return nil;
+      }] waitUntilFinished];
+    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    [AWSS3TransferUtility removeS3TransferUtilityForKey:key];
+}
+
+- (void)testMultiPartDataUploadWithURLSessionException {
+    NSString *key = @"testMultiPartDataUploadException";
+    NSData *uploadData = [@"1234343454" dataUsingEncoding:NSUTF8StringEncoding];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSS3TransferUtility registerS3TransferUtilityWithConfiguration:configuration forKey:key];
+    AWSS3TransferUtility *transferUtility = [AWSS3TransferUtility S3TransferUtilityForKey:key];
+    
+    [awss3client setValue:mockNetworking forKey:@"networking"];
+    [transferUtility setValue:awss3client forKey:@"s3"];
+    [transferUtility setValue:awss3PresignedUrlBuilder forKey:@"preSignedURLBuilder"];
+    [transferUtility setValue:urlSession forKey:@"session"];
+    
+    AWSS3CreateMultipartUploadOutput *output = [AWSS3CreateMultipartUploadOutput new];
+    output.uploadId = @"uploadID";
+    AWSTask *createMultipartUploadResultTask = [AWSTask taskWithResult:output];
+    OCMStub([awss3client createMultipartUpload:[OCMArg isKindOfClass:[AWSS3CreateMultipartUploadRequest class]]]).andReturn(createMultipartUploadResultTask);
+    
+    NSURL *preSignedURL = [NSURL URLWithString:@"http://asd.com/"];
+    AWSTask *getPreSignedURLResultTask = [AWSTask taskWithResult:preSignedURL];
+    OCMStub([awss3PresignedUrlBuilder getPreSignedURL:[OCMArg isKindOfClass:[AWSS3GetPreSignedURLRequest class]]]).andReturn(getPreSignedURLResultTask);
+
+    NSException *exp = [[NSException alloc]initWithName:@"S3exception" reason:NULL userInfo:NULL];
+    OCMStub([urlSession uploadTaskWithRequest:[OCMArg isKindOfClass:[NSURLRequest class]]
+                                     fromFile:[OCMArg isKindOfClass:[NSURL class]]]).andThrow(exp);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    [[[transferUtility uploadDataUsingMultiPart:uploadData
+                                         bucket:@"unittestBucket"
+                                            key:@"unittestKey.txt"
+                                    contentType:@"text/plain"
+                                     expression:[AWSS3TransferUtilityMultiPartUploadExpression new]
+                              completionHandler:nil]
+      continueWithBlock:^id (AWSTask *task) {
+          XCTAssertNotNil(task.error);
+          XCTAssertNotNil(task);
+          dispatch_semaphore_signal(semaphore);
+          return nil;
+      }] waitUntilFinished];
+    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    [AWSS3TransferUtility removeS3TransferUtilityForKey:key];
+}
+
+@end
+
+

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		B4A4E03F22B427F600379396 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		B4A4E04022B4281000379396 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8EF551C6A6A2E0098B15B /* libOCMock.a */; };
 		B4A4E04122B4282000379396 /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF3E1C6A69AB0098B15B /* credentials.json */; };
+		B47FAF4322C577CE00014548 /* AWSS3TransferUtilityUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */; };
 		B52FBE921F17414A000F0C00 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B52FBE911F17414A000F0C00 /* Media.xcassets */; };
 		B5AF36DB20FF1EA5004D194C /* AWSCore.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B5AF36DC20FF1EB1004D194C /* AWSKinesisVideo.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1778554320F9A72800D083BB /* AWSKinesisVideo.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -3400,6 +3401,7 @@
 		B4A4E03222B423C700379396 /* AWSGeneralSageMakerRuntimeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralSageMakerRuntimeTests.m; sourceTree = "<group>"; };
 		B4A4E03A22B4272A00379396 /* AWSSageMakerRuntimeTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSSageMakerRuntimeTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		B4A4E03C22B4272E00379396 /* AWSSageMakerRuntimeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSSageMakerRuntimeTests.swift; sourceTree = "<group>"; };
+		B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSS3TransferUtilityUnitTests.m; sourceTree = "<group>"; };
 		B52FBE911F17414A000F0C00 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE0D416F1C6A66E5006B91B5 /* AWSCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSCore.h; sourceTree = "<group>"; };
@@ -6178,6 +6180,7 @@
 			children = (
 				CE5605261C6BCDD300B4E00B /* AWSGeneralS3Tests.m */,
 				CE5604A31C6BC97600B4E00B /* Info.plist */,
+				B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */,
 			);
 			path = AWSS3UnitTests;
 			sourceTree = "<group>";
@@ -9977,6 +9980,7 @@
 					};
 					CE56049E1C6BC97600B4E00B = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 1020;
 					};
 					CE5604AD1C6BC98800B4E00B = {
 						CreatedOnToolsVersion = 7.2.1;
@@ -11582,6 +11586,7 @@
 			files = (
 				CE5605271C6BCDD300B4E00B /* AWSGeneralS3Tests.m in Sources */,
 				CE5604F21C6BCAA000B4E00B /* AWSTestUtility.m in Sources */,
+				B47FAF4322C577CE00014548 /* AWSS3TransferUtilityUnitTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -15483,6 +15488,7 @@
 		CE5604A81C6BC97600B4E00B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSS3UnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -15493,12 +15499,16 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSS3UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "AWSS3UnitTests/AWSS3UnitTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		CE5604A91C6BC97600B4E00B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSS3UnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -15509,6 +15519,8 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSS3UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "AWSS3UnitTests/AWSS3UnitTests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
*Issue #, if available:* 1249

*Description of changes:*

Multipart upload was causing crash due to file not found exception. This change fails the upload if file is missing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
