### PR TITLE
Separated signIn and confirmSignIn callback

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -130,13 +130,14 @@
 		17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1786CA4D1F2BEDB8003421FF /* Images.xcassets */; };
 		17F4F75021F6B0750068B553 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		17F4F75121F6B0750068B553 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */; };
+		B4031BE623105727009EB524 /* AWSMobileClientSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */; };
+		B4C8E4212306064D0064C158 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E3A72306056A0064C158 /* JSONHelper.swift */; };
 		B4C8E4A023073D7B0064C158 /* AWSMobileClientBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E49F23073D7B0064C158 /* AWSMobileClientBaseTests.swift */; };
 		B4C8E4A2230740200064C158 /* AWSMobileClientSignoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A1230740200064C158 /* AWSMobileClientSignoutTests.swift */; };
 		B4C8E4A42307415C0064C158 /* AWSMobileClientDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A32307415C0064C158 /* AWSMobileClientDeviceTests.swift */; };
 		B4C8E4A6230742200064C158 /* AWSMobileClientUserAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */; };
 		B4C8E4A8230743780064C158 /* AWSMobileClientPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A7230743780064C158 /* AWSMobileClientPasswordTests.swift */; };
 		B4C8E4AA2307447F0064C158 /* AWSMobileClientCredentialsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A92307447F0064C158 /* AWSMobileClientCredentialsTest.swift */; };
-		B4C8E4212306064D0064C158 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E3A72306056A0064C158 /* JSONHelper.swift */; };
 		B5150AB21F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = B5150AB11F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m */; };
 		B5150AB31F3BF04C00AC8D08 /* AWSAuthUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = B5150A531F3BF00F00AC8D08 /* AWSAuthUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5150B1C1F3CE0E500AC8D08 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5150B1A1F3C389C00AC8D08 /* Images.xcassets */; };
@@ -1213,13 +1214,14 @@
 		17D61FA6216BBC59009B2B9C /* AWSMobileClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClient.swift; sourceTree = "<group>"; };
 		17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
 		17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
+		B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientSignInTests.swift; sourceTree = "<group>"; };
+		B4C8E3A72306056A0064C158 /* JSONHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
 		B4C8E49F23073D7B0064C158 /* AWSMobileClientBaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientBaseTests.swift; sourceTree = "<group>"; };
 		B4C8E4A1230740200064C158 /* AWSMobileClientSignoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientSignoutTests.swift; sourceTree = "<group>"; };
 		B4C8E4A32307415C0064C158 /* AWSMobileClientDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientDeviceTests.swift; sourceTree = "<group>"; };
 		B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientUserAttributeTests.swift; sourceTree = "<group>"; };
 		B4C8E4A7230743780064C158 /* AWSMobileClientPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientPasswordTests.swift; sourceTree = "<group>"; };
 		B4C8E4A92307447F0064C158 /* AWSMobileClientCredentialsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientCredentialsTest.swift; sourceTree = "<group>"; };
-		B4C8E3A72306056A0064C158 /* JSONHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
 		B5150A531F3BF00F00AC8D08 /* AWSAuthUIConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIConfiguration.h; path = Sources/AWSAuthUI/AWSAuthUIConfiguration.h; sourceTree = SOURCE_ROOT; };
 		B5150AB11F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIConfiguration.m; path = Sources/AWSAuthUI/AWSAuthUIConfiguration.m; sourceTree = SOURCE_ROOT; };
 		B5150B1A1F3C389C00AC8D08 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Sources/AWSAuthUI/Images.xcassets; sourceTree = SOURCE_ROOT; };
@@ -1541,6 +1543,7 @@
 				B4C8E4A1230740200064C158 /* AWSMobileClientSignoutTests.swift */,
 				17CD4AA6218241AD00953483 /* AWSMobileClientTests.swift */,
 				B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */,
+				B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */,
 			);
 			path = AWSMobileClientTests;
 			sourceTree = "<group>";
