### PR TITLE
Add generic test helper function to create and delete bucket for integration test

### DIFF
--- a/AWSS3Tests/AWSS3TestHelper.h
+++ b/AWSS3Tests/AWSS3TestHelper.h
@@ -1,0 +1,32 @@
+//
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "AWSS3.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AWSS3TestHelper : NSObject
+
++ (BOOL)createBucketWithName:(NSString *)bucketName
+                   andRegion:(AWSRegionType)regionType;
+
++ (void)deleteAllObjectsFromBucket:(NSString *)bucketName;
+
++ (BOOL)deleteBucketWithName:(NSString *)bucketName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSS3Tests/AWSS3TestHelper.m
+++ b/AWSS3Tests/AWSS3TestHelper.m
@@ -1,0 +1,141 @@
+//
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import "AWSS3TestHelper.h"
+#define AWS_TEST_BAH_INSTEAD true
+
+@interface AWSS3CreateBucketConfiguration()
+
++ (NSValueTransformer *)locationConstraintJSONTransformer;
+
+@end
+
+@interface AWSEndpoint()
+
++ (NSString *)regionNameFromType:(AWSRegionType)regionType;
+
+@end
+
+@implementation AWSS3TestHelper
+
++ (BOOL)createBucketWithName:(NSString *)bucketName
+                   andRegion:(AWSRegionType)regionType {
+    
+    AWSS3 *s3 = [AWSS3 defaultS3];
+    
+    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
+    createBucketReq.bucket = bucketName;
+    
+    if (regionType != AWSRegionUSEast1) {
+        NSString *regionName = [AWSEndpoint regionNameFromType:regionType];
+        NSValueTransformer *locationConstraintTransformer = [AWSS3CreateBucketConfiguration locationConstraintJSONTransformer];
+        NSNumber *constraint = [locationConstraintTransformer transformedValue:regionName];
+        AWSS3BucketLocationConstraint dupcon = constraint.integerValue;
+        AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
+        createBucketConfiguration.locationConstraint = dupcon;
+        createBucketReq.createBucketConfiguration = createBucketConfiguration;
+    }
+
+    
+    __block BOOL success = NO;
+    [[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
+        if (task.error) {
+            success = NO;
+        } else {
+            success = YES;
+        }
+        return nil;
+    }] waitUntilFinished];
+    
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    
+    return success;
+}
+
++ (BOOL)deleteBucketWithName:(NSString *)bucketName {
+    AWSS3 *s3 = [AWSS3 defaultS3];
+    
+    AWSS3ListObjectVersionsRequest *listObjectVersionsRequest = [AWSS3ListObjectVersionsRequest new];
+    listObjectVersionsRequest.bucket = bucketName;
+    
+    [[[s3 listObjectVersions:listObjectVersionsRequest] continueWithSuccessBlock:^id(AWSTask *task) {
+        NSMutableArray *tasks = [NSMutableArray new];
+        
+        AWSS3ListObjectVersionsOutput *listObjectVersionsOutput = task.result;
+        for (AWSS3ObjectVersion *version in listObjectVersionsOutput.versions) {
+            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
+            deleteObjectRequest.bucket = bucketName;
+            deleteObjectRequest.key = version.key;
+            deleteObjectRequest.versionId = version.versionId;
+            AWSTask *task = [s3 deleteObject:deleteObjectRequest];
+            [tasks addObject:task];
+        }
+        for (AWSS3DeleteMarkerEntry *deleteMarker in listObjectVersionsOutput.deleteMarkers) {
+            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
+            deleteObjectRequest.bucket = bucketName;
+            deleteObjectRequest.key = deleteMarker.key;
+            deleteObjectRequest.versionId = deleteMarker.versionId;
+            AWSTask *task = [s3 deleteObject:deleteObjectRequest];
+            [tasks addObject:task];
+        }
+        
+        return [AWSTask taskForCompletionOfAllTasks:tasks];
+    }] waitUntilFinished];
+    
+    AWSS3DeleteBucketRequest *deleteBucketReq = [AWSS3DeleteBucketRequest new];
+    deleteBucketReq.bucket = bucketName;
+    
+    __block BOOL success = NO;
+    [[[s3 deleteBucket:deleteBucketReq] continueWithBlock:^id(AWSTask *task) {
+        if (task.error) {
+            success = NO;
+        } else {
+            success = YES;
+        }
+        return nil;
+    }] waitUntilFinished];
+    
+    return success;
+}
+
++ (void)deleteAllObjectsFromBucket:(NSString *)bucketName {
+    AWSS3 *s3 = [AWSS3 defaultS3];
+    
+    AWSS3ListObjectsRequest *listObjectsRequest = [AWSS3ListObjectsRequest new];
+    listObjectsRequest.bucket = bucketName;
+    
+    [[[s3 listObjects:listObjectsRequest] continueWithBlock:^id(AWSTask *task) {
+        AWSS3ListObjectsOutput *output = task.result;
+        
+        for (AWSS3Object *object in output.contents) {
+            // Delete the object
+            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
+            deleteObjectRequest.bucket = bucketName;
+            deleteObjectRequest.key = object.key;
+            
+            [[s3 deleteObject:deleteObjectRequest] continueWithBlock:^id(AWSTask *task) {
+                if (task.error) {
+                    NSLog(@"Failed to delete: %@", object.key);
+                } else {
+                    NSLog(@"Successfully deleted: %@", object.key);
+                }
+                return nil;
+            }];
+        }
+        return nil;
+    }] waitUntilFinished];
+}
+
+@end

