### PR TITLE
Moved user state listener before completion handler call (#1822)

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -460,6 +460,7 @@ final public class AWSMobileClient: _AWSMobileClient {
                     signInInfo[self.ProviderKey] = "OAuth"
                     
                     self.performHostedUISuccessfulSignInTasks(disableFederation: hostedUIOptions.disableFederation, session: session, federationToken: federationToken!, federationProviderIdentifier: federationProviderIdentifier, signInInfo: &signInInfo)
+                    self.mobileClientStatusChanged(userState: .signedIn, additionalInfo: signInInfo)
                     completionHandler(.signedIn, nil)
                     if self.pendingGetTokensCompletion != nil {
                         self.tokenFetchLock.leave()
@@ -478,6 +479,10 @@ final public class AWSMobileClient: _AWSMobileClient {
                         self.currentUser?.getSession().continueWith(block: { (task) -> Any? in
                             if let session = task.result {
                                 self.performUserPoolSuccessfulSignInTasks(session: session)
+                                let tokenString = session.idToken!.tokenString
+                                self.mobileClientStatusChanged(userState: .signedIn,
+                                                               additionalInfo: [self.ProviderKey:self.userPoolClient!.identityProviderName,
+                                                                                self.TokenKey:tokenString])
                                 completionHandler(.signedIn, nil)
                             } else {
                                 completionHandler(nil, task.error)

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
@@ -27,7 +27,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             }
             credentialsExpectation.fulfill()
         }
-        wait(for: [credentialsExpectation], timeout: 5)
+        wait(for: [credentialsExpectation], timeout: 10)
     }
     
     func testUploadPrivateFile() {
@@ -41,7 +41,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             XCTAssertNotNil(creds)
             verifyCredentialsExpectation.fulfill()
         }
-        wait(for: [verifyCredentialsExpectation], timeout: 5)
+        wait(for: [verifyCredentialsExpectation], timeout: 10)
         
         guard let identityId = AWSMobileClient.sharedInstance().identityId else {
             XCTFail("Could not find identityId to do private upload.")
@@ -58,7 +58,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             }
             uploadExpectation.fulfill()
         }
-        wait(for: [uploadExpectation], timeout: 5)
+        wait(for: [uploadExpectation], timeout: 10)
     }
     
     func testDownloadPrivateFile() {
@@ -72,7 +72,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             XCTAssertNotNil(creds)
             verifyCredentialsExpectation.fulfill()
         }
-        wait(for: [verifyCredentialsExpectation], timeout: 5)
+        wait(for: [verifyCredentialsExpectation], timeout: 10)
         
         guard let identityId = AWSMobileClient.sharedInstance().identityId else {
             XCTFail("Could not find identityId to do private upload.")
@@ -91,7 +91,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             }
             uploadExpectation.fulfill()
         }
-        wait(for: [uploadExpectation], timeout: 5)
+        wait(for: [uploadExpectation], timeout: 10)
         
         let downloadExpectation = expectation(description: "Successful file download.")
         transferUtility.downloadData(forKey: uploadKey, expression: nil) { (task, url, data, error) in
@@ -106,8 +106,160 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
             }
             downloadExpectation.fulfill()
         }
-        wait(for: [downloadExpectation], timeout: 5)
+        wait(for: [downloadExpectation], timeout: 10)
         
