### PR TITLE
Updated AWSMobileClient to access the new header as public

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  *Swift*
  
- let mobileClient = AWSMobileClient.sharedInstance()
+ let mobileClient = AWSMobileClient.default()
  
  *Objective-C*
  

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientBaseTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientBaseTests.swift
@@ -42,9 +42,9 @@ class AWSMobileClientBaseTests: XCTestCase {
     }
     
     override func tearDown() {
-        AWSMobileClient.sharedInstance().signOut()
-        AWSMobileClient.sharedInstance().clearCredentials()
-        AWSMobileClient.sharedInstance().clearKeychain()
+        AWSMobileClient.default().signOut()
+        AWSMobileClient.default().clearCredentials()
+        AWSMobileClient.default().clearKeychain()
     }
     
     //MARK: Helper methods
@@ -59,7 +59,7 @@ class AWSMobileClientBaseTests: XCTestCase {
     func initializeMobileClient() {
         
         let mobileClientIsInitialized = expectation(description: "AWSMobileClient is initialized")
-        AWSMobileClient.sharedInstance().initialize { (userState, error) in
+        AWSMobileClient.default().initialize { (userState, error) in
             if let error = error {
                 XCTFail("Encountered unexpected error in initialize: \(error.localizedDescription)")
                 return
@@ -71,7 +71,7 @@ class AWSMobileClientBaseTests: XCTestCase {
             }
             
             if userState != UserState.signedOut {
-                AWSMobileClient.sharedInstance().signOut()
+                AWSMobileClient.default().signOut()
             }
             mobileClientIsInitialized.fulfill()
         }
@@ -81,7 +81,7 @@ class AWSMobileClientBaseTests: XCTestCase {
     func signIn(username: String, password: String? = nil, verifySignState: SignInState = .signedIn) {
         let passwordToUse = password ?? sharedPassword
         let signInWasSuccessful = expectation(description: "signIn was successful")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: passwordToUse) { (signInResult, error) in
+        AWSMobileClient.default().signIn(username: username, password: passwordToUse) { (signInResult, error) in
             if let error = error {
                 XCTFail("User login failed: \(error.localizedDescription)")
                 return
@@ -100,7 +100,7 @@ class AWSMobileClientBaseTests: XCTestCase {
     func confirmSign(challengeResponse: String, userAttributes:[String:String] = [:], verifySignState: SignInState = .signedIn) {
         
         let signInConfirmWasSuccessful = expectation(description: "signIn confirm was successful")
-        AWSMobileClient.sharedInstance().confirmSignIn(challengeResponse: challengeResponse,
+        AWSMobileClient.default().confirmSignIn(challengeResponse: challengeResponse,
                                                        userAttributes: userAttributes) {
                                                         (signInResult, error) in
                                                         
@@ -124,7 +124,7 @@ class AWSMobileClientBaseTests: XCTestCase {
         }
         
         let signUpExpectation = expectation(description: "successful sign up expectation.")
-        AWSMobileClient.sharedInstance().signUp(
+        AWSMobileClient.default().signUp(
             username: username,
             password: sharedPassword,
             userAttributes: userAttributes) { (signUpResult, error) in

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientDeviceTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientDeviceTests.swift
@@ -19,7 +19,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let initialRememberDeviceExpectation = expectation(description: "initial remember device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.updateStatus(remembered: true) { (result, error) in
+        AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
             if error != nil {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
             }
@@ -30,7 +30,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let listDevicesExpectation = expectation(description: "list devices expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.list(limit: 60) { (result, error) in
+        AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
             defer {
                 listDevicesExpectation.fulfill()
             }
@@ -56,7 +56,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let initialRememberDeviceExpectation = expectation(description: "initial remember device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.updateStatus(remembered: true) { (result, error) in
+        AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
             if error != nil {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
             }
@@ -67,7 +67,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let listDevicesExpectation = expectation(description: "list devices expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.list(limit: 60) { (result, error) in
+        AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
             
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
@@ -82,7 +82,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let getDeviceExpectation = expectation(description: "get device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.get { (device, error) in
+        AWSMobileClient.default().deviceOperations.get { (device, error) in
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
                 getDeviceExpectation.fulfill()
@@ -98,7 +98,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let notRememberDeviceExpectation = expectation(description: "forget device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.updateStatus(remembered: false) { (result, error) in
+        AWSMobileClient.default().deviceOperations.updateStatus(remembered: false) { (result, error) in
             if error != nil {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
             }
@@ -109,7 +109,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let listDevicesExpectation2 = expectation(description: "list devices expectation2.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.list(limit: 60) { (result, error) in
+        AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
             
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
@@ -124,7 +124,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let rememberDeviceExpectation = expectation(description: "remember device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.updateStatus(remembered: true) { (result, error) in
+        AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
             if error != nil {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
             }
@@ -136,7 +136,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let listDevicesExpectation3 = expectation(description: "list devices expectation3.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.list(limit: 60) { (result, error) in
+        AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
             
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
@@ -158,7 +158,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let initialRememberDeviceExpectation = expectation(description: "initial remember device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.updateStatus(remembered: true) { (result, error) in
+        AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
             if error != nil {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
             }
@@ -169,7 +169,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let listDevicesExpectation = expectation(description: "list devices expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.list(limit: 60) { (result, error) in
+        AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
             
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
@@ -184,7 +184,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let getDeviceExpectation = expectation(description: "get device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.get { (device, error) in
+        AWSMobileClient.default().deviceOperations.get { (device, error) in
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
                 getDeviceExpectation.fulfill()
@@ -200,7 +200,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let notRememberDeviceExpectation = expectation(description: "forget device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.forget({ (error) in
+        AWSMobileClient.default().deviceOperations.forget({ (error) in
             if error != nil {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
             }
@@ -211,7 +211,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let listDevicesExpectation2 = expectation(description: "list devices expectation2.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.list(limit: 60) { (result, error) in
+        AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
             
             guard error == nil else {
                 XCTFail("Received un-expected error: \(error!.localizedDescription)")
@@ -226,7 +226,7 @@ class AWSMobileClientDeviceTests: AWSMobileClientBaseTests {
         
         let rememberDeviceExpectation = expectation(description: "remember device expectation.")
         
-        AWSMobileClient.sharedInstance().deviceOperations.updateStatus(remembered: true) { (result, error) in
+        AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
             XCTAssertNotNil(error, "Expecting error but didn't get one.")
             if let mobileError = error as? AWSMobileClientError {
                 

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
@@ -16,7 +16,7 @@ class AWSMobileClientPasswordTests: AWSMobileClientBaseTests {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         let forgotPasswordExpection = expectation(description: "Expecting code to be sent for forgot password.")
-        AWSMobileClient.sharedInstance().forgotPassword(username: username) { (forgotPasswordResult, error) in
+        AWSMobileClient.default().forgotPassword(username: username) { (forgotPasswordResult, error) in
             XCTAssertNotNil(error, "should get error which mentions there is no verified email or phone.")
             forgotPasswordExpection.fulfill()
         }
@@ -28,7 +28,7 @@ class AWSMobileClientPasswordTests: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         let changePasswordExpectation = expectation(description: "Change password should be successful")
-        AWSMobileClient.sharedInstance().changePassword(currentPassword: sharedPassword, proposedPassword: "NewPassword123!@") { (error) in
+        AWSMobileClient.default().changePassword(currentPassword: sharedPassword, proposedPassword: "NewPassword123!@") { (error) in
             XCTAssertNil(error)
             changePasswordExpectation.fulfill()
         }
@@ -40,7 +40,7 @@ class AWSMobileClientPasswordTests: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         let changePasswordExpectation = expectation(description: "Change password should fail")
-        AWSMobileClient.sharedInstance().changePassword(currentPassword: "WronPassword", proposedPassword: "NewPassword123!@") { (error) in
+        AWSMobileClient.default().changePassword(currentPassword: "WronPassword", proposedPassword: "NewPassword123!@") { (error) in
             XCTAssertNotNil(error)
             guard let _ = error as? AWSMobileClientError else {
                 XCTFail("Error should be of type AWSMobileClientError")

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
@@ -31,7 +31,7 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         
         let signInListenerWasSuccessful = expectation(description: "signIn listener was successful")
-        AWSMobileClient.sharedInstance().addUserStateListener(self) { (userState, info) in
+        AWSMobileClient.default().addUserStateListener(self) { (userState, info) in
             switch (userState) {
             case .signedIn:
                 signInListenerWasSuccessful.fulfill()
@@ -42,7 +42,7 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
         }
         
         let signInWasSuccessful = expectation(description: "signIn was successful")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
+        AWSMobileClient.default().signIn(username: username, password: sharedPassword) { (signInResult, error) in
             if let error = error {
                 XCTFail("User login failed: \(error.localizedDescription)")
                 return
@@ -56,9 +56,9 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
             signInWasSuccessful.fulfill()
         }
         wait(for: [signInWasSuccessful, signInListenerWasSuccessful], timeout: 10)
-        XCTAssertNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentSignInHandlerCallback,
+        XCTAssertNil(AWSMobileClient.default().userpoolOpsHelper.currentSignInHandlerCallback,
                      "Current sign callback should be nil after callback is invoked")
-        AWSMobileClient.sharedInstance().removeUserStateListener(self)
+        AWSMobileClient.default().removeUserStateListener(self)
     }
     
     /// Test unsuccessful sign in
@@ -73,13 +73,13 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         let signInShouldFail = expectation(description: "Sign In should fail")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: "WrongPassword") { (signInResult, error) in
+        AWSMobileClient.default().signIn(username: username, password: "WrongPassword") { (signInResult, error) in
             XCTAssertNil(signInResult)
             XCTAssertNotNil(error, "Expecting error for wrong password.")
             signInShouldFail.fulfill()
         }
         wait(for: [signInShouldFail], timeout: 10)
-        XCTAssertNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentSignInHandlerCallback,
+        XCTAssertNil(AWSMobileClient.default().userpoolOpsHelper.currentSignInHandlerCallback,
                      "Current sign callback should be nil after callback is invoked")
     }
 
@@ -97,7 +97,7 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         let signInWasSuccessfulExpectation = expectation(description: "signIn was successful")
         
-        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
+        AWSMobileClient.default().signIn(username: username, password: sharedPassword) { (signInResult, error) in
             if let error = error {
                 XCTFail("User login failed: \(error.localizedDescription)")
                 return
@@ -110,16 +110,16 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
             
             // Manually set password completion task to mock confirm signIn flow.
             let newPasswordRequiredTask = AWSTaskCompletionSource<AWSCognitoIdentityNewPasswordRequiredDetails>()
-            AWSMobileClient.sharedInstance().userpoolOpsHelper.newPasswordRequiredTaskCompletionSource = newPasswordRequiredTask
-            AWSMobileClient.sharedInstance().confirmSignIn(challengeResponse: "code") { (signInResult, error) in
+            AWSMobileClient.default().userpoolOpsHelper.newPasswordRequiredTaskCompletionSource = newPasswordRequiredTask
+            AWSMobileClient.default().confirmSignIn(challengeResponse: "code") { (signInResult, error) in
                 // Completion will not be called because the continuation is mocked above.
             }
             signInWasSuccessfulExpectation.fulfill()
         }
         wait(for: [signInWasSuccessfulExpectation], timeout: 10)
-        XCTAssertNotNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentConfirmSignInHandlerCallback,
+        XCTAssertNotNil(AWSMobileClient.default().userpoolOpsHelper.currentConfirmSignInHandlerCallback,
                         "Current confirmsign callback should not be nil")
-        XCTAssertNil(AWSMobileClient.sharedInstance().userpoolOpsHelper.currentSignInHandlerCallback,
+        XCTAssertNil(AWSMobileClient.default().userpoolOpsHelper.currentSignInHandlerCallback,
                      "Current sign callback should be nil")
     }
     
@@ -141,7 +141,7 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
         signUpAndVerifyUser(username: username)
         let firstSignInExpectation = expectation(description: "First signIn was successful")
         let secondSignInExpectation = expectation(description: "Second signIn was successful")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
+        AWSMobileClient.default().signIn(username: username, password: sharedPassword) { (signInResult, error) in
             
             defer {
                 firstSignInExpectation.fulfill()
@@ -156,12 +156,12 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
                 return
             }
             XCTAssertEqual(signInResult.signInState, .signedIn, "Could not verify sign in state for first signIn")
-            XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedIn, "User should be in signedIn state after first signIn")
-            AWSMobileClient.sharedInstance().signOut()
-            XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
+            XCTAssertEqual(AWSMobileClient.default().currentUserState, .signedIn, "User should be in signedIn state after first signIn")
+            AWSMobileClient.default().signOut()
+            XCTAssertEqual(AWSMobileClient.default().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
             
             // Second signIn call
-            AWSMobileClient.sharedInstance().signIn(username: username, password: self.sharedPassword) { (signInResult, error) in
+            AWSMobileClient.default().signIn(username: username, password: self.sharedPassword) { (signInResult, error) in
                 defer {
                     secondSignInExpectation.fulfill()
                 }
@@ -176,7 +176,7 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
                     return
                 }
                 XCTAssertEqual(signInResult.signInState, .signedIn, "Could not verify sign in state for second signIn")
-                XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedIn, "User should be in signedIn state after second signIn")
+                XCTAssertEqual(AWSMobileClient.default().currentUserState, .signedIn, "User should be in signedIn state after second signIn")
             }
             
         }
@@ -189,14 +189,14 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
     /// - When:
     ///    - I invoke `signIn` valid username and password
     /// - Then:
-    ///    - I should successfully signIn with AWSMobileClient.sharedInstance().currentUserState
-    ///    - with state signedIn and AWSMobileClient.sharedInstance().isSignedIn to be true
+    ///    - I should successfully signIn with AWSMobileClient.default().currentUserState
+    ///    - with state signedIn and AWSMobileClient.default().isSignedIn to be true
     ///
     func testUserStateAfterSignIn() {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         let firstSignInExpectation = expectation(description: "First signIn was successful")
-        AWSMobileClient.sharedInstance().signIn(username: username, password: sharedPassword) { (signInResult, error) in
+        AWSMobileClient.default().signIn(username: username, password: sharedPassword) { (signInResult, error) in
             if let error = error {
                 XCTFail("User login failed: \(error.localizedDescription)")
                 return
@@ -207,8 +207,8 @@ class AWSMobileClientSignInTests: AWSMobileClientBaseTests {
                 return
             }
             XCTAssertEqual(signInResult.signInState, .signedIn, "Could not verify sign in state")
-            XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedIn, "User should be in signedIn state after signIn")
-            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn, "AWSMobileClient isSignedIn should be true after signIn")
+            XCTAssertEqual(AWSMobileClient.default().currentUserState, .signedIn, "User should be in signedIn state after signIn")
+            XCTAssertTrue(AWSMobileClient.default().isSignedIn, "AWSMobileClient isSignedIn should be true after signIn")
             firstSignInExpectation.fulfill()
         }
         wait(for: [firstSignInExpectation], timeout: 10)

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignoutTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignoutTests.swift
@@ -16,10 +16,10 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         signIn(username: username)
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == true, "Expected to return true for isSignedIn")
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn == true, "Expected to return true for isSignedIn")
         sleep(1)
-        AWSMobileClient.sharedInstance().signOut()
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+        AWSMobileClient.default().signOut()
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn == false, "Expected to return false for isSignedIn")
     }
     
     /// Test successful sign out with callback and no option on an Authenticated User
@@ -36,10 +36,10 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         let signoutExpectation = expectation(description: "Successfully signout")
         signUpAndVerifyUser(username: username)
         signIn(username: username)
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == true, "Expected to return true for isSignedIn")
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn == true, "Expected to return true for isSignedIn")
         sleep(1)
-        AWSMobileClient.sharedInstance().signOut { (error) in
-            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+        AWSMobileClient.default().signOut { (error) in
+            XCTAssertTrue(AWSMobileClient.default().isSignedIn == false, "Expected to return false for isSignedIn")
             signoutExpectation.fulfill()
         }
         wait(for: [signoutExpectation], timeout: 2)
@@ -59,12 +59,12 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         let signoutExpectation = expectation(description: "Successfully signout")
         signUpAndVerifyUser(username: username)
         signIn(username: username)
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == true, "Expected to return true for isSignedIn")
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn == true, "Expected to return true for isSignedIn")
         sleep(1)
         
         let signoutOptions = SignOutOptions(signOutGlobally: true, invalidateTokens: true)
-        AWSMobileClient.sharedInstance().signOut(options: signoutOptions) { (error) in
-            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+        AWSMobileClient.default().signOut(options: signoutOptions) { (error) in
+            XCTAssertTrue(AWSMobileClient.default().isSignedIn == false, "Expected to return false for isSignedIn")
             signoutExpectation.fulfill()
         }
         wait(for: [signoutExpectation], timeout: 2)
@@ -83,10 +83,10 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         let username = "testUser" + UUID().uuidString
         let signoutExpectation = expectation(description: "Successfully signout for unauthenticated User")
         signUpAndVerifyUser(username: username)
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn == false, "Expected to return false for isSignedIn")
         sleep(1)
-        AWSMobileClient.sharedInstance().signOut { (error) in
-            XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn == false, "Expected to return false for isSignedIn")
+        AWSMobileClient.default().signOut { (error) in
+            XCTAssertTrue(AWSMobileClient.default().isSignedIn == false, "Expected to return false for isSignedIn")
             signoutExpectation.fulfill()
         }
         wait(for: [signoutExpectation], timeout: 2)
@@ -104,10 +104,10 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         signIn(username: username)
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return true for isSignedIn")
-        AWSMobileClient.sharedInstance().signOut()
-        XCTAssertFalse(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return false for isSignedIn")
-        XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn, "Expected to return true for isSignedIn")
+        AWSMobileClient.default().signOut()
+        XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Expected to return false for isSignedIn")
+        XCTAssertEqual(AWSMobileClient.default().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
     }
     
     /// Test successfull sign out using callback and check the state of AWSMobileClient
@@ -123,11 +123,11 @@ class AWSMobileClientSignoutTests: AWSMobileClientBaseTests {
         let signoutExpectation = expectation(description: "Successfully signout")
         signUpAndVerifyUser(username: username)
         signIn(username: username)
-        XCTAssertTrue(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return true for isSignedIn")
+        XCTAssertTrue(AWSMobileClient.default().isSignedIn, "Expected to return true for isSignedIn")
         let signoutOptions = SignOutOptions(signOutGlobally: true, invalidateTokens: true)
-        AWSMobileClient.sharedInstance().signOut(options: signoutOptions) { (error) in
-            XCTAssertFalse(AWSMobileClient.sharedInstance().isSignedIn, "Expected to return false for isSignedIn")
-            XCTAssertEqual(AWSMobileClient.sharedInstance().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
+        AWSMobileClient.default().signOut(options: signoutOptions) { (error) in
+            XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Expected to return false for isSignedIn")
+            XCTAssertEqual(AWSMobileClient.default().currentUserState, .signedOut, "User should be in signedOut state after signedOut")
             signoutExpectation.fulfill()
         }
         wait(for: [signoutExpectation], timeout: 2)

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
@@ -17,7 +17,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientBaseTests {
         signIn(username: username)
         let verifyAttrExpectation = expectation(description: "verify attribute expectation.")
         
-        AWSMobileClient.sharedInstance().verifyUserAttribute(attributeName: "email") { (codeDeliveryDetails, error) in
+        AWSMobileClient.default().verifyUserAttribute(attributeName: "email") { (codeDeliveryDetails, error) in
             if let codeDeliveryDetails = codeDeliveryDetails {
                 print(codeDeliveryDetails.deliveryMedium)
             } else if let error = error {
@@ -36,7 +36,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientBaseTests {
         signIn(username: username)
         let getAttrExpectation = expectation(description: "get attributes expectation.")
         
-        AWSMobileClient.sharedInstance().getUserAttributes { (attributes, error) in
+        AWSMobileClient.default().getUserAttributes { (attributes, error) in
             if let attributes = attributes {
                 XCTAssertEqual(attributes.count, 4, "Expected 4 attributes for user.")
                 XCTAssertEqual(attributes["email_verified"], "false", "Email should not be verified.")
@@ -64,7 +64,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientBaseTests {
             "custom:mutableStringAttr2": "value for never-before-set attribute"
         ]
         
-        AWSMobileClient.sharedInstance().updateUserAttributes(attributeMap: newUserAttributes) { result, error in
+        AWSMobileClient.default().updateUserAttributes(attributeMap: newUserAttributes) { result, error in
             defer {
                 updateUserAttributesResultHandlerInvoked.fulfill()
             }
@@ -84,7 +84,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientBaseTests {
         wait(for: [updateUserAttributesResultHandlerInvoked], timeout: 5)
         
         let getUserAttributesResultHandlerInvoked = expectation(description: "getUserAttributes result handler should be invoked")
-        AWSMobileClient.sharedInstance().getUserAttributes { attributes, error in
+        AWSMobileClient.default().getUserAttributes { attributes, error in
             defer {
                 getUserAttributesResultHandlerInvoked.fulfill()
             }
@@ -127,7 +127,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientBaseTests {
         let updateUserAttributesResultHandlerInvoked = expectation(description: "updateUserAttributes result handler should be invoked")
         let newUserAttributes = ["custom:mutableStringAttr1": "new value for previously set attribute"]
         
-        AWSMobileClient.sharedInstance().updateUserAttributes(attributeMap: newUserAttributes) { result, error in
+        AWSMobileClient.default().updateUserAttributes(attributeMap: newUserAttributes) { result, error in
             defer {
                 updateUserAttributesResultHandlerInvoked.fulfill()
             }
@@ -144,7 +144,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientBaseTests {
         wait(for: [updateUserAttributesResultHandlerInvoked], timeout: 5)
         
         let getTokenExpectation = expectation(description: "Get token result handler should be invoked")
-        AWSMobileClient.sharedInstance().getTokens { (token, error) in
+        AWSMobileClient.default().getTokens { (token, error) in
             defer {
                 getTokenExpectation.fulfill()
             }

--- a/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientConfigTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientConfigTests.swift
@@ -23,7 +23,7 @@ class AWSMobileClientConfigTests: XCTestCase {
     }
 
     func testSharedInstanceReference() {
-        XCTAssertEqual(AWSMobileClient.sharedInstance(), AWSMobileClient.default())
+        XCTAssertEqual(AWSMobileClient.default(), AWSMobileClient.default())
     }
 
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientConfigTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientConfigTests.swift
@@ -23,7 +23,7 @@ class AWSMobileClientConfigTests: XCTestCase {
     }
 
     func testSharedInstanceReference() {
-        XCTAssertEqual(AWSMobileClient.default(), AWSMobileClient.default())
+        XCTAssertEqual(AWSMobileClient.sharedInstance(), AWSMobileClient.default())
     }
 
 }

--- a/AWSMobileClient.podspec
+++ b/AWSMobileClient.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
    s.dependency 'AWSAuthCore', '2.10.3'
    s.dependency 'AWSCognitoIdentityProvider', '2.10.3'
    s.source_files = 'AWSAuthSDK/Sources/AWSMobileClient/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/*.swift', 'AWSCognitoAuth/**/*.{h,m,c}', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/*.swift'
-   s.public_header_files = 'AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h', 'AWSCognitoAuth/*.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h, AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h'
+   s.public_header_files = 'AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h', 'AWSCognitoAuth/*.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h'
  end

--- a/AWSMobileClient.podspec
+++ b/AWSMobileClient.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
    s.dependency 'AWSAuthCore', '2.10.3'
    s.dependency 'AWSCognitoIdentityProvider', '2.10.3'
    s.source_files = 'AWSAuthSDK/Sources/AWSMobileClient/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/*.swift', 'AWSCognitoAuth/**/*.{h,m,c}', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/*.swift'
-   s.public_header_files = 'AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h', 'AWSCognitoAuth/*.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h'
+   s.public_header_files = 'AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h', 'AWSCognitoAuth/*.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h, AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h'
  end


### PR DESCRIPTION
Also updated test classes to use AWSMobileClient.default instead of AWSMobileClient.sharedInstance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
