### PR TITLE
Test cleanup & port to new roles/resources

### DIFF
--- a/AWSAPIGatewayTests/AWSAPIGatewayInvokeTest.swift
+++ b/AWSAPIGatewayTests/AWSAPIGatewayInvokeTest.swift
@@ -49,23 +49,24 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(stringBodyRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                XCTAssertEqual(404, apiResponse.statusCode)
+            
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
                 return nil
             }
+            
+            let apiResponse = result
+            XCTAssertEqual(404, apiResponse.statusCode)
+
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
     }
     
     func testInvokeStringBody() {
         let bodyString = "{\"key3\": \"value3\",\"key2\": \"value2\",\"key1\": \"value1\"}"
-        
-        
         
         let stringBodyRequest = AWSAPIGatewayRequest(httpMethod: "POST",
                                                      urlString: "/TestFunction",
@@ -75,19 +76,34 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(stringBodyRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertEqual("\"value1\"", datastring)
+
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
                 return nil
             }
+
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Unable to convert response data to JSON Object")
+                return nil
+            }
+
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Expected JSON to be a dictionary")
+                return nil
+            }
+
+            XCTAssertEqual(json["key1"] as? String, "value1")
+            XCTAssertEqual(json["key2"] as? String, "value2")
+            XCTAssertEqual(json["key3"] as? String, "value3")
+
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
         
     }
     
@@ -103,19 +119,33 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(rawDataBodyRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertEqual("\"value1\"", datastring)
+            
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
                 return nil
             }
+    
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Unable to convert response data to JSON Object")
+                return nil
+            }
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Expected JSON to be a dictionary")
+                return nil
+            }
+
+            XCTAssertEqual(json["key1"] as? String, "value1")
+            XCTAssertEqual(json["key2"] as? String, "value2")
+            XCTAssertEqual(json["key3"] as? String, "value3")
+
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
     }
     
     func testInvokeInputStreamBody() {
@@ -136,19 +166,34 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(rawDataBodyRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertEqual("\"value1\"", datastring)
+
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
                 return nil
             }
+            
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Unable to convert response data to JSON Object")
+                return nil
+            }
+
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Expected JSON to be a dictionary")
+                return nil
+            }
+
+            XCTAssertEqual(json["key1"] as? String, "value1")
+            XCTAssertEqual(json["key2"] as? String, "value2")
+            XCTAssertEqual(json["key3"] as? String, "value3")
+
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
     }
     
     func testInvokeDictionaryBody() {
@@ -166,17 +211,32 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(dictionaryBodyRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertEqual("\"value1\"", datastring)
+
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
                 return nil
             }
+            
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Unable to convert response data to JSON Object")
+                return nil
+            }
+
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Expected JSON to be a dictionary")
+                return nil
+            }
+
+            XCTAssertEqual(json["key1"] as? String, "value1")
+            XCTAssertEqual(json["key2"] as? String, "value2")
+            XCTAssertEqual(json["key3"] as? String, "value3")
+            
             return nil
             }).waitUntilFinished()
     }
@@ -191,95 +251,141 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(proxyPathRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertEqual(datastring!, "\"myuser%7B%7D\"")
+            
+            if let error = task.error {
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
+
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
+                return nil
+            }
+            
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Unable to convert response data to JSON Object")
+                return nil
+            }
+            
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Expected JSON to be a dictionary")
+                return nil
+            }
+
+            guard let value = json["value"] as? String else {
+                XCTFail("Can't get String 'value' from JSON object")
+                return nil
+            }
+            
+            XCTAssertEqual(value, "myuser%7B%7D")
+
             return nil
             }).waitUntilFinished()
       
     }
     
     func testInvokePathWithQueryString() {
-        
         let proxyPathRequest = AWSAPIGatewayRequest(httpMethod: "GET",
                                                     urlString: "/TestFunction",
-                                                    queryParameters: ["key1":"myuser{}"],
+                                                    queryParameters: ["key1": "myuser{}"],
                                                     headerParameters: headerParameters,
                                                     httpBody: nil)
         
         client!.invoke(proxyPathRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertEqual(datastring!, "\"myuser{}\"")
+            
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
                 return nil
             }
+        
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Can't create JSON object from apiResponse.responseData")
+                return nil
+            }
+            
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Can't cast jsonObject as [String:Any]")
+                return nil
+            }
+            
+            guard let value = json["value"] as? String else {
+                XCTFail("Can't get String 'value' from JSON object")
+                return nil
+            }
+
+            XCTAssertEqual(value, "myuser{}")
+            
             return nil
-            }).waitUntilFinished()
+
+        }).waitUntilFinished()
         
     }
     
     func testGet() {
-        
         client!.helloWorldGet().continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                
-                XCTAssertEqual("Hello World", result as? String);
+            
+            guard let result = task.result as? String else {
+                XCTFail("Result unexpectedly nil or not convertible to String")
                 return nil
             }
+
+            XCTAssertEqual("Hello World", result);
+
             return nil
         }).waitUntilFinished()
     }
     
     func testPathParametersWithGet() {
-
         client!.userUsernameGet("myuser{}").continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                XCTAssertEqual("myuser%7B%7D", result as? String);
+            
+            guard let result = task.result as? AWSStringValue else {
+                XCTFail("Result unexpectedly nil or does not cast to AWSStringValue")
                 return nil
             }
+            
+            XCTAssertEqual("myuser%7B%7D", result.value);
+
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
     }
     
     func testQueryStringParametersWithGet() {
-        
         client!.testFunctionGet("myuser{}").continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                XCTAssertEqual("myuser{}", result as? String);
+            
+            guard let result = task.result as? AWSStringValue else {
+                XCTFail("Result unexpectedly nil or does not cast to AWSStringValue")
                 return nil
             }
+            
+            XCTAssertEqual("myuser{}", result.value);
+
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
     }
     
     func testPathParametersWithInvoke() {
@@ -292,19 +398,41 @@ class TestAPIGatewayInvoke: XCTestCase {
         
         client!.invoke(parameterPathRequest).continueWith(block: { (task:AWSTask) -> AnyObject? in
             if let error = task.error {
-                print("\(error)")
-                XCTFail("Encountered unexpected error")
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
-            if let result = task.result {
-                let apiResponse = result
-                let datastring = NSString(data: apiResponse.responseData!, encoding: String.Encoding.utf8.rawValue)
-                XCTAssertEqual(200, apiResponse.statusCode)
-                XCTAssertNotNil(datastring)
-                XCTAssertEqual(datastring, "\"myuser2\"")
+            
+            if let error = task.error {
+                XCTFail("Encountered unexpected error: \(error)")
                 return nil
             }
+
+            guard let result = task.result else {
+                XCTFail("Result unexpectedly nil")
+                return nil
+            }
+            
+            let apiResponse = result
+            XCTAssertEqual(200, apiResponse.statusCode)
+
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: apiResponse.responseData!) else {
+                XCTFail("Unable to convert response data to JSON Object")
+                return nil
+            }
+            
+            guard let json = jsonObject as? [String: Any] else {
+                XCTFail("Expected JSON to be a dictionary")
+                return nil
+            }
+            
+            guard let value = json["value"] as? String else {
+                XCTFail("Can't get String 'value' from JSON object")
+                return nil
+            }
+            
+            XCTAssertEqual(value, "myuser2")
+            
             return nil
-            }).waitUntilFinished()
+        }).waitUntilFinished()
     }
 }

--- a/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.h
+++ b/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.h
@@ -17,30 +17,190 @@
 #import <Foundation/Foundation.h>
 #import <AWSAPIGateway/AWSAPIGateway.h>
 
+#import "AWSStringValue.h"
+
+
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ The service client object.
+ */
 @interface AWSLambdaMicroserviceClient: AWSAPIGatewayClient
 
+/**
+ Returns the singleton service client. If the singleton object does not exist, the SDK instantiates the default service client with `defaultServiceConfiguration` from `[AWSServiceManager defaultServiceManager]`. The reference to this object is maintained by the SDK, and you do not need to retain it manually.
+
+ If you want to enable AWS Signature, set the default service configuration in `- application:didFinishLaunchingWithOptions:`
+ 
+ *Swift*
+
+     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+         let credentialProvider = AWSCognitoCredentialsProvider(regionType: .USEast1, identityPoolId: "YourIdentityPoolId")
+         let configuration = AWSServiceConfiguration(region: .USEast1, credentialsProvider: credentialProvider)
+         AWSServiceManager.defaultServiceManager().defaultServiceConfiguration = configuration
+
+         return true
+     }
+
+ *Objective-C*
+
+     - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+          AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+                                                                                                          identityPoolId:@"YourIdentityPoolId"];
+          AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+                                                                               credentialsProvider:credentialsProvider];
+          [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
+
+          return YES;
+      }
+
+ Then call the following to get the default service client:
+
+ *Swift*
+
+     let serviceClient = AWSLambdaMicroserviceClient.defaultClient()
+
+ *Objective-C*
+
+     AWSLambdaMicroserviceClient *serviceClient = [AWSLambdaMicroserviceClient defaultClient];
+
+ Alternatively, this configuration could also be set in the `info.plist` file of your app under `AWS` dictionary with a configuration dictionary by name `AWSLambdaMicroserviceClient`.
+
+ @return The default service client.
+ */
 + (instancetype)defaultClient;
 
