### PR TITLE
Fix the default value of batchRecordsByteLimit

### DIFF
--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -20,7 +20,7 @@
 NSUInteger const AWSKinesisAbstractClientByteLimitDefault = 5 * 1024 * 1024; // 5MB
 NSTimeInterval const AWSKinesisAbstractClientAgeLimitDefault = 0.0; // Keeps the data indefinitely unless it hits the size limit.
 NSString *const AWSKinesisAbstractClientUserAgent = @"recorder";
-NSUInteger const AWSKinesisAbstractClientBatchRecordByteLimitDefault = 512 * 1024 * 1024;
+NSUInteger const AWSKinesisAbstractClientBatchRecordByteLimitDefault = 512 * 1024; // 512KB
 NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazonaws/AWSKinesisRecorder";
 
 @protocol AWSKinesisRecorderHelper <NSObject>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I fixed the default value of batchRecordsByteLimit from 512 **MB** to 512 **KB**.
This default value is 512KB in the documents.
https://aws-amplify.github.io/aws-sdk-ios/docs/reference/Classes/AWSAbstractKinesisRecorder.html#//api/name/batchRecordsByteLimit



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