--- a/AWSS3Tests/AWSS3Tests-Bridging-Header.h
+++ b/AWSS3Tests/AWSS3Tests-Bridging-Header.h
@@ -3,4 +3,5 @@
 //
 
 #import "AWSTestUtility.h"
+#import "AWSS3TestHelper.h"
 #import <CommonCrypto/CommonCrypto.h>

--- a/AWSS3Tests/AWSS3Tests.m
+++ b/AWSS3Tests/AWSS3Tests.m
@@ -26,7 +26,7 @@
 
 NSUInteger const AWSS3Test256KB = 1024 * 256;
 NSUInteger const AWSS3TestsTransferManagerMinimumPartSize = 5 * 1024 * 1024;
-NSString *const AWSS3TestBucketNamePrefix = @"ios-v2-test-";
+NSString *const AWSS3TestBucketNamePrefix = @"s3-integ-test-";
 
 static NSURL *tempLargeURL = nil;
 static NSURL *tempSmallURL = nil;
@@ -109,11 +109,10 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 
 + (void)tearDown {
     
-    // Delete all contents of the bucket
-    [AWSS3TestHelper deleteAllObjectsFromBucket:testBucketNameGeneral];
-    
     //Delete Buckets
     for ( NSString *bucketName in testBucketsCreated) {
+        // Delete all contents of the bucket
+        [AWSS3TestHelper deleteAllObjectsFromBucket:bucketName];
         [AWSS3TestHelper deleteBucketWithName:bucketName];
     }
     

--- a/AWSS3Tests/AWSS3Tests.m
+++ b/AWSS3Tests/AWSS3Tests.m
@@ -16,6 +16,7 @@
 #import <XCTest/XCTest.h>
 #import "AWSS3.h"
 #import "AWSTestUtility.h"
+#import "AWSS3TestHelper.h"
 
 @interface AWSS3Tests : XCTestCase
 
@@ -45,7 +46,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testBucketNameGeneral = [NSString stringWithFormat:@"%@%lld", AWSS3TestBucketNamePrefix, (int64_t)timeIntervalSinceReferenceDate];
 
-    [AWSS3Tests createBucketWithName:testBucketNameGeneral];
+    [AWSS3TestHelper createBucketWithName:testBucketNameGeneral andRegion:AWSRegionUSEast1];
     [testBucketsCreated addObject:testBucketNameGeneral];
     
     //Create a large temporary file for uploading & downloading test
@@ -67,12 +68,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
             [tempBaseString appendFormat:@"%d", i];
         }
         