+/**
+ Creates a service client with the given service configuration and registers it for the key.
+
+ If you want to enable AWS Signature, set the default service configuration in `- application:didFinishLaunchingWithOptions:`
+
+ *Swift*
+
+     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+         let credentialProvider = AWSCognitoCredentialsProvider(regionType: .USEast1, identityPoolId: "YourIdentityPoolId")
+         let configuration = AWSServiceConfiguration(region: .USWest2, credentialsProvider: credentialProvider)
+         AWSLambdaMicroserviceClient.registerClientWithConfiguration(configuration, forKey: "USWest2AWSLambdaMicroserviceClient")
+
+         return true
+     }
+
+ *Objective-C*
+
+     - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+         AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+                                                                                                         identityPoolId:@"YourIdentityPoolId"];
+         AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSWest2
+                                                                              credentialsProvider:credentialsProvider];
+
+         [AWSLambdaMicroserviceClient registerClientWithConfiguration:configuration forKey:@"USWest2AWSLambdaMicroserviceClient"];
+
+         return YES;
+     }
+
+ Then call the following to get the service client:
+
+ *Swift*
+
+     let serviceClient = AWSLambdaMicroserviceClient(forKey: "USWest2AWSLambdaMicroserviceClient")
+
+ *Objective-C*
+
+     AWSLambdaMicroserviceClient *serviceClient = [AWSLambdaMicroserviceClient clientForKey:@"USWest2AWSLambdaMicroserviceClient"];
+
+ @warning After calling this method, do not modify the configuration object. It may cause unspecified behaviors.
+
+ @param configuration A service configuration object.
+ @param key           A string to identify the service client.
+ */
++ (void)registerClientWithConfiguration:(AWSServiceConfiguration *)configuration forKey:(NSString *)key;
+
+/**
+ Retrieves the service client associated with the key. You need to call `+ registerClientWithConfiguration:forKey:` before invoking this method or alternatively, set the configuration in your application's `info.plist` file. If `+ registerClientWithConfiguration:forKey:` has not been called in advance or if a configuration is not present in the `info.plist` file of the app, this method returns `nil`.
+
+ For example, set the default service configuration in `- application:didFinishLaunchingWithOptions:`
+
+ *Swift*
+
+     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+         let credentialProvider = AWSCognitoCredentialsProvider(regionType: .USEast1, identityPoolId: "YourIdentityPoolId")
+         let configuration = AWSServiceConfiguration(region: .USWest2, credentialsProvider: credentialProvider)
+         AWSLambdaMicroserviceClient.registerClientWithConfiguration(configuration, forKey: "USWest2AWSLambdaMicroserviceClient")
+
+         return true
+     }
+
+ *Objective-C*
+
+     - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+         AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+                                                                                                         identityPoolId:@"YourIdentityPoolId"];
+         AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSWest2
+                                                                              credentialsProvider:credentialsProvider];
+
+         [AWSLambdaMicroserviceClient registerClientWithConfiguration:configuration forKey:@"USWest2AWSLambdaMicroserviceClient"];
+
+         return YES;
+     }
+
+ Then call the following to get the service client:
+
+ *Swift*
+
+     let serviceClient = AWSLambdaMicroserviceClient(forKey: "USWest2AWSLambdaMicroserviceClient")
+
+ *Objective-C*
+
+     AWSLambdaMicroserviceClient *serviceClient = [AWSLambdaMicroserviceClient clientForKey:@"USWest2AWSLambdaMicroserviceClient"];
+
+ @param key A string to identify the service client.
+
+ @return An instance of the service client.
+ */
++ (instancetype)clientForKey:(NSString *)key;
+
+/**
+ Removes the service client associated with the key and release it.
+ 
+ @warning Before calling this method, make sure no method is running on this client.
+ 
+ @param key A string to identify the service client.
+ */
++ (void)removeClientForKey:(NSString *)key;
+
+/**
+ 
+ 
+ 
+ return type: 
+ */
 - (AWSTask *)helloWorldGet;
 
+/**
+ 
+ 
+ @param key1 
+ 
+ return type: AWSStringValue *
+ */
+- (AWSTask *)testFunctionGet:(nullable NSString *)key1;
+
+/**
+ 
+ 
+ 
+ return type: 
+ */
 - (AWSTask *)testFunctionPost;
 
 /**
  
- @param username
  
- return type: AWS_Empty *
+ @param username 
+ 
+ return type: AWSStringValue *
  */
 - (AWSTask *)userUsernameGet:( NSString *)username;
-
-/**
- @param key1
- 
- return type: AWSEmpty *
- */
-- (AWSTask *)testFunctionGet:(nullable NSString *)key1;
 
 @end
 

--- a/AWSAPIGatewayTests/AWSStringValue.h
+++ b/AWSAPIGatewayTests/AWSStringValue.h
@@ -1,0 +1,26 @@
+/*
+ Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ A copy of the License is located at
+
+ http://aws.amazon.com/apache2.0
+
+ or in the "license" file accompanying this file. This file is distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing
+ permissions and limitations under the License.
+ */
+ 
+
+#import <Foundation/Foundation.h>
+#import <AWSCore/AWSCore.h>
+
+ 
+@interface AWSStringValue : AWSModel
+
+@property (nonatomic, strong, nullable) NSString *value;
+
+
+@end

--- a/AWSAPIGatewayTests/AWSStringValue.m
+++ b/AWSAPIGatewayTests/AWSStringValue.m
@@ -1,0 +1,27 @@
+/*
+ Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ A copy of the License is located at
+
+ http://aws.amazon.com/apache2.0
+
+ or in the "license" file accompanying this file. This file is distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing
+ permissions and limitations under the License.
+ */
+ 
+
+#import "AWSStringValue.h"
+
+@implementation AWSStringValue
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+    return @{
+             @"value": @"value"
+             };
+}
+
+@end

--- a/AWSCognitoTests/AWSCognitoClientTest.m
+++ b/AWSCognitoTests/AWSCognitoClientTest.m
@@ -92,13 +92,8 @@ Method _mockMethod;
 
 @implementation AWSCognitoClientTest
 + (void)setUp {
-    [CognitoTestUtils createFBAccount];
-    [CognitoTestUtils createIdentityPool];
-
-
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
                                                                                          identityPoolId:[CognitoTestUtils identityPoolId]];
-
 
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:provider];
 
@@ -107,8 +102,6 @@ Method _mockMethod;
 
 + (void)tearDown {
     [[AWSCognito defaultCognito] wipe];
-    [CognitoTestUtils deleteFBAccount];
-    [CognitoTestUtils deleteIdentityPool];
 }
 
 - (void)forceUpdate:(NSString *)datasetName withKey:(NSString *)key {

--- a/AWSCognitoTests/AWSCognitoSyncServiceTests.m
+++ b/AWSCognitoTests/AWSCognitoSyncServiceTests.m
@@ -28,8 +28,6 @@ NSString *_identityId;
 @implementation AWSCognitoSyncTests
 
 + (void)setUp {
-    [CognitoTestUtils createIdentityPool];
-
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
                                                                                          identityPoolId:[CognitoTestUtils identityPoolId]
                                                                                           unauthRoleArn:[CognitoTestUtils unauthRoleArn]
@@ -46,11 +44,7 @@ NSString *_identityId;
                                                   forKey:@"AWSCognitoSyncTests"];
 }
 
-+ (void)tearDown {
-    [CognitoTestUtils deleteIdentityPool];
-}
-
-- (void)testExample {
+- (void)testListRecords {
     AWSCognitoSyncListRecordsRequest *request = [AWSCognitoSyncListRecordsRequest new];
     request.datasetName = @"mydataset";
     request.identityPoolId = [CognitoTestUtils identityPoolId];
@@ -63,7 +57,7 @@ NSString *_identityId;
     }] waitUntilFinished];
 }
 
-- (void)testExampleFailed {
+- (void)testInvalidDatasetNameFails {
     NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials" ofType:@"json"];
     NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
                                                                     options:NSJSONReadingMutableContainers

--- a/AWSCognitoTests/CognitoTestUtils.h
+++ b/AWSCognitoTests/CognitoTestUtils.h
@@ -18,10 +18,6 @@
 
 @interface CognitoTestUtils : NSObject
 
-+ (void)createFBAccount;
-+ (void)createIdentityPool;
-+ (void)deleteFBAccount;
-+ (void)deleteIdentityPool;
 + (NSString *) accountId;
 + (NSString *) unauthRoleArn;
 + (NSString *) authRoleArn;

--- a/AWSCognitoTests/CognitoTestUtils.m
+++ b/AWSCognitoTests/CognitoTestUtils.m
@@ -21,11 +21,7 @@ NSString * AWSCognitoClientTestsFacebookAppID = nil;
 NSString * AWSCognitoClientTestsFacebookAppSecret = nil;
 NSString * AWSCognitoClientTestsUnauthRoleArn = nil;
 NSString * AWSCognitoClientTestsAuthRoleArn = nil;
-
-NSString *_identityPoolId = nil;
-NSString *_facebookToken = nil;
-NSString *_facebookAppToken = nil;
-NSString *_facebookId = nil;
+NSString * AWSCognitoClientTestsIdentityPoolId = nil;
 
 @implementation CognitoTestUtils
 
@@ -42,6 +38,7 @@ NSString *_facebookId = nil;
         AWSCognitoClientTestsFacebookAppSecret = credentialsJson[@"facebookAppSecret"];
         AWSCognitoClientTestsUnauthRoleArn = credentialsJson[@"unauthRoleArn"];
         AWSCognitoClientTestsAuthRoleArn = credentialsJson[@"authRoleArn"];
+        AWSCognitoClientTestsIdentityPoolId = credentialsJson[@"identityPoolId"];
     });
 }
 
