### PR TITLE
Fix memory leaks from missing invalidations

### DIFF
--- a/AWSCore/Networking/AWSNetworking.h
+++ b/AWSCore/Networking/AWSNetworking.h
@@ -19,7 +19,8 @@
 FOUNDATION_EXPORT NSString *const AWSNetworkingErrorDomain;
 typedef NS_ENUM(NSInteger, AWSNetworkingErrorType) {
     AWSNetworkingErrorUnknown,
-    AWSNetworkingErrorCancelled
+    AWSNetworkingErrorCancelled,
+    AWSNetworkingErrorSessionInvalid
 };
 
 typedef NS_ENUM(NSInteger, AWSNetworkingRetryType) {

--- a/AWSCore/Networking/AWSNetworking.m
+++ b/AWSCore/Networking/AWSNetworking.m
@@ -86,6 +86,13 @@ NSString *const AWSNetworkingErrorDomain = @"com.amazonaws.AWSNetworkingErrorDom
 - (AWSTask *)sendRequest:(AWSNetworkingRequest *)request {
     return [self.networkManager dataTaskWithRequest:request];
 }
+
+- (void)dealloc {
+    // If this is being released, the network manager should be notified so it can invalidate
+    // its NSURLSession to avoid a memory leak.
+    [_networkManager invalidate];
+}
+
 @end
 
 #pragma mark - AWSNetworkingConfiguration

--- a/AWSCore/Networking/AWSNetworking.m
+++ b/AWSCore/Networking/AWSNetworking.m
@@ -58,11 +58,19 @@ NSString *const AWSNetworkingErrorDomain = @"com.amazonaws.AWSNetworkingErrorDom
 
 @end
 
+#pragma mark - AWSURLSessionManager
+
+@interface AWSURLSessionManager()
+
+- (void)invalidate;
+
+@end
+
 #pragma mark - AWSNetworking
 
 @interface AWSNetworking()
 
-@property (nonatomic, strong) AWSURLSessionManager *networkManager;
+@property (nonatomic, strong) AWSURLSessionManager *sessionManager;
 
 @end
 
@@ -77,20 +85,20 @@ NSString *const AWSNetworkingErrorDomain = @"com.amazonaws.AWSNetworkingErrorDom
 
 - (instancetype)initWithConfiguration:(AWSNetworkingConfiguration *)configuration {
     if (self = [super init]) {
-        _networkManager = [[AWSURLSessionManager alloc] initWithConfiguration:configuration];
+        _sessionManager = [[AWSURLSessionManager alloc] initWithConfiguration:configuration];
     }
 
     return self;
 }
 
 - (AWSTask *)sendRequest:(AWSNetworkingRequest *)request {
-    return [self.networkManager dataTaskWithRequest:request];
+    return [self.sessionManager dataTaskWithRequest:request];
 }
 
 - (void)dealloc {
     // If this is being released, the network manager should be notified so it can invalidate
     // its NSURLSession to avoid a memory leak.
-    [_networkManager invalidate];
+    [_sessionManager invalidate];
 }
 
 @end

--- a/AWSCore/Networking/AWSURLSessionManager.h
+++ b/AWSCore/Networking/AWSURLSessionManager.h
@@ -24,11 +24,4 @@
 
 - (AWSTask *)dataTaskWithRequest:(AWSNetworkingRequest *)request;
 
-/**
- Invalidates the underlying NSURLSession to avoid memory leaks.
- 
- @warning Before calling this method, make sure no method is running on this manager.
- */
-- (void)invalidate;
-
 @end

--- a/AWSCore/Networking/AWSURLSessionManager.h
+++ b/AWSCore/Networking/AWSURLSessionManager.h
@@ -24,4 +24,11 @@
 
 - (AWSTask *)dataTaskWithRequest:(AWSNetworkingRequest *)request;
 
+/**
+ Invalidates the underlying NSURLSession to avoid memory leaks.
+ 
+ @warning Before calling this method, make sure no method is running on this manager.
+ */
+- (void)invalidate;
+
 @end

--- a/AWSCore/Networking/AWSURLSessionManager.m
+++ b/AWSCore/Networking/AWSURLSessionManager.m
@@ -82,6 +82,7 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
 
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, strong) AWSSynchronizedMutableDictionary *sessionManagerDelegates;
+@property (nonatomic) BOOL isSessionValid;
 
 @end
 
@@ -92,6 +93,10 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
                                    reason:@"`- init` is not a valid initializer. Use `- initWithConfiguration` instead."
                                  userInfo:nil];
     return nil;