-        int multiplier;
-#if AWS_TEST_BJS_INSTEAD
-        multiplier = 5;
-#else
-        multiplier = 5;
-#endif
+        int multiplier = 5;
         for (int32_t j = 0; j < multiplier; j++) {
             @autoreleasepool {
                 [fileHandle writeData:[tempBaseString dataUsingEncoding:NSUTF8StringEncoding]];
@@ -114,11 +110,11 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 + (void)tearDown {
     
     // Delete all contents of the bucket
-    [AWSS3Tests deleteAllObjectsFromBucket:testBucketNameGeneral];
+    [AWSS3TestHelper deleteAllObjectsFromBucket:testBucketNameGeneral];
     
     //Delete Buckets
     for ( NSString *bucketName in testBucketsCreated) {
-        [AWSS3Tests deleteBucketWithName:bucketName];
+        [AWSS3TestHelper deleteBucketWithName:bucketName];
     }
     
     //Delete Temp files
@@ -134,107 +130,6 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 - (void)tearDown {
     // Put teardown code here; it will be run once, after the last test case.
     [super tearDown];
-}
-
-+ (void)deleteAllObjectsFromBucket:(NSString *)bucketName {
-    AWSS3 *s3 = [AWSS3 defaultS3];
-    
-    AWSS3ListObjectsRequest *listObjectsRequest = [AWSS3ListObjectsRequest new];
-    listObjectsRequest.bucket = testBucketNameGeneral;
-    
-    [[[s3 listObjects:listObjectsRequest] continueWithBlock:^id(AWSTask *task) {
-        AWSS3ListObjectsOutput *output = task.result;
-        
-        for (AWSS3Object *object in output.contents) {
-            // Delete the object
-            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
-            deleteObjectRequest.bucket = testBucketNameGeneral;
-            deleteObjectRequest.key = object.key;
-            
-            [[s3 deleteObject:deleteObjectRequest] continueWithBlock:^id(AWSTask *task) {
-                if (task.error) {
-                    NSLog(@"Failed to delete: %@", object.key);
-                } else {
-                    NSLog(@"Successfully deleted: %@", object.key);
-                }
-                return nil;
-            }];
-        }
-        return nil;
-    }] waitUntilFinished];
-}
-
-+ (BOOL)createBucketWithName:(NSString *)bucketName {
-    AWSS3 *s3 = [AWSS3 defaultS3];
-
-    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
-    createBucketReq.bucket = bucketName;
-
-#if AWS_TEST_BJS_INSTEAD
-    AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
-    createBucketConfiguration.locationConstraint = AWSS3BucketLocationConstraintCNNorth1;
-    createBucketReq.createBucketConfiguration = createBucketConfiguration;
-#endif
-
-    __block BOOL success = NO;
-    [[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            success = NO;
-        } else {
-            success = YES;
-        }
-        return nil;
-    }] waitUntilFinished];
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
-
-    return success;
-}
-
-+ (BOOL)deleteBucketWithName:(NSString *)bucketName {
-    AWSS3 *s3 = [AWSS3 defaultS3];
-
-    AWSS3ListObjectVersionsRequest *listObjectVersionsRequest = [AWSS3ListObjectVersionsRequest new];
-    listObjectVersionsRequest.bucket = bucketName;
-
-    [[[s3 listObjectVersions:listObjectVersionsRequest] continueWithSuccessBlock:^id(AWSTask *task) {
-        NSMutableArray *tasks = [NSMutableArray new];
-
-        AWSS3ListObjectVersionsOutput *listObjectVersionsOutput = task.result;
-        for (AWSS3ObjectVersion *version in listObjectVersionsOutput.versions) {
-            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
-            deleteObjectRequest.bucket = bucketName;
-            deleteObjectRequest.key = version.key;
-            deleteObjectRequest.versionId = version.versionId;
-            AWSTask *task = [s3 deleteObject:deleteObjectRequest];
-            [tasks addObject:task];
-        }
-        for (AWSS3DeleteMarkerEntry *deleteMarker in listObjectVersionsOutput.deleteMarkers) {
-            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
-            deleteObjectRequest.bucket = bucketName;
-            deleteObjectRequest.key = deleteMarker.key;
-            deleteObjectRequest.versionId = deleteMarker.versionId;
-            AWSTask *task = [s3 deleteObject:deleteObjectRequest];
-            [tasks addObject:task];
-        }
-
-        return [AWSTask taskForCompletionOfAllTasks:tasks];
-    }] waitUntilFinished];
-
-    AWSS3DeleteBucketRequest *deleteBucketReq = [AWSS3DeleteBucketRequest new];
-    deleteBucketReq.bucket = bucketName;
-
-    __block BOOL success = NO;
-    [[[s3 deleteBucket:deleteBucketReq] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            success = NO;
-        } else {
-            success = YES;
-        }
-        return nil;
-    }] waitUntilFinished];
-
-    return success;
 }
 
 - (BOOL)isContainBucketName:(NSString *)bucketName inBucketArray:(NSArray *)bucketsArray {
@@ -496,7 +391,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 - (void)testPutBucketWithGrants {
     NSString *grantBucketName = [testBucketNameGeneral stringByAppendingString:@"-grant"];
     [testBucketsCreated addObject:grantBucketName];
-    XCTAssertTrue([AWSS3Tests createBucketWithName:grantBucketName]);
+    XCTAssertTrue([AWSS3TestHelper createBucketWithName:grantBucketName andRegion:AWSRegionUSEast1]);
 
     AWSS3 *s3 = [AWSS3 defaultS3];
     XCTAssertNotNil(s3);
@@ -539,9 +434,9 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
     
     // Delete all objects from the bucket
-    [AWSS3Tests deleteAllObjectsFromBucket:grantBucketName];
+    [AWSS3TestHelper deleteAllObjectsFromBucket:grantBucketName];
     
-    XCTAssertTrue([AWSS3Tests deleteBucketWithName:grantBucketName]);
+    XCTAssertTrue([AWSS3TestHelper deleteBucketWithName:grantBucketName]);
 }
 
 - (void)testListObjects {

--- a/AWSS3Tests/AWSS3TransferManagerTests.m
+++ b/AWSS3Tests/AWSS3TransferManagerTests.m
@@ -16,6 +16,7 @@
 #import <XCTest/XCTest.h>
 #import "AWSS3.h"
 #import "AWSTestUtility.h"
+#import "AWSS3TestHelper.h"
 
 @interface AWSS3TransferManagerTests : XCTestCase
 
@@ -35,8 +36,11 @@ static NSURL *tempSmallURL = nil;
     //Create bucketName
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testBucketNameGeneral = [NSString stringWithFormat:@"%@%lld", AWSS3TestBucketNamePrefix, (int64_t)timeIntervalSinceReferenceDate];
-
-    [[self class] createBucketWithName:testBucketNameGeneral];
+    AWSRegionType regionType = AWSRegionUSEast1;
+    #if AWS_TEST_BJS_INSTEAD
+    regionType = AWSRegionCNNorth1;
+    #endif
+    [AWSS3TestHelper createBucketWithName:testBucketNameGeneral andRegion:regionType];
 
     //Create a large temporary file for uploading & downloading test
     tempLargeURL = [NSURL fileURLWithPath:[[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-s3tmTestTempLarge",testBucketNameGeneral]]];
@@ -97,10 +101,10 @@ static NSURL *tempSmallURL = nil;
     [super tearDown];
     
     // make sure bucket is empty before attempting to delete
-    [AWSS3TransferManagerTests deleteAllObjectsFromBucket:testBucketNameGeneral];
+    [AWSS3TestHelper deleteAllObjectsFromBucket:testBucketNameGeneral];
 
     //Delete Bucket
-    [AWSS3TransferManagerTests deleteBucketWithName:testBucketNameGeneral];
+    [AWSS3TestHelper deleteBucketWithName:testBucketNameGeneral];
 
     //Delete Temp files
     if (tempLargeURL) {
@@ -109,34 +113,6 @@ static NSURL *tempSmallURL = nil;
     if (tempSmallURL) {
         [[NSFileManager defaultManager] removeItemAtURL:tempSmallURL error:nil];
     }
-}
-
-+ (void)deleteAllObjectsFromBucket:(NSString *)bucketName {
-    AWSS3 *s3 = [AWSS3 defaultS3];
-    
-    AWSS3ListObjectsRequest *listObjectsRequest = [AWSS3ListObjectsRequest new];
-    listObjectsRequest.bucket = testBucketNameGeneral;
-    
-    [[[s3 listObjects:listObjectsRequest] continueWithBlock:^id(AWSTask *task) {
-        AWSS3ListObjectsOutput *output = task.result;
-        
-        for (AWSS3Object *object in output.contents) {
-            // Delete the object
-            AWSS3DeleteObjectRequest *deleteObjectRequest = [AWSS3DeleteObjectRequest new];
-            deleteObjectRequest.bucket = testBucketNameGeneral;
-            deleteObjectRequest.key = object.key;
-            
-            [[s3 deleteObject:deleteObjectRequest] continueWithBlock:^id(AWSTask *task) {
-                if (task.error) {
-                    NSLog(@"Failed to delete: %@", object.key);
-                } else {
-                    NSLog(@"Successfully deleted: %@", object.key);
-                }
-                return nil;
-            }];
-        }
-        return nil;
-    }] waitUntilFinished];
 }
 
 - (void)testDownloadWithSpecialEncodedCharacters {
@@ -2954,54 +2930,6 @@ static NSURL *tempSmallURL = nil;
     XCTAssertEqualObjects(unarchivedObject.bucket, uploadRequest.bucket);
     XCTAssertEqualObjects(unarchivedObject.key, uploadRequest.key);
     XCTAssertEqualObjects(unarchivedObject.body, uploadRequest.body);
-}
-
-#pragma mark -
-
-+ (BOOL)createBucketWithName:(NSString *)bucketName {
-    AWSS3 *s3 = [AWSS3 defaultS3];
-    
-    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
-    createBucketReq.bucket = bucketName;
-    
-#if AWS_TEST_BJS_INSTEAD
-    AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
-    createBucketConfiguration.locationConstraint = AWSS3BucketLocationConstraintCNNorth1;
-    createBucketReq.createBucketConfiguration = createBucketConfiguration;
-#endif
-    
-    __block BOOL success = NO;
-    [[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            success = NO;
-        } else {
-            success = YES;
-        }
-        return nil;
-    }] waitUntilFinished];
-    
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]];
-    
-    return success;
-}
-
-+ (BOOL)deleteBucketWithName:(NSString *)bucketName {
-    AWSS3 *s3 = [AWSS3 defaultS3];
-    
-    AWSS3DeleteBucketRequest *deleteBucketReq = [AWSS3DeleteBucketRequest new];
-    deleteBucketReq.bucket = bucketName;
-    
-    __block BOOL success = NO;
-    [[[s3 deleteBucket:deleteBucketReq] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            success = NO;
-        } else {
-            success = YES;
-        }
-        return nil;
-    }] waitUntilFinished];
-    
-    return success;
 }
 
 @end