@@ -61,110 +58,8 @@ NSString *_facebookId = nil;
 }
 
 + (NSString *) identityPoolId {
-    return _identityPoolId;
-}
-
-+ (NSString *) facebookToken {
-    return _facebookToken;
-}
-
-+ (void)createFBAccount {
     [CognitoTestUtils loadConfig];
-
-    NSString *accessURI = [NSString stringWithFormat:@"https://graph.facebook.com/oauth/access_token?client_id=%@&client_secret=%@&grant_type=client_credentials", AWSCognitoClientTestsFacebookAppID, AWSCognitoClientTestsFacebookAppSecret];
-
-    /* This code uses FB's test user API
-     See the following URL for more information
-     https://developers.facebook.com/docs/test_users/ */
-
-    // Get the FB APP access token
-    NSString *raw_response = [NSString stringWithContentsOfURL:[NSURL URLWithString:accessURI] encoding:NSUTF8StringEncoding error:nil];
-    NSDictionary *accessTokenDictionary = [NSJSONSerialization JSONObjectWithData:[raw_response dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableLeaves error:nil];
-    NSString *accessToken = accessTokenDictionary[@"access_token"];
-
-    // Add a new test user, the result contains an access key we can use to test assume role
-    NSString *addUserURI = [NSString stringWithFormat:@"https://graph.facebook.com/%@/accounts/test-users?installed=true&name=Foo%%20Bar&locale=en_US&permissions=read_stream&method=post&access_token=%@", AWSCognitoClientTestsFacebookAppID, [accessToken aws_stringWithURLEncodingPath]];
-    
-    NSString *newUser = [NSString stringWithContentsOfURL:[NSURL URLWithString:addUserURI] encoding:NSASCIIStringEncoding error:nil];
-    NSDictionary *user = [NSJSONSerialization JSONObjectWithData: [newUser dataUsingEncoding:NSUTF8StringEncoding]
-                                                         options: NSJSONReadingMutableContainers
-                                                           error: nil];
-
-    _facebookToken = [user objectForKey:@"access_token"];
-    _facebookId = [user objectForKey:@"id"];
+    return AWSCognitoClientTestsIdentityPoolId;
 }
-
-+ (void)deleteFBAccount {
-    NSString *deleteURI = [NSString stringWithFormat:@"https://graph.facebook.com/%@?method=delete&access_token=%@",
-                           _facebookId,
-                           [_facebookAppToken stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    [[[NSURLSession sharedSession] dataTaskWithRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:deleteURI]]
-                                    completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-                                        dispatch_semaphore_signal(semaphore);
-                                    }] resume];
-
-    if (dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)) != 0) {
-        @throw [NSException exceptionWithName:@"Request time out" reason:nil userInfo:nil];
-    }
-}
-
-+ (void)createIdentityPool {
-    [CognitoTestUtils loadConfig];
-
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                      secretKey:credentialsJson[@"secretKey"]];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
-                                                                         credentialsProvider:credentialsProvider];
-    [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration forKey:@"createIdentityPool"];
-    AWSCognitoIdentity *cib = [AWSCognitoIdentity CognitoIdentityForKey:@"createIdentityPool"];
-
-    AWSCognitoIdentityCreateIdentityPoolInput *createPoolForAuthProvider = [AWSCognitoIdentityCreateIdentityPoolInput new];
-    createPoolForAuthProvider.identityPoolName = @"CognitoSynciOSTests";
-    createPoolForAuthProvider.allowUnauthenticatedIdentities = @YES;
-    createPoolForAuthProvider.supportedLoginProviders = @{@"graph.facebook.com" : AWSCognitoClientTestsFacebookAppID};
-
-    [[[cib createIdentityPool:createPoolForAuthProvider] continueWithSuccessBlock:^id(AWSTask *task) {
-        AWSCognitoIdentityIdentityPool *identityPool = task.result;
-        _identityPoolId = identityPool.identityPoolId;
-
-        AWSCognitoIdentitySetIdentityPoolRolesInput *setRoles = [AWSCognitoIdentitySetIdentityPoolRolesInput new];
-        setRoles.roles = @{ @"unauthenticated": AWSCognitoClientTestsUnauthRoleArn,
-                            @"authenticated": AWSCognitoClientTestsAuthRoleArn};
-        setRoles.identityPoolId = _identityPoolId;
-
-        return [cib setIdentityPoolRoles:setRoles];
-    }] waitUntilFinished];
-
-    [AWSCognitoIdentity removeCognitoIdentityForKey:@"createIdentityPool"];
-
-    [NSThread sleepForTimeInterval:20];
-}
-
-+ (void)deleteIdentityPool {
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                      secretKey:credentialsJson[@"secretKey"]];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
-                                                                         credentialsProvider:credentialsProvider];
-    [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration forKey:@"deleteIdentityPool"];
-    AWSCognitoIdentity *cib = [AWSCognitoIdentity CognitoIdentityForKey:@"deleteIdentityPool"];
-
-    AWSCognitoIdentityDeleteIdentityPoolInput *deletePoolForAuth = [AWSCognitoIdentityDeleteIdentityPoolInput new];
-    deletePoolForAuth.identityPoolId = _identityPoolId;
-    [[cib deleteIdentityPool:deletePoolForAuth] waitUntilFinished];
-
-    [AWSCognitoIdentity removeCognitoIdentityForKey:@"deleteIdentityPool"];
-}
-
 
 @end