@@ -2976,6 +2979,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4031BE623105727009EB524 /* AWSMobileClientSignInTests.swift in Sources */,
 				B4C8E4A42307415C0064C158 /* AWSMobileClientDeviceTests.swift in Sources */,
 				B4C8E4A6230742200064C158 /* AWSMobileClientUserAttributeTests.swift in Sources */,
 				17CD4AA7218241AD00953483 /* AWSMobileClientTests.swift in Sources */,

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -142,28 +142,28 @@ extension AWSMobileClient {
         return self.userPoolClient?.currentUser()
     }
     
-    /// SignIn can be a two way process where the developer has to call signIn first and then
+    /// SignIn can be a two phase process where the developer has to call signIn first and then
     /// call the confirmSignIn method. Both of these apis can result in the same callback path.
     /// This method is called for any signIn related callback. We check whether the callback
     /// is available and then invoke the callback. Before invoking the callback we make sure that the
-    /// internal callback representation is set to nil.
+    /// internal callback reference is set to nil.
     /// - Parameters:
     ///     - signResult: signIn result if there is no error
     ///     - error: error occured
     internal func invokeSignInCallback(signResult: SignInResult?, error: Error?) {
-        if let signCallback = self.userpoolOpsHelper.currentSignInHandlerCallback {
-            self.invalidateSignInCallbacks()
+        if let signCallback = userpoolOpsHelper.currentSignInHandlerCallback {
+            invalidateSignInCallbacks()
             signCallback(signResult, error)
             
-        } else if let confirmSignCallback = self.userpoolOpsHelper.currentConfirmSignInHandlerCallback {
-            self.invalidateSignInCallbacks()
+        } else if let confirmSignCallback = userpoolOpsHelper.currentConfirmSignInHandlerCallback {
+            invalidateSignInCallbacks()
             confirmSignCallback(signResult, error)
         }
     }
     
     internal func invalidateSignInCallbacks() {
-        self.userpoolOpsHelper.currentSignInHandlerCallback = nil
-        self.userpoolOpsHelper.currentConfirmSignInHandlerCallback = nil
+        userpoolOpsHelper.currentSignInHandlerCallback = nil
+        userpoolOpsHelper.currentConfirmSignInHandlerCallback = nil
     }
     
     /// Signs in a user with the given username and password.
@@ -495,7 +495,7 @@ extension AWSMobileClient {
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
         }
         self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
-        self.invokeSignInCallback(signResult: nil, error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
+        invokeSignInCallback(signResult: nil, error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
         self.userPoolClient?.clearAll()
     }
     
@@ -826,12 +826,12 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
             }
         
         let result = SignInResult(signInState: .smsMFA, codeDetails: codeDeliveryDetails)
-        self.invokeSignInCallback(signResult: result, error: nil)
+        invokeSignInCallback(signResult: result, error: nil)
     }
     
     func didCompleteMultifactorAuthenticationStepWithError(_ error: Error?) {
         if let error = error {
-            self.invokeSignInCallback(signResult: nil, error: AWSMobileClientError.makeMobileClientError(from: error))
+            invokeSignInCallback(signResult: nil, error: AWSMobileClientError.makeMobileClientError(from: error))
         }
     }
 }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -142,6 +142,14 @@ extension AWSMobileClient {
         return self.userPoolClient?.currentUser()
     }
     