--- a/AWSS3Tests/AWSS3TransferManagerTests.m
+++ b/AWSS3Tests/AWSS3TransferManagerTests.m
@@ -25,7 +25,7 @@
 @implementation AWSS3TransferManagerTests
 
 static NSString *testBucketNameGeneral = nil;
-static NSString *const AWSS3TestBucketNamePrefix = @"ios-v2-tm-test-";
+static NSString *const AWSS3TestBucketNamePrefix = @"s3-integ-transfermanager-test-";
 static NSURL *tempLargeURL = nil;
 static NSURL *tempSmallURL = nil;
 

--- a/AWSS3Tests/AWSS3TransferUtilityTests.swift
+++ b/AWSS3Tests/AWSS3TransferUtilityTests.swift
@@ -89,8 +89,8 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         testData = dataString.data(using: String.Encoding.utf8)!
         
-        let timeInterval = Date.timeIntervalSinceReferenceDate
-        generalTestBucket = "ios-v2-s3.periods\(timeInterval)"
+        let timeInterval = (Int)((Date.timeIntervalSinceReferenceDate * 1000).rounded())
+        generalTestBucket = "s3-integ-transferutil-test-\(timeInterval)"
         AWSS3TestHelper.createBucket(withName: generalTestBucket, andRegion: AWSRegionType.USEast1)
     }
 

--- a/AWSS3Tests/AWSS3TransferUtilityTests.swift
+++ b/AWSS3Tests/AWSS3TransferUtilityTests.swift
@@ -17,6 +17,8 @@ import XCTest
 import AWSS3
 
 var testData = Data()
+var generalTestBucket = ""
+var transferAccelerationBucket = "ios-v2-s3-transfer-acceleration"
 
 class AWSS3TransferUtilityTests: XCTestCase {
 
@@ -86,12 +88,22 @@ class AWSS3TransferUtilityTests: XCTestCase {
             dataString += dataString
         }
         testData = dataString.data(using: String.Encoding.utf8)!
+        
+        let timeInterval = Date.timeIntervalSinceReferenceDate
+        generalTestBucket = "ios-v2-s3.periods\(timeInterval)"
+        AWSS3TestHelper.createBucket(withName: generalTestBucket, andRegion: AWSRegionType.USEast1)
     }
 
     override func setUp() {
         super.setUp()
     }
 