+}
+
+- (void)dealloc {
+    // Do nothing
 }
 
 - (instancetype)initWithConfiguration:(AWSNetworkingConfiguration *)configuration {
@@ -114,6 +119,7 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
                                                  delegate:self
                                             delegateQueue:nil];
         _sessionManagerDelegates = [AWSSynchronizedMutableDictionary new];
+        _isSessionValid = YES;
     }
 
     return self;
@@ -136,6 +142,13 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
 }
 
 - (void)taskWithDelegate:(AWSURLSessionManagerDelegate *)delegate {
+    if (!self.session || !self.isSessionValid) {
+        delegate.taskCompletionSource.error = [NSError errorWithDomain:AWSNetworkingErrorDomain
+                                                                  code:AWSNetworkingErrorSessionInvalid
+                                                              userInfo:@{NSLocalizedDescriptionKey: @"URLSession is nil or invalidated"}];
+        return;
+    }
+
     if (delegate.downloadingFileURL) delegate.shouldWriteToFile = YES;
     delegate.responseData = nil;
     delegate.responseObject = nil;
@@ -181,6 +194,13 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
         }
 
         if (delegate.request.task) {
+            if (!self.session || !self.isSessionValid) {
+                AWSDDLogError(@"Invalid AWSURLSessionTaskType.");
+                return [AWSTask taskWithError:[NSError errorWithDomain:AWSNetworkingErrorDomain
+                                                                  code:AWSNetworkingErrorSessionInvalid
+                                                              userInfo:@{NSLocalizedDescriptionKey: @"URLSession is nil or invalidated."}]];
+            }
+
             [self.sessionManagerDelegates setObject:delegate
                                              forKey:@(((NSURLSessionTask *)delegate.request.task).taskIdentifier)];
 
@@ -204,9 +224,28 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
     }];
 }
 
+/**
+ Invalidates the underlying NSURLSession to avoid memory leaks. Internally, calls
+ `-[NSURLSession finishTasksAndInvalidate]` so that any in-process tasks are allowed
+ to complete before invalidating.
+
+ @warning Before calling this method, make sure no method is running on this manager.
+ */
 - (void)invalidate {
     // Invalidate the session so its strong reference to self is released.
-    [_session invalidateAndCancel];
+    self.isSessionValid = NO;
+    [self.session finishTasksAndInvalidate];
+}
+
+#pragma mark - NSURLSessionDelegate
+
+- (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
+    if (session == self.session) {
+        // If the session became invalid because of a call to `invalidate`, this should already be set, but we'll
+        // set it defensively in case there are other paths to invalidation.
+        self.isSessionValid = NO;
+        self.session = nil;
+    }
 }
 
 #pragma mark - NSURLSessionTaskDelegate

--- a/AWSCore/Networking/AWSURLSessionManager.m
+++ b/AWSCore/Networking/AWSURLSessionManager.m
@@ -204,6 +204,11 @@ typedef NS_ENUM(NSInteger, AWSURLSessionTaskType) {
     }];
 }
 
+- (void)invalidate {
+    // Invalidate the session so its strong reference to self is released.
+    [_session invalidateAndCancel];
+}
+
 #pragma mark - NSURLSessionTaskDelegate
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)sessionTask didCompleteWithError:(NSError *)error {

--- a/AWSCoreTests/AWSNetworkingTests.m
+++ b/AWSCoreTests/AWSNetworkingTests.m
@@ -129,7 +129,7 @@
     XCTAssertEqual(STS.configuration.timeoutIntervalForRequest, 0);
     XCTAssertEqual(STS.configuration.timeoutIntervalForResource, 0);
     XCTAssertEqual(STS.configuration.maxRetryCount, 3);
-    NSURLSessionConfiguration *URLSessionConfiguration = [STS valueForKeyPath:@"networking.networkManager.session.configuration"];
+    NSURLSessionConfiguration *URLSessionConfiguration = [STS valueForKeyPath:@"networking.sessionManager.session.configuration"];
     XCTAssertEqual(URLSessionConfiguration.timeoutIntervalForRequest, 60);
     XCTAssertEqual(URLSessionConfiguration.timeoutIntervalForResource, 604800); // 1 week
 }
@@ -148,7 +148,7 @@
     XCTAssertEqual(STS.configuration.timeoutIntervalForRequest, 123);
     XCTAssertEqual(STS.configuration.timeoutIntervalForResource, 321);
     XCTAssertEqual(STS.configuration.maxRetryCount, 4);
