### PR TITLE
Fix signOut callback

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -579,7 +579,7 @@ extension AWSMobileClient {
             return
         }
         signOut()
-        
+        completionHandler(nil)
     }
     
     /// Signs out the current logged in user and clears the local keychain store.

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -567,9 +567,9 @@ extension AWSMobileClient {
         if federationProvider == .userPools && options.signOutGlobally == true {
             let _ = self.userpoolOpsHelper.currentActiveUser!.globalSignOut().continueWith { (task) -> Any? in
                 if task.result != nil {
-                    completionHandler(nil)
                     // If global signout is successful, we clear tokens locally and perform signout flow.
                     self.signOut()
+                    completionHandler(nil)
                 } else if let error = task.error {
                     // If there is an error signing out globally, we notify the developer.
                     completionHandler(self.getMobileError(for: error))

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -622,6 +622,20 @@ class AWSMobileClientTests: XCTestCase {
         XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
     }
     
+    func testSignOutWithCallback() {
+        let username = "testUser" + UUID().uuidString
+        let signoutExpectation = expectation(description: "Successfully signout")
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == true, "Expected to return true for isSignedIn")
+        sleep(1)
+        AWSMobileClient.sharedInstance().signOut { (error) in
+            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+            signoutExpectation.fulfill()
+        }
+        wait(for: [signoutExpectation], timeout: 2)
+    }
+    
     func testFederatedSignInDeveloperAuthenticatedIdentities() {
         let getOpendIdRequest = AWSCognitoIdentityGetOpenIdTokenForDeveloperIdentityInput()
         getOpendIdRequest?.identityPoolId = identityPoolId

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -622,11 +622,10 @@ class AWSMobileClientTests: XCTestCase {
         XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
     }
     
-    /// Test successful sign out with callback and no option
+    /// Test successful sign out with callback and no option on an Authenticated User
     ///
-    /// - Given: An unauthenticated session
+    /// - Given: An authenticated session
     /// - When:
-    ///    - I invoke `signIn` with a completion callback
     ///    - I invoke `signOut` with completion callback
     /// - Then:
     ///    - My `signOut` completion callback is invoked
@@ -646,11 +645,10 @@ class AWSMobileClientTests: XCTestCase {
         wait(for: [signoutExpectation], timeout: 2)
     }
     
-    /// Test successful sign out with options and callback
+    /// Test successful sign out with options and callback on an Authenticated User
     ///
-    /// - Given: An unauthenticated session
+    /// - Given: An authenticated session
     /// - When:
-    ///    - I invoke `signIn` with a completion callback
     ///    - I invoke `signOut` with signoutoptions and completion callback
     /// - Then:
     ///    - My `signOut` completion callback is invoked
@@ -666,6 +664,28 @@ class AWSMobileClientTests: XCTestCase {
         
         let signoutOptions = SignOutOptions(signOutGlobally: true, invalidateTokens: true)
         AWSMobileClient.sharedInstance().signOut(options: signoutOptions) { (error) in
+            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+            signoutExpectation.fulfill()
+        }
+        wait(for: [signoutExpectation], timeout: 2)
+    }
+    
+    /// Test successful sign out with callback and no option on a UnAuthenticated user
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I invoke `signOut` with completion callback
+    /// - Then:
+    ///    - My `signOut` completion callback is invoked
+    ///    - The user state is `signedOut`
+    ///
+    func testSignOutUnAuthenticatedUser() {
+        let username = "testUser" + UUID().uuidString
+        let signoutExpectation = expectation(description: "Successfully signout for unauthenticated User")
+        signUpAndVerifyUser(username: username)
+        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+        sleep(1)
+        AWSMobileClient.sharedInstance().signOut { (error) in
             XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
             signoutExpectation.fulfill()
         }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -622,6 +622,16 @@ class AWSMobileClientTests: XCTestCase {
         XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
     }
     
+    /// Test successful sign out with callback and no option
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I invoke `signIn` with a completion callback
+    ///    - I invoke `signOut` with completion callback
+    /// - Then:
+    ///    - My `signOut` completion callback is invoked
+    ///    - The user state is `signedOut`
+    ///
     func testSignOutWithCallback() {
         let username = "testUser" + UUID().uuidString
         let signoutExpectation = expectation(description: "Successfully signout")
@@ -630,6 +640,32 @@ class AWSMobileClientTests: XCTestCase {
         XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == true, "Expected to return true for isSignedIn")
         sleep(1)
         AWSMobileClient.sharedInstance().signOut { (error) in
+            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+            signoutExpectation.fulfill()
+        }
+        wait(for: [signoutExpectation], timeout: 2)
+    }
+    
+    /// Test successful sign out with options and callback
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I invoke `signIn` with a completion callback
+    ///    - I invoke `signOut` with signoutoptions and completion callback
+    /// - Then:
+    ///    - My `signOut` completion callback is invoked
+    ///    - The user state is `signedOut`
+    ///
+    func testSignOutWithCallbackAndSignoutOption() {
+        let username = "testUser" + UUID().uuidString
+        let signoutExpectation = expectation(description: "Successfully signout")
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == true, "Expected to return true for isSignedIn")
+        sleep(1)
+        
+        let signoutOptions = SignOutOptions(signOutGlobally: true, invalidateTokens: true)
+        AWSMobileClient.sharedInstance().signOut(options: signoutOptions) { (error) in
             XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
             signoutExpectation.fulfill()
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - **AWSMobileClient**
   - Fixes the crash during signout while setting error on completed task (See [Issue 1505](https://github.com/aws-amplify/aws-sdk-ios/issues/1505) and [Issue 1682](https://github.com/aws-amplify/aws-sdk-ios/issues/1682).)
+  - Fixed an issue where signOut callback is not called (See [Issue 1717](https://github.com/aws-amplify/aws-sdk-ios/issues/1717).)
 
 ### Misc. Updates
 - Model updates for the following services


### PR DESCRIPTION
signOut with callback was not invoking the callback if we do not pass any options. This change resolves that.

*Issue #1717 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