+    /// SignIn can be a two way process where the developer has to call signIn first and then
+    /// call the confirmSignIn method. Both of these apis can result in the same callback path.
+    /// This method is called for any signIn related callback. We check whether the callback
+    /// is available and then invoke the callback. Before invoking the callback we make sure that the
+    /// internal callback representation is set to nil.
+    /// - Parameters:
+    ///     - signResult: signIn result if there is no error
+    ///     - error: error occured
     internal func invokeSignInCallback(signResult: SignInResult?, error: Error?) {
         if let signCallback = self.userpoolOpsHelper.currentSignInHandlerCallback {
             self.invalidateSignInCallbacks()

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -53,6 +53,7 @@ internal class UserPoolOperationsHandler: NSObject, AWSCognitoIdentityInteractiv
     internal var mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>?
     
     internal var currentSignInHandlerCallback: ((SignInResult?, Error?) -> Void)?
+    internal var currentConfirmSignInHandlerCallback: ((SignInResult?, Error?) -> Void)?
     
     var authHelperDelegate: UserPoolAuthHelperlCallbacks?
     

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
@@ -1,0 +1,129 @@
+//
+//  AWSMobileClientSignInTests.swift
+//  AWSMobileClientTests
+//
+
+import XCTest
+@testable import AWSMobileClient
+import AWSCognitoIdentityProvider
+
+class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
+
+    func testSignIn() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+    }
+    
+    /// Test successful sign in with callback
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I set listener to AWSMobileClient
+    ///    - I invoke `signIn` with completion callback
+    /// - Then:
+    ///    - My `signIn` completion callback is invoked
+    ///    - My listener is invoked with signedIn state
+    ///    - The user state is `signedIn`
+    ///
+    func testSignInCallbacks() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        
+        let signInListenerWasSuccessful = expectation(description: "signIn listener was successful")
+        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
+            switch (userState) {
+            case .signedIn:
+                signInListenerWasSuccessful.fulfill()
+                print("Listener user is signed in.")
+            default:
+                print("Listener \(userState)")
+            }
+        }
+        
+        let signInWasSuccessful = expectation(description: "signIn was successful")
+        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
+            if let error = error {
+                XCTFail("User login failed: \(error.localizedDescription)")
+                return
+            }
+            
+            guard let signInResult = signInResult else {
+                XCTFail("User login failed, signInResult unexpectedly nil")
+                return
+            }
+            XCTAssertEqual(signInResult.signInState, .signedIn, "Could not verify sign in state")
+            signInWasSuccessful.fulfill()
+        }
+        wait(for: [signInWasSuccessful, signInListenerWasSuccessful], timeout: 5)
+        XCTAssertNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentSignInHandlerCallback,
+                     "Current sign callback should be nil after callback is invoked")
+        AWSMobileClient.sharedInstance().removeUserStateListener(self)
+    }
+    
+    /// Test unsuccessful sign in
+    ///
+    /// - Given: An unauthenticated session with confirmed user
+    /// - When:
+    ///    - I invoke `signIn` with completion callback and wrong password
+    /// - Then:
+    ///    - My `signIn` callback should be called with error.
+    ///
+    func testSignInFailCase() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        let signInShouldFail = expectation(description: "Sign In should fail")
+        AWSMobileClient.sharedInstance().signIn(username: username, password: "WrongPassword") { (signInResult, error) in
+            XCTAssertNil(signInResult)
+            XCTAssertNotNil(error, "Expecting error for wrong password.")
+            signInShouldFail.fulfill()
+        }
+        wait(for: [signInShouldFail], timeout: 5)
+        XCTAssertNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentSignInHandlerCallback,
+                     "Current sign callback should be nil after callback is invoked")
+    }
+
+    /// Test whether the confirm sign in callback is set and is not nil
+    ///
+    /// - Given: An unauthenticated session with MFA
+    /// - When:
+    ///    - I invoke `signIn` with completion callback
+    ///    - And then invoke `confirmSignIn` from the above callback
+    /// - Then:
+    ///    - My `confirmSignIn` callback should not be nil
+    ///
+    func testConfirmSignCallbacksValue() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        let signInWasSuccessfulExpectation = expectation(description: "signIn was successful")
+        
+        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
+            if let error = error {
+                XCTFail("User login failed: \(error.localizedDescription)")
+                return
+            }
+            
+            if signInResult == nil {
+                XCTFail("User login failed, signInResult unexpectedly nil")
+                return
+            }
+            
+            // Manually set password completion task to mock confirm signIn flow.
+            let newPasswordRequiredTask = AWSTaskCompletionSource<AWSCognitoIdentityNewPasswordRequiredDetails>()
+            AWSMobileClient.sharedInstance().userpoolOpsHelper.newPasswordRequiredTaskCompletionSource = newPasswordRequiredTask
+            AWSMobileClient.sharedInstance().confirmSignIn(challengeResponse: "code") { (signInResult, error) in
+                // Completion will not be called because the continuation is mocked above.
+            }
+            signInWasSuccessfulExpectation.fulfill()
+        }
+        wait(for: [signInWasSuccessfulExpectation], timeout: 5)
+        XCTAssertNotNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentConfirmSignInHandlerCallback,
+                        "Current confirmsign callback should not be nil")
+        XCTAssertNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentSignInHandlerCallback,
+                     "Current sign callback should be nil")
+        
+        
+        
+    }
+
+}

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -47,68 +47,6 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
         wait(for: [verificationCodeSent], timeout: 5)
     }
     
