### PR TITLE
Release VC after CognitoAuth getSession

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -65,7 +65,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
 /**
  Set this delegate to obtain the current view controller to interact with the end user
  */
-@property (nonatomic, strong) id <AWSCognitoAuthDelegate> delegate;
+@property (nonatomic, weak) id <AWSCognitoAuthDelegate> delegate;
 
 /**
  The auth configuration
@@ -116,7 +116,6 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param completion completion block to invoke on completion
  */
 - (void)getSession: (nullable AWSCognitoAuthGetSessionBlock) completion;
-
 
 /**
  Sign out locally and from the server.
@@ -205,7 +204,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
 /**
  Whether user context information to drive the advanced security feature is emitted.
  */
-@property (nonatomic, assign, readonly,getter=isASFEnabled) BOOL asfEnabled;
+@property (nonatomic, assign, readonly, getter=isASFEnabled) BOOL asfEnabled;
 
 /**
  If using iOS 11 or above, the SDK will use `SFAuthenticationSession` for signIn and signOut operations if this flag is set. Below iOS 11, the SDK will use SFSafariViewController regardless of this setting.
@@ -249,7 +248,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
                           webDomain:(NSString *) webDomain
                    identityProvider:(nullable NSString *) identityProvider
                       idpIdentifier:(nullable NSString *) idpIdentifier
-                         userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF;
+           userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF;
 
 /**
  Configuration object for CognitoAuth
@@ -262,7 +261,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param identityProvider Optional provider name to authenticate with directly
  @param idpIdentifier Optional provider identifier to authenticate with directly
  @param userPoolIdForEnablingASF Optional user pool id for enabling advanced security features
- @param enableSFAuthSession If set true, will use `SFAuthenticationSession` if available. Below iOS 11, the SDK will use SFSafariViewController regardless of this setting
+ @param enableSFAuthSession If true, will use `SFAuthenticationSession` if available. Below iOS 11, the SDK will use SFSafariViewController regardless of this setting
  */
 - (instancetype)initWithAppClientId:(NSString *) appClientId
                     appClientSecret:(nullable NSString *) appClientSecret

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -751,7 +751,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                 //clean up vc
                 self.svc = nil;
             }];
-        }else {
+        } else {
             dismissBlock();
         }
     });

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -93,7 +93,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		170C2D471EDFAE43008A2E52 /* AWSCognitoAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EFDE85AC1ED203D9008841EC /* AWSCognitoAuthTests.m */; };
 		173641DE1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 173641DC1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.h */; };
 		173641DF1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 173641DD1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.m */; };
 		174A59F01D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 174A59EF1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m */; };
@@ -1212,6 +1211,7 @@
 		FA5DFE5821FB8E4700C554E7 /* AWSCognitoIdentityASF.m in Sources */ = {isa = PBXBuildFile; fileRef = FA5DFE5721FB8E4700C554E7 /* AWSCognitoIdentityASF.m */; };
 		FA62A7172167C9F100EFB444 /* AWSGZIPBaseTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = FA62A7162167C9F100EFB444 /* AWSGZIPBaseTestCase.m */; };
 		FA6978C821FA63D50092C8F3 /* AWSPinpointBackgroundBehaviorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA6978C721FA63D40092C8F3 /* AWSPinpointBackgroundBehaviorTests.m */; };
+		FA81D84E22FB8FBF0018DB1B /* AWSCognitoAuthUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EFDE85A91ED203D9008841EC /* AWSCognitoAuthUnitTests.m */; };
 		FA99CF25216C0E190086F9A7 /* AWSGZIPEncodingJSONRequestSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = FA99CF23216C0E190086F9A7 /* AWSGZIPEncodingJSONRequestSerializer.h */; };
 		FA99CF26216C0E190086F9A7 /* AWSGZIPEncodingJSONRequestSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = FA99CF24216C0E190086F9A7 /* AWSGZIPEncodingJSONRequestSerializer.m */; };
 		FA99CF2D216C13E30086F9A7 /* AWSKinesisSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = FA99CF2B216C13E20086F9A7 /* AWSKinesisSerializer.h */; };
@@ -12690,7 +12690,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				170C2D471EDFAE43008A2E52 /* AWSCognitoAuthTests.m in Sources */,
+				FA81D84E22FB8FBF0018DB1B /* AWSCognitoAuthUnitTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.10.3
 
+### Bug Fixes
+
+- **AWSCognitoAuth**
+  - `delegate` property is now retained weakly
+
 ### Misc. Updates
 - Model updates for the following services
   - Amazon Polly


### PR DESCRIPTION
*Description of changes:*

Customer reports retain cycle in the view controller they're using as their CognitoAuth delegate. This change sets the delegate to `weak` ownership.

We don't have a good way of integration testing this, because the interaction depends on a view controller to present the Safari login page. However, I have verified the behavior manually by inspecting the object retain graph and noting that CognitoAuth no longer maintains a reference to the delegate after the VC is popped off the stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