-    NSURLSessionConfiguration *URLSessionConfiguration = [STS valueForKeyPath:@"networking.networkManager.session.configuration"];
+    NSURLSessionConfiguration *URLSessionConfiguration = [STS valueForKeyPath:@"networking.sessionManager.session.configuration"];
     XCTAssertEqual(URLSessionConfiguration.timeoutIntervalForRequest, 123);
     XCTAssertEqual(URLSessionConfiguration.timeoutIntervalForResource, 321);
 }
@@ -167,7 +167,7 @@
     XCTAssertEqual(STS.configuration.timeoutIntervalForRequest, 1);
     XCTAssertEqual(STS.configuration.timeoutIntervalForResource, 1);
     XCTAssertEqual(STS.configuration.maxRetryCount, 1);
-    NSURLSessionConfiguration *URLSessionConfiguration = [STS valueForKeyPath:@"networking.networkManager.session.configuration"];
+    NSURLSessionConfiguration *URLSessionConfiguration = [STS valueForKeyPath:@"networking.sessionManager.session.configuration"];
     XCTAssertEqual(URLSessionConfiguration.timeoutIntervalForRequest, 1);
     XCTAssertEqual(URLSessionConfiguration.timeoutIntervalForResource, 1);
 }

--- a/AWSCoreUnitTests/AWSURLSessionManagerTests.m
+++ b/AWSCoreUnitTests/AWSURLSessionManagerTests.m
@@ -1,0 +1,116 @@
+//
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWSCore.h"
+#import "AWSTestUtility.h"
+
+@interface AWSCognitoIdentity()
+
+@property (nonatomic, strong) AWSNetworking *networking;
+
+@end
+
+@interface AWSNetworking()
+
+@property (nonatomic, strong) AWSURLSessionManager *sessionManager;
+
+@end
+
+@interface AWSURLSessionManager()
+
+- (void)invalidate;
+
+@end
+
+@interface AWSURLSessionManagerTests : XCTestCase
+
+@end
+
+// These tests rely on knowledge of AWSNetworking internals, but are needed to assert that we're properly releasing
+// objects from memory.
+@implementation AWSURLSessionManagerTests
+
+- (void)setUp {
+    [AWSTestUtility setupFakeCognitoCredentialsProvider];
+}
+
+/**
+ - Given: An AWS service configuration
+ - When: A service is registered with the configuration
+ - Then: The service has an AWSURLSessionManager object
+ */
+- (void)testServiceHasAWSNetworking {
+    AWSCognitoIdentity *cognitoIdentityClient = [AWSCognitoIdentity defaultCognitoIdentity];
+    XCTAssertNotNil(cognitoIdentityClient.networking.sessionManager);
+}
+
+/**
+ - Given: A registered AWS Service
+ - When: The service is released
+ - Then: The AWSURLSessionManager object is released
+ */
+- (void)testSessionManagerIsDeallocatedWhenServiceIsDeallocated {
+    __weak AWSURLSessionManager *sessionManager;
+
+    @autoreleasepool {
+        // Doing all allocations in the autorelease pool to ensure dealloc happens within timeframe of test
+        AWSServiceConfiguration *serviceConfig = [[AWSServiceManager defaultServiceManager] defaultServiceConfiguration];
+        [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:serviceConfig forKey:@"localClient"];
+        AWSCognitoIdentity *localClient = [AWSCognitoIdentity CognitoIdentityForKey:@"localClient"];
+        sessionManager = localClient.networking.sessionManager;
+
+        localClient = nil;
+
+        // Overwrite previously registered client
+        [AWSCognitoIdentity removeCognitoIdentityForKey:@"localClient"];
+    }
+
+    XCTestExpectation *sessionManagerIsReleased = [self expectationWithDescription:@"sessionManager is released"];
+
+    // Watch for session manager to be released in the background, and fulfill the expectation when complete.
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        while (YES) {
+            if (sessionManager == nil) {
+                [sessionManagerIsReleased fulfill];
+                break;
+            }
+            sleep(0.25);
+        }
+    });
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+/**
+ - Given: An invalidated AWSURLSessionManager
+ - When: A task is submitted
+ - Then: The task returns with an `AWSNetworkingErrorSessionInvalid` error
+ */
+- (void)testErrorWhenAddingToInvalidatedSession {
+    AWSCognitoIdentity *cognitoIdentityClient = [AWSCognitoIdentity defaultCognitoIdentity];
+    AWSURLSessionManager *sessionManager = cognitoIdentityClient.networking.sessionManager;
+    [sessionManager invalidate];
+
+    AWSCognitoIdentityListIdentitiesInput *input = [[AWSCognitoIdentityListIdentitiesInput alloc] init];
+
+    [[[cognitoIdentityClient listIdentities:input] continueWithBlock:^id _Nullable(AWSTask<AWSCognitoIdentityListIdentitiesResponse *> * _Nonnull t) {
+        XCTAssertNotNil(t.error);
+        XCTAssertEqual(t.error.code, AWSNetworkingErrorSessionInvalid);
+        return nil;
+    }] waitUntilFinished];
+}
+
+@end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -1203,6 +1203,7 @@
 		EFF1B9F21CBC42FF001F4CF1 /* aws_tommath_class.h in Headers */ = {isa = PBXBuildFile; fileRef = EFF1B9EE1CBC42FF001F4CF1 /* aws_tommath_class.h */; };
 		EFF1B9F31CBC42FF001F4CF1 /* aws_tommath_superclass.h in Headers */ = {isa = PBXBuildFile; fileRef = EFF1B9EF1CBC42FF001F4CF1 /* aws_tommath_superclass.h */; };
 		EFF1B9F41CBC42FF001F4CF1 /* tommath.c in Sources */ = {isa = PBXBuildFile; fileRef = EFF1B9F01CBC42FF001F4CF1 /* tommath.c */; };
