### PR TITLE
AWSMobile Client fixes - Balance semaphore's wait and signal calls.

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -543,7 +543,6 @@ extension AWSMobileClient {
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: provider)
         self.internalCredentialsProvider?.clearCredentials()
-        self.internalCredentialsProvider?.clearKeychain()
         self.internalCredentialsProvider?.credentials()
     }
     

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -490,6 +490,7 @@ extension AWSMobileClient {
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: .none)
         self.performUserPoolSignOut()
+        self.internalCredentialsProvider?.identityProvider.identityId = nil
         self.internalCredentialsProvider?.clearKeychain()
         self.mobileClientStatusChanged(userState: .signedOut, additionalInfo: [:])
         self.federationProvider = .none

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -490,7 +490,6 @@ extension AWSMobileClient {
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: .none)
         self.performUserPoolSignOut()
-        self.internalCredentialsProvider?.identityProvider.identityId = nil
         self.internalCredentialsProvider?.clearKeychain()
         self.mobileClientStatusChanged(userState: .signedOut, additionalInfo: [:])
         self.federationProvider = .none

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -494,6 +494,7 @@ extension AWSMobileClient {
         self.internalCredentialsProvider?.identityProvider.identityId = nil
         self.internalCredentialsProvider?.clearKeychain()
         self.mobileClientStatusChanged(userState: .signedOut, additionalInfo: [:])
+        federationProvider = .none
     }
     
     internal func performUserPoolSignOut() {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -489,12 +489,11 @@ extension AWSMobileClient {
         _AWSMobileClient.sharedInstance().setCustomRoleArnInternal(nil, for: self)
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: .none)
-        self.internalCredentialsProvider?.clearKeychain()
         self.performUserPoolSignOut()
         self.internalCredentialsProvider?.identityProvider.identityId = nil
         self.internalCredentialsProvider?.clearKeychain()
         self.mobileClientStatusChanged(userState: .signedOut, additionalInfo: [:])
-        federationProvider = .none
+        self.federationProvider = .none
     }
     
     internal func performUserPoolSignOut() {
@@ -545,6 +544,7 @@ extension AWSMobileClient {
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: provider)
         self.internalCredentialsProvider?.clearCredentials()
+        self.internalCredentialsProvider?.clearKeychain()
         self.internalCredentialsProvider?.credentials()
     }
     

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
@@ -283,7 +283,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
             credentialFetchAfterSignIn.fulfill()
         })
-        wait(for: [credentialFetchAfterSignIn], timeout: 30)
+        wait(for: [credentialFetchAfterSignIn], timeout: 15)
         
         AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
             // We do not need to check the values here, this can succeed
@@ -297,6 +297,6 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             credentialFetchAfterSignOut.fulfill()
         })
         wait(for: [credentialFetchAfterSignOut, credentialFetchAfterSignIn2, credentialFetchBeforeSignIn],
-             timeout: 30)
+             timeout: 15)
     }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
@@ -262,4 +262,33 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         AWSMobileClient.sharedInstance().removeUserStateListener(self)
     }
 
+    
+    func testMultipleGetCredentials() {
+        AWSDDLog.sharedInstance.logLevel = .verbose
+        AWSDDLog.add(AWSDDTTYLogger.sharedInstance)
+        let username = "testUser" + UUID().uuidString
+        let credentialFetchBeforeSignIn = expectation(description: "Request to getAWSCredentials before signIn")
+        let credentialFetchAfterSignIn = expectation(description: "Request to getAWSCredentials after signIn")
+        let credentialFetchAfterSignOut = expectation(description: "Request to getAWSCredentials after signOut")
+        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
+            credentialFetchBeforeSignIn.fulfill()
+        })
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
+            credentialFetchAfterSignIn.fulfill()
+        })
+        AWSMobileClient.sharedInstance().signOut()
+        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
+            credentialFetchAfterSignOut.fulfill()
+        })
+        wait(for: [credentialFetchAfterSignOut, credentialFetchAfterSignIn, credentialFetchBeforeSignIn],
+             timeout: 30)
+    }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
@@ -269,6 +269,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         let username = "testUser" + UUID().uuidString
         let credentialFetchBeforeSignIn = expectation(description: "Request to getAWSCredentials before signIn")
         let credentialFetchAfterSignIn = expectation(description: "Request to getAWSCredentials after signIn")