+    }
+    
+    /// Test to check aws credentials fetched for unauth user
+    ///
+    /// - Given:
+    ///     - An unauthenticated session
+    ///     - AWSMobileClient configured to use Cognito with an unauthenticated role
+    /// - When:
+    ///    - I fetch AWS credentials
+    /// - Then:
+    ///    - I should get credentials
+    ///
+    func testUnAuthCredentialsForSignOutUser() {
+        let verifyCredentialsExpectation = expectation(description: "Credentials should be retrieved successfully")
+        AWSMobileClient.sharedInstance().getAWSCredentials { (credentials, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(credentials)
+            XCTAssertNotNil(credentials?.accessKey)
+            XCTAssertNotNil(credentials?.secretKey)
+            XCTAssertNotNil(credentials?.sessionKey)
+            XCTAssertNotNil(credentials?.expiration)
+            verifyCredentialsExpectation.fulfill()
+        }
+        wait(for: [verifyCredentialsExpectation], timeout: 10)
+    }
+    
+    /// Test that upload to s3 fails for a signedOut user
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I try to upload a file to S3
+    /// - Then:
+    ///    - I should get an error
+    ///
+    func testUploadFileWithSignOutUser() {
+
+        let transferUtility = AWSS3TransferUtility.default()
+        let verifyCredentialsExpectation = expectation(description: "Credentials should be retrieved successfully")
+        AWSMobileClient.sharedInstance().getAWSCredentials { (_, _) in
+            verifyCredentialsExpectation.fulfill()
+        }
+        wait(for: [verifyCredentialsExpectation], timeout: 10)
+        
+        XCTAssertFalse(AWSMobileClient.sharedInstance().isSignedIn, "User should be in signOut state")
+        let uploadKey = "private/file.txt"
+        let s3UploadDataCompletionExpectation = expectation(description: "S3 transfer utility uploadData task completed")
+        let content = "Hello World"
+        print("Uploading file to : \(uploadKey)")
+        
+        transferUtility.uploadData(content.data(using: .utf8)!,
+                                   key: uploadKey,
+                                   contentType: "text/plain",
+                                   expression: nil) { (_, error) in
+            defer {
+                s3UploadDataCompletionExpectation.fulfill()
+            }
+            guard let error = error as NSError? else {
+                XCTFail("Error unexpectedly nil")
+                return
+            }
+            XCTAssertEqual(error.domain, AWSS3TransferUtilityErrorDomain)
+            XCTAssertEqual(error.code, AWSS3TransferUtilityErrorType.clientError.rawValue)
+        }
+        wait(for: [s3UploadDataCompletionExpectation], timeout: 10)
+    }
+    
+    /// Test that S3 upload works if we call it inside the user state listener
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I invoke signIn
+    ///    - I invoke upload to s3 inside the user state listener for signedIn case
+    /// - Then:
+    ///    - I should be able to upload to S3 without any error
+    ///
+    func testUploadFileInUserStateListener() {
+        let username = "testUser" + UUID().uuidString
+        let transferUtility = AWSS3TransferUtility.default()
+        let content = "Hello World"
+        let uploadKey = "private/\(username)/file.txt"
+        let s3UploadDataCompletionExpectation = expectation(description: "S3 transfer utility uploadData task completed")
+        let signInListenerWasSuccessful = expectation(description: "signIn listener was successful")
+        
+        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
+            defer {
+                signInListenerWasSuccessful.fulfill()
+            }
+            
+            guard userState == .signedIn else {
+                XCTFail("User state should be signed In")
+                return
+            }
+            
+            print("Listener user is signed in.")
+            print("Uploading file to : \(uploadKey)")
+            transferUtility.uploadData(content.data(using: .utf8)!,
+                                       key: uploadKey,
+                                       contentType: "text/plain",
+                                       expression: nil) { (_, error) in
+                                        XCTAssertNil(error, "Upload data should not produce any error.")
+                                        s3UploadDataCompletionExpectation.fulfill()
+            }
+        }
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        wait(for: [signInListenerWasSuccessful, s3UploadDataCompletionExpectation], timeout: 10)
+        AWSMobileClient.sharedInstance().removeUserStateListener(self)
+    }
+    
+    /// Test user state are in consistent state when we upload a file from state listener
+    ///
+    /// - Given: An unauthenticated session
+    /// - When:
+    ///    - I invoke signIn
+    ///    - I invoke upload to s3 inside the user state listener for signedIn case
+    /// - Then:
+    ///    - I should be able to upload to S3 without any error
+    ///    - Only state change that happen should be signedIn state
+    ///
+    func testUserStateWhileUploadingInsideStateListener() {
+        let username = "testUser" + UUID().uuidString
+        let transferUtility = AWSS3TransferUtility.default()
+        let uploadKey = "private/\(username)/file.txt"
+        let content = "Hello World"
+        
+        let s3UploadDataCompletionExpectation = expectation(description: "S3 transfer utility uploadData task completed")
+        let signInListenerWasSuccessful = expectation(description: "signIn listener was successful")
+        let noOtherSignInStateReceived = expectation(description: "No other state should be called")
+        noOtherSignInStateReceived.isInverted = true
+        
+        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
+            
+            defer {
+                signInListenerWasSuccessful.fulfill()
+            }
+            
+            guard userState == .signedIn else {
+                XCTFail("User state should be signed In")
+                return
+            }
+            
+            transferUtility.uploadData(content.data(using: .utf8)!,
+                                       key: uploadKey,
+                                       contentType: "text/plain",
+                                       expression: nil) { (_, _) in
+                                        s3UploadDataCompletionExpectation.fulfill()
+            }
+        }
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        wait(for: [signInListenerWasSuccessful, s3UploadDataCompletionExpectation, noOtherSignInStateReceived], timeout: 10)
+        AWSMobileClient.sharedInstance().removeUserStateListener(self)
     }
 
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignoutTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignoutTests.swift
@@ -91,5 +91,47 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         }
         wait(for: [signoutExpectation], timeout: 2)
     }