+		FA0A61CD22FE3B2400B051BE /* AWSURLSessionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA0A61CA22FE0E3300B051BE /* AWSURLSessionManagerTests.m */; };
 		FA2800EE22C9C1E1000B41F4 /* AWSStringValue.m in Sources */ = {isa = PBXBuildFile; fileRef = FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */; };
 		FA40A91221FA2F2A0050F4B2 /* AWSDateFormatterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA40A91121FA2F2A0050F4B2 /* AWSDateFormatterTests.m */; };
 		FA41B39322C652E300142F8D /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF3E1C6A69AB0098B15B /* credentials.json */; };
@@ -4279,6 +4280,7 @@
 		EFF1B9EE1CBC42FF001F4CF1 /* aws_tommath_class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aws_tommath_class.h; sourceTree = "<group>"; };
 		EFF1B9EF1CBC42FF001F4CF1 /* aws_tommath_superclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aws_tommath_superclass.h; sourceTree = "<group>"; };
 		EFF1B9F01CBC42FF001F4CF1 /* tommath.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tommath.c; sourceTree = "<group>"; };
+		FA0A61CA22FE0E3300B051BE /* AWSURLSessionManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSURLSessionManagerTests.m; sourceTree = "<group>"; };
 		FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSStringValue.m; sourceTree = "<group>"; };
 		FA2800EF22C9C1E5000B41F4 /* AWSStringValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSStringValue.h; sourceTree = "<group>"; };
 		FA40A91121FA2F2A0050F4B2 /* AWSDateFormatterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSDateFormatterTests.m; sourceTree = "<group>"; };
@@ -6277,6 +6279,7 @@
 				CE5603DE1C6BC7C700B4E00B /* AWSGeneralCognitoIdentityTests.m */,
 				CE5603DF1C6BC7C700B4E00B /* AWSGeneralSTSTests.m */,
 				CE96C3FA1C6EA4670092D828 /* AWSServiceTests.m */,
+				FA0A61CA22FE0E3300B051BE /* AWSURLSessionManagerTests.m */,
 				CE5603D61C6BC74500B4E00B /* Info.plist */,
 			);
 			path = AWSCoreUnitTests;
@@ -11949,6 +11952,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA0A61CD22FE3B2400B051BE /* AWSURLSessionManagerTests.m in Sources */,
 				CE5603E01C6BC7C700B4E00B /* AWSGeneralCognitoIdentityTests.m in Sources */,
 				FA40A91221FA2F2A0050F4B2 /* AWSDateFormatterTests.m in Sources */,
 				CE5603E41C6BC82E00B4E00B /* AWSTestUtility.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Bug Fixes
 
+- **AWS Core**
+  - `-[AWSURLSessionManager invalidate]` now invokes `-[NSURLSession finishTasksAndInvalidate]` before releasing the underlying URLSession.
+    If you attempt to start a new task on the invalidated session, AWSNetworking will now throw an `AWSNetworkingErrorSessionInvalid` error.
+    (See [PR #1203](https://github.com/aws-amplify/aws-sdk-ios/pull/1203) and [PR #1556](https://github.com/aws-amplify/aws-sdk-ios/pull/1556)).
+    Thanks @jkennington and @jaetzold!
+
 - **AWSCognitoAuth**
   - `delegate` property is now retained weakly
 


### PR DESCRIPTION
*Issue #, if available:*

Extended #1203, and #1556 with a flag that indicates a session is in the process of being invalidated, and added an error type to return when attempting to add a task to an invalidated session.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