+        let credentialFetchAfterSignIn2 = expectation(description: "Request to getAWSCredentials after signIn")
         let credentialFetchAfterSignOut = expectation(description: "Request to getAWSCredentials after signOut")
         AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
             XCTAssertNil(error)
@@ -282,13 +283,20 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
             credentialFetchAfterSignIn.fulfill()
         })
+        wait(for: [credentialFetchAfterSignIn], timeout: 30)
+        
+        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+            // We do not need to check the values here, this can succeed
+            // or fail based on whether this method completes before the below signOut.
+            credentialFetchAfterSignIn2.fulfill()
+        })
         AWSMobileClient.sharedInstance().signOut()
         AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
             credentialFetchAfterSignOut.fulfill()
         })
-        wait(for: [credentialFetchAfterSignOut, credentialFetchAfterSignIn, credentialFetchBeforeSignIn],
+        wait(for: [credentialFetchAfterSignOut, credentialFetchAfterSignIn2, credentialFetchBeforeSignIn],
              timeout: 30)
     }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -207,8 +207,7 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
             return nil
         })
         wait(for: [identityIdExpectation1, identityIdExpectation2, identityIdExpectation3, identityIdExpectation4, identityIdExpectation5],
-             timeout: 15,
-             enforceOrder: true)
+             timeout: 15)
     }
     
     /// Test whether we are getting different identity Id on signOut and signIn state

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -211,6 +211,16 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
              enforceOrder: true)
     }
     
+    /// Test whether we are getting different identity Id on signOut and signIn state
+    ///
+    /// - Given: An unauthenticated user session
+    /// - When:
+    ///    - I fetch Identity Id, id1
+    ///    - Then I signIn and fetch identity id , id2
+    ///    - Then I signOut and fetch another id , id3
+    /// - Then:
+    ///    - All identity id1 != id2 and id2 != id3
+    ///
     func testGetIdentityWithSignOutAndSignIn() {
         XCTAssertNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should be nil after initialize.")
         var identityIdBeforeSignIn: String?

--- a/AWSCore/Authentication/AWSIdentityProvider.m
+++ b/AWSCore/Authentication/AWSIdentityProvider.m
@@ -100,7 +100,7 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
         [userInfo setObject:self.identityId forKey:AWSCognitoNotificationPreviousId];
     }
     [userInfo setObject:newId forKey:AWSCognitoNotificationNewId];
-
+    
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [[NSNotificationCenter defaultCenter] postNotificationName:AWSCognitoIdentityIdChangedNotification
                                                             object:self
@@ -114,10 +114,9 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
 
 @property (nonatomic, strong) AWSCognitoIdentity *cognitoIdentity;
 @property (nonatomic, strong) AWSExecutor *executor;
+@property (atomic, assign) int32_t count;
+@property (nonatomic, strong) dispatch_semaphore_t semaphore;
 @property (atomic, assign) BOOL hasClearedIdentityId;
-
-@property (nonatomic, strong) NSOperationQueue *serialOperationQueue;
-@property (nonatomic, strong) dispatch_group_t fetchIdentityLock;
 
 @end
 
@@ -129,20 +128,18 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
            identityProviderManager:(id<AWSIdentityProviderManager>)identityProviderManager {
     if (self = [super init]) {
         _executor = [AWSExecutor executorWithOperationQueue:[NSOperationQueue new]];
-        _serialOperationQueue = [[NSOperationQueue alloc] init];
-        _serialOperationQueue.maxConcurrentOperationCount = 1;
-        _fetchIdentityLock = dispatch_group_create();
-        
+        _count = 0;
+        _semaphore = dispatch_semaphore_create(0);
         _useEnhancedFlow = useEnhancedFlow;
         self.identityPoolId = identityPoolId;
         self.identityProviderManager = identityProviderManager;
-
+        
         AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
         AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
                                                                              credentialsProvider:credentialsProvider];
         _cognitoIdentity = [[AWSCognitoIdentity alloc] initWithConfiguration:configuration];
     }
-
+    
     return self;
 }
 