+    
+    /// Test successfull sign out and check the state of AWSMobileClient
+    ///
+    /// - Given: An authenticated session
+    /// - When:
+    ///    - I invoke `signOut` without callback
+    /// - Then:
+    ///    - The user state is `signedOut` and isSignedIn is false
+    ///
+    func testSignOutState() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return true for isSignedIn")
+        AWSMobileClient.sharedInstance().signOut()
+        XCTAssertFalse(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return false for isSignedIn")
+        XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
+    }
+    
+    /// Test successfull sign out using callback and check the state of AWSMobileClient
+    ///
+    /// - Given: An authenticated session
+    /// - When:
+    ///    - I invoke `signOut` with callback
+    /// - Then:
+    ///    - The user state is `signedOut` and isSignedIn is false
+    ///
+    func testSignOutStateWithCallback() {
+        let username = "testUser" + UUID().uuidString
+        let signoutExpectation = expectation(description: "Successfully signout")
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return true for isSignedIn")
+        let signoutOptions = SignOutOptions(signOutGlobally: true, invalidateTokens: true)
+        AWSMobileClient.sharedInstance().signOut(options: signoutOptions) { (error) in
+            XCTAssertFalse(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return false for isSignedIn")
+            XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
+            signoutExpectation.fulfill()
+        }
+        wait(for: [signoutExpectation], timeout: 2)
+        
+    }
 
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **AWSMobileClient**
   - Fixed a race condition where the confirm signIn callback becoming nil. See issues [#1248](https://github.com/aws-amplify/aws-sdk-ios/issues/1248) and
     [#1686](https://github.com/aws-amplify/aws-sdk-ios/issues/1686), and [PR #1815](https://github.com/aws-amplify/aws-sdk-ios/pull/1815).
+  - Fix an issue where the signIn callback and user state listener callback are out of sync. See issues [#1700](https://github.com/aws-amplify/aws-sdk-ios/issues/1700) and 
+    [#1314](https://github.com/aws-amplify/aws-sdk-ios/issues/1314), and [PR #1822](https://github.com/aws-amplify/aws-sdk-ios/pull/1822).
 
 ### Misc. Updates
 - Model updates for the following services


### PR DESCRIPTION
Moved the user state listener callbacks before the completion handler of signIn calls. This allows the signIn tasks to be completed and then inform the listeners that the signIn is done.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