-    func testSignIn() {
-        let username = "testUser" + UUID().uuidString
-        signUpAndVerifyUser(username: username)
-        signIn(username: username)
-    }
-    
-    /// Test successful sign in with callback
-    ///
-    /// - Given: An unauthenticated session
-    /// - When:
-    ///    - I set listener to AWSMobileClient
-    ///    - I invoke `signIn` with completion callback
-    /// - Then:
-    ///    - My `signIn` completion callback is invoked
-    ///    - My listener is invoked with signedIn state
-    ///    - The user state is `signedIn`
-    ///
-    func testSignInCallbacks() {
-        let username = "testUser" + UUID().uuidString
-        signUpAndVerifyUser(username: username)
-        
-         let signInListenerWasSuccessful = expectation(description: "signIn listener was successful")
-        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
-            switch (userState) {
-            case .signedIn:
-                signInListenerWasSuccessful.fulfill()
-                print("Listener user is signed in.")
-            default:
-                print("Listener \(userState)")
-            }
-        }
-        
-        let signInWasSuccessful = expectation(description: "signIn was successful")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
-            if let error = error {
-                XCTFail("User login failed: \(error.localizedDescription)")
-                return
-            }
-            
-            guard let signInResult = signInResult else {
-                XCTFail("User login failed, signInResult unexpectedly nil")
-                return
-            }
-            XCTAssertEqual(signInResult.signInState, .signedIn, "Could not verify sign in state")
-            signInWasSuccessful.fulfill()
-        }
-        wait(for: [signInWasSuccessful, signInListenerWasSuccessful], timeout: 5)
-        AWSMobileClient.sharedInstance().removeUserStateListener(self)
-    }
-    
-    func testSignInFailCase() {
-        let username = "testUser" + UUID().uuidString
-        signUpAndVerifyUser(username: username)
-        let signInShouldFail = expectation(description: "Sign In should fail")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: "WrongPassword") { (signInResult, error) in
-            XCTAssertNil(signInResult)
-            XCTAssertNotNil(error, "Expecting error for wrong password.")
-            signInShouldFail.fulfill()
-        }
-        wait(for: [signInShouldFail], timeout: 5)
-    }
-    
     func testGetTokens() {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -226,6 +226,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
  */
 - (AWSTask<AWSCognitoIdentityUserSession*>*) getSession:(NSString *)username password:(NSString *)password validationData:(NSArray<AWSCognitoIdentityUserAttributeType*>*)validationData {
     AWSTask *authenticationTask = self.pool.userPoolConfiguration.migrationEnabled ? [self migrationAuth:username password:password validationData:validationData lastChallenge:nil] : [self srpAuthInternal:username password:password validationData:validationData lastChallenge:nil isInitialCustomChallenge:NO];
+    
     return [self setConfirmationStatus: [authenticationTask continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderRespondToAuthChallengeResponse *> * _Nonnull task) {
         return [self getSessionInternal:task];
     }]];


### PR DESCRIPTION
*Issue #1248 

*Description of changes:*

Fixes a race condition where the confirm signIn callback becoming nil.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