+    override class func tearDown() {
+        AWSS3TestHelper.deleteAllObjects(fromBucket: generalTestBucket)
+        AWSS3TestHelper.deleteBucket(withName: generalTestBucket)
+        super.tearDown()
+    }
+    
     override func tearDown() {
         super.tearDown()
     }
@@ -139,7 +151,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 }
 
                 transferUtility?.downloadData(
-                    fromBucket: "ios-v2-s3.periods",
+                    fromBucket: generalTestBucket,
                     key: "test-swift-upload&~:'()|[] i.txt",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -153,7 +165,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
 
         transferUtility?.uploadData(
             testData,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "test-swift-upload&~:'()|[] i.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -216,7 +228,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 }
                 
                 transferUtility?.downloadData(
-                    fromBucket: "ios-v2-s3.periods",
+                    fromBucket: generalTestBucket,
                     key: "testUploadAndDownloadLargeData.txt",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -230,7 +242,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility?.uploadData(
             dataString.data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testUploadAndDownloadLargeData.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -294,7 +306,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 var refDownloadTask:AWSS3TransferUtilityDownloadTask?
                 
                 transferUtility?.downloadData(
-                    fromBucket: "ios-v2-s3.periods",
+                    fromBucket: generalTestBucket,
                     key: "testSuspendResumeUploadAndDownloadLargeData.txt",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -320,7 +332,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility?.uploadData(
             dataString.data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testSuspendResumeUploadAndDownloadLargeData.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -391,7 +403,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 var refDownloadTask:AWSS3TransferUtilityDownloadTask?
                 
                 transferUtility?.downloadData(
-                    fromBucket: "ios-v2-s3.periods",
+                    fromBucket: generalTestBucket,
                     key: "testCancelDownload.txt",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -413,7 +425,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility?.uploadData(
             dataString.data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testCancelDownload.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -475,7 +487,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 var refDownloadTask:AWSS3TransferUtilityDownloadTask?
                 
                 transferUtility?.downloadData(
-                    fromBucket: "ios-v2-s3.periods",
+                    fromBucket: generalTestBucket,
                     key: "testSuspendResumeUploadAndDownloadLargeDataLongDelay.txt",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -503,7 +515,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility?.uploadData(
             dataString.data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testSuspendResumeUploadAndDownloadLargeDataLongDelay.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -557,7 +569,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility?.uploadData(
             testData,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "test-swift-upload",
             contentType: "application/octet-stream",
             expression: uploadExpression,
@@ -584,7 +596,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             XCTAssertNil(error)
             if let HTTPResponse = task.response {
                 XCTAssertEqual(HTTPResponse.statusCode, 200)
-
+                
                 let downloadExpression = AWSS3TransferUtilityDownloadExpression()
 
                 let downloadCompletionHandler = { (task: AWSS3TransferUtilityDownloadTask, URL: Foundation.URL?, data: Data?, error: Error?) in
@@ -599,7 +611,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 }
 
                 transferUtility?.downloadData(
-                    fromBucket: "ios-v2-s3-transfer-acceleration",
+                    fromBucket: transferAccelerationBucket,
                     key: "test-swift-upload",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith (block: { (task) -> AnyObject? in
@@ -613,7 +625,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
 
         transferUtility?.uploadData(
             testData,
-            bucket: "ios-v2-s3-transfer-acceleration",
+            bucket: transferAccelerationBucket,
             key: "test-swift-upload",
             contentType: "application/octet-stream",
             expression: uploadExpression,
@@ -713,7 +725,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: "with-retry")
         XCTAssertNotNil(transferUtility)
         transferUtility?.uploadFile(URL(fileURLWithPath: "~/abc.txt"),
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                       key: "should-have-failed-testBadFilePathUpload.txt",
                               contentType: "text/plain",
                                expression: nil,
@@ -755,7 +767,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testGoodFilePathUpload.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -775,7 +787,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
         transferUtility?.uploadFile(fileURL,
-                                    bucket: "ios-v2-s3.periods",
+                                    bucket: generalTestBucket,
                                        key: "testGoodFilePathUpload.txt",
                                contentType: "text/plain",
                                 expression: expression,
@@ -822,7 +834,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testLargeFileUpload.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -842,7 +854,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
         transferUtility?.uploadFile(fileURL,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testLargeFileUpload.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -883,7 +895,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         var refUploadTask: AWSS3TransferUtilityUploadTask?
         
         transferUtility?.uploadFile(fileURL,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testLargeFileUploadCancel.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -929,7 +941,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testSuspendResumeLargeFileUpload.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -950,7 +962,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         var refUploadTask: AWSS3TransferUtilityUploadTask?
         transferUtility?.uploadFile(fileURL,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testSuspendResumeLargeFileUpload.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1004,7 +1016,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testSuspendResumeLargeFileUploadLongDelay.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1025,7 +1037,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         var refUploadTask: AWSS3TransferUtilityUploadTask?
         
         transferUtility?.uploadFile(fileURL,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testSuspendResumeLargeFileUploadLongDelay.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1052,7 +1064,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: "with-retry")
         XCTAssertNotNil(transferUtility)
         let transferUtilityCongiguration = AWSS3TransferUtilityConfiguration()
-        transferUtilityCongiguration.bucket = "ios-v2-s3.periods"
+        transferUtilityCongiguration.bucket = generalTestBucket
         AWSS3TransferUtility.register(with: transferUtility!.configuration,
                                       transferUtilityConfiguration: transferUtilityCongiguration,
                                       forKey: "CustomConfig")
@@ -1079,7 +1091,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testGoodFilePathUpload.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1139,7 +1151,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "test-spaces-Good-spaces-File-spaces-Path-spaces-Upload.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1158,7 +1170,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
         transferUtility?.uploadFile(fileURL,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "test-spaces-Good-spaces-File-spaces-Path-spaces-Upload.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1203,7 +1215,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testMultiPartUploadSmallFile.txt"
             
             
@@ -1218,7 +1230,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     XCTAssertEqual(uuid, output.metadata?["id"])
                 }
                 //Download the file and make sure that contents are the same.
-                self.verifyContent(tu: transferUtility, bucket: "ios-v2-s3.periods", key: "testMultiPartUploadSmallFile.txt", hash: calculatedHash)
+                self.verifyContent(tu: transferUtility, bucket: generalTestBucket, key: "testMultiPartUploadSmallFile.txt", hash: calculatedHash)
                 
                 expectation.fulfill()
                 return nil
@@ -1226,7 +1238,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
     
         transferUtility.uploadUsingMultiPart(fileURL:fileURL,
-                                                 bucket: "ios-v2-s3.periods",
+                                                 bucket: generalTestBucket,
                                                  key: "testMultiPartUploadSmallFile.txt",
                                                  contentType: "text/plain",
                                                  expression: expression,
@@ -1273,7 +1285,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testMultiPartUploadSmallFileNilTransferUtilityConfiguration.txt"
 
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1286,7 +1298,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     XCTAssertEqual(author, output.metadata?["author"])
                     XCTAssertEqual(uuid, output.metadata?["id"])
                 }
-                self.verifyContent(tu: transferUtility!, bucket: "ios-v2-s3.periods", key: "testMultiPartUploadSmallFileNilTransferUtilityConfiguration.txt", hash: calculatedHash)
+                self.verifyContent(tu: transferUtility!, bucket: generalTestBucket, key: "testMultiPartUploadSmallFileNilTransferUtilityConfiguration.txt", hash: calculatedHash)
                 expectation.fulfill()
                 return nil
             })
@@ -1294,7 +1306,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
 
         transferUtility?.uploadUsingMultiPart(fileURL:fileURL,
-                                             bucket: "ios-v2-s3.periods",
+                                             bucket: generalTestBucket,
                                              key: "testMultiPartUploadSmallFileNilTransferUtilityConfiguration.txt",
                                              contentType: "text/plain",
                                              expression: expression,
@@ -1354,7 +1366,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testMultiPartUploadLargeFile.txt"
             headObjectRequest?.sseCustomerAlgorithm = "AES256"
             headObjectRequest?.sseCustomerKey = customerKey
@@ -1377,7 +1389,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     "x-amz-server-side-encryption-customer-key-MD5" : customerKeyMD5]
                 
                 self.verifyContent(tu: transferUtility!,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testMultiPartUploadLargeFile.txt",
                                    hash: calculatedHash,
                                    headerKeyValues: headers)
@@ -1388,7 +1400,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             
         }
         
-        transferUtility?.uploadUsingMultiPart(fileURL: fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL: fileURL, bucket: generalTestBucket,
                                    key: "testMultiPartUploadLargeFile.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1439,7 +1451,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testMultiPartSinglePartEdgeCase.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1453,7 +1465,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     XCTAssertEqual(uuid, output.metadata?["id"])
                 }
                 self.verifyContent(tu: transferUtility!,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testMultiPartSinglePartEdgeCase.txt",
                                    hash: calculatedHash)
                 expectation.fulfill()
@@ -1463,7 +1475,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
        
-        transferUtility?.uploadUsingMultiPart(fileURL:fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL:fileURL, bucket: generalTestBucket,
                                    key: "testMultiPartSinglePartEdgeCase.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1514,7 +1526,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testMultiPartEdgeCase.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1528,7 +1540,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     XCTAssertEqual(uuid, output.metadata?["id"])
                 }
                 self.verifyContent(tu: transferUtility!,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testMultiPartEdgeCase.txt",
                                    hash: calculatedHash)
                 expectation.fulfill()
@@ -1537,7 +1549,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             
         }
         
-        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: generalTestBucket,
                                    key: "testMultiPartEdgeCase.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1572,7 +1584,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
 
         let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: "with-retry")
         XCTAssertNotNil(transferUtility)
-        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: generalTestBucket,
                                    key: "testCancelMultipartUpload.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1623,7 +1635,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testSuspendResumeMultipartUpload.txt"
 
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1637,7 +1649,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     XCTAssertEqual(uuid, output.metadata?["id"])
                 }
                 self.verifyContent(tu: transferUtility!,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testSuspendResumeMultipartUpload.txt",
                                    hash: calculatedHash)
                 expectation.fulfill()
@@ -1649,7 +1661,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         var refUploadTask: AWSS3TransferUtilityMultiPartUploadTask?
         
         
-        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: generalTestBucket,
                                    key: "testSuspendResumeMultipartUpload.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1708,7 +1720,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testPauseResumeUploadLongDelay.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1723,7 +1735,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 }
                 
                 self.verifyContent(tu: transferUtility!,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testPauseResumeUploadLongDelay.txt",
                                    hash: calculatedHash)
                 
@@ -1735,7 +1747,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         var refUploadTask: AWSS3TransferUtilityMultiPartUploadTask?
         
-        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL:  fileURL, bucket: generalTestBucket,
                                    key: "testPauseResumeUploadLongDelay.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1783,7 +1795,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             XCTAssertNil(error)
             XCTAssertEqual(task.status, AWSS3TransferUtilityTransferStatusType.completed)
             self.verifyContent(tu: transferUtility!,
-                               bucket: "ios-v2-s3-transfer-acceleration",
+                               bucket: transferAccelerationBucket,
                                key: "testMultiPartUploadTransferAcceleration.txt",
                                hash: calculatedHash)
             expectation.fulfill()
@@ -1795,7 +1807,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
        
-        transferUtility?.uploadUsingMultiPart(fileURL:fileURL, bucket: "ios-v2-s3-transfer-acceleration",
+        transferUtility?.uploadUsingMultiPart(fileURL:fileURL, bucket: transferAccelerationBucket,
                                    key: "testMultiPartUploadTransferAcceleration.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -1846,7 +1858,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 //Get Meta Data and verify that it has been updated
                 let s3 = AWSS3.default()
                 let headObjectRequest = AWSS3HeadObjectRequest()
-                headObjectRequest?.bucket = "ios-v2-s3.periods"
+                headObjectRequest?.bucket = generalTestBucket
                 headObjectRequest?.key = "testUploadAndDownloadDataWithCustomMetaData"
                 
                 s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1869,7 +1881,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility.uploadData(
             testData,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testUploadAndDownloadDataWithCustomMetaData",
             contentType: "video/mp4",
             expression: uploadExpression,
@@ -1935,7 +1947,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             //Get Meta Data and verify that it has been updated. This will indicate that the upload has succeeded.
             let s3 = AWSS3.default()
             let headObjectRequest = AWSS3HeadObjectRequest()
-            headObjectRequest?.bucket = "ios-v2-s3.periods"
+            headObjectRequest?.bucket = generalTestBucket
             headObjectRequest?.key = "testMultiPartUploadLargeFileWithCustomMetaData.txt"
             
             s3.headObject(headObjectRequest!).continueWith(block: { (task:AWSTask<AWSS3HeadObjectOutput> ) -> Any? in
@@ -1960,7 +1972,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: "with-retry")
         XCTAssertNotNil(transferUtility)
-        transferUtility?.uploadUsingMultiPart(fileURL: fileURL, bucket: "ios-v2-s3.periods",
+        transferUtility?.uploadUsingMultiPart(fileURL: fileURL, bucket: generalTestBucket,
                                              key: "testMultiPartUploadLargeFileWithCustomMetaData.txt",
                                              contentType: "video/mp4" ,
                                              expression: expression,
@@ -2016,7 +2028,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                 }
                 
                 transferUtility.downloadData(
-                    fromBucket: "ios-v2-s3.periods",
+                    fromBucket: generalTestBucket,
                     key: "testDataForIfModifiedSince.txt",
                     expression: downloadExpression,
                     completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -2030,7 +2042,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility.uploadData(
             "1234567890".data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testDataForIfModifiedSince.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -2089,7 +2101,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         transferUtility?.uploadUsingMultiPart(
             data: "1234567890".data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "any-file-which-gets-rejected.txt",
             contentType: "text/plain",
             expression: nil,
@@ -2126,7 +2138,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
         transferUtility?.downloadData(
-            fromBucket: "ios-v2-s3.periods",
+            fromBucket: generalTestBucket,
             key: "some-non-existent-key-" + UUID().uuidString,
             expression: downloadExpression,
             completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -2158,7 +2170,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         
         transferUtility?.downloadData(
-            fromBucket: "ios-v2-s3.periods",
+            fromBucket: generalTestBucket,
             key: "some-non-existent-key-" + UUID().uuidString,
             expression: downloadExpression,
             completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -2244,7 +2256,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     XCTAssertNotNil(transferUtility)
                     
                     transferUtility?.download(to: url!,
-                        bucket: "ios-v2-s3.periods",
+                        bucket: generalTestBucket,
                         key: "testDataForConcurrentDownloads.txt",
                         expression: downloadExpression,
                         completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -2263,7 +2275,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         }
         transferUtility.uploadData(
             testData.data(using: String.Encoding.utf8)!,
-            bucket: "ios-v2-s3.periods",
+            bucket: generalTestBucket,
             key: "testDataForConcurrentDownloads.txt",
             contentType: "text/plain",
             expression: uploadExpression,
@@ -2332,7 +2344,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
                     let transferUtility = AWSS3TransferUtility.s3TransferUtility(forKey: "with-retry")
                     XCTAssertNotNil(transferUtility)
                     transferUtility?.download(to: url!,
-                                            bucket: "ios-v2-s3.periods",
+                                            bucket: generalTestBucket,
                                             key: "testDataForConcurrentDownloads\(i).txt",
                                      expression: downloadExpression,
                               completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -2344,7 +2356,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
             
                 transferUtility?.uploadData(
                     testData.data(using: String.Encoding.utf8)!,
-                    bucket: "ios-v2-s3.periods",
+                    bucket: generalTestBucket,
                     key: "testDataForConcurrentDownloads\(i).txt",
                     contentType: "text/plain",
                     expression: uploadExpression,
@@ -2392,7 +2404,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         
         var refUploadTask: AWSS3TransferUtilityUploadTask?
         transferUtility?.uploadFile(fileURL,
-                                   bucket: "ios-v2-s3.periods",
+                                   bucket: generalTestBucket,
                                    key: "testShortExpiryLargeFileUpload.txt",
                                    contentType: "text/plain",
                                    expression: expression,
@@ -2530,7 +2542,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...3 {
             transferUtility?.uploadData(
                 testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods",
+                bucket: generalTestBucket,
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: uploadExpression,
@@ -2552,7 +2564,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 4...6 {
             transferUtility?.uploadUsingMultiPart(
                 data: testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods",
+                bucket: generalTestBucket,
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: multiPartUploadExpression,
@@ -2573,7 +2585,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...6 {
             let url = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("file\(i)")
             transferUtility?.download(to: url!,
-                                 bucket: "ios-v2-s3.periods",
+                                 bucket: generalTestBucket,
                                     key: "testFileForGetTasks\(i).txt",
                 expression: downloadExpression,
                 completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in
@@ -2672,7 +2684,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...3 {
             transferUtility?.uploadData(
                 testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods",
+                bucket: generalTestBucket,
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: uploadExpression,
@@ -2693,7 +2705,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 4...6 {
             transferUtility?.uploadUsingMultiPart(
                 data: testData.data(using: String.Encoding.utf8)!,
-                bucket: "ios-v2-s3.periods",
+                bucket: generalTestBucket,
                 key: "testFileForGetTasks\(i).txt",
                 contentType: "text/plain",
                 expression: multiPartUploadExpression,
@@ -2713,7 +2725,7 @@ class AWSS3TransferUtilityTests: XCTestCase {
         for i in 1...6 {
             let url = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("file\(i)")
             transferUtility?.download(to: url!,
-                                      bucket: "ios-v2-s3.periods",
+                                      bucket: generalTestBucket,
                                       key: "testFileForGetTasks\(i).txt",
                 expression: downloadExpression,
                 completionHandler: downloadCompletionHandler).continueWith(block: { (task) -> Any? in

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		9AD5842820F63E6700042041 /* singleface.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 9AD5842620F63E6700042041 /* singleface.jpg */; };
 		9AD5842A20F63E9B00042041 /* city_thumb.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 9AD5842920F63E9B00042041 /* city_thumb.jpg */; };
 		B47FAF4322C577CE00014548 /* AWSS3TransferUtilityUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */; };
+		B482E84722EEA9F20075A0A3 /* AWSS3TestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B482E84622EEA9F20075A0A3 /* AWSS3TestHelper.m */; };
 		B4A4DFFE22B4201400379396 /* AWSSageMakerRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4A4DFF522B4201300379396 /* AWSSageMakerRuntime.framework */; };
 		B4A4E01222B420C500379396 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		B4A4E01B22B4212A00379396 /* AWSSageMakerRuntimeService.h in Headers */ = {isa = PBXBuildFile; fileRef = B4A4E01422B4212900379396 /* AWSSageMakerRuntimeService.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3389,6 +3390,8 @@
 		9AD5842620F63E6700042041 /* singleface.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = singleface.jpg; sourceTree = "<group>"; };
 		9AD5842920F63E9B00042041 /* city_thumb.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = city_thumb.jpg; sourceTree = "<group>"; };
 		B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSS3TransferUtilityUnitTests.m; sourceTree = "<group>"; };
+		B482E84522EEA9F10075A0A3 /* AWSS3TestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSS3TestHelper.h; sourceTree = "<group>"; };
+		B482E84622EEA9F20075A0A3 /* AWSS3TestHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSS3TestHelper.m; sourceTree = "<group>"; };
 		B4A4DFF522B4201300379396 /* AWSSageMakerRuntime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSSageMakerRuntime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4A4DFF822B4201400379396 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B4A4DFFD22B4201400379396 /* AWSSageMakerRuntimeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSSageMakerRuntimeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6801,6 +6804,8 @@
 				CE9DE9F31C6A7CA50060793F /* AWSS3TransferManagerTests.m */,
 				CE9DE9CD1C6A7C2E0060793F /* Info.plist */,
 				CE1F3A911CD96A9E00C8EBCB /* AWSS3TransferUtilityTests.swift */,
+				B482E84522EEA9F10075A0A3 /* AWSS3TestHelper.h */,
+				B482E84622EEA9F20075A0A3 /* AWSS3TestHelper.m */,
 			);
 			path = AWSS3Tests;
 			sourceTree = "<group>";
@@ -12119,6 +12124,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE9DE9F51C6A7CA50060793F /* AWSS3PreSignedURLBuilderTests.m in Sources */,
+				B482E84722EEA9F20075A0A3 /* AWSS3TestHelper.m in Sources */,
 				CE9DEB481C6A9C0B0060793F /* AWSTestUtility.m in Sources */,
 				CE9DE9F71C6A7CA50060793F /* AWSS3TransferManagerTests.m in Sources */,
 				CE1F3A921CD96A9E00C8EBCB /* AWSS3TransferUtilityTests.swift in Sources */,

--- a/AWSiOSSDKv2.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/AWSiOSSDKv2.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,12 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/schmelte/src/github-repos/aws-sdk-ios/AWSAPIGatewayTests/AWSStringValue.h">
-   </FileRef>
-   <FileRef
-      location = "group:/Users/schmelte/src/github-repos/aws-sdk-ios/AWSAPIGatewayTests/AWSStringValue.m">
-   </FileRef>
-   <FileRef
       location = "self:">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
S3 transferutility required to have a predefined bucket in S3 for the integration test to work. This change creates the bucket before test and delete it after.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