@@ -162,7 +159,7 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
                                                               code:AWSCognitoCredentialsProviderHelperErrorTypeIdentityIsNil
                                                           userInfo:@{NSLocalizedDescriptionKey: @"identityId shouldn't be nil"}]];
         }
-
+        
         if (self.identityProviderManager) {
             return [self.identityProviderManager logins];
         } else {
@@ -180,17 +177,17 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
                 return [AWSTask taskWithResult:[task.result objectForKey:[self identityProviderName]]];
             }
         }
-
+        
         AWSCognitoIdentityGetOpenIdTokenInput *getTokenInput = [AWSCognitoIdentityGetOpenIdTokenInput new];
         getTokenInput.identityId = self.identityId;
         getTokenInput.logins = logins;
-
+        
         return [[[self.cognitoIdentity getOpenIdToken:getTokenInput] continueWithBlock:^id(AWSTask *task) {
             // When an invalid identityId is cached in the keychain for auth,
             // we will refresh the identityId and try to get OpenID token again.
             if (task.error) {
                 AWSDDLogError(@"GetOpenIdToken failed. Error is [%@]", task.error);
-
+                
                 // If it's auth or we caught a not found or validation error
                 // we want to reset the identity id, otherwise, just return
                 // the error to our caller
@@ -198,18 +195,18 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
                                                             authenticated:[self isAuthenticated]]) {
                     return task;
                 }
-
+                
                 if (self.hasClearedIdentityId) {
                     return [AWSTask taskWithError:[NSError errorWithDomain:AWSCognitoCredentialsProviderErrorDomain
                                                                       code:AWSCognitoCredentialsProviderInvalidConfiguration
                                                                   userInfo:@{NSLocalizedDescriptionKey : @"GetCredentialsForIdentity keeps failing. Clearing identityId did not help. Please check your Amazon Cognito Identity configuration."}]];
                 }
-
+                
                 AWSDDLogDebug(@"Resetting identity Id and calling getIdentityId");
                 // if it's auth, reset id and refetch
                 self.identityId = nil;
                 self.hasClearedIdentityId = YES;
-
+                
                 return [[self getIdentityId] continueWithSuccessBlock:^id(AWSTask *task) {
                     // This should never happen, but just in case
                     if (!self.identityId) {
@@ -220,14 +217,14 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
                                                                       userInfo:@{NSLocalizedDescriptionKey: @"identityId shouldn't be nil"}]
                                 ];
                     }
-
+                    
                     AWSDDLogDebug(@"Retrying GetOpenIdToken");
-
+                    
                     // retry get token
                     AWSCognitoIdentityGetOpenIdTokenInput *tokenRetry = [AWSCognitoIdentityGetOpenIdTokenInput new];
                     tokenRetry.identityId = self.identityId;
                     tokenRetry.logins = self.cachedLogins;
-
+                    
                     return [self.cognitoIdentity getOpenIdToken:tokenRetry];
                 }];
             }
@@ -237,7 +234,7 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
             AWSCognitoIdentityGetOpenIdTokenResponse *getTokenResponse = task.result;
             NSString *token = getTokenResponse.token;
             NSString *identityIdFromToken = getTokenResponse.identityId;
-
+            
             // This should never happen, but just in case
             if (!identityIdFromToken) {
                 AWSDDLogError(@"identityId from getOpenIdToken is nil");
@@ -246,11 +243,11 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
                                                               userInfo:@{NSLocalizedDescriptionKey: @"identityId shouldn't be nil"}]
                         ];
             }
-
+            
             if (![self.identityId isEqualToString:identityIdFromToken]) {
                 self.identityId = identityIdFromToken;
             }
-
+            
             return [AWSTask taskWithResult:token];
         }];
     }];
@@ -270,7 +267,7 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
             }
         }];
     }
