### PR TITLE
Changing intValue to longLongValue

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -2230,7 +2230,7 @@ didCompleteWithError:(NSError *)error {
                     totalBytesSent += aSubTask.totalBytesExpectedToSend;
                 }
                 
-                if (totalBytesSent != transferUtilityMultiPartUploadTask.contentLength.intValue ) {
+                if (totalBytesSent != transferUtilityMultiPartUploadTask.contentLength.longLongValue ) {
                     NSString *errorMessage = [NSString stringWithFormat:@"Expected to send [%@], but sent [%@] and there are no remaining parts. Failing transfer ",
                                               transferUtilityMultiPartUploadTask.contentLength, @(totalBytesSent)];
                     


### PR DESCRIPTION
I was having an issue that if the file being uploaded is bigger than 2323693218 bytes, then the intValue call results in an overflow and the comparison fails. The change to longLongValue prevents the overflow.

*Description of changes:*
Changed the length of bytes sent so far in a multipart task to be of type longLongValue rather than intValue that it was previously

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
