### PR TITLE
Call out runtime overrides of awsconfiguration values

### DIFF
--- a/AWSAuthSDK/AWSAuthSDKTestApp/ViewController.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/ViewController.swift
@@ -36,6 +36,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func onLaunchCognitoAuthFacebookSignIn(_ sender: Any) {
+        // Note: the scopes provided here will override options provided in the app's awsconfiguration.json
         let hostedUIOptions = HostedUIOptions(scopes: ["openid", "email"], identityProvider: "Facebook")
         
         AWSMobileClient.sharedInstance().showSignIn(navigationController: self.navigationController!, hostedUIOptions: hostedUIOptions) { (userState, error) in
@@ -48,6 +49,7 @@ class ViewController: UIViewController {
         }
     }
     @IBAction func onLaunchCognitoAuthGoogleSignIn(_ sender: Any) {
+        // Note: the scopes provided here will override options provided in the app's awsconfiguration.json
         let hostedUIOptions = HostedUIOptions(scopes: ["openid", "email"], identityProvider: "Google")
         
         AWSMobileClient.sharedInstance().showSignIn(navigationController: self.navigationController!, hostedUIOptions: hostedUIOptions) { (userState, error) in
@@ -61,7 +63,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func onLaunchAuth0SignIn(_ sender: Any) {
-        
+        // Note: the scopes provided here will override options provided in the app's awsconfiguration.json
         let hostedUIOptions = HostedUIOptions(scopes: ["openid", "email"], federationProviderName: AWSInfo.default().rootInfoDictionary["Auth0FederationProviderName"] as? String)
         
         AWSMobileClient.sharedInstance().showSignIn(navigationController: self.navigationController!, hostedUIOptions: hostedUIOptions) { (userState, error) in

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
@@ -68,6 +68,9 @@ public struct FederatedSignInOptions {
 
 
 /// The options object for `showSignIn` API when using Hosted Auth solution like Amazon Cognito UserPools or AUth0.
+///
+/// NOTE: If specified, some of the values in this type will override the corresponding values in `awsconfiguration.json`. See
+/// the `init` method below.
 public struct HostedUIOptions {
     let scopes: [String]?
     


### PR DESCRIPTION
Add API doc note that some values of HostedUIOptions override values in the
awsconfiguration.json file. (#1588)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
