### PR TITLE
Added Cancellation token to cancel on going credential fetch

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		B4C8E4A6230742200064C158 /* AWSMobileClientUserAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */; };
 		B4C8E4A8230743780064C158 /* AWSMobileClientPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A7230743780064C158 /* AWSMobileClientPasswordTests.swift */; };
 		B4C8E4AA2307447F0064C158 /* AWSMobileClientCredentialsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E4A92307447F0064C158 /* AWSMobileClientCredentialsTest.swift */; };
+		B4F4C8D02321CC26001C87CD /* AWSCognitoCredentialsProvider+Extension.h in Headers */ = {isa = PBXBuildFile; fileRef = B4F4C8692321CB6B001C87CD /* AWSCognitoCredentialsProvider+Extension.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5150AB21F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = B5150AB11F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m */; };
 		B5150AB31F3BF04C00AC8D08 /* AWSAuthUIConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = B5150A531F3BF00F00AC8D08 /* AWSAuthUIConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5150B1C1F3CE0E500AC8D08 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5150B1A1F3C389C00AC8D08 /* Images.xcassets */; };
@@ -1235,6 +1236,7 @@
 		B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientUserAttributeTests.swift; sourceTree = "<group>"; };
 		B4C8E4A7230743780064C158 /* AWSMobileClientPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientPasswordTests.swift; sourceTree = "<group>"; };
 		B4C8E4A92307447F0064C158 /* AWSMobileClientCredentialsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientCredentialsTest.swift; sourceTree = "<group>"; };
+		B4F4C8692321CB6B001C87CD /* AWSCognitoCredentialsProvider+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoCredentialsProvider+Extension.h"; sourceTree = "<group>"; };
 		B5150A531F3BF00F00AC8D08 /* AWSAuthUIConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AWSAuthUIConfiguration.h; path = Sources/AWSAuthUI/AWSAuthUIConfiguration.h; sourceTree = SOURCE_ROOT; };
 		B5150AB11F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AWSAuthUIConfiguration.m; path = Sources/AWSAuthUI/AWSAuthUIConfiguration.m; sourceTree = SOURCE_ROOT; };
 		B5150B1A1F3C389C00AC8D08 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Sources/AWSAuthUI/Images.xcassets; sourceTree = SOURCE_ROOT; };
@@ -1372,6 +1374,7 @@
 				B5FC69031FAFA1AA004790CB /* _AWSMobileClient.h */,
 				B4C8E3A72306056A0064C158 /* JSONHelper.swift */,
 				B4031B78230F044A009EB524 /* AWSMobileClientUserDetails.swift */,
+				B4F4C8692321CB6B001C87CD /* AWSCognitoCredentialsProvider+Extension.h */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1884,6 +1887,7 @@
 				177B8AE021E52C730051068F /* AWSCognitoAuthUICKeyChainStore.h in Headers */,
 				177B8ADF21E52C730051068F /* AWSCognitoAuth.h in Headers */,
 				17F4F75021F6B0750068B553 /* AWSCognitoAuth+Extensions.h in Headers */,