--- a/AWSComprehendTests/AWSComprehendTests.swift
+++ b/AWSComprehendTests/AWSComprehendTests.swift
@@ -70,7 +70,7 @@ class AWSComprehendTests: XCTestCase {
         
         comprehendClient.detectEntities(detectEntitiesRequest!).continueWith{ (task) -> Any? in
             guard let result = task.result else {
-                XCTAssertFalse(true, "got error.")
+                XCTAssertFalse(true, "got error: \(String(describing: task.error))")
                 return nil
             }
             XCTAssertNotNil(result)

--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -149,7 +149,7 @@ NSString *const AWSSignatureV4Terminator = @"aws4_request";
 }
 
 - (AWSTask *)interceptRequest:(NSMutableURLRequest *)request {
-    [request addValue:request.URL.host forHTTPHeaderField:@"Host"];
+    [request setValue:request.URL.host forHTTPHeaderField:@"Host"];
     return [[self.credentialsProvider credentials] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCredentials *> * _Nonnull task) {
         AWSCredentials *credentials = task.result;
         // clear authorization header if set

--- a/AWSCoreTests/AWSCognitoCredentialsProviderTests.m
+++ b/AWSCoreTests/AWSCognitoCredentialsProviderTests.m
@@ -19,18 +19,17 @@
 #import "AWSCore.h"
 #import "AWSTestUtility.h"
 
-// FACEBOOK - tied to the aws-dr-mobile-test-android@amazon.com FB account
+NSString * AWSCognitoCredentialsProviderTestsIdentityPoolId = nil;
 NSString * AWSCognitoCredentialsProviderTestsAccountID = nil;
 NSString * AWSCognitoCredentialsProviderTestsFacebookAppID = nil;
 NSString * AWSCognitoCredentialsProviderTestsFacebookAppSecret = nil;
 NSString * AWSCognitoCredentialsProviderTestsUnauthRoleArn = nil;
 NSString * AWSCognitoCredentialsProviderTestsAuthRoleArn = nil;
 
-NSString *_identityPoolIdAuth;
-NSString *_identityPoolIdUnauth;
 NSString *_facebookToken;
 NSString *_facebookAppToken;
 NSString *_facebookId;
+
 BOOL _identityChanged;
 
 @interface AWSTestFacebookIdentityProvider : NSObject<AWSIdentityProvider, AWSIdentityProviderManager>
@@ -195,15 +194,14 @@ BOOL _identityChanged;
     [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration
                                                           forKey:@"Static"];
     
+    AWSCognitoCredentialsProviderTestsIdentityPoolId = credentialsJson[@"identityPoolId"];
     AWSCognitoCredentialsProviderTestsAccountID = credentialsJson[@"accountId"];
     AWSCognitoCredentialsProviderTestsFacebookAppID = credentialsJson[@"facebookAppId"];
     AWSCognitoCredentialsProviderTestsFacebookAppSecret = credentialsJson[@"facebookAppSecret"];
     AWSCognitoCredentialsProviderTestsUnauthRoleArn = credentialsJson[@"unauthRoleArn"];
     AWSCognitoCredentialsProviderTestsAuthRoleArn = credentialsJson[@"authRoleArn"];
 
-    //[AWSCognitoCredentialsProviderTests cleanupIdentityPools];
     [AWSCognitoCredentialsProviderTests createFBAccount];
-    [AWSCognitoCredentialsProviderTests createIdentityPools];
 }
 
 - (void)setUp {
@@ -218,18 +216,13 @@ BOOL _identityChanged;
 - (void)tearDown {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                         identityPoolId:_identityPoolIdAuth];
+                                                                                         identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
     [provider clearKeychain];
-    provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                          identityPoolId:_identityPoolIdUnauth];
-    [provider clearKeychain];
-
     [super tearDown];
 }
 
 + (void)tearDown {
     [AWSCognitoCredentialsProviderTests deleteFBAccount];
-    [AWSCognitoCredentialsProviderTests deleteIdentityPools];
 }
 
 #pragma mark - Tests
@@ -263,7 +256,7 @@ BOOL _identityChanged;
 - (void)testProvider {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                         identityPoolId:_identityPoolIdAuth
+                                                                                         identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                           unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                             authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                                                 identityProviderManager:identityProvider];
@@ -293,7 +286,7 @@ BOOL _identityChanged;
 - (void)testProviderEnhancedFlow {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                         identityPoolId:_identityPoolIdAuth
+                                                                                         identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                 identityProviderManager:identityProvider];
     [[[[provider credentials] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCredentials *> * _Nonnull task) {
         AWSCredentials *credentials = task.result;
@@ -322,7 +315,7 @@ BOOL _identityChanged;
     AWSTestFacebookIdentityProvider *identityProvider1 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSTestFacebookIdentityProvider *identityProvider2 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
     AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                          identityPoolId:_identityPoolIdAuth
+                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                            unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                              authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                                                  identityProviderManager:identityProvider1];
@@ -336,7 +329,7 @@ BOOL _identityChanged;
 
         [provider1 clearKeychain];
         provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                               identityPoolId:_identityPoolIdAuth
+                                                               identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                 unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                   authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                       identityProviderManager:identityProvider2];
@@ -366,7 +359,7 @@ BOOL _identityChanged;
 - (void)testProviderKeychain {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                          identityPoolId:_identityPoolIdAuth
+                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                            unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                              authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                                                  identityProviderManager:identityProvider];
@@ -379,7 +372,7 @@ BOOL _identityChanged;
         XCTAssertNotNil(provider1.identityId, @"Unable to get identityId");
 
         provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                               identityPoolId:_identityPoolIdAuth
+                                                               identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                 unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                   authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                       identityProviderManager:nil];
@@ -400,7 +393,7 @@ BOOL _identityChanged;
 - (void)testProviderFailure {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                         identityPoolId:_identityPoolIdUnauth
+                                                                                         identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                           unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                             authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                                                 identityProviderManager:identityProvider];
@@ -424,7 +417,7 @@ BOOL _identityChanged;
 - (void)testEnhancedProvider {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                         identityPoolId:_identityPoolIdAuth
+                                                                                         identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                 identityProviderManager:identityProvider];
 
     [[[[provider credentials] continueWithSuccessBlock:^id(AWSTask *task) {
@@ -455,7 +448,7 @@ BOOL _identityChanged;
     AWSTestFacebookIdentityProvider *identityProvider1 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSTestFacebookIdentityProvider *identityProvider2 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
     AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                          identityPoolId:_identityPoolIdAuth
+                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                  identityProviderManager:identityProvider1];
 
     __block AWSCognitoCredentialsProvider *provider2 = nil;
@@ -467,7 +460,7 @@ BOOL _identityChanged;
 
         [provider1 clearKeychain];
         provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                               identityPoolId:_identityPoolIdAuth
+                                                               identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                       identityProviderManager:identityProvider2];
         return [provider2 getIdentityId];
     }] continueWithSuccessBlock:^id(AWSTask *task) {
@@ -494,7 +487,7 @@ BOOL _identityChanged;
 
 - (void)testEnhancedProviderKeychain {
     AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                          identityPoolId:_identityPoolIdAuth
+                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                  identityProviderManager:[AWSTestFacebookIdentityProvider new]];
 
     __block AWSCognitoCredentialsProvider *provider2 = nil;
@@ -504,7 +497,7 @@ BOOL _identityChanged;
         XCTAssertNotNil(provider1.identityId, @"Unable to get identityId");
 
         provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                               identityPoolId:_identityPoolIdAuth];
+                                                               identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
         return [provider2 getIdentityId];
     }] continueWithSuccessBlock:^id _Nullable(AWSTask * _Nonnull task) {
         return [provider2 credentials];
@@ -528,7 +521,7 @@ BOOL _identityChanged;
 - (void)testEnhancedProviderFailure {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                         identityPoolId:_identityPoolIdUnauth
+                                                                                         identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                 identityProviderManager:identityProvider];
 
     [[[[provider getIdentityId] continueWithSuccessBlock:^id(AWSTask *task) {
@@ -551,7 +544,7 @@ BOOL _identityChanged;
 
 - (void)testBYOIProvider {
     AWSFakeCognitoIdentityProvider *fakeIdentityProvider = [[AWSFakeCognitoIdentityProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                                       identityPoolId:_identityPoolIdAuth];
+                                                                                                       identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
 
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
                                                                                           unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
@@ -572,7 +565,7 @@ BOOL _identityChanged;
 
 - (void)testBYOIProviderWithEnhancedFlow {
     AWSFakeCognitoIdentityProvider *fakeIdentityProvider = [[AWSFakeCognitoIdentityProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                                       identityPoolId:_identityPoolIdAuth];
+                                                                                                       identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
 
     AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
                                                                                        identityProvider:fakeIdentityProvider];
@@ -632,86 +625,6 @@ BOOL _identityChanged;
     [NSURLConnection sendSynchronousRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:deleteURI]]
                           returningResponse:nil
                                       error:nil];
-}
-
-+ (void)createIdentityPools {
-    NSMutableArray *tasks = [NSMutableArray new];
-
-    AWSCognitoIdentityCreateIdentityPoolInput *createPoolForAuthProvider = [AWSCognitoIdentityCreateIdentityPoolInput new];
-    createPoolForAuthProvider.identityPoolName = @"CIBiOSTestAuthProvider";
-    createPoolForAuthProvider.allowUnauthenticatedIdentities = @YES;
-    createPoolForAuthProvider.supportedLoginProviders = @{@"graph.facebook.com" : AWSCognitoCredentialsProviderTestsFacebookAppID};
-    createPoolForAuthProvider.developerProviderName = @"iostests.com";
-
-    [tasks addObject:[[[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] createIdentityPool:createPoolForAuthProvider] continueWithSuccessBlock:^id(AWSTask *task) {
-        AWSCognitoIdentityIdentityPool *identityPool = task.result;
-        _identityPoolIdAuth = identityPool.identityPoolId;
-
-        AWSCognitoIdentitySetIdentityPoolRolesInput *setRoleInput = [AWSCognitoIdentitySetIdentityPoolRolesInput new];
-        setRoleInput.identityPoolId = identityPool.identityPoolId;
-        setRoleInput.roles = @{ @"unauthenticated": AWSCognitoCredentialsProviderTestsUnauthRoleArn,
-                                @"authenticated": AWSCognitoCredentialsProviderTestsAuthRoleArn};
-
-        return [[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] setIdentityPoolRoles:setRoleInput];
-    }]];
-
-    AWSCognitoIdentityCreateIdentityPoolInput *createPoolForUnauthProvider = [AWSCognitoIdentityCreateIdentityPoolInput new];
-    createPoolForUnauthProvider.identityPoolName = @"CIBiOSTUnauthProvider";
-    createPoolForUnauthProvider.allowUnauthenticatedIdentities = @YES;
-
-    [tasks addObject:[[[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] createIdentityPool:createPoolForUnauthProvider] continueWithSuccessBlock:^id(AWSTask *task) {
-        AWSCognitoIdentityIdentityPool *identityPool = task.result;
-        _identityPoolIdUnauth = identityPool.identityPoolId;
-
-        AWSCognitoIdentitySetIdentityPoolRolesInput *setRoleInput = [AWSCognitoIdentitySetIdentityPoolRolesInput new];
-        setRoleInput.identityPoolId = identityPool.identityPoolId;
-        setRoleInput.roles = @{ @"unauthenticated": AWSCognitoCredentialsProviderTestsUnauthRoleArn,
-                                @"authenticated": AWSCognitoCredentialsProviderTestsAuthRoleArn};
-
-        return [[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] setIdentityPoolRoles:setRoleInput];
-    }]];
-
-    [[AWSTask taskForCompletionOfAllTasks:tasks] waitUntilFinished];
-
-    // sleep for 60 seconds becaue identity pool config is cached
-    [NSThread sleepForTimeInterval:60];
-}
-
-+ (void)deleteIdentityPools {
-    NSMutableArray *tasks = [NSMutableArray new];
-
-    AWSCognitoIdentityDeleteIdentityPoolInput *deletePoolForAuth = [AWSCognitoIdentityDeleteIdentityPoolInput new];
-    deletePoolForAuth.identityPoolId = _identityPoolIdAuth;
-    [tasks addObject:[[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] deleteIdentityPool:deletePoolForAuth]];
-
-    AWSCognitoIdentityDeleteIdentityPoolInput *deletePoolForUnauth = [AWSCognitoIdentityDeleteIdentityPoolInput new];
-    deletePoolForUnauth.identityPoolId = _identityPoolIdUnauth;
-    [tasks addObject:[[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] deleteIdentityPool:deletePoolForUnauth]];
-    
-    [[AWSTask taskForCompletionOfAllTasks:tasks] waitUntilFinished];
-}
-
-
-+ (void)cleanupIdentityPools {
-    AWSCognitoIdentityListIdentityPoolsInput *lpi = [AWSCognitoIdentityListIdentityPoolsInput new];
-    lpi.maxResults = [NSNumber numberWithInteger:60];
-    
-    [[[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] listIdentityPools:lpi] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityListIdentityPoolsResponse *> * _Nonnull task) {
-        NSMutableArray *tasks = [NSMutableArray new];
-        for (AWSCognitoIdentityIdentityPoolShortDescription *object in task.result.identityPools) {
-            NSLog(@"Inspecting %@: %@", object.identityPoolName, object.identityPoolId);
-            if([object.identityPoolName containsString:@"CIBiOS"]){
-                AWSCognitoIdentityDeleteIdentityPoolInput *deletePoolForAuth = [AWSCognitoIdentityDeleteIdentityPoolInput new];
-                deletePoolForAuth.identityPoolId= object.identityPoolId;
-                NSLog(@"Deleting %@",object.identityPoolId);
-                [tasks addObject:[[AWSCognitoIdentity CognitoIdentityForKey:@"Static"] deleteIdentityPool:deletePoolForAuth]];
-            }
-        }
-        
-        [[AWSTask taskForCompletionOfAllTasks:tasks] waitUntilFinished];
-
-        return nil;
-    }];
 }
 
 - (void)identityIdDidChange:(NSNotification *)notification {

--- a/AWSDynamoDBTests/AWSDynamoDBTests.m
+++ b/AWSDynamoDBTests/AWSDynamoDBTests.m
@@ -620,6 +620,7 @@ static NSString *table2Name = nil;
 
     if (![[self class] createTable:table2Name]) {
         XCTFail(@"failed to createTable: %@",table2Name);
+        return;
     }
 
     NSNumber *newCapacity = @2;

--- a/AWSKinesisVideoTests/AWSKinesisVideoTests.swift
+++ b/AWSKinesisVideoTests/AWSKinesisVideoTests.swift
@@ -16,7 +16,6 @@
 import XCTest
 import AWSKinesisVideo
 
-
 class AWSKinesisVideoTests: XCTestCase {
     
     let streamPrefix = "kinesisvideo-integration-test-"

--- a/AWSLambdaTests/AWSLambdaInvokerTests.m
+++ b/AWSLambdaTests/AWSLambdaInvokerTests.m
@@ -43,7 +43,7 @@
     XCTAssertNotNil(lambdaInvoker);
     
     AWSLambdaInvokerInvocationRequest *invocationRequest = [AWSLambdaInvokerInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     invocationRequest.logType = AWSLambdaLogTypeTail;
     invocationRequest.payload = @{@"key1" : @"value1",
@@ -73,7 +73,7 @@
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
 
     AWSLambdaInvokerInvocationRequest *invocationRequest = [AWSLambdaInvokerInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     invocationRequest.logType = AWSLambdaLogTypeTail;
     invocationRequest.payload = @{@"key1" : @"value1",
@@ -101,7 +101,7 @@
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
 
     AWSLambdaInvokerInvocationRequest *invocationRequest = [AWSLambdaInvokerInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     invocationRequest.logType = AWSLambdaLogTypeTail;
     invocationRequest.payload = @{@"key1" : @"value1",
@@ -134,7 +134,7 @@
 - (void)testInvokeError {
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
     AWSLambdaInvokerInvocationRequest *invocationRequest = [AWSLambdaInvokerInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     invocationRequest.payload = @{@"key1" : @"value1",
                                   @"key2" : @"value2",
@@ -147,6 +147,7 @@
         XCTAssertNil(task.result);
         XCTAssertEqualObjects(task.error.domain, AWSLambdaInvokerErrorDomain);
         XCTAssertEqual(task.error.code, AWSLambdaInvokerErrorTypeFunctionError);
+        // This does not get set on Node 10 runtimes
         XCTAssertEqualObjects(task.error.userInfo[AWSLambdaInvokerFunctionErrorKey], @"Handled");
         XCTAssertEqualObjects(task.error.userInfo[AWSLambdaInvokerErrorMessageKey], @"Invalid Request");
         return nil;
@@ -155,7 +156,7 @@
 
 - (void)testInvokeFunction {
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
-    [[[lambdaInvoker invokeFunction:@"helloWorldExample"
+    [[[lambdaInvoker invokeFunction:@"echo"
                          JSONObject:@{@"key1" : @"value1",
                                       @"key2" : @"value2",
                                       @"key3" : @"value3",
@@ -175,7 +176,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called."];
 
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
-    [lambdaInvoker invokeFunction:@"helloWorldExample"
+    [lambdaInvoker invokeFunction:@"echo"
                        JSONObject:@{@"key1" : @"value1",
                                     @"key2" : @"value2",
                                     @"key3" : @"value3",
@@ -200,14 +201,13 @@
 - (void)testInvokeFunction2 {
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
     
-    NSDictionary *jsonObject = @{@"firstName" : NSStringFromSelector(_cmd)};
-    [[[lambdaInvoker invokeFunction:@"lambdaDebugging" JSONObject:jsonObject] continueWithBlock:^id(AWSTask *task) {
+    NSDictionary *jsonObject = @{@"firstName" : @"testInvokeFunction2"};
+    [[[lambdaInvoker invokeFunction:@"echo-2" JSONObject:jsonObject] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error);
         XCTAssertNotNil(task.result);
         XCTAssertTrue([task.result isKindOfClass:[NSDictionary class]]);
         NSDictionary *result = task.result;
-        NSString *expectedString = [NSString stringWithFormat:@"Hello %@",NSStringFromSelector(_cmd)];
-        XCTAssertEqualObjects(expectedString,result[@"message"]);
+        XCTAssertEqualObjects(@"testInvokeFunction2", result[@"firstName"]);
         return nil;
     }] waitUntilFinished];
      
@@ -215,7 +215,7 @@
      
 - (void)testInvokeFunctionError {
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
-    [[[lambdaInvoker invokeFunction:@"helloWorldExample"
+    [[[lambdaInvoker invokeFunction:@"echo"
                          JSONObject:@{@"key1" : @"value1",
                                       @"key2" : @"value2",
                                       @"key3" : @"value3",
@@ -233,7 +233,7 @@
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
 
     AWSLambdaInvokerInvocationRequest *invocationRequest = [AWSLambdaInvokerInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     invocationRequest.logType = AWSLambdaLogTypeTail;
     invocationRequest.payload = @{@"key1" : @"value1",
@@ -248,8 +248,7 @@
         XCTAssertTrue([task.result isKindOfClass:[AWSLambdaInvokerInvocationResponse class]]);
         AWSLambdaInvokerInvocationResponse *invocationResponse = task.result;
         XCTAssertTrue([invocationResponse.payload isKindOfClass:[NSDictionary class]]);
-        NSDictionary *result = invocationResponse.payload;
-        XCTAssertEqualObjects(result[@"version"], @"1");
+        XCTAssertEqualObjects(invocationResponse.executedVersion, @"2");
         XCTAssertNotNil(invocationResponse.logResult);
         XCTAssertTrue([invocationResponse.logResult isKindOfClass:[NSString class]]);
         return nil;
@@ -260,14 +259,14 @@
     AWSLambdaInvoker *lambdaInvoker = [AWSLambdaInvoker defaultLambdaInvoker];
 
     AWSLambdaInvokerInvocationRequest *invocationRequest = [AWSLambdaInvokerInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     invocationRequest.logType = AWSLambdaLogTypeTail;
     invocationRequest.payload = @{@"key1" : @"value1",
                                   @"key2" : @"value2",
                                   @"key3" : @"value3",
                                   @"isError" : @NO};
-    invocationRequest.qualifier = @"version2";
+    invocationRequest.qualifier = @"Version2Alias";
 
     [[[lambdaInvoker invoke:invocationRequest] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error);
@@ -275,8 +274,7 @@
         XCTAssertTrue([task.result isKindOfClass:[AWSLambdaInvokerInvocationResponse class]]);
         AWSLambdaInvokerInvocationResponse *invocationResponse = task.result;
         XCTAssertTrue([invocationResponse.payload isKindOfClass:[NSDictionary class]]);
-        NSDictionary *result = invocationResponse.payload;
-        XCTAssertEqualObjects(result[@"version"], @"1");
+        XCTAssertEqualObjects(invocationResponse.executedVersion, @"2");
         XCTAssertNotNil(invocationResponse.logResult);
         XCTAssertTrue([invocationResponse.logResult isKindOfClass:[NSString class]]);
         return nil;

--- a/AWSLambdaTests/AWSLambdaTests.m
+++ b/AWSLambdaTests/AWSLambdaTests.m
@@ -53,7 +53,7 @@
     AWSLambda *lambda = [AWSLambda defaultLambda];
 
     AWSLambdaGetFunctionRequest *getFunctionsRequest = [AWSLambdaGetFunctionRequest new];
-    getFunctionsRequest.functionName = @"helloWorldExample";
+    getFunctionsRequest.functionName = @"echo";
 
     [[[lambda getFunction:getFunctionsRequest] continueWithBlock:^id(AWSTask *task) {
         if (task.error) {
@@ -110,7 +110,7 @@
 - (void)testInvoke {
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
                                  @"key2" : @"value2",
@@ -142,7 +142,7 @@
     
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
                                  @"key2" : @"value2",
@@ -170,23 +170,25 @@
 
 - (void)testInvoke2 {
     AWSLambda *lambda = [AWSLambda defaultLambda];
+
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"lambdaDebugging";
+    invocationRequest.functionName = @"echo-2";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
-    NSDictionary *parameters = @{@"firstName" : NSStringFromSelector(_cmd)};
+    NSDictionary *parameters = @{@"firstName" : @"testInvokeFunction2",
+                                 @"isError" : @NO};
     invocationRequest.payload = [NSJSONSerialization dataWithJSONObject:parameters
                                                                 options:kNilOptions
                                                                   error:nil];
+
     invocationRequest.clientContext = [[AWSClientContext new] base64EncodedJSONString];
-    
+
     [[[lambda invoke:invocationRequest] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error);
         XCTAssertNotNil(task.result);
         AWSLambdaInvocationResponse *invocationResponse = task.result;
         XCTAssertTrue([invocationResponse.payload isKindOfClass:[NSDictionary class]]);
         NSDictionary *result = invocationResponse.payload;
-        NSString *expectedString = [NSString stringWithFormat:@"Hello %@",NSStringFromSelector(_cmd)];
-        XCTAssertEqualObjects(expectedString,result[@"message"]);
+        XCTAssertEqualObjects(@"testInvokeFunction2", result[@"firstName"]);
         return nil;
     }] waitUntilFinished];
 }
@@ -194,7 +196,7 @@
 - (void)testInvokeWithVersion {
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
+    invocationRequest.functionName = @"echo";
     invocationRequest.qualifier = @"2";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
@@ -211,8 +213,7 @@
         XCTAssertNotNil(task.result);
         AWSLambdaInvocationResponse *invocationResponse = task.result;
         XCTAssertTrue([invocationResponse.payload isKindOfClass:[NSDictionary class]]);
-        NSDictionary *result = invocationResponse.payload;
-        XCTAssertEqualObjects(result[@"version"], @"1");
+        XCTAssertEqualObjects(invocationResponse.executedVersion, @"2");
         return nil;
     }] waitUntilFinished];
 }
@@ -220,8 +221,8 @@
 - (void)testInvokeWithVersionAlias {
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"helloWorldExample";
-    invocationRequest.qualifier = @"version2";
+    invocationRequest.functionName = @"echo";
+    invocationRequest.qualifier = @"Version2Alias";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
                                  @"key2" : @"value2",
@@ -231,14 +232,13 @@
                                                                 options:kNilOptions
                                                                   error:nil];
     invocationRequest.clientContext = [[AWSClientContext new] base64EncodedJSONString];
-
+    
     [[[lambda invoke:invocationRequest] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error);
         XCTAssertNotNil(task.result);
         AWSLambdaInvocationResponse *invocationResponse = task.result;
         XCTAssertTrue([invocationResponse.payload isKindOfClass:[NSDictionary class]]);
-        NSDictionary *result = invocationResponse.payload;
-        XCTAssertEqualObjects(result[@"version"], @"1");
+        XCTAssertEqualObjects(invocationResponse.executedVersion, @"2");
         return nil;
     }] waitUntilFinished];
 }

--- a/AWSMachineLearning/AWSMachineLearningService.m
+++ b/AWSMachineLearning/AWSMachineLearningService.m
@@ -270,6 +270,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         headers[@"X-Amz-Target"] = [NSString stringWithFormat:@"%@.%@", targetPrefix, operationName];
         networkingRequest.headers = headers;
         networkingRequest.HTTPMethod = HTTPMethod;
+        networkingRequest.URLString = URLString;
         networkingRequest.requestSerializer = [[AWSJSONRequestSerializer alloc] initWithJSONDefinition:[[AWSMachineLearningResources sharedInstance] JSONObject]
                                                                                                    actionName:operationName];
         networkingRequest.responseSerializer = [[AWSMachineLearningResponseSerializer alloc] initWithJSONDefinition:[[AWSMachineLearningResources sharedInstance] JSONObject]

--- a/AWSMobileAnalyticsLegacyTests/AZIOSClientContextTests.m
+++ b/AWSMobileAnalyticsLegacyTests/AZIOSClientContextTests.m
@@ -41,9 +41,7 @@
     //App details
     assertThat(clientContext.serviceDetails[@"mobile_analytics"][@"app_id"], is(equalTo(@"appId")));
 
-    assertThat(clientContext.appPackageName, is(equalTo(@"Unknown")));
     assertThat(clientContext.appVersion, is(equalTo(@"Unknown")));
-    assertThat(clientContext.appPackageName, is(equalTo(@"Unknown")));
     assertThat(clientContext.appName, is(equalTo(@"Unknown")));
 
     //Device details
@@ -76,9 +74,7 @@
     //App details
     assertThat(clientContext.serviceDetails[@"mobile_analytics"][@"app_id"], is(equalTo(@"appId")));
 
-    assertThat(clientContext.appPackageName, is(equalTo(@"Unknown")));
     assertThat(clientContext.appVersion, is(equalTo(@"Unknown")));
-    assertThat(clientContext.appPackageName, is(equalTo(@"Unknown")));
     assertThat(clientContext.appName, is(equalTo(@"Unknown")));
 
     //Device details

--- a/AWSRekognitionTests/AWSRekognitionTests.swift
+++ b/AWSRekognitionTests/AWSRekognitionTests.swift
@@ -38,13 +38,13 @@ class AWSRekognitionTests: XCTestCase {
         let collectionRequest = AWSRekognitionCreateCollectionRequest()
         collectionRequest?.collectionId = "MyCollectionID"
         rekognition.createCollection(collectionRequest!).continueWith { (response) -> Any? in
-            if let error = response.error {
-                XCTAssertEqual(error.localizedDescription, "The operation couldn’t be completed. (com.amazonaws.AWSRekognitionErrorDomain error 11.)")
-            }
-            else {
+            if let error = response.error as NSError? {
+                XCTAssertEqual(error.domain , AWSRekognitionErrorDomain)
+                XCTAssertEqual(error.code, AWSRekognitionErrorType.resourceAlreadyExists.rawValue)
+            } else {
                 XCTAssertNotNil(response.result)
                 if let result = response.result {
-                    print (result)
+                    print(result)
                 }
             }
             return nil
@@ -55,8 +55,6 @@ class AWSRekognitionTests: XCTestCase {
         let fileURL = testBundle.url(forResource: "singleface", withExtension: "jpg")
         var data:Data?
         do {
-            
-            
             data = try Data(contentsOf:fileURL!)
             let image = AWSRekognitionImage()
             image?.bytes = data
@@ -82,18 +80,18 @@ class AWSRekognitionTests: XCTestCase {
         
     }
     
-    func testFaceIndexMultipeFaces() {
+    func testFaceIndexMultipleFacesFromS3Bucket() {
         let rekognition = AWSRekognition.default()
         let collectionRequest = AWSRekognitionCreateCollectionRequest()
         collectionRequest?.collectionId = "MyCollectionID"
         rekognition.createCollection(collectionRequest!).continueWith { (response) -> Any? in
-            if let error = response.error {
-                XCTAssertEqual(error.localizedDescription, "The operation couldn’t be completed. (com.amazonaws.AWSRekognitionErrorDomain error 11.)")
-            }
-            else {
+            if let error = response.error as NSError? {
+                XCTAssertEqual(error.domain , AWSRekognitionErrorDomain)
+                XCTAssertEqual(error.code, AWSRekognitionErrorType.resourceAlreadyExists.rawValue)
+            } else {
                 XCTAssertNotNil(response.result)
                 if let result = response.result {
-                    print (result)
+                    print(result)
                 }
             }
             return nil
@@ -127,13 +125,13 @@ class AWSRekognitionTests: XCTestCase {
         let collectionRequest = AWSRekognitionCreateCollectionRequest()
         collectionRequest?.collectionId = "MyCollectionID"
         rekognition.createCollection(collectionRequest!).continueWith { (response) -> Any? in
-            if let error = response.error {
-                XCTAssertEqual(error.localizedDescription, "The operation couldn’t be completed. (com.amazonaws.AWSRekognitionErrorDomain error 11.)")
-            }
-            else {
+            if let error = response.error as NSError? {
+                XCTAssertEqual(error.domain , AWSRekognitionErrorDomain)
+                XCTAssertEqual(error.code, AWSRekognitionErrorType.resourceAlreadyExists.rawValue)
+            } else {
                 XCTAssertNotNil(response.result)
                 if let result = response.result {
-                    print (result)
+                    print(result)
                 }
             }
             return nil

--- a/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
+++ b/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
@@ -45,10 +45,16 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 
 @end
 
-@implementation AWSS3PreSignedURLBuilderTests
+@implementation AWSS3PreSignedURLBuilderTests {
+    
+    NSArray *bucketNameArray;
+
+}
 
 - (void)setUp {
     [super setUp];
+    bucketNameArray = @[@"ios-v2-s3-tm-testdata", @"ios-v2-s3.periods", @"ios-v2-s3-eu-central", @"ios-v2-s3-eu-c.periods"];
+
     // Put setup code here. This method is called before the invocation of each test method in the class.
     [AWSTestUtility setupCognitoCredentialsProvider];
 
@@ -131,8 +137,6 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 }
 
 -(void)testObjectWithGreedyKey {
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata", @"ios-v2-s3.periods", @"ios-v2-s3-eu-central", @"ios-v2-s3-eu-c.periods"];
-
     int32_t count = 0;
     for (NSString *myBucketName in bucketNameArray) {
 
@@ -385,8 +389,6 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 }
 
 - (void)testPutObjectWithSpecialCharacters {
-
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata",@"ios-v2-s3.periods",@"ios-v2-s3-eu-central",@"ios-v2-s3-eu-c.periods"];
     NSArray *keyNameArray = @[@"a:b/&$@=;:+ ,?.zip",@"\\^`><{}/[]#  %'~|"]; //characters might require special handling and characters to avoid
     NSString *testContentType = @"application/x-authorware-bin";
 
@@ -562,9 +564,6 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 }
 
 - (void)testGetObject {
-
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata",@"ios-v2-s3.periods",@"ios-v2-s3-eu-central",@"ios-v2-s3-eu-c.periods"];
-
     int32_t count = 0;
     for (NSString *myBucketName in bucketNameArray) {
 
@@ -812,7 +811,6 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 }
 
 - (void)testPutObject2 {
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata",@"ios-v2-s3.periods",@"ios-v2-s3-eu-central",@"ios-v2-s3-eu-c.periods"];
     NSString *testContentType = @"application/x-authorware-bin";
     int32_t count = 0;
     for (NSString *myBucketName in bucketNameArray) {
@@ -1021,8 +1019,6 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 
 }
 - (void)testPutObject {
-
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata",@"ios-v2-s3.periods",@"ios-v2-s3-eu-central",@"ios-v2-s3-eu-c.periods"];
     NSString *testContentType = @"application/x-authorware-bin";
     int32_t count = 0;
 
@@ -1147,9 +1143,6 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 }
 
 - (void)testHEADObject {
-
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata",@"ios-v2-s3.periods",@"ios-v2-s3-eu-central",@"ios-v2-s3-eu-c.periods"];
-
     int32_t count = 0;
     for (NSString *myBucketName in bucketNameArray) {
 
@@ -1221,9 +1214,7 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
 
 }
 
-- (void)testDeleteBucket {
-    NSArray *bucketNameArray = @[@"ios-v2-s3-tm-testdata",@"ios-v2-s3.periods",@"ios-v2-s3-eu-central",@"ios-v2-s3-eu-c.periods"];
-
+- (void)testDeleteObjectFromBucket {
     int32_t count = 0;
     for (NSString *myBucketName in bucketNameArray) {
 

--- a/AWSS3Tests/AWSS3Tests.m
+++ b/AWSS3Tests/AWSS3Tests.m
@@ -952,7 +952,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     
 }
 - (void)testPutGetAndDeleteObjectByFilePathWithProgressFeedback {
-    NSString *keyName = @"ios-test-put-get-and-delete-obj";
+    NSString *keyName = @"ios-v2-do-not-delete-s3test-put-get-delete-obj";
     NSString *getObjectFilePath = tempSmallURL.path;
     XCTAssertNotNil(getObjectFilePath);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:getObjectFilePath]);
@@ -966,7 +966,6 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     putObjectRequest.body = [NSURL fileURLWithPath:getObjectFilePath];
     putObjectRequest.contentLength = [NSNumber numberWithUnsignedLongLong:fileSize];
    
-
     __block int64_t totalUploadedBytes = 0;
     __block int64_t totalExpectedUploadBytes = 0;
     putObjectRequest.uploadProgress = ^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
@@ -1568,9 +1567,9 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 }
 
 - (void)testInventorySetupOnBucket {
-    NSString *sourceBucketName = @"ios-v2-test-508881905";
+    NSString *sourceBucketName = @"ios-v2-do-not-delete-s3test-inventory-source";
 
-    NSString *destinationBucketName = @"ios-v2-test-508883511";
+    NSString *destinationBucketName = @"ios-v2-do-not-delete-s3test-inventory";
 
     AWSS3 *s3 = [AWSS3 defaultS3];
     XCTAssertNotNil(s3);
@@ -1578,7 +1577,6 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     AWSS3PutBucketInventoryConfigurationRequest *putBucketInventoryRequest = [AWSS3PutBucketInventoryConfigurationRequest new];
     putBucketInventoryRequest.bucket = sourceBucketName;
     putBucketInventoryRequest.identifier=@"123";
-
 
     putBucketInventoryRequest.inventoryConfiguration=[AWSS3InventoryConfiguration new];
     putBucketInventoryRequest.inventoryConfiguration.isEnabled=@(YES);

--- a/AWSSESTests/AWSSESTests.m
+++ b/AWSSESTests/AWSSESTests.m
@@ -143,7 +143,8 @@ static NSString *_verifiedEmailAddress = nil;
 
     [[[ses verifyEmailIdentity:identityRequest] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error, @"expected InvalidParameterValue Error but got nil");
-        XCTAssertEqual(task.error.code, 0);
+        XCTAssertEqualObjects(task.error.domain, AWSSESErrorDomain);
+        XCTAssertEqual(task.error.code, AWSSESErrorUnknown);
         XCTAssertTrue([@"InvalidParameterValue" isEqualToString:task.error.userInfo[@"Code"]]);
         XCTAssertTrue([@"Email address not specified." isEqualToString:task.error.userInfo[@"Message"]]);
         return nil;

--- a/AWSSNSTests/AWSSNSTests.m
+++ b/AWSSNSTests/AWSSNSTests.m
@@ -93,6 +93,7 @@
     
     [[[sns getEndpointAttributes:input] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error, @"expected InvalidParameters Error but got nil");
+        XCTAssertEqualObjects(task.error.domain, AWSSNSErrorDomain);
         XCTAssertEqual(task.error.code, AWSSNSErrorInvalidParameter);
         XCTAssertTrue([@"InvalidParameter" isEqualToString:task.error.userInfo[@"Code"]]);
         XCTAssertTrue([@"Invalid parameter: EndpointArn Reason: An ARN must have at least 6 elements, not 1" isEqualToString:task.error.userInfo[@"Message"]]);

--- a/AWSSQSTests/AWSSQSTests.m
+++ b/AWSSQSTests/AWSSQSTests.m
@@ -94,7 +94,8 @@
     
     [[[sqs getQueueAttributes:attributesRequest] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error, @"expected InvalidAddress Error but got nil");
-        XCTAssertEqual(task.error.code, 0);
+        XCTAssertEqualObjects(task.error.domain, AWSSQSErrorDomain);
+        XCTAssertEqual(task.error.code, AWSSQSErrorUnknown);
         XCTAssertTrue([@"InvalidAddress" isEqualToString:task.error.userInfo[@"Code"]]);
         XCTAssertTrue([@"The address  is not valid for this endpoint." isEqualToString:task.error.userInfo[@"Message"]]);
         return nil;

--- a/AWSSageMakerRuntimeTests/AWSSageMakerRuntimeTests.swift
+++ b/AWSSageMakerRuntimeTests/AWSSageMakerRuntimeTests.swift
@@ -26,11 +26,9 @@ class AWSSageMakerRuntimeTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        AWSTestUtility.setupCredentialsViaFile()
-        let credentialsJson: [String : String]? = AWSTestUtility.getCredentialsJsonAsDictionary()
-        if credentialsJson?["sageMaker-endpoint"] != nil {
-            sageMakerEndpoint = credentialsJson?["sageMaker-endpoint"]
-        }
+        AWSTestUtility.setupCognitoCredentialsProvider()
+        let credentialsJson = AWSTestUtility.getCredentialsJsonAsDictionary()
+        sageMakerEndpoint = credentialsJson?["sageMaker-endpoint"]
     }
     
     func testInvokeAPIWithSucess() {
@@ -79,8 +77,8 @@ class AWSSageMakerRuntimeTests: XCTestCase {
 
     func testInvokeApiWithUnAuthorizedUser() {
         let credentialProvider = AWSStaticCredentialsProvider(
-            accessKey: "XXXXXXXNAAHXQ",
-            secretKey: "xxxxxoQvW")
+            accessKey: "BAD_KEY_ID",
+            secretKey: "BAD_SECRET_KEY")
         let config = AWSServiceConfiguration(
             region: .USEast1,
             credentialsProvider: credentialProvider)

--- a/AWSSimpleDBTests/AWSSimpleDBTests.m
+++ b/AWSSimpleDBTests/AWSSimpleDBTests.m
@@ -323,7 +323,8 @@ static NSString *_testDomainName = nil;
 
     [[[sdb domainMetadata:metaDataRequest] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error, @"expected InvalidParameterValue error but got nil");
-        XCTAssertEqual(task.error.code, 6);
+        XCTAssertEqualObjects(task.error.domain, AWSSimpleDBErrorDomain);
+        XCTAssertEqual(task.error.code, AWSSimpleDBErrorInvalidParameterValue);
         XCTAssertTrue([@"InvalidParameterValue" isEqualToString:task.error.userInfo[@"Code"]]);
         XCTAssertTrue([@"Value () for parameter DomainName is invalid. " isEqualToString: (NSString *)task.error.userInfo[@"Message"]]);
         return nil;

--- a/AWSTranscribeTests/AWSTranscribeTests.swift
+++ b/AWSTranscribeTests/AWSTranscribeTests.swift
@@ -32,7 +32,7 @@ class AWSTranscribeTests: XCTestCase {
         super.tearDown()
     }
     
-    func testList() {
+    func testListTranscriptionJobs() {
         let transcribeClient = AWSTranscribe.default()
         
         // We fetch the jobs we have in our account. This test checks basic request response from the service.
@@ -205,8 +205,13 @@ class AWSTranscribeTests: XCTestCase {
         
         // kick off transcribe job to transcribe a simple "Hello, world" file stored in above specified location
         transcribeClient.startTranscriptionJob(jobRequest!).continueWith { (task) -> Any? in
+            if let error = task.error {
+                XCTAssertNil(error, "Expected no error, got \(error)")
+                return nil
+            }
+            
             guard let result = task.result else {
-                XCTAssertTrue(false, "Expected to start a transcribe job, not get error")
+                XCTAssertTrue(false, "Result unexpectedly nil starting transcription job")
                 return nil
             }
             

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -1178,7 +1178,10 @@
 		EFF1B9F21CBC42FF001F4CF1 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = EFF1B9EE1CBC42FF001F4CF1 /* aws_tommath_class.h */; };
 		EFF1B9F31CBC42FF001F4CF1 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = EFF1B9EF1CBC42FF001F4CF1 /* aws_tommath_superclass.h */; };
 		EFF1B9F41CBC42FF001F4CF1 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = EFF1B9F01CBC42FF001F4CF1 /* tommath.c */; };
+		FA2800EE22C9C1E1000B41F4 /* AWSStringValue.m in Sources */ = {isa = PBXBuildFile; fileRef = FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */; };
 		FA40A91221FA2F2A0050F4B2 /* AWSDateFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA40A91121FA2F2A0050F4B2 /* AWSDateFormatterTests.m */; };
+		FA41B39322C652E300142F8D /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF3E1C6A69AB0098B15B /* credentials.json */; };
+		FA41B39422C652E700142F8D /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF3E1C6A69AB0098B15B /* credentials.json */; };
 		FA4DB84D2199E33C00AE7F20 /* AWSCognitoIdentityProviderSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4DB84C2199E33C00AE7F20 /* AWSCognitoIdentityProviderSwiftTests.swift */; };
 		FA5DFE5821FB8E4700C554E7 /* AWSCognitoIdentityASF.m in Sources */ = {isa = PBXBuildFile; fileRef = FA5DFE5721FB8E4700C554E7 /* AWSCognitoIdentityASF.m */; };
 		FA62A7172167C9F100EFB444 /* AWSGZIPBaseTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = FA62A7162167C9F100EFB444 /* AWSGZIPBaseTestCase.m */; };
@@ -4182,6 +4185,8 @@
 		EFF1B9EE1CBC42FF001F4CF1 /* aws_tommath_class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aws_tommath_class.h; sourceTree = "<group>"; };
 		EFF1B9EF1CBC42FF001F4CF1 /* aws_tommath_superclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aws_tommath_superclass.h; sourceTree = "<group>"; };
 		EFF1B9F01CBC42FF001F4CF1 /* tommath.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tommath.c; sourceTree = "<group>"; };
+		FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSStringValue.m; sourceTree = "<group>"; };
+		FA2800EF22C9C1E5000B41F4 /* AWSStringValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSStringValue.h; sourceTree = "<group>"; };
 		FA40A91121FA2F2A0050F4B2 /* AWSDateFormatterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSDateFormatterTests.m; sourceTree = "<group>"; };
 		FA4DB84B2199E33B00AE7F20 /* AWSCognitoIdentityProviderUnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityProviderUnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		FA4DB84C2199E33C00AE7F20 /* AWSCognitoIdentityProviderSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSCognitoIdentityProviderSwiftTests.swift; sourceTree = "<group>"; };
@@ -6893,11 +6898,13 @@
 		CE9DEB2B1C6A81160060793F /* AWSAPIGatewayTests */ = {
 			isa = PBXGroup;
 			children = (
-				CE9DEB2E1C6A81160060793F /* Info.plist */,
-				174A59EE1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.h */,
-				174A59EF1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m */,
 				17C4BC071D88F45200A5E757 /* AWSAPIGatewayInvokeTest.swift */,
 				17C4BC061D88F45100A5E757 /* AWSAPIGatewayTests-Bridging-Header.h */,
+				174A59EE1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.h */,
+				174A59EF1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m */,
+				FA2800EF22C9C1E5000B41F4 /* AWSStringValue.h */,
+				FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */,
+				CE9DEB2E1C6A81160060793F /* Info.plist */,
 			);
 			path = AWSAPIGatewayTests;
 			sourceTree = "<group>";
@@ -10279,6 +10286,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA41B39322C652E300142F8D /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10300,6 +10308,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA41B39422C652E700142F8D /* credentials.json in Resources */,
 				17F389C520F9B51400DADF5B /* AWSCore.framework in Resources */,
 				17F389C420F9B50E00DADF5B /* AWSKinesisVideo.framework in Resources */,
 			);
@@ -12025,6 +12034,7 @@
 			files = (
 				CE9DEB3F1C6A9C010060793F /* AWSTestUtility.m in Sources */,
 				174A59F01D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m in Sources */,
+				FA2800EE22C9C1E1000B41F4 /* AWSStringValue.m in Sources */,
 				17C4BC081D88F45200A5E757 /* AWSAPIGatewayInvokeTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AWSiOSSDKv2.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/AWSiOSSDKv2.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,12 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:/Users/schmelte/src/github-repos/aws-sdk-ios/AWSAPIGatewayTests/AWSStringValue.h">
+   </FileRef>
+   <FileRef
+      location = "group:/Users/schmelte/src/github-repos/aws-sdk-ios/AWSAPIGatewayTests/AWSStringValue.m">
+   </FileRef>
+   <FileRef
       location = "self:">
    </FileRef>
 </Workspace>

--- a/AWSiOSSDKv2.xcodeproj/xcshareddata/xcschemes/AWSLex.xcscheme
+++ b/AWSiOSSDKv2.xcodeproj/xcshareddata/xcschemes/AWSLex.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:AWSiOSSDKv2.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18F572501D8A08FB0068546F"
+               BuildableName = "AWSLexUnitTests.xctest"
+               BlueprintName = "AWSLexUnitTests"
+               ReferencedContainer = "container:AWSiOSSDKv2.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/AWSiOSSDKv2.xcodeproj/xcshareddata/xcschemes/AWSLogs.xcscheme
+++ b/AWSiOSSDKv2.xcodeproj/xcshareddata/xcschemes/AWSLogs.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "181270C81E8EB53A00174785"
+               BuildableName = "AWSLogsUnitTests.xctest"
+               BlueprintName = "AWSLogsUnitTests"
+               ReferencedContainer = "container:AWSiOSSDKv2.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "181270C01E8EB53900174785"
+            BuildableName = "AWSLogs.framework"
+            BlueprintName = "AWSLogs"
+            ReferencedContainer = "container:AWSiOSSDKv2.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.9.10
 
+### Bug Fixes
+
+- **AWSCore**
+  - Fixed a bug where multiple values would be added to the 'host' header when using the V4 signer on a request that already included a 'host' header.
+
 ### Misc. Updates
 
 * Model updates for the following services


### PR DESCRIPTION
Fixed a bug where multiple values would be added to the 'host' header when using the V4 signer on a request that already included a 'host' header.

- Manually updated AWSMachineLearningService.m to propagate URLString parameter
  to sendRequest. This will be overwritten by the next automatic model update

Also: Test cleanup & migration to new policies & resources

- APIGateway: error reporting; use new functions, including regenerating AWSLambdaMicroservice client
- Cognito: cleanup
- KinesisVideoStreams: credentials management
- Lambda: use new functions
- Lex: Added AWSLexUnitTests to AWSLex scheme
- Logs: Added AWSLogsUnitTests to AWSLogs scheme
- MobileAnalytics: Removed 'Unknown' context attributes since it is a
  deprecated client and those attribute tests are broken in newer Xcode
  environments
- Rekognition: cleanup
- S3: cleanup, use new buckets
- SageMaker: use Cognito credentials instead of static AWS creds
- SES: cleanup
- SDB: cleanup
- SNS: cleanup
- SQS: cleanup
- Transcribe: cleanup

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