-
+    
     return [[self token] continueWithSuccessBlock:^id _Nullable(AWSTask<NSString *> * _Nonnull task) {
         if (!task.result) {
             return [AWSTask taskWithResult:nil];
@@ -282,59 +279,56 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
 
 #pragma mark -
 
-- (AWSTask<NSString *> *)fetchIdentityId {
-    AWSTaskCompletionSource<NSString *> *completionSource = [AWSTaskCompletionSource new];
-    
-    // Serial operation queue is used here so that only one fetch identity Id happens at a time.
-    [self.serialOperationQueue addOperationWithBlock:^{
-
-        dispatch_group_enter(self.fetchIdentityLock);
-        if (self.identityId) {
-            dispatch_group_leave(self.fetchIdentityLock);
-        } else {
-            AWSTask *task = [AWSTask taskWithResult:nil];
-            if (self.identityProviderManager) {
-                task = [self.identityProviderManager logins];
-            }
-            [[task continueWithExecutor:self.executor withSuccessBlock:^id _Nullable(AWSTask<NSDictionary<NSString *,NSString *> *> * _Nonnull task) {
-                
-                NSDictionary<NSString *, NSString *> *logins = task.result;
-                AWSCognitoIdentityGetIdInput *getIdInput = [AWSCognitoIdentityGetIdInput new];
-                getIdInput.identityPoolId = self.identityPoolId;
-                getIdInput.logins = logins;
-                return [self.cognitoIdentity getId:getIdInput];
-            }] continueWithBlock:^id(AWSTask *task) {
-                
-                if (task.error) {
-                    AWSDDLogError(@"GetId failed. Error is [%@]", task.error);
-                } else if (task.result) {
-                    AWSCognitoIdentityGetIdResponse *getIdResponse = task.result;
-                    self.identityId = getIdResponse.identityId;
-                }
-                dispatch_group_leave(self.fetchIdentityLock);
-                return nil;
-            }];
-        }
-        dispatch_group_wait(self.fetchIdentityLock, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
-        if(!self.identityId){
-            NSString * error = @"Obtaining an identity id in another thread failed or didn't complete within 5 seconds.";
-            AWSDDLogError(@"%@",error);
-            [completionSource setError:[NSError errorWithDomain:AWSCognitoCredentialsProviderHelperErrorDomain
-                                                           code:AWSCognitoCredentialsProviderHelperErrorTypeIdentityIsNil
-                                                       userInfo:@{NSLocalizedDescriptionKey: error}]];
-        } else {
-            [completionSource setResult:self.identityId];
-        }
-
-    }];
-    return completionSource.task;
-}
-
 - (AWSTask<NSString *> *)getIdentityId {
     if (self.identityId) {
         return [AWSTask taskWithResult:self.identityId];
     } else {
-        return [self fetchIdentityId];
+        AWSTask *task = [AWSTask taskWithResult:nil];
+        if (self.identityProviderManager) {
+            task = [self.identityProviderManager logins];
+        }
+        return [[task continueWithExecutor:self.executor withSuccessBlock:^id _Nullable(AWSTask<NSDictionary<NSString *,NSString *> *> * _Nonnull task) {
+            NSDictionary<NSString *, NSString *> *logins = task.result;
+            self.cachedLogins = logins;
+            self.count++;
+            
+            // Create an identity id via GetID if the call to logins didn't set it which DevAuth does
+            // And there are no other calls in flight to create one
+            if (!self.identityId && self.count <= 1) {
+                dispatch_semaphore_wait(self.semaphore, dispatch_time(DISPATCH_TIME_NOW, 0));
+                AWSCognitoIdentityGetIdInput *getIdInput = [AWSCognitoIdentityGetIdInput new];
+                getIdInput.identityPoolId = self.identityPoolId;
+                getIdInput.logins = logins;
+                return [self.cognitoIdentity getId:getIdInput];
+            } else {
+                dispatch_semaphore_wait(self.semaphore, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+                return [AWSTask taskWithResult:nil];
+            }
+        }] continueWithBlock:^id(AWSTask *task) {
+            if (task.error) {
+                AWSDDLogError(@"GetId failed. Error is [%@]", task.error);
+            } else if (task.result) {
+                AWSCognitoIdentityGetIdResponse *getIdResponse = task.result;
+                self.identityId = getIdResponse.identityId;
+            }
+            
+            //ensure that the identityID is set before the semaphore is signaled, otherwise it's possible
+            //that continuation blocks execute before the identityID is set
+            self.count--;
+            dispatch_semaphore_signal(self.semaphore);
+            if (task.faulted) {
+                return task;
+            }
+            if(!self.identityId){
+                NSString * error = @"Obtaining an identity id in another thread failed or didn't complete within 5 seconds.";
+                AWSDDLogError(@"%@",error);
+                return [AWSTask taskWithError:[NSError errorWithDomain:AWSCognitoCredentialsProviderHelperErrorDomain
+                                                                  code:AWSCognitoCredentialsProviderHelperErrorTypeIdentityIsNil
+                                                              userInfo:@{NSLocalizedDescriptionKey: error}]];
+            } else {
+                return [AWSTask taskWithResult:self.identityId];
+            }
+        }];
     }
 }
 

--- a/AWSCore/Authentication/AWSIdentityProvider.m
+++ b/AWSCore/Authentication/AWSIdentityProvider.m
@@ -295,6 +295,7 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
             // Create an identity id via GetID if the call to logins didn't set it which DevAuth does
             // And there are no other calls in flight to create one
             if (!self.identityId && self.count <= 1) {
+                dispatch_semaphore_wait(self.semaphore, dispatch_time(DISPATCH_TIME_NOW, 0));
                 AWSCognitoIdentityGetIdInput *getIdInput = [AWSCognitoIdentityGetIdInput new];
                 getIdInput.identityPoolId = self.identityPoolId;
                 getIdInput.logins = logins;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     [#1686](https://github.com/aws-amplify/aws-sdk-ios/issues/1686), and [PR #1815](https://github.com/aws-amplify/aws-sdk-ios/pull/1815).
   - Fix an issue where the signIn callback and user state listener callback are out of sync. See issues [#1700](https://github.com/aws-amplify/aws-sdk-ios/issues/1700) and 
     [#1314](https://github.com/aws-amplify/aws-sdk-ios/issues/1314), and [PR #1822](https://github.com/aws-amplify/aws-sdk-ios/pull/1822).
+  - Fix an issue where getIdentity call fails without waiting. Also makes sure that identityId is different between unauth and auth roles. See PR [#182](https://github.com/aws-amplify/aws-sdk-ios/pull/1824)
 
 ### Misc. Updates
 - Model updates for the following services

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     [#1686](https://github.com/aws-amplify/aws-sdk-ios/issues/1686), and [PR #1815](https://github.com/aws-amplify/aws-sdk-ios/pull/1815).
   - Fix an issue where the signIn callback and user state listener callback are out of sync. See issues [#1700](https://github.com/aws-amplify/aws-sdk-ios/issues/1700) and 
     [#1314](https://github.com/aws-amplify/aws-sdk-ios/issues/1314), and [PR #1822](https://github.com/aws-amplify/aws-sdk-ios/pull/1822).
-  - Fix an issue where getIdentity call fails without waiting. Also makes sure that identityId is different between unauth and auth roles. See PR [#182](https://github.com/aws-amplify/aws-sdk-ios/pull/1824)
+  - Fix an issue where getIdentity call fails without waiting. See PR [#1824](https://github.com/aws-amplify/aws-sdk-ios/pull/1824)
 
 ### Misc. Updates
 - Model updates for the following services


### PR DESCRIPTION
*Description of changes:* 

1. GetIdentity inside `AWSIdentityProvider.m` process one request at a time. If a new request comes in while we are processing another, we ask the new request to wait using semaphore `dispatch_semaphore_wait(self.semaphore, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));`.

This semaphore is signaled when we receive a request back for identity `dispatch_semaphore_signal(self.semaphore);`. But in the case where there is only one getIdentityId request, we signal the semaphore without calling a wait and thus increasing the semaphore value. So now when a new concurrent getIdentity is encountered, the semaphore is not decreased to a negative value and it wont wait.

To fix this, I changed made a call to wait semaphore with 0 second for a single request.

2. Call signOut doesnot make federationProvider to .none. This is an intermittent race condition.
Because of this calls to getCredentials goes to the federationProvider getSession and waits for user to enter signIn details. Our integration tests fails because of this situation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