+				B4F4C8D02321CC26001C87CD /* AWSCognitoCredentialsProvider+Extension.h in Headers */,
 				170AD35321921764004E1E88 /* AWSMobileClient.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h
@@ -17,6 +17,7 @@
 #import <AWSMobileClient/_AWSMobileClient.h>
 #import <AWSMobileClient/AWSCognitoAuth.h>
 #import <AWSMobileClient/AWSCognitoAuth+Extensions.h>
+#import <AWSMobileClient/AWSCognitoCredentialsProvider+Extension.h>
 
 //! Project version number for AWSMobileClient.
 FOUNDATION_EXPORT double AWSMobileClientVersionNumber;

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -93,7 +93,7 @@ final public class AWSMobileClient: _AWSMobileClient {
     
     /// This token is invoked when the developer explicitly calls the signOut from
     /// AWSMobileClient, thus invalidating all credentials calls.
-    var credentialsFetchCancellationSource: AWSCancellationTokenSource? = AWSCancellationTokenSource()
+    var credentialsFetchCancellationSource: AWSCancellationTokenSource = AWSCancellationTokenSource()
     
     // MARK: AWSMobileClient helpers
     

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -91,6 +91,8 @@ final public class AWSMobileClient: _AWSMobileClient {
     }()
     internal let credentialsFetchLock = DispatchGroup()
     
+    var credentialsFetchCancellationSource: AWSCancellationTokenSource? = AWSCancellationTokenSource()
+    
     // MARK: AWSMobileClient helpers
     
     let ProviderKey: String = "provider"

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -91,6 +91,8 @@ final public class AWSMobileClient: _AWSMobileClient {
     }()
     internal let credentialsFetchLock = DispatchGroup()
     
+    /// This token is invoked when the developer explicitly calls the signOut from
+    /// AWSMobileClient, thus invalidating all credentials calls.
     var credentialsFetchCancellationSource: AWSCancellationTokenSource? = AWSCancellationTokenSource()
     
     // MARK: AWSMobileClient helpers

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -546,7 +546,6 @@ extension AWSMobileClient {
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: provider)
         self.internalCredentialsProvider?.clearCredentials()
-        self.credentialsFetchCancellationSource = AWSCancellationTokenSource()
         self.internalCredentialsProvider?.credentials(withCancellationToken:self.credentialsFetchCancellationSource)
     }
     

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -481,6 +481,10 @@ extension AWSMobileClient {
     /// Signs out the current logged in user and clears the local keychain store.
     /// Note: This does not invalidate the tokens from the service or sign out the user from other devices. 
     public func signOut() {
+        if let cancellationSource = self.credentialsFetchCancellationSource {
+            cancellationSource.cancel()
+        }
+        
         if federationProvider == .hostedUI {
             AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOutLocallyAndClearLastKnownUser()
         }
@@ -494,6 +498,7 @@ extension AWSMobileClient {
         self.internalCredentialsProvider?.clearKeychain()
         self.mobileClientStatusChanged(userState: .signedOut, additionalInfo: [:])
         self.federationProvider = .none
+        self.credentialsFetchCancellationSource = AWSCancellationTokenSource()
     }
     
     internal func performUserPoolSignOut() {
@@ -544,7 +549,8 @@ extension AWSMobileClient {
         self.saveLoginsMapInKeychain()
         self.setLoginProviderMetadataAndSaveInKeychain(provider: provider)
         self.internalCredentialsProvider?.clearCredentials()
-        self.internalCredentialsProvider?.credentials()
+        self.credentialsFetchCancellationSource = AWSCancellationTokenSource()
+        self.internalCredentialsProvider?.credentials(withCancellationToken:self.credentialsFetchCancellationSource)
     }
     
     /// Confirm a sign in which requires additional validation via steps like SMS MFA.
@@ -594,23 +600,34 @@ extension AWSMobileClient {
             completionHandler(nil, AWSMobileClientError.cognitoIdentityPoolNotConfigured(message: "There is no valid cognito identity pool configured in `awsconfiguration.json`."))
         }
         
+        let cancellationToken = self.credentialsFetchCancellationSource!
         credentialsFetchOperationQueue.addOperation {
             self.credentialsFetchLock.enter()
-            self.internalCredentialsProvider?.credentials().continueWith(block: { (task) -> Any? in
+            self.internalCredentialsProvider?.credentials(withCancellationToken: cancellationToken).continueWith(block: { (task) -> Any? in
+                // If we have called cancellation already, leave the block without doing anything
+                // with the fetched credentials.
+                if (task.isCancelled || cancellationToken.isCancellationRequested) {
+                    self.credentialsFetchLock.leave()
+                    completionHandler(task.result, task.error)
+                    return nil
+                }
+                
                 if let error = task.error {
                     if error._domain == AWSCognitoIdentityErrorDomain
                         && error._code == AWSCognitoIdentityErrorType.notAuthorized.rawValue
                         && self.federationProvider == .none {
+                        
                         self.credentialsFetchLock.leave()
                         completionHandler(nil, AWSMobileClientError.guestAccessNotAllowed(message: "Your backend is not configured with cognito identity pool to allow guest acess. Please allow un-authenticated access to identity pool to use this feature."))
+                        
                     } else if error._domain == AWSCognitoIdentityErrorDomain
                         && error._code == AWSCognitoIdentityErrorType.notAuthorized.rawValue
                         && self.federationProvider == .oidcFederation {
-
-                        self.mobileClientStatusChanged(userState: .signedOutFederatedTokensInvalid, additionalInfo: [self.ProviderKey:self.cachedLoginsMap.first!.key])
                         
+                        self.mobileClientStatusChanged(userState: .signedOutFederatedTokensInvalid, additionalInfo: [self.ProviderKey:self.cachedLoginsMap.first!.key])
                         // store a reference to the completion handler which we would be calling later on.
                         self.pendingAWSCredentialsCompletion = completionHandler
+                        
                     } else {
                         self.credentialsFetchLock.leave()
                         completionHandler(nil, error)
@@ -622,6 +639,7 @@ extension AWSMobileClient {
                     self.credentialsFetchLock.leave()
                     completionHandler(result, nil)
                 }
+                
                 return nil
             })
             self.credentialsFetchLock.wait()

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -481,10 +481,7 @@ extension AWSMobileClient {
     /// Signs out the current logged in user and clears the local keychain store.
     /// Note: This does not invalidate the tokens from the service or sign out the user from other devices. 
     public func signOut() {
-        if let cancellationSource = self.credentialsFetchCancellationSource {
-            cancellationSource.cancel()
-        }
-        
+        self.credentialsFetchCancellationSource.cancel()
         if federationProvider == .hostedUI {
             AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOutLocallyAndClearLastKnownUser()
         }
@@ -600,7 +597,7 @@ extension AWSMobileClient {
             completionHandler(nil, AWSMobileClientError.cognitoIdentityPoolNotConfigured(message: "There is no valid cognito identity pool configured in `awsconfiguration.json`."))
         }
         
-        let cancellationToken = self.credentialsFetchCancellationSource!
+        let cancellationToken = self.credentialsFetchCancellationSource
         credentialsFetchOperationQueue.addOperation {
             self.credentialsFetchLock.enter()
             self.internalCredentialsProvider?.credentials(withCancellationToken: cancellationToken).continueWith(block: { (task) -> Any? in

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h
@@ -15,6 +15,9 @@
 #ifndef AWSCognitoCredentialsProvider_Extension_h
 #define AWSCognitoCredentialsProvider_Extension_h
 
+/**
+ Internal interface to be used inside AWSMobileClient.
+ **/
 @interface AWSCognitoCredentialsProvider (Internal)
 
 - (AWSTask<AWSCredentials *> * _Nonnull)credentialsWithCancellationToken:(AWSCancellationTokenSource * _Nullable)cancellationTokenSource;

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h
@@ -1,0 +1,24 @@
+//
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+#ifndef AWSCognitoCredentialsProvider_Extension_h
+#define AWSCognitoCredentialsProvider_Extension_h
+
+@interface AWSCognitoCredentialsProvider (Internal)
+
+- (AWSTask<AWSCredentials *> * _Nonnull)credentialsWithCancellationToken:(AWSCancellationTokenSource * _Nullable)cancellationTokenSource;
+
+@end
+
+#endif

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
@@ -18,7 +18,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         let credentialsExpectation = expectation(description: "Successfully fetch AWS Credentials")
-        AWSMobileClient.sharedInstance().getAWSCredentials { (credentials, error) in
+        AWSMobileClient.default().getAWSCredentials { (credentials, error) in
             if let credentials = credentials {
                 XCTAssertNotNil(credentials.accessKey)
                 XCTAssertNotNil(credentials.secretKey)
@@ -36,14 +36,14 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         signIn(username: username)
         let transferUtility = AWSS3TransferUtility.default()
         let verifyCredentialsExpectation = expectation(description: "Credentials should be retrieved successfully")
-        AWSMobileClient.sharedInstance().getAWSCredentials { (creds, error) in
+        AWSMobileClient.default().getAWSCredentials { (creds, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(creds)
             verifyCredentialsExpectation.fulfill()
         }
         wait(for: [verifyCredentialsExpectation], timeout: 10)
         
-        guard let identityId = AWSMobileClient.sharedInstance().identityId else {
+        guard let identityId = AWSMobileClient.default().identityId else {
             XCTFail("Could not find identityId to do private upload.")
             return
         }
@@ -67,14 +67,14 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         signIn(username: username)
         let transferUtility = AWSS3TransferUtility.default()
         let verifyCredentialsExpectation = expectation(description: "Credentials should be retrieved successfully")
-        AWSMobileClient.sharedInstance().getAWSCredentials { (creds, error) in
+        AWSMobileClient.default().getAWSCredentials { (creds, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(creds)
             verifyCredentialsExpectation.fulfill()
         }
         wait(for: [verifyCredentialsExpectation], timeout: 10)
         
-        guard let identityId = AWSMobileClient.sharedInstance().identityId else {
+        guard let identityId = AWSMobileClient.default().identityId else {
             XCTFail("Could not find identityId to do private upload.")
             return
         }
@@ -122,7 +122,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
     ///
     func testUnAuthCredentialsForSignOutUser() {
         let verifyCredentialsExpectation = expectation(description: "Credentials should be retrieved successfully")
-        AWSMobileClient.sharedInstance().getAWSCredentials { (credentials, error) in
+        AWSMobileClient.default().getAWSCredentials { (credentials, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(credentials)
             XCTAssertNotNil(credentials?.accessKey)
@@ -146,12 +146,12 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
 
         let transferUtility = AWSS3TransferUtility.default()
         let verifyCredentialsExpectation = expectation(description: "Credentials should be retrieved successfully")
-        AWSMobileClient.sharedInstance().getAWSCredentials { (_, _) in
+        AWSMobileClient.default().getAWSCredentials { (_, _) in
             verifyCredentialsExpectation.fulfill()
         }
         wait(for: [verifyCredentialsExpectation], timeout: 10)
         
-        XCTAssertFalse(AWSMobileClient.sharedInstance().isSignedIn, "User should be in signOut state")
+        XCTAssertFalse(AWSMobileClient.default().isSignedIn, "User should be in signOut state")
         let uploadKey = "private/file.txt"
         let s3UploadDataCompletionExpectation = expectation(description: "S3 transfer utility uploadData task completed")
         let content = "Hello World"
@@ -191,7 +191,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         let s3UploadDataCompletionExpectation = expectation(description: "S3 transfer utility uploadData task completed")
         let signInListenerWasSuccessful = expectation(description: "signIn listener was successful")
         
-        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
+        AWSMobileClient.default().addUserStateListener(self) { (userState, info) in
             defer {
                 signInListenerWasSuccessful.fulfill()
             }
@@ -214,7 +214,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         wait(for: [signInListenerWasSuccessful, s3UploadDataCompletionExpectation], timeout: 10)
-        AWSMobileClient.sharedInstance().removeUserStateListener(self)
+        AWSMobileClient.default().removeUserStateListener(self)
     }
     
     /// Test user state are in consistent state when we upload a file from state listener
@@ -238,7 +238,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         let noOtherSignInStateReceived = expectation(description: "No other state should be called")
         noOtherSignInStateReceived.isInverted = true
         
-        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
+        AWSMobileClient.default().addUserStateListener(self) { (userState, info) in
             
             defer {
                 signInListenerWasSuccessful.fulfill()
@@ -259,7 +259,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         wait(for: [signInListenerWasSuccessful, s3UploadDataCompletionExpectation, noOtherSignInStateReceived], timeout: 10)
-        AWSMobileClient.sharedInstance().removeUserStateListener(self)
+        AWSMobileClient.default().removeUserStateListener(self)
     }
 
     
@@ -271,32 +271,31 @@ class AWSMobileClientCredentialsTest: AWSMobileClientBaseTests {
         let credentialFetchAfterSignIn = expectation(description: "Request to getAWSCredentials after signIn")
         let credentialFetchAfterSignIn2 = expectation(description: "Request to getAWSCredentials after signIn")
         let credentialFetchAfterSignOut = expectation(description: "Request to getAWSCredentials after signOut")
-        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+        AWSMobileClient.default().getAWSCredentials({ (awscredentials, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
             credentialFetchBeforeSignIn.fulfill()
         })
         signUpAndVerifyUser(username: username)
         signIn(username: username)
-        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+        AWSMobileClient.default().getAWSCredentials({ (awscredentials, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
             credentialFetchAfterSignIn.fulfill()
         })
         wait(for: [credentialFetchAfterSignIn], timeout: 15)
         
-        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+        AWSMobileClient.default().getAWSCredentials({ (awscredentials, error) in
             // We do not need to check the values here, this can succeed
             // or fail based on whether this method completes before the below signOut.
             credentialFetchAfterSignIn2.fulfill()
         })
-        AWSMobileClient.sharedInstance().signOut()
-        AWSMobileClient.sharedInstance().getAWSCredentials({ (awscredentials, error) in
+        AWSMobileClient.default().signOut()
+        AWSMobileClient.default().getAWSCredentials({ (awscredentials, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(awscredentials, "Credentials should not return nil.")
             credentialFetchAfterSignOut.fulfill()
         })
-        wait(for: [credentialFetchAfterSignOut, credentialFetchAfterSignIn2, credentialFetchBeforeSignIn],
-             timeout: 15)
+        wait(for: [credentialFetchAfterSignIn2, credentialFetchBeforeSignIn, credentialFetchAfterSignOut], timeout: 15)
     }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -169,38 +169,38 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
     }
     
     func testMultipleGetIdentityId() {
-        XCTAssertNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should be nil after initialize.")
+        XCTAssertNil(AWSMobileClient.default().identityId, "Identity Id should be nil after initialize.")
         
         let identityIdExpectation1 = expectation(description: "Request to GetIdentityID 1 is complete")
         let identityIdExpectation2 = expectation(description: "Request to GetIdentityID 2 is complete")
         let identityIdExpectation3 = expectation(description: "Request to GetIdentityID 3 is complete")
         let identityIdExpectation4 = expectation(description: "Request to GetIdentityID 4 is complete")
         let identityIdExpectation5 = expectation(description: "Request to GetIdentityID 5 is complete")
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdExpectation1.fulfill()
             return nil
         })
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdExpectation2.fulfill()
             return nil
         })
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdExpectation3.fulfill()
             return nil
         })
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdExpectation4.fulfill()
             return nil
         })
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdExpectation5.fulfill()
@@ -219,10 +219,10 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
     ///    - Then I signOut and fetch another id , id3
     ///    - Then I signIn again and fetch identity id , id4
     /// - Then:
-    ///    - All identity id1 == id2 and id2 != id3 and id3 == id3.
+    ///    - All identity id1 == id2 and id2 != id3 and id3 == id4.
     ///
     func testGetIdentityWithSignOutAndSignIn() {
-        XCTAssertNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should be nil after initialize.")
+        XCTAssertNil(AWSMobileClient.default().identityId, "Identity Id should be nil after initialize.")
         var identityIdBeforeSignIn: String?
         var identityIdAfterSignIn: String?
         var identityIdAfterSignOut: String?
@@ -233,7 +233,7 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
         let signOutIdentityIdExpectation2 = expectation(description: "Request to GetIdentityID before signOut is complete")
         let signInIdentityIdExpectation2 = expectation(description: "Request to GetIdentityID before second signIn is complete")
         
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdBeforeSignIn = task.result as String?
@@ -241,13 +241,13 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
             return nil
         })
         wait(for: [signOutIdentityIdExpectation], timeout: 5)
-        XCTAssertNotNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should not be nil.")
+        XCTAssertNotNil(AWSMobileClient.default().identityId, "Identity Id should not be nil.")
         
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdAfterSignIn = task.result as String?
@@ -255,11 +255,11 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
             return nil
         })
         wait(for: [signInIdentityIdExpectation], timeout: 5)
-        XCTAssertNotNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should not be nil.")
+        XCTAssertNotNil(AWSMobileClient.default().identityId, "Identity Id should not be nil.")
         XCTAssertEqual(identityIdBeforeSignIn, identityIdAfterSignIn)
-        AWSMobileClient.sharedInstance().signOut()
+        AWSMobileClient.default().signOut()
         
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdAfterSignOut = task.result as String?
@@ -267,14 +267,14 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
             return nil
         })
         wait(for: [signOutIdentityIdExpectation2], timeout: 5)
-        XCTAssertNotNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should not be nil.")
+        XCTAssertNotNil(AWSMobileClient.default().identityId, "Identity Id should not be nil.")
         XCTAssertNotEqual(identityIdAfterSignIn, identityIdAfterSignOut)
         
         let username2 = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username2)
         signIn(username: username2)
         
-        AWSMobileClient.sharedInstance().getIdentityId().continueWith(block: { (task) -> Any? in
+        AWSMobileClient.default().getIdentityId().continueWith(block: { (task) -> Any? in
             XCTAssertNil(task.error)
             XCTAssertNotNil(task.result, "GetIdentityId should not return nil.")
             identityIdAfterSignIn2 = task.result as String?
@@ -282,7 +282,9 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
             return nil
         })
         wait(for: [signInIdentityIdExpectation2], timeout: 5)
-        XCTAssertNotNil(AWSMobileClient.sharedInstance().identityId, "Identity Id should not be nil.")
+        XCTAssertNotNil(AWSMobileClient.default().identityId, "Identity Id should not be nil.")
         XCTAssertEqual(identityIdAfterSignIn2, identityIdAfterSignOut)
+        
+        print ("Ids -> \(identityIdBeforeSignIn) \(identityIdAfterSignIn) \(identityIdAfterSignOut) \(identityIdAfterSignIn2)")
     }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -284,7 +284,5 @@ class AWSMobileClientTests: AWSMobileClientBaseTests {
         wait(for: [signInIdentityIdExpectation2], timeout: 5)
         XCTAssertNotNil(AWSMobileClient.default().identityId, "Identity Id should not be nil.")
         XCTAssertEqual(identityIdAfterSignIn2, identityIdAfterSignOut)
-        
-        print ("Ids -> \(identityIdBeforeSignIn) \(identityIdAfterSignIn) \(identityIdAfterSignOut) \(identityIdAfterSignIn2)")
     }
 }

--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -259,8 +259,6 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
 
 - (void)setIdentityProviderManagerOnce:(id<AWSIdentityProviderManager>)identityProviderManager;
 
-- (AWSTask<AWSCredentials *> *)credentialsWithCancellationToken:(AWSCancellationTokenSource * _Nullable)cancellationTokenSource;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -29,6 +29,7 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
 };
 
 @class AWSTask<__covariant ResultType>;
+@class AWSCancellationTokenSource;
 
 /**
  An AWS credentials container class.
@@ -257,6 +258,8 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
 - (void)clearCredentials;
 
 - (void)setIdentityProviderManagerOnce:(id<AWSIdentityProviderManager>)identityProviderManager;
+
+- (AWSTask<AWSCredentials *> *)credentialsWithCancellationToken:(AWSCancellationTokenSource * _Nullable)cancellationTokenSource;
 
 @end
 

--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -409,7 +409,13 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 }
 
 - (AWSTask<AWSCredentials *> *)getCredentialsWithSTS:(NSDictionary<NSString *,NSString *> *)logins
-                                       authenticated:(BOOL)auth {
+                                       authenticated:(BOOL)auth
+                               withCancellationToken:(AWSCancellationTokenSource *)cancellationTokenSource {
+    
+    if (cancellationTokenSource.isCancellationRequested) {
+        return [AWSTask cancelledTask];
+    }
+    
     NSString *roleArn = self.unAuthRoleArn;
     if (auth) {
         roleArn = self.authRoleArn;
@@ -432,6 +438,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     webIdentityRequest.webIdentityToken = [logins objectForKey:AWSIdentityProviderAmazonCognitoIdentity];
     webIdentityRequest.roleSessionName = @"iOS-Provider";
     return [[self.sts assumeRoleWithWebIdentity:webIdentityRequest] continueWithBlock:^id(AWSTask *task) {
+        
+        if (cancellationTokenSource.isCancellationRequested) {
+            return [AWSTask cancelledTask];
+        }
         if (task.result) {
             AWSSTSAssumeRoleWithWebIdentityResponse *webIdentityResponse = task.result;
             self.internalCredentials = [[AWSCredentials alloc] initWithAccessKey:webIdentityResponse.credentials.accessKeyId
@@ -451,7 +461,13 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 
 - (AWSTask<AWSCredentials *> *)getCredentialsWithCognito:(NSDictionary<NSString *,NSString *> *)logins
                                            authenticated:(BOOL)isAuthenticated
-                                           customRoleArn:(NSString *)customRoleArn {
+                                           customRoleArn:(NSString *)customRoleArn
+                                   withCancellationToken:(AWSCancellationTokenSource *)cancellationTokenSource{
+    
+    if (cancellationTokenSource.isCancellationRequested) {
+        return [AWSTask cancelledTask];
+    }
+    
     // Grab a reference to our provider in case it changes out from under us
     id<AWSCognitoCredentialsProviderHelper> providerRef = self.identityProvider;
 
@@ -461,6 +477,11 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     getCredentialsInput.customRoleArn = customRoleArn;
 
     return [[[self.cognitoIdentity getCredentialsForIdentity:getCredentialsInput] continueWithBlock:^id(AWSTask *task) {
+        
+        if (cancellationTokenSource.isCancellationRequested) {
+            return [AWSTask cancelledTask];
+        }
+        
         // When an invalid identityId is cached in the keychain for auth,
         // we will refresh the identityId and try to get credentials token again.
         if (task.error) {
@@ -481,6 +502,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
             return [[providerRef logins] continueWithSuccessBlock:^id _Nullable(AWSTask<NSDictionary<NSString *,NSString *> *> * _Nonnull task) {
                 NSDictionary<NSString *,NSString *> *logins = task.result;
 
+                if (cancellationTokenSource.isCancellationRequested) {
+                    return [AWSTask cancelledTask];
+                }
+                
                 // This should never happen, but just in case
                 if (!providerRef.identityId) {
                     AWSDDLogError(@"In refresh, but identitId is nil.");
@@ -500,6 +525,11 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                 getCredentialsRetry.customRoleArn = customRoleArn;
                 
                 return [[self.cognitoIdentity getCredentialsForIdentity:getCredentialsRetry] continueWithBlock:^id _Nullable(AWSTask<AWSCognitoIdentityGetCredentialsForIdentityResponse *> * _Nonnull task) {
+                    
+                    if (cancellationTokenSource.isCancellationRequested) {
+                        return [AWSTask cancelledTask];
+                    }
+                    
                     if (task.error) {
                         return [AWSTask taskWithError:[NSError errorWithDomain:AWSCognitoCredentialsProviderErrorDomain
                                                                           code:AWSCognitoCredentialsProviderInvalidConfiguration
@@ -528,6 +558,11 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                     ];
         }
 
+        if (cancellationTokenSource.isCancellationRequested) {
+            return [AWSTask cancelledTask];
+        }
+        
+        // Identity Id can change based on whether the user has signed in on a different device
         if (![self.identityId isEqualToString:identityIdFromResponse]) {
             self.identityId = identityIdFromResponse;
             providerRef.identityId = identityIdFromResponse;
@@ -537,9 +572,11 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     }];
 }
 
-#pragma mark - AWSCredentialsProvider methods
-
-- (AWSTask<AWSCredentials *> *)credentials {
+- (AWSTask<AWSCredentials *> *)credentialsWithCancellationToken:(AWSCancellationTokenSource *) cancellationTokenSource {
+    
+    if (cancellationTokenSource.isCancellationRequested) {
+        return [AWSTask cancelledTask];
+    }
     // Returns cached credentials when all of the following conditions are true:
     // 1. The cached credentials are not nil.
     // 2. The credentials do not expire within 10 minutes.
@@ -550,6 +587,11 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     
     id<AWSCognitoCredentialsProviderHelper> providerRef = self.identityProvider;
     return [[[providerRef logins] continueWithExecutor:self.refreshExecutor withSuccessBlock:^id _Nullable(AWSTask<NSDictionary<NSString *,NSString *> *> * _Nonnull task) {
+        
+        if (cancellationTokenSource.isCancellationRequested) {
+            return [AWSTask cancelledTask];
+        }
+        
         NSDictionary<NSString *,NSString *> *logins = task.result;
         
         AWSTask * getIdentityIdTask = nil;
@@ -562,6 +604,11 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
         }
         
         return [getIdentityIdTask continueWithSuccessBlock:^id _Nullable(AWSTask * _Nonnull task) {
+            
+            if (cancellationTokenSource.isCancellationRequested) {
+                return [AWSTask cancelledTask];
+            }
+            
             // Refreshes the credentials if any of the following is true:
             // 1. The cached logins are different from the one the identity provider provided.
             // 2. The cached credentials is nil.
@@ -580,6 +627,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                                                      userInfo:nil];
                     return [AWSTask taskWithError:error];
                 }
+            }
+            
+            if (cancellationTokenSource.isCancellationRequested) {
+                return [AWSTask cancelledTask];
             }
             
             if ((!self.cachedLogins || [self.cachedLogins isEqualToDictionary:logins])
@@ -601,10 +652,12 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
                 }
                 return [self getCredentialsWithCognito:logins
                                          authenticated:[providerRef isAuthenticated]
-                                         customRoleArn:customRoleArn];
+                                         customRoleArn:customRoleArn
+                                 withCancellationToken:cancellationTokenSource];
             } else {
                 return [self getCredentialsWithSTS:logins
-                                     authenticated:[providerRef isAuthenticated]];
+                                     authenticated:[providerRef isAuthenticated]
+                             withCancellationToken:cancellationTokenSource];
             }
             
         }];
@@ -618,6 +671,12 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
         
         return task;
     }];
+}
+
+#pragma mark - AWSCredentialsProvider methods
+
+- (AWSTask<AWSCredentials *> *)credentials {
+    return [self credentialsWithCancellationToken:nil];
 }
 
 - (void)invalidateCachedTemporaryCredentials {

--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -284,6 +284,8 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 // This is a temporary solution to bypass the requirement of protocol check for `AWSIdentityProviderManager`.
 @property (nonatomic, strong) NSString *customRoleArnOverride;
 
+- (AWSTask<AWSCredentials *> *)credentialsWithCancellationToken:(AWSCancellationTokenSource * _Nullable)cancellationTokenSource;
+
 @end
 
 @implementation AWSCognitoCredentialsProvider


### PR DESCRIPTION
*Description of changes:*

Cancellation token were added to control the credential fetch calls. This token is invoked when the developer explicitly calls the signOut from AWSMobileClient, thus invalidating all credentials calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
