### PR TITLE
add support for dark mode on AuthUI (fixes #1953)

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -42,8 +42,6 @@
 		1711A4EA1F43A49E006105D3 /* AWSUserPools.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1711A4C61F43A461006105D3 /* AWSUserPools.storyboard */; };
 		1711A4ED1F43A49E006105D3 /* AWSUserPoolSignUpViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4C91F43A461006105D3 /* AWSUserPoolSignUpViewController.h */; };
 		1711A4EE1F43A49E006105D3 /* AWSUserPoolSignUpViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1711A4CA1F43A461006105D3 /* AWSUserPoolSignUpViewController.m */; };
-		1711A4EF1F43A49E006105D3 /* AWSUserPoolsUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4CB1F43A461006105D3 /* AWSUserPoolsUIHelper.h */; };
-		1711A4F01F43A49E006105D3 /* AWSUserPoolsUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 1711A4CC1F43A461006105D3 /* AWSUserPoolsUIHelper.m */; };
 		1711A4F51F43D7D6006105D3 /* AWSUserPoolsUIOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4B91F43A461006105D3 /* AWSUserPoolsUIOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		173A453E21E92A0200F9C579 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
 		173A453F21E92A0200F9C579 /* AWSAuthCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -166,7 +164,6 @@
 		B5170D351F44FDB6008FD811 /* AWSUserPoolForgotPasswordViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4C21F43A461006105D3 /* AWSUserPoolForgotPasswordViewController.h */; };
 		B5170D361F44FDBF008FD811 /* AWSUserPoolMFAViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4C41F43A461006105D3 /* AWSUserPoolMFAViewController.h */; };
 		B5170D371F44FDC8008FD811 /* AWSUserPoolSignUpViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4C91F43A461006105D3 /* AWSUserPoolSignUpViewController.h */; };
-		B5170D381F44FDCC008FD811 /* AWSUserPoolsUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 1711A4CB1F43A461006105D3 /* AWSUserPoolsUIHelper.h */; };
 		B5170DA01F466CFE008FD811 /* AWSIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B5C5648B1F2B2162004FF3CF /* AWSIdentityManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5170DA11F466CFE008FD811 /* AWSIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5C5648C1F2B2162004FF3CF /* AWSIdentityManager.m */; };
 		B5170DA21F466CFE008FD811 /* AWSAuthCore.h in Headers */ = {isa = PBXBuildFile; fileRef = B5C564901F2B2162004FF3CF /* AWSAuthCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -188,6 +185,8 @@
 		B92BA3CB2318859D007C1175 /* AWSMobileClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5FC69011FAFA1AA004790CB /* AWSMobileClient.framework */; };
 		B92BA3D223188606007C1175 /* AWSMobileClientConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92BA3D123188605007C1175 /* AWSMobileClientConfigTests.swift */; };
 		B92BA3D42318867D007C1175 /* AWSMobileClientConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92BA3D32318867D007C1175 /* AWSMobileClientConfig.swift */; };
+		B9AC6319234F00FA00A713A5 /* AWSAuthUIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B9AC6317234F00F900A713A5 /* AWSAuthUIHelper.m */; };
+		B9AC631A234F00FA00A713A5 /* AWSAuthUIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = B9AC6318234F00FA00A713A5 /* AWSAuthUIHelper.h */; };
 		B9E2F6CD231EEE63009EAA48 /* AWSMobileClientInitializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9E2F6CC231EEE63009EAA48 /* AWSMobileClientInitializerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1205,8 +1204,6 @@
 		1711A4C61F43A461006105D3 /* AWSUserPools.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AWSUserPools.storyboard; sourceTree = "<group>"; };
 		1711A4C91F43A461006105D3 /* AWSUserPoolSignUpViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSUserPoolSignUpViewController.h; sourceTree = "<group>"; };
 		1711A4CA1F43A461006105D3 /* AWSUserPoolSignUpViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSUserPoolSignUpViewController.m; sourceTree = "<group>"; };
-		1711A4CB1F43A461006105D3 /* AWSUserPoolsUIHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSUserPoolsUIHelper.h; sourceTree = "<group>"; };
-		1711A4CC1F43A461006105D3 /* AWSUserPoolsUIHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSUserPoolsUIHelper.m; sourceTree = "<group>"; };
 		1711A4F31F43D701006105D3 /* AWSUIConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSUIConfiguration.h; sourceTree = "<group>"; };
 		1744D05A21FFD84E00A81008 /* DeviceOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceOperations.swift; sourceTree = "<group>"; };
 		1750D0071F2D4DFA006D915E /* AWSUserPoolsSignIn.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSUserPoolsSignIn.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1338,6 +1335,8 @@
 		B92BA3CA2318859D007C1175 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B92BA3D123188605007C1175 /* AWSMobileClientConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSMobileClientConfigTests.swift; sourceTree = "<group>"; };
 		B92BA3D32318867D007C1175 /* AWSMobileClientConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientConfig.swift; sourceTree = "<group>"; };
+		B9AC6317234F00F900A713A5 /* AWSAuthUIHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSAuthUIHelper.m; sourceTree = "<group>"; };
+		B9AC6318234F00FA00A713A5 /* AWSAuthUIHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSAuthUIHelper.h; sourceTree = "<group>"; };
 		B9E2F6CC231EEE63009EAA48 /* AWSMobileClientInitializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientInitializerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1468,8 +1467,6 @@
 				1711A4C61F43A461006105D3 /* AWSUserPools.storyboard */,
 				1711A4C91F43A461006105D3 /* AWSUserPoolSignUpViewController.h */,
 				1711A4CA1F43A461006105D3 /* AWSUserPoolSignUpViewController.m */,
-				1711A4CB1F43A461006105D3 /* AWSUserPoolsUIHelper.h */,
-				1711A4CC1F43A461006105D3 /* AWSUserPoolsUIHelper.m */,
 				1711A4C21F43A461006105D3 /* AWSUserPoolForgotPasswordViewController.h */,
 				1711A4C31F43A461006105D3 /* AWSUserPoolForgotPasswordViewController.m */,
 				B468215F233D19DE00CB404D /* AWSUserPoolNewPasswordRequiredViewController.h */,
@@ -1686,16 +1683,16 @@
 		B5345D101F366AFA009C1041 /* AWSAuthUI */ = {
 			isa = PBXGroup;
 			children = (
-				17C77CB41F417B3800AE8632 /* AWSAuthUIViewController.h */,
-				17C77CB51F417B3800AE8632 /* AWSAuthUIViewController.m */,
-				B5150B1A1F3C389C00AC8D08 /* Images.xcassets */,
-				B58F53D51F381A51009ED450 /* SignIn.storyboard */,
-				B58F53D61F381A51009ED450 /* AWSSignInViewController.h */,
-				B58F53D71F381A51009ED450 /* AWSSignInViewController.m */,
 				B5345D741F366E4A009C1041 /* AWSAuthUI.h */,
-				B5345D751F366E4A009C1041 /* Info.plist */,
 				B5150A531F3BF00F00AC8D08 /* AWSAuthUIConfiguration.h */,
 				B5150AB11F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m */,
+				17C77CB41F417B3800AE8632 /* AWSAuthUIViewController.h */,
+				17C77CB51F417B3800AE8632 /* AWSAuthUIViewController.m */,
+				B58F53D61F381A51009ED450 /* AWSSignInViewController.h */,
+				B58F53D71F381A51009ED450 /* AWSSignInViewController.m */,
+				B5150B1A1F3C389C00AC8D08 /* Images.xcassets */,
+				B5345D751F366E4A009C1041 /* Info.plist */,
+				B58F53D51F381A51009ED450 /* SignIn.storyboard */,
 			);
 			path = AWSAuthUI;
 			sourceTree = "<group>";
@@ -1819,16 +1816,18 @@
 		B5C564B61F2B2302004FF3CF /* AWSAuthCore */ = {
 			isa = PBXGroup;
 			children = (
+				B5C564901F2B2162004FF3CF /* AWSAuthCore.h */,
+				B9AC6318234F00FA00A713A5 /* AWSAuthUIHelper.h */,
+				B9AC6317234F00F900A713A5 /* AWSAuthUIHelper.m */,
 				B5C5648B1F2B2162004FF3CF /* AWSIdentityManager.h */,
 				B5C5648C1F2B2162004FF3CF /* AWSIdentityManager.m */,
-				B5C564901F2B2162004FF3CF /* AWSAuthCore.h */,
 				B5C564911F2B2162004FF3CF /* AWSSignInButtonView.h */,
 				B5C564921F2B2162004FF3CF /* AWSSignInManager.h */,
 				B5C564931F2B2162004FF3CF /* AWSSignInManager.m */,
 				B5C564941F2B2162004FF3CF /* AWSSignInProvider.h */,
 				B5C564951F2B2162004FF3CF /* AWSSignInProviderApplicationIntercept.h */,
-				B5C564961F2B2162004FF3CF /* Info.plist */,
 				1711A4F31F43D701006105D3 /* AWSUIConfiguration.h */,
+				B5C564961F2B2162004FF3CF /* Info.plist */,
 			);
 			path = AWSAuthCore;
 			sourceTree = "<group>";
@@ -1870,7 +1869,6 @@
 				1711A4E21F43A49E006105D3 /* AWSFormTableDelegate.h in Headers */,
 				B5170D301F44F098008FD811 /* AWSUserPoolsSignIn.h in Headers */,
 				1711A4E01F43A49E006105D3 /* AWSFormTableCell.h in Headers */,
-				1711A4EF1F43A49E006105D3 /* AWSUserPoolsUIHelper.h in Headers */,
 				B4682161233D19DF00CB404D /* AWSUserPoolNewPasswordRequiredViewController.h in Headers */,
 				1711A4ED1F43A49E006105D3 /* AWSUserPoolSignUpViewController.h in Headers */,
 				1711A4E61F43A49E006105D3 /* AWSUserPoolForgotPasswordViewController.h in Headers */,
@@ -1939,6 +1937,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5170DA31F466CFE008FD811 /* AWSSignInButtonView.h in Headers */,
+				B9AC631A234F00FA00A713A5 /* AWSAuthUIHelper.h in Headers */,
 				B5170DA01F466CFE008FD811 /* AWSIdentityManager.h in Headers */,
 				B5170DA41F466CFE008FD811 /* AWSSignInManager.h in Headers */,
 				B5170DA71F466CFE008FD811 /* AWSSignInProviderApplicationIntercept.h in Headers */,
@@ -1954,7 +1953,6 @@
 			files = (
 				B5170D371F44FDC8008FD811 /* AWSUserPoolSignUpViewController.h in Headers */,
 				B5170D331F44FD8C008FD811 /* AWSFormTableDelegate.h in Headers */,
-				B5170D381F44FDCC008FD811 /* AWSUserPoolsUIHelper.h in Headers */,
 				B58F54C31F382449009ED450 /* AWSSignInViewController.h in Headers */,
 				B5150AB31F3BF04C00AC8D08 /* AWSAuthUIConfiguration.h in Headers */,
 				17C77CB61F417B3800AE8632 /* AWSAuthUIViewController.h in Headers */,
@@ -3146,7 +3144,6 @@
 				1711A4E71F43A49E006105D3 /* AWSUserPoolForgotPasswordViewController.m in Sources */,
 				1750D0121F2D4E23006D915E /* AWSCognitoUserPoolsSignInProvider.m in Sources */,
 				1711A4E91F43A49E006105D3 /* AWSUserPoolMFAViewController.m in Sources */,
-				1711A4F01F43A49E006105D3 /* AWSUserPoolsUIHelper.m in Sources */,
 				1711A4E51F43A49E006105D3 /* AWSTableInputCell.m in Sources */,
 				B4682160233D19DF00CB404D /* AWSUserPoolNewPasswordRequiredViewController.m in Sources */,
 				1711A4EE1F43A49E006105D3 /* AWSUserPoolSignUpViewController.m in Sources */,
@@ -3214,6 +3211,7 @@
 			files = (
 				B5170DA11F466CFE008FD811 /* AWSIdentityManager.m in Sources */,
 				B5170DA51F466CFE008FD811 /* AWSSignInManager.m in Sources */,
+				B9AC6319234F00FA00A713A5 /* AWSAuthUIHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -1123,6 +1123,27 @@
 			remoteGlobalIDString = B5FC69001FAFA1AA004790CB;
 			remoteInfo = AWSMobileClient;
 		};
+		B97FFF0B234D49A000DC327D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 178A800C22AF7DA600B167D6;
+			remoteInfo = AWSTranscribeStreaming;
+		};
+		B97FFF0D234D49A000DC327D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 178A804D22B097B900B167D6;
+			remoteInfo = AWSTranscribeStreamingTests;
+		};
+		B97FFF0F234D49A000DC327D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FA53332B22D4D47D00BD88AF;
+			remoteInfo = AWSTranscribeStreamingUnitTests;
+		};
 		E496D9411FDB0632000CF290 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
@@ -1460,10 +1481,10 @@
 		1750D0081F2D4DFA006D915E /* AWSUserPoolsSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				1711A4BB1F43A461006105D3 /* UserPoolsUI */,
 				B5170D2E1F44F091008FD811 /* AWSUserPoolsSignIn.h */,
 				1711A4B91F43A461006105D3 /* AWSUserPoolsUIOperations.h */,
 				1711A4BA1F43A461006105D3 /* AWSUserPoolsUIOperations.m */,
-				1711A4BB1F43A461006105D3 /* UserPoolsUI */,
 				1750D00F1F2D4E23006D915E /* AWSCognitoUserPoolsSignInProvider.h */,
 				1750D0101F2D4E23006D915E /* AWSCognitoUserPoolsSignInProvider.m */,
 				1750D00A1F2D4DFA006D915E /* Info.plist */,
@@ -1698,15 +1719,15 @@
 				B55D57261F44EC3F005A0E56 /* AWSCloudWatchTests.xctest */,
 				B55D57281F44EC3F005A0E56 /* AWSCloudWatchUnitTests.xctest */,
 				B55D572A1F44EC3F005A0E56 /* AWSCognito.framework */,
-				B55D572C1F44EC3F005A0E56 /* AWSCognitoTests.xctest */,
-				B55D572E1F44EC3F005A0E56 /* AWSCognitoUnitTests.xctest */,
 				B55D57301F44EC3F005A0E56 /* AWSCognitoAuth.framework */,
 				B55D57321F44EC3F005A0E56 /* AWSCognitoAuthTests.xctest */,
 				B55D57341F44EC3F005A0E56 /* AWSCognitoAuthUnitTests.xctest */,
-				E496D9421FDB0632000CF290 /* AWSCognitoIdentityProviderASF.framework */,
 				B55D57361F44EC3F005A0E56 /* AWSCognitoIdentityProvider.framework */,
+				E496D9421FDB0632000CF290 /* AWSCognitoIdentityProviderASF.framework */,
 				B55D57381F44EC3F005A0E56 /* AWSCognitoIdentityProviderTests.xctest */,
 				B55D573A1F44EC3F005A0E56 /* AWSCognitoIdentityProviderUnitTests.xctest */,
+				B55D572C1F44EC3F005A0E56 /* AWSCognitoTests.xctest */,
+				B55D572E1F44EC3F005A0E56 /* AWSCognitoUnitTests.xctest */,
 				B51E4F6A215449FB001BC958 /* AWSComprehend.framework */,
 				B51E4F6E215449FB001BC958 /* AWSComprehendTests.xctest */,
 				B51E4F6C215449FB001BC958 /* AWSComprehendUnitTests.xctest */,
@@ -1725,6 +1746,9 @@
 				B55D574E1F44EC3F005A0E56 /* AWSIoT.framework */,
 				B55D57501F44EC3F005A0E56 /* AWSIoTTests.xctest */,
 				B55D57521F44EC3F005A0E56 /* AWSIoTUnitTests.xctest */,
+				B55D575A1F44EC3F005A0E56 /* AWSKMS.framework */,
+				B55D575C1F44EC3F005A0E56 /* AWSKMSTests.xctest */,
+				B55D575E1F44EC3F005A0E56 /* AWSKMSUnitTests.xctest */,
 				B55D57541F44EC3F005A0E56 /* AWSKinesis.framework */,
 				B55D57561F44EC3F005A0E56 /* AWSKinesisTests.xctest */,
 				B55D57581F44EC3F005A0E56 /* AWSKinesisUnitTests.xctest */,
@@ -1734,9 +1758,6 @@
 				B51E4F76215449FB001BC958 /* AWSKinesisVideoArchivedMedia.framework */,
 				B51E4F7A215449FB001BC958 /* AWSKinesisVideoArchivedMediaTests.xctest */,
 				B51E4F78215449FB001BC958 /* AWSKinesisVideoArchivedMediaUnitTests.xctest */,
-				B55D575A1F44EC3F005A0E56 /* AWSKMS.framework */,
-				B55D575C1F44EC3F005A0E56 /* AWSKMSTests.xctest */,
-				B55D575E1F44EC3F005A0E56 /* AWSKMSUnitTests.xctest */,
 				B55D57601F44EC3F005A0E56 /* AWSLambda.framework */,
 				B55D57621F44EC3F005A0E56 /* AWSLambdaTests.xctest */,
 				B55D57641F44EC3F005A0E56 /* AWSLambdaUnitTests.xctest */,
@@ -1785,9 +1806,12 @@
 				B51E4F60215449FB001BC958 /* AWSTranscribe.framework */,
 				B51E4F62215449FB001BC958 /* AWSTranscribeTests.xctest */,
 				B51E4F64215449FB001BC958 /* AWSTranscribeUnitTests.xctest */,
+				B97FFF0C234D49A000DC327D /* AWSTranscribeStreaming.framework */,
+				B97FFF0E234D49A000DC327D /* AWSTranscribeStreamingTests.xctest */,
+				B97FFF10234D49A000DC327D /* AWSTranscribeStreamingUnitTests.xctest */,
 				B51E4F66215449FB001BC958 /* AWSTranslate.framework */,
-				B51E4F68215449FB001BC958 /* AWSTranslateUnitTests.xctest */,
 				B51E4F70215449FB001BC958 /* AWSTranslateTests.xctest */,
+				B51E4F68215449FB001BC958 /* AWSTranslateUnitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2981,6 +3005,27 @@
 			fileType = wrapper.application;
 			path = AWSAllTestsHost.app;
 			remoteRef = B55D57AD1F44EC3F005A0E56 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B97FFF0C234D49A000DC327D /* AWSTranscribeStreaming.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = AWSTranscribeStreaming.framework;
+			remoteRef = B97FFF0B234D49A000DC327D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B97FFF0E234D49A000DC327D /* AWSTranscribeStreamingTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = AWSTranscribeStreamingTests.xctest;
+			remoteRef = B97FFF0D234D49A000DC327D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B97FFF10234D49A000DC327D /* AWSTranscribeStreamingUnitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = AWSTranscribeStreamingUnitTests.xctest;
+			remoteRef = B97FFF0F234D49A000DC327D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		E496D9421FDB0632000CF290 /* AWSCognitoIdentityProviderASF.framework */ = {

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <AWSAuthCore/AWSUIConfiguration.h>
+#import "AWSUIConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface AWSUserPoolsUIHelper : NSObject
+@interface AWSAuthUIHelper : NSObject
 
 /**
  Set up shadow around specified view
@@ -29,8 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (void) setUpFormShadowForView:(UIView *)view;
 
 /**
- Get background color set in the config or
- return the default background color
+ Get background color set in the config or return the default background color.
+ This is resilient to light/dark mode setting on iOS 13 (`UIColor.systemBackgroundColor`).
  
  @param config The object conforming to `AWSUIConfiguration` protocol
  @return backgroundColor
@@ -38,19 +38,30 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIColor *) getBackgroundColor:(id<AWSUIConfiguration>)config;
 
 /**
- Get the default background color. This is resilient to light/dark mode
- setting on iOS 13.
+ Get the default secondary background color. This is resilient to
+ light/dark mode setting on iOS 13 (`UIColor.secondarySystemBackgroundColor`).
  */
-+ (UIColor *) getDefaultBackgroundColor;
++ (UIColor *) getSecondaryBackgroundColor;
 
 /**
  Apply button-like primary color to buttons and labels.
+ 
+ @param config The object conforming to `AWSUIConfiguration` protocol
+ @param view The view (usually a `UIButton` or `UILabel`)
+ @param background wheter the color should be applied to the background of
+ the component or to the foreground. This is useful when styling buttons
+ that look like hyperlinks.
  */
-+ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
++ (void) applyPrimaryColorFromConfig:(id<AWSUIConfiguration>)config
                            toView:(UIView *) view
                        background:(BOOL) background;
 
-+ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
+/**
+ Apply primary color to the view's background.
+ 
+ @see applyPrimaryColorFromConfig:(id<AWSUIConfiguration>) toView:(UIView *) background:(BOOL)
+ */
++ (void) applyPrimaryColorFromConfig:(id<AWSUIConfiguration>)config
                            toView:(UIView *) view;
 
 /**
@@ -68,6 +79,23 @@ NS_ASSUME_NONNULL_BEGIN
  @return isFullScreenBackgroundColorEnabled
  **/
 + (BOOL) isBackgroundColorFullScreen:(id<AWSUIConfiguration>)config;
+
+/**
+ Check if a `UIColor` is bright or dark. Based on http://www.w3.org/WAI/ER/WD-AERT/#color-contrast
+ */
++ (BOOL) isDarkColor:(UIColor *) color;
+
+/**
+ Get the primary text color. Based on the configured background color.
+ 
+ On iOS 13 or greater is uses `UIColor.labelColor` so it auto-adapts to
+ light/dark mode. On older systems is picks a light or a dark color to
+ contrast with the main background color.
+ 
+ @param config The object conforming to `AWSUIConfiguration` protocol
+ @return a text color that contrasts with the background color.
+ */
++ (UIColor *) getTextColor:(id<AWSUIConfiguration>)config;
 
 /**
  Set the AWSAuthUIConfiguration object.

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.h
@@ -48,13 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param config The object conforming to `AWSUIConfiguration` protocol
  @param view The view (usually a `UIButton` or `UILabel`)
- @param background wheter the color should be applied to the background of
+ @param background whether the color should be applied to the background of
  the component or to the foreground. This is useful when styling buttons
  that look like hyperlinks.
  */
 + (void) applyPrimaryColorFromConfig:(id<AWSUIConfiguration>)config
-                           toView:(UIView *) view
-                       background:(BOOL) background;
+                              toView:(UIView *) view
+                          background:(BOOL) background;
 
 /**
  Apply primary color to the view's background.
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  @see applyPrimaryColorFromConfig:(id<AWSUIConfiguration>) toView:(UIView *) background:(BOOL)
  */
 + (void) applyPrimaryColorFromConfig:(id<AWSUIConfiguration>)config
-                           toView:(UIView *) view;
+                              toView:(UIView *) view;
 
 /**
  Retrieve the font set in the config or return nil
@@ -80,10 +80,6 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 + (BOOL) isBackgroundColorFullScreen:(id<AWSUIConfiguration>)config;
 
-/**
- Check if a `UIColor` is bright or dark. Based on http://www.w3.org/WAI/ER/WD-AERT/#color-contrast
- */
-+ (BOOL) isDarkColor:(UIColor *) color;
 
 /**
  Get the primary text color. Based on the configured background color.

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m
@@ -1,5 +1,5 @@
 //
-// Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
@@ -13,10 +13,9 @@
 // permissions and limitations under the License.
 //
 
-#import <AWSAuthCore/AWSUIConfiguration.h>
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 
-@implementation AWSUserPoolsUIHelper
+@implementation AWSAuthUIHelper
 
 static id<AWSUIConfiguration> awsUIConfiguration;
 
@@ -37,29 +36,31 @@ static id<AWSUIConfiguration> awsUIConfiguration;
     } else if (@available(iOS 13.0, *)) {
         return [UIColor systemBackgroundColor];
     }
-    return [UIColor darkGrayColor];
-}
-
-+ (UIColor *) getDefaultBackgroundColor {
-    if (@available(iOS 13.0, *)) {
-        return [UIColor secondarySystemBackgroundColor];
-    }
+    // matches light systemBackgroundColor on iOS >= 13
     return [UIColor whiteColor];
 }
 
-+ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
-                           toView:(UIView *) view {
-    [self applyTintColorFromConfig:config toView:view background:YES];
++ (UIColor *) getSecondaryBackgroundColor {
+    if (@available(iOS 13.0, *)) {
+        return [UIColor secondarySystemBackgroundColor];
+    }
+    // light grey (matches light secondarySystemBackgroundColor on iOS >= 13)
+    return [UIColor colorWithRed:0.95 green:0.95 blue:0.97 alpha:1.0];
 }
 
-+ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
-                           toView:(UIView *) view
-                       background:(BOOL) background {
-    if (config.tintColor) {
++ (void) applyPrimaryColorFromConfig:(id<AWSUIConfiguration>)config
+                              toView:(UIView *) view {
+    [self applyPrimaryColorFromConfig:config toView:view background:YES];
+}
+
++ (void) applyPrimaryColorFromConfig:(id<AWSUIConfiguration>)config
+                              toView:(UIView *) view
+                          background:(BOOL) background {
+    if (config.primaryColor) {
         if (background) {
-            view.backgroundColor = config.tintColor;
+            view.backgroundColor = config.primaryColor;
         } else {
-            view.tintColor = config.tintColor;
+            view.tintColor = config.primaryColor;
         }
     }
 }
@@ -67,17 +68,34 @@ static id<AWSUIConfiguration> awsUIConfiguration;
 + (UIFont *) getFont:(id<AWSUIConfiguration>)config {
     if (config != nil && config.font != nil) {
         return config.font;
-    } else {
-        return nil;
     }
+    return nil;
 }
 
 + (BOOL) isBackgroundColorFullScreen:(id<AWSUIConfiguration>)config {
     if (config != nil) {
         return config.isBackgroundColorFullScreen;
-    } else {
-        return false;
     }
+    return false;
+}
+
++ (BOOL) isDarkColor:(UIColor *) color {
+    const CGFloat *componentColors = CGColorGetComponents(color.CGColor);
+    CGFloat colorBrightness = (
+                               (componentColors[0] * 299) +
+                               (componentColors[1] * 587) +
+                               (componentColors[2] * 114)
+                              ) / 1000;
+    return colorBrightness < 0.5;
+}
+
++ (UIColor *) getTextColor:(id<AWSUIConfiguration>)config {
+    if (@available(iOS 13.0, *)) {
+        return [UIColor labelColor];
+    } else if ([self isDarkColor:[self getBackgroundColor:config]]) {
+        return [UIColor whiteColor];
+    }
+    return [UIColor darkTextColor];
 }
 
 + (void) setAWSUIConfiguration:(id<AWSUIConfiguration>)config {

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSAuthUIHelper.m
@@ -79,6 +79,9 @@ static id<AWSUIConfiguration> awsUIConfiguration;
     return false;
 }
 
+/**
+ Check if a `UIColor` is bright or dark. Based on http://www.w3.org/WAI/ER/WD-AERT/#color-contrast
+*/
 + (BOOL) isDarkColor:(UIColor *) color {
     const CGFloat *componentColors = CGColorGetComponents(color.CGColor);
     CGFloat colorBrightness = (

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h
@@ -23,21 +23,22 @@
 
 /**
  @property backgroundColor
- @brief The background color of the sign-in screen.
+ @brief The background color of the auth screens.
  **/
 @property (nonatomic, nullable) UIColor *backgroundColor;
 
 /**
- @property backgroundBottomColor
- @brief The background color applited to the bottom panel of the sign-in screen.
+ @property secondaryBackgroundColor
+ @brief The secondary background color. It's applied to the bottom panel
+ of the auth screens.
  */
-@property (nonatomic, nullable) UIColor *backgroundBottomColor;
+@property (nonatomic, nullable) UIColor *secondaryBackgroundColor;
 
 /**
- @property tintColor
- @brief The view tint (foreground) color used for highlighted elements (button background, links).
+ @property primaryColor
+ @brief The view primary color used for highlighted elements (button background, links).
  */
-@property (nonatomic, nullable) UIColor *tintColor;
+@property (nonatomic, nullable) UIColor *primaryColor;
 
 /**
  @property fullScreenBackgroundColor

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSUIConfiguration.h
@@ -17,15 +17,27 @@
 
 /**
  @property logoImage
- @brief The logo to be used on the Auth UI Screen
+ @brief The logo to be used on the Auth UI Screen.
  **/
 @property (nonatomic, nullable) UIImage *logoImage;
 
 /**
  @property backgroundColor
- @brief Gets the backgorund color of the sign in screen configured by the user
+ @brief The background color of the sign-in screen.
  **/
 @property (nonatomic, nullable) UIColor *backgroundColor;
+
+/**
+ @property backgroundBottomColor
+ @brief The background color applited to the bottom panel of the sign-in screen.
+ */
+@property (nonatomic, nullable) UIColor *backgroundBottomColor;
+
+/**
+ @property tintColor
+ @brief The view tint (foreground) color used for highlighted elements (button background, links).
+ */
+@property (nonatomic, nullable) UIColor *tintColor;
 
 /**
  @property fullScreenBackgroundColor

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h
@@ -48,21 +48,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  @property backgroundColor
- @brief The background color of the sign-in screen.
+ @brief The background color of the auth screens.
  **/
 @property (nonatomic, nullable) UIColor *backgroundColor;
 
 /**
- @property backgroundBottomColor
- @brief The background color applited to the bottom panel of the sign-in screen.
+ @property secondaryBackgroundColor
+ @brief The secondary background color. It's applied to the bottom panel
+ of the auth screens.
  */
-@property (nonatomic, nullable) UIColor *backgroundBottomColor;
+@property (nonatomic, nullable) UIColor *secondaryBackgroundColor;
 
 /**
- @property tintColor
- @brief The view tint (foreground) color used for highlighted elements (button background, links).
+ @property primaryColor
+ @brief The view primary color used for highlighted elements (button background, links).
  */
-@property (nonatomic, nullable) UIColor *tintColor;
+@property (nonatomic, nullable) UIColor *primaryColor;
 
 /**
  @property enableUserPoolsUI

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h
@@ -36,23 +36,33 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  @property canCancel
- @brief If set to `YES` user can hit cancel button to dismiss sign in UI
+ @brief If set to `YES` user can hit cancel button to dismiss sign in UI.
  **/
 @property (atomic) BOOL canCancel;
 
 /**
  @property logoImage
- @brief The logo to be used on the Auth UI Screen
+ @brief The logo to be used on the Auth UI Screen.
  **/
 @property (nonatomic, nullable) UIImage *logoImage;
 
-
 /**
  @property backgroundColor
- @brief Gets the backgorund color of the sign in screen configured by the user
+ @brief The background color of the sign-in screen.
  **/
 @property (nonatomic, nullable) UIColor *backgroundColor;
 
+/**
+ @property backgroundBottomColor
+ @brief The background color applited to the bottom panel of the sign-in screen.
+ */
+@property (nonatomic, nullable) UIColor *backgroundBottomColor;
+
+/**
+ @property tintColor
+ @brief The view tint (foreground) color used for highlighted elements (button background, links).
+ */
+@property (nonatomic, nullable) UIColor *tintColor;
 
 /**
  @property enableUserPoolsUI

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.m
@@ -32,9 +32,9 @@
 
 @synthesize backgroundColor;
 
-@synthesize backgroundBottomColor;
+@synthesize secondaryBackgroundColor;
 
-@synthesize tintColor;
+@synthesize primaryColor;
 
 @synthesize registeredSignInButtonViews;
 

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.m
@@ -32,6 +32,10 @@
 
 @synthesize backgroundColor;
 
+@synthesize backgroundBottomColor;
+
+@synthesize tintColor;
+
 @synthesize registeredSignInButtonViews;
 
 @synthesize enableUserPoolsUI;

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.m
@@ -47,12 +47,7 @@ static NSString *const AWSInfoGoogleIdentifier = @"GoogleSignIn";
     AWSAuthUIConfiguration *config = [AWSAuthUIViewController getDefaultAuthUIConfiguration];
     if(configDictionary[@"canCancel"]) {
         NSString *canCancelValue = (NSString *)configDictionary[@"canCancel"];
-        if ([canCancelValue isEqual: @"YES"]) {
-            [config setCanCancel:true];
-        } else {
-            [config setCanCancel:false];
-        }
-        
+        [config setCanCancel:[canCancelValue isEqual: @"YES"]];
     }
     if (configDictionary[@"logoImage"]) {
         [config setLogoImage:(UIImage *)configDictionary[@"logoImage"]];
@@ -60,11 +55,11 @@ static NSString *const AWSInfoGoogleIdentifier = @"GoogleSignIn";
     if (configDictionary[@"backgroundColor"]) {
         [config setBackgroundColor:(UIColor *)configDictionary[@"backgroundColor"]];
     }
-    if (configDictionary[@"backgroundBottomColor"]) {
-        [config setBackgroundBottomColor:(UIColor *)configDictionary[@"backgroundBottomColor"]];
+    if (configDictionary[@"secondaryBackgroundColor"]) {
+        [config setSecondaryBackgroundColor:(UIColor *)configDictionary[@"secondaryBackgroundColor"]];
     }
-    if (configDictionary[@"tintColor"]) {
-        [config setTintColor:(UIColor *)configDictionary[@"tintColor"]];
+    if (configDictionary[@"primaryColor"]) {
+        [config setPrimaryColor:(UIColor *)configDictionary[@"primaryColor"]];
     }
     
     [[AWSSignInManager sharedInstance] setDontFederate];

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.m
@@ -54,11 +54,17 @@ static NSString *const AWSInfoGoogleIdentifier = @"GoogleSignIn";
         }
         
     }
-    if(configDictionary[@"logoImage"]) {
+    if (configDictionary[@"logoImage"]) {
         [config setLogoImage:(UIImage *)configDictionary[@"logoImage"]];
     }
-    if(configDictionary[@"backgroundColor"]) {
+    if (configDictionary[@"backgroundColor"]) {
         [config setBackgroundColor:(UIColor *)configDictionary[@"backgroundColor"]];
+    }
+    if (configDictionary[@"backgroundBottomColor"]) {
+        [config setBackgroundBottomColor:(UIColor *)configDictionary[@"backgroundBottomColor"]];
+    }
+    if (configDictionary[@"tintColor"]) {
+        [config setTintColor:(UIColor *)configDictionary[@"tintColor"]];
     }
     
     [[AWSSignInManager sharedInstance] setDontFederate];

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -20,11 +20,8 @@
 #import "AWSFormTableCell.h"
 #import "AWSTableInputCell.h"
 #import "AWSFormTableDelegate.h"
-#import "AWSUserPoolsUIHelper.h"
 #import "AWSSignInViewController.h"
 
-#define DEFAULT_BACKGROUND_COLOR_TOP [UIColor darkGrayColor]
-#define DEFAULT_BACKGROUND_COLOR_BOTTOM [UIColor whiteColor]
 #define NAVIGATION_BAR_HEIGHT 64
 
 static NSString *const RESOURCES_BUNDLE = @"AWSAuthUI.bundle";
@@ -240,13 +237,13 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         self.tableView.delegate = self.tableDelegate;
         self.tableView.dataSource = self.tableDelegate;
         [self.tableView reloadData];
-        Class AWSUserPoolsUIHelper = NSClassFromString(@"AWSUserPoolsUIHelper");
-        if ([AWSUserPoolsUIHelper respondsToSelector:@selector(setUpFormShadowForView:)]) {
-            [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+        Class AWSAuthUIHelper = NSClassFromString(@"AWSAuthUIHelper");
+        if ([AWSAuthUIHelper respondsToSelector:@selector(setUpFormShadowForView:)]) {
+            [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
         }
         
-        if ([AWSUserPoolsUIHelper respondsToSelector:@selector(setAWSUIConfiguration:)]) {
-            [AWSUserPoolsUIHelper setAWSUIConfiguration:self.config];
+        if ([AWSAuthUIHelper respondsToSelector:@selector(setAWSUIConfiguration:)]) {
+            [AWSAuthUIHelper setAWSUIConfiguration:self.config];
         }
         
         // Add SignInButton to the view
@@ -272,11 +269,11 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
             [self.signUpButton removeFromSuperview];
         }
         
-        // style buttons (tintColor)
-        if (self.config.tintColor) {
-            self.signInButton.backgroundColor = self.config.tintColor;
-            self.signUpButton.tintColor = self.config.tintColor;
-            self.forgotPasswordButton.tintColor = self.config.tintColor;
+        // style buttons (primary color)
+        if (self.config.primaryColor) {
+            self.signInButton.backgroundColor = self.config.primaryColor;
+            self.signUpButton.tintColor = self.config.primaryColor;
+            self.forgotPasswordButton.tintColor = self.config.primaryColor;
         }
         
     } else {
@@ -331,17 +328,10 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
 }
 
 - (void)setUpBackground:(UIColor *)color {
-    UIColor *backgroundColor = DEFAULT_BACKGROUND_COLOR_TOP;
-    UIColor *secondaryBackgroundColor = DEFAULT_BACKGROUND_COLOR_BOTTOM;
-    if (@available(iOS 13.0, *)) {
-        backgroundColor = [UIColor systemBackgroundColor];
-        secondaryBackgroundColor = [UIColor secondarySystemBackgroundColor];
-    }
-
     if (self.config.isBackgroundColorFullScreen) {
-        self.view.backgroundColor = color ?: backgroundColor;
+        self.view.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = self.config.backgroundBottomColor ?: secondaryBackgroundColor;
+        self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     }
     
     if (self.config.enableUserPoolsUI) {
@@ -349,7 +339,7 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         if (color != nil) {
             backgroundImageView.backgroundColor = color;
         } else {
-            backgroundImageView.backgroundColor = backgroundColor;
+            backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
         }
         backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         [self.view insertSubview:backgroundImageView atIndex:0];
@@ -369,6 +359,8 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
 }
 
 - (void)setUpNavigationController {
+    UIColor *textColor = [AWSAuthUIHelper getTextColor:config];
+
     self.navigationController.navigationBar.topItem.title = @"Sign In";
     self.canCancel = self.config.canCancel;
     if (self.canCancel) {
@@ -376,15 +368,16 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
                                                                          style:UIBarButtonItemStylePlain
                                                                         target:self
                                                                         action:@selector(barButtonClosePressed)];
-        cancelButton.tintColor = [UIColor whiteColor];
+        cancelButton.tintColor = textColor;
         self.navigationController.navigationBar.topItem.leftBarButtonItem = cancelButton;
     }
+    
     self.navigationController.navigationBar.titleTextAttributes = @{
-                                                                    NSForegroundColorAttributeName: [UIColor whiteColor],
+                                                                    NSForegroundColorAttributeName: textColor,
                                                                     };
     self.navigationController.navigationBar.translucent = NO;
-    self.navigationController.navigationBar.barTintColor = self.config.backgroundColor ?: DEFAULT_BACKGROUND_COLOR_TOP;
-    self.navigationController.navigationBar.tintColor = DEFAULT_BACKGROUND_COLOR_BOTTOM;
+    self.navigationController.navigationBar.barTintColor = [AWSAuthUIHelper getBackgroundColor:config];
+    self.navigationController.navigationBar.tintColor = textColor;
     
 }
 
@@ -424,8 +417,8 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         UIButton *btn = buttons[[buttonViews indexOfObject:signInButtonViewClass]];
         UIView<AWSSignInButtonView> *buttonView = [[signInButtonViewClass alloc] initWithFrame:CGRectMake(0, 0, btn.frame.size.width, btn.frame.size.height)];
         buttonView.buttonStyle = AWSSignInButtonStyleLarge;
-        if (self.config.tintColor) {
-            buttonView.backgroundColor = self.config.tintColor;
+        if (self.config.primaryColor) {
+            buttonView.backgroundColor = self.config.primaryColor;
         }
         buttonView.delegate = self;
         

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -271,6 +271,14 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         } else {
             [self.signUpButton removeFromSuperview];
         }
+        
+        // style buttons (tintColor)
+        if (self.config.tintColor) {
+            self.signInButton.backgroundColor = self.config.tintColor;
+            self.signUpButton.tintColor = self.config.tintColor;
+            self.forgotPasswordButton.tintColor = self.config.tintColor;
+        }
+        
     } else {
         [self.tableFormView removeFromSuperview];
         self.orSignInWithLabel.text = @"Sign in with";
@@ -323,10 +331,17 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
 }
 
 - (void)setUpBackground:(UIColor *)color {
+    UIColor *backgroundColor = DEFAULT_BACKGROUND_COLOR_TOP;
+    UIColor *secondaryBackgroundColor = DEFAULT_BACKGROUND_COLOR_BOTTOM;
+    if (@available(iOS 13.0, *)) {
+        backgroundColor = [UIColor systemBackgroundColor];
+        secondaryBackgroundColor = [UIColor secondarySystemBackgroundColor];
+    }
+
     if (self.config.isBackgroundColorFullScreen) {
-        self.view.backgroundColor = color ?: DEFAULT_BACKGROUND_COLOR_TOP;
+        self.view.backgroundColor = color ?: backgroundColor;
     } else {
-        self.view.backgroundColor = DEFAULT_BACKGROUND_COLOR_BOTTOM;
+        self.view.backgroundColor = self.config.backgroundBottomColor ?: secondaryBackgroundColor;
     }
     
     if (self.config.enableUserPoolsUI) {
@@ -334,7 +349,7 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         if (color != nil) {
             backgroundImageView.backgroundColor = color;
         } else {
-            backgroundImageView.backgroundColor = DEFAULT_BACKGROUND_COLOR_TOP;
+            backgroundImageView.backgroundColor = backgroundColor;
         }
         backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         [self.view insertSubview:backgroundImageView atIndex:0];
@@ -409,6 +424,9 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         UIButton *btn = buttons[[buttonViews indexOfObject:signInButtonViewClass]];
         UIView<AWSSignInButtonView> *buttonView = [[signInButtonViewClass alloc] initWithFrame:CGRectMake(0, 0, btn.frame.size.width, btn.frame.size.height)];
         buttonView.buttonStyle = AWSSignInButtonStyleLarge;
+        if (self.config.tintColor) {
+            buttonView.backgroundColor = self.config.tintColor;
+        }
         buttonView.delegate = self;
         
         [btn addSubview:buttonView];

--- a/AWSAuthSDK/Sources/AWSAuthUI/SignIn.storyboard
+++ b/AWSAuthSDK/Sources/AWSAuthUI/SignIn.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,15 +20,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IkO-GD-xvp">
-                                <rect key="frame" x="47.5" y="336" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="47.5" y="318" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="280" id="UmK-eX-imF"/>
-                                    <constraint firstAttribute="height" constant="35" id="kTS-QO-wG8"/>
+                                    <constraint firstAttribute="height" constant="40" id="kTS-QO-wG8"/>
                                 </constraints>
                                 <state key="normal" title="Sign In">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" systemColor="systemGrayColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="layer.maskToBounds" value="YES"/>
@@ -40,75 +38,74 @@
                                 </userDefinedRuntimeAttributes>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cMG-il-Rxs">
-                                <rect key="frame" x="16" y="376" width="167.5" height="27"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <rect key="frame" x="16" y="368" width="167.5" height="28"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <state key="normal" title="Create new account">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bl8-r9-Ysa">
+                                <rect key="frame" x="191.5" y="368" width="167.5" height="28"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <state key="normal" title="Forgot your password?">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                            </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DRt-0S-n1y" userLabel="Left Horizontal Bar">
-                                <rect key="frame" x="16" y="419.5" width="112" height="1"/>
+                                <rect key="frame" x="16" y="412.5" width="113.5" height="1"/>
                                 <color key="backgroundColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="2qA-yh-cev"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cbu-Mw-6RD" userLabel="Right Horizontal Bar">
-                                <rect key="frame" x="247" y="419.5" width="112" height="1"/>
+                                <rect key="frame" x="245.5" y="412.5" width="113.5" height="1"/>
                                 <color key="backgroundColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="3N7-7L-emb"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or sign in with" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oXD-JT-iR2">
-                                <rect key="frame" x="136" y="411" width="103" height="18"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                <color key="textColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="137.5" y="404" width="100" height="18"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                <color key="textColor" systemColor="tertiaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bl8-r9-Ysa">
-                                <rect key="frame" x="191.5" y="376" width="167.5" height="27"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <state key="normal" title="Forgot your password?">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                            </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S1T-RK-06i">
-                                <rect key="frame" x="16" y="20" width="343" height="0.0"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="0.0"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="C4Q-l4-qCO">
-                                <rect key="frame" x="16" y="30" width="343" height="140"/>
+                                <rect key="frame" x="16" y="10" width="343" height="140"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="140" id="69B-iV-vXW"/>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8lZ-tI-ceJ">
-                                <rect key="frame" x="47.5" y="178" width="280" height="150"/>
+                                <rect key="frame" x="47.5" y="158" width="280" height="150"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="R0w-bP-9eV">
                                         <rect key="frame" x="4" y="4" width="271" height="142"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="Rbi-NZ-Uh5" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="271" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Rbi-NZ-Uh5" id="HkR-c7-hhs">
-                                                    <rect key="frame" x="0.0" y="0.0" width="271" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="271" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xVu-TI-i2u">
                                                             <rect key="frame" x="0.0" y="0.0" width="271" height="37"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B1j-jz-tSY">
+                                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B1j-jz-tSY">
                                                                     <rect key="frame" x="8" y="14" width="255" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="B1j-jz-tSY" firstAttribute="top" secondItem="xVu-TI-i2u" secondAttribute="top" constant="14" id="0Zu-8z-O5B"/>
                                                                 <constraint firstItem="B1j-jz-tSY" firstAttribute="trailing" secondItem="xVu-TI-i2u" secondAttribute="trailingMargin" id="8g7-3u-FNb"/>
@@ -116,11 +113,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="unJ-u8-DYw">
-                                                            <rect key="frame" x="0.0" y="60" width="271" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="271" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="r7a-4e-Qv0">
                                                                     <rect key="frame" x="8" y="3" width="255" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -129,7 +125,7 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                            <color key="tintColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                             <constraints>
                                                                 <constraint firstItem="r7a-4e-Qv0" firstAttribute="top" secondItem="unJ-u8-DYw" secondAttribute="top" constant="3" id="L6b-nV-zmu"/>
                                                                 <constraint firstItem="r7a-4e-Qv0" firstAttribute="leading" secondItem="unJ-u8-DYw" secondAttribute="leadingMargin" id="LoW-uC-eZi"/>
@@ -137,16 +133,15 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P0j-LZ-SLU">
-                                                            <rect key="frame" x="0.0" y="0.0" width="271" height="74.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="271" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="db7-Ph-RET">
-                                                                    <rect key="frame" x="13" y="28" width="250" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="250" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="db7-Ph-RET" firstAttribute="bottom" secondItem="P0j-LZ-SLU" secondAttribute="bottomMargin" id="Zek-i7-2hc"/>
                                                                 <constraint firstItem="db7-Ph-RET" firstAttribute="top" secondItem="P0j-LZ-SLU" secondAttribute="topMargin" id="bsp-sp-AdR"/>
@@ -155,6 +150,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="xVu-TI-i2u" secondAttribute="trailing" id="2OW-Ag-8Fg"/>
                                                         <constraint firstItem="xVu-TI-i2u" firstAttribute="leading" secondItem="HkR-c7-hhs" secondAttribute="leading" id="2sH-ZM-411"/>
@@ -183,14 +179,15 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                                <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="280" id="9WQ-vQ-rQE"/>
                                     <constraint firstAttribute="height" constant="150" id="zys-vp-19s"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jyk-z8-NkG">
-                                <rect key="frame" x="47.5" y="485" width="280" height="40"/>
+                                <rect key="frame" x="47.5" y="478" width="280" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="6Kt-TZ-ALm"/>
                                     <constraint firstAttribute="height" constant="40" id="lKw-a6-kGk"/>
@@ -208,7 +205,7 @@
                                 </variation>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xK4-QM-voz">
-                                <rect key="frame" x="47.5" y="437" width="280" height="40"/>
+                                <rect key="frame" x="47.5" y="430" width="280" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="0lC-Yd-Hj0"/>
                                     <constraint firstAttribute="width" constant="280" id="U76-ZU-UHt"/>
@@ -226,7 +223,7 @@
                                 </variation>
                             </button>
                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Utd-qw-giI">
-                                <rect key="frame" x="47.5" y="533" width="280" height="40"/>
+                                <rect key="frame" x="47.5" y="526" width="280" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="71S-dD-q9S"/>
                                     <constraint firstAttribute="width" constant="280" id="ExG-9m-gcO"/>
@@ -244,7 +241,7 @@
                                 </variation>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="cMG-il-Rxs" firstAttribute="width" secondItem="bl8-r9-Ysa" secondAttribute="width" id="2Cc-uu-9Oz"/>
                             <constraint firstItem="C4Q-l4-qCO" firstAttribute="top" secondItem="iDn-EW-gbn" secondAttribute="bottom" constant="10" id="4OM-G4-lBy"/>
@@ -254,11 +251,11 @@
                             <constraint firstAttribute="trailingMargin" secondItem="Cbu-Mw-6RD" secondAttribute="trailing" id="DwQ-lt-FYP"/>
                             <constraint firstItem="Utd-qw-giI" firstAttribute="leading" secondItem="jyk-z8-NkG" secondAttribute="leading" id="H3y-fy-sx7"/>
                             <constraint firstItem="Cbu-Mw-6RD" firstAttribute="leading" secondItem="oXD-JT-iR2" secondAttribute="trailing" constant="8" symbolic="YES" id="ItQ-JO-rAp"/>
-                            <constraint firstItem="cMG-il-Rxs" firstAttribute="top" secondItem="IkO-GD-xvp" secondAttribute="bottom" constant="5" id="J70-5p-G0w"/>
+                            <constraint firstItem="cMG-il-Rxs" firstAttribute="top" secondItem="IkO-GD-xvp" secondAttribute="bottom" constant="10" id="J70-5p-G0w"/>
                             <constraint firstItem="Utd-qw-giI" firstAttribute="top" secondItem="jyk-z8-NkG" secondAttribute="bottom" constant="8" symbolic="YES" id="KV3-jp-6N3"/>
                             <constraint firstItem="xK4-QM-voz" firstAttribute="top" secondItem="oXD-JT-iR2" secondAttribute="bottom" constant="8" symbolic="YES" id="Nkw-5h-fyV"/>
                             <constraint firstItem="8lZ-tI-ceJ" firstAttribute="top" secondItem="C4Q-l4-qCO" secondAttribute="bottom" constant="8" symbolic="YES" id="OhP-Az-vWQ"/>
-                            <constraint firstItem="IkO-GD-xvp" firstAttribute="top" secondItem="8lZ-tI-ceJ" secondAttribute="bottom" constant="8" symbolic="YES" id="Ovg-yb-uYe"/>
+                            <constraint firstItem="IkO-GD-xvp" firstAttribute="top" secondItem="8lZ-tI-ceJ" secondAttribute="bottom" constant="10" id="Ovg-yb-uYe"/>
                             <constraint firstItem="S1T-RK-06i" firstAttribute="leading" secondItem="n6k-Ut-fuw" secondAttribute="leadingMargin" id="TBQ-kj-KwZ"/>
                             <constraint firstItem="oXD-JT-iR2" firstAttribute="top" secondItem="cMG-il-Rxs" secondAttribute="bottom" constant="8" symbolic="YES" id="XQu-Hf-Ljn"/>
                             <constraint firstItem="Cbu-Mw-6RD" firstAttribute="top" secondItem="DRt-0S-n1y" secondAttribute="top" id="Z6Q-o6-9eB"/>

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
@@ -14,22 +14,22 @@ import Foundation
     @objc public let logoImage: UIImage?
     /// The background color of the sign-in screen.
     @objc public let backgroundColor: UIColor?
-    /// The background color applited to the bottom panel of the sign-in screen.
-    @objc public let backgroundBottomColor: UIColor?
-    /// The view tint (foreground) color used for highlighted elements (button background, links).
-    @objc public let tintColor: UIColor?
+    /// The secondary background color. It's applied to the bottom panel of the sign-in screen.
+    @objc public let secondaryBackgroundColor: UIColor?
+    /// The view primary color used for highlighted elements (button background, links).
+    @objc public let primaryColor: UIColor?
     
     /// Initializer for the drop-in UI configuration.
     @objc public init(canCancel: Bool = false,
                       logoImage: UIImage? = nil,
                       backgroundColor: UIColor? = nil,
-                      backgroundBottomColor: UIColor? = nil,
-                      tintColor: UIColor? = .systemBlue) {
+                      secondaryBackgroundColor: UIColor? = nil,
+                      primaryColor: UIColor? = .systemBlue) {
         self.canCancel = canCancel
         self.logoImage = logoImage
         self.backgroundColor = backgroundColor
-        self.backgroundBottomColor = backgroundBottomColor
-        self.tintColor = tintColor
+        self.secondaryBackgroundColor = secondaryBackgroundColor
+        self.primaryColor = primaryColor
     }
 }
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
@@ -14,18 +14,22 @@ import Foundation
     @objc public let logoImage: UIImage?
     /// The background color of the sign-in screen.
     @objc public let backgroundColor: UIColor?
-    
+    /// The background color applited to the bottom panel of the sign-in screen.
+    @objc public let backgroundBottomColor: UIColor?
+    /// The view tint (foreground) color used for highlighted elements (button background, links).
+    @objc public let tintColor: UIColor?
     
     /// Initializer for the drop-in UI configuration.
-    ///
-    /// - Parameters:
-    ///   - canCancel: If set to true, the end user can cancel the sign-in operation and go back to previous view controller.
-    ///   - logoImage: The logo image to be displayed on the sign-in screen.
-    ///   - backgroundColor: The background color of the sign-in screen.
-    @objc public init(canCancel: Bool = false,logoImage: UIImage? = nil, backgroundColor: UIColor? = nil) {
+    @objc public init(canCancel: Bool = false,
+                      logoImage: UIImage? = nil,
+                      backgroundColor: UIColor? = nil,
+                      backgroundBottomColor: UIColor? = nil,
+                      tintColor: UIColor? = .systemBlue) {
         self.canCancel = canCancel
         self.logoImage = logoImage
         self.backgroundColor = backgroundColor
+        self.backgroundBottomColor = backgroundBottomColor
+        self.tintColor = tintColor
     }
 }
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m
@@ -145,8 +145,8 @@ signInUIConfiguration:(SignInUIOptions *)signInUIConfiguration
         NSMutableDictionary<NSString *, id> *parameters = [NSMutableDictionary new];
         parameters[@"logoImage"] = signInUIConfiguration.logoImage;
         parameters[@"backgroundColor"] = signInUIConfiguration.backgroundColor;
-        parameters[@"backgroundBottomColor"] = signInUIConfiguration.backgroundBottomColor;
-        parameters[@"tintColor"] = signInUIConfiguration.tintColor;
+        parameters[@"secondaryBackgroundColor"] = signInUIConfiguration.secondaryBackgroundColor;
+        parameters[@"primaryColor"] = signInUIConfiguration.primaryColor;
         parameters[@"navigationController"] = navController;
         parameters[@"canCancel"] = signInUIConfiguration.canCancel ? @"YES" : @"NO";
         

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m
@@ -145,6 +145,8 @@ signInUIConfiguration:(SignInUIOptions *)signInUIConfiguration
         NSMutableDictionary<NSString *, id> *parameters = [NSMutableDictionary new];
         parameters[@"logoImage"] = signInUIConfiguration.logoImage;
         parameters[@"backgroundColor"] = signInUIConfiguration.backgroundColor;
+        parameters[@"backgroundBottomColor"] = signInUIConfiguration.backgroundBottomColor;
+        parameters[@"tintColor"] = signInUIConfiguration.tintColor;
         parameters[@"navigationController"] = navController;
         parameters[@"canCancel"] = signInUIConfiguration.canCancel ? @"YES" : @"NO";
         

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import "AWSFormTableCell.h"
 #import "AWSTableInputCell.h"
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.m
@@ -92,7 +92,7 @@
                          forState:UIControlStateNormal];
     }
     if (formCell.inputType == InputTypeStaticText) {
-        inputCell.placeHolderView.hidden = YES;
+        [inputCell showHeaderLabel:YES];
         inputCell.inputBox.text = formCell.staticText;
     }
     

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.m
@@ -61,8 +61,8 @@
 }
 
 - (void)setButtonFont:(UIButton *)button {
-    if ([AWSUserPoolsUIHelper getAWSUIConfiguration].font != nil) {
-        button.titleLabel.font = [AWSUserPoolsUIHelper getAWSUIConfiguration].font;
+    if ([AWSAuthUIHelper getAWSUIConfiguration].font != nil) {
+        button.titleLabel.font = [AWSAuthUIHelper getAWSUIConfiguration].font;
     } else {
         button.titleLabel.font = [UIFont systemFontOfSize:14.0];
     }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setAWSTableInputCellFont;
 
+- (void)showHeaderLabel:(BOOL)visible;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.m
@@ -20,44 +20,42 @@
 // Handle event when user finishes inputting text into a text field
 - (IBAction)textEditingDidEnd:(id)sender {
     if ([self.inputBox.text isEqual: @""]) {
+        [self showHeaderLabel:NO];
+    }
+}
+
+- (IBAction)textEditingDidBegin:(id)sender {
+    [self showHeaderLabel:YES];
+}
+
+- (void)onTap {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self showHeaderLabel:YES];
+        [self.inputBox becomeFirstResponder];
+    });
+}
+
+- (void)showHeaderLabel:(BOOL)visible {
+    if (visible && self.headerLabel.hidden) {
+        [UIView transitionWithView:self.placeHolderView
+                          duration:0.3
+                           options:UIViewAnimationOptionTransitionCrossDissolve
+                        animations:^{
+                            self.placeHolderView.hidden = YES;
+                            self.headerLabel.hidden = NO;
+                            self.inputBox.hidden = NO;
+                        }
+                        completion:nil];
+    } else if (!visible && self.placeHolderView.isHidden) {
         self.placeHolderView.alpha = 0;
         self.placeHolderView.hidden = NO;
-        [UIView animateWithDuration:0.5
+        [UIView animateWithDuration:0.3
                          animations:^{
                              self.placeHolderView.alpha = 1;
                              self.headerLabel.hidden = YES;
                              self.inputBox.hidden = YES;
                          }];
     }
-}
-
-- (IBAction)textEditingDidBegin:(id)sender {
-    if (!self.placeHolderView.isHidden) {
-        [self onTap];
-    }
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    // handle the case where the just added input has pre-set content
-    // so we can re-use the placeholder/label animation provided by onTap
-    if (![self.inputBox.text isEqual: @""] && self.placeHolderView.isHidden) {
-        [self onTap];
-    }
-}
-
-- (void)onTap {
-    dispatch_async(dispatch_get_main_queue(), ^{
-       [UIView transitionWithView:self.placeHolderView
-                         duration:0.5
-                          options:UIViewAnimationOptionTransitionCrossDissolve
-                       animations:^{
-                           self.placeHolderView.hidden = YES;
-                           self.headerLabel.hidden = NO;
-                           self.inputBox.hidden = NO;
-                       } completion:nil];
-        [self.inputBox becomeFirstResponder];
-    });
 }
 
 - (void)setAWSTableInputCellFont {

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.m
@@ -61,7 +61,7 @@
 }
 
 - (void)setAWSTableInputCellFont {
-    UIFont *font = [AWSUserPoolsUIHelper getFont:[AWSUserPoolsUIHelper getAWSUIConfiguration]];
+    UIFont *font = [AWSAuthUIHelper getFont:[AWSAuthUIHelper getAWSUIConfiguration]];
     if (font != nil) {
         [self.placeHolderLabel setFont:font];
         [self.headerLabel setFont:font];

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.m
@@ -36,7 +36,15 @@
         [self onTap];
     }
 }
-    
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    // handle the case where the just added input has pre-set content
+    // so we can re-use the placeholder/label animation provided by onTap
+    if (![self.inputBox.text isEqual: @""] && self.placeHolderView.isHidden) {
+        [self onTap];
+    }
+}
 
 - (void)onTap {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nonatomic) IBOutlet UIView *tableFormView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+@property (weak, nonatomic) IBOutlet UIButton *forgotPasswordButton;
 @property (strong, nonatomic) id<AWSUIConfiguration> config;
 
 @end
@@ -31,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nonatomic) IBOutlet UIView *tableFormView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+@property (weak, nonatomic) IBOutlet UIButton *updatePasswordButton;
 @property (strong, nonatomic) id<AWSUIConfiguration> config;
 
 @end

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.m
@@ -17,7 +17,7 @@
 #import <AWSUserPoolsSignIn/AWSUserPoolsSignIn.h>
 #import "AWSFormTableCell.h"
 #import "AWSFormTableDelegate.h"
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 #import <AWSAuthCore/AWSUIConfiguration.h>
 
 @interface AWSUserPoolForgotPasswordViewController ()
@@ -66,24 +66,24 @@
     self.tableView.delegate = self.tableDelegate;
     self.tableView.dataSource = self.tableDelegate;
     [self.tableView reloadData];
-    [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+    [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
     
     // setup button background
-    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
-                                            toView:self.forgotPasswordButton];
+    [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
+                                          toView:self.forgotPasswordButton];
 }
 
 - (void)setUpBackground {
-    if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    if ([AWSAuthUIHelper isBackgroundColorFullScreen:self.config]) {
+        self.view.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
+        self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     }
     
     self.title = @"Forgot Password";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
-    backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self.view insertSubview:backgroundImageView atIndex:0];
 }
@@ -160,24 +160,24 @@
     self.tableView.delegate = self.tableDelegate;
     self.tableView.dataSource = self.tableDelegate;
     [self.tableView reloadData];
-    [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+    [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
     
     // setup button background
-    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
-                                            toView:self.updatePasswordButton];
+    [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
+                                          toView:self.updatePasswordButton];
 }
 
 - (void)setUpBackground {
-    if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    if ([AWSAuthUIHelper isBackgroundColorFullScreen:self.config]) {
+        self.view.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
+        self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     }
     
     self.title = @"Forgot Password";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
-    backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self.view insertSubview:backgroundImageView atIndex:0];
 }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.m
@@ -68,13 +68,17 @@
     [self.tableView reloadData];
     [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
+    
+    // setup button background
+    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
+                                            toView:self.forgotPasswordButton];
 }
 
 - (void)setUpBackground {
     if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
         self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [UIColor whiteColor];
+        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
     }
     
     self.title = @"Forgot Password";
@@ -158,13 +162,17 @@
     [self.tableView reloadData];
     [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
+    
+    // setup button background
+    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
+                                            toView:self.updatePasswordButton];
 }
 
 - (void)setUpBackground {
     if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
         self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [UIColor whiteColor];
+        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
     }
     
     self.title = @"Forgot Password";

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolForgotPasswordViewController.m
@@ -92,6 +92,7 @@
 
     if([@"NewPasswordSegue" isEqualToString:segue.identifier]){
         AWSUserPoolNewPasswordViewController * confirmForgot = segue.destinationViewController;
+        confirmForgot.config = self.config;
         confirmForgot.user = self.user;
     }
 }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolMFAViewController.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolMFAViewController.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UIView *tableFormView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
 @property (weak, nonatomic) IBOutlet UILabel *codeSentTo;
+@property (weak, nonatomic) IBOutlet UIButton *signInButton;
 @property (strong, nonatomic) id<AWSUIConfiguration> config;
 
 @end

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolMFAViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolMFAViewController.m
@@ -62,13 +62,17 @@
     [self.tableView reloadData];
     [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
+    
+    // setup button background
+    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
+                                            toView:self.signInButton];
 }
 
 - (void)setUpBackground {
     if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
         self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [UIColor whiteColor];
+        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
     }
     
     self.title = @"MFA";

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolMFAViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolMFAViewController.m
@@ -17,7 +17,7 @@
 
 #import "AWSFormTableCell.h"
 #import "AWSFormTableDelegate.h"
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 #import <AWSAuthCore/AWSUIConfiguration.h>
 
 @interface AWSUserPoolMFAViewController () 
@@ -60,24 +60,24 @@
     self.tableView.delegate = self.tableDelegate;
     self.tableView.dataSource = self.tableDelegate;
     [self.tableView reloadData];
-    [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+    [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
     
     // setup button background
-    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
-                                            toView:self.signInButton];
+    [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
+                                          toView:self.signInButton];
 }
 
 - (void)setUpBackground {
-    if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    if ([AWSAuthUIHelper isBackgroundColorFullScreen:self.config]) {
+        self.view.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
+        self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     }
     
     self.title = @"MFA";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
-    backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self.view insertSubview:backgroundImageView atIndex:0];
 }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolNewPasswordRequiredViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolNewPasswordRequiredViewController.m
@@ -17,7 +17,7 @@
 #import "AWSUserPoolNewPasswordRequiredViewController.h"
 #import "AWSFormTableCell.h"
 #import "AWSFormTableDelegate.h"
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 #import <AWSAuthCore/AWSUIConfiguration.h>
 
 @interface AWSUserPoolNewPasswordRequiredViewController ()
@@ -54,20 +54,20 @@
     self.tableView.delegate = self.tableDelegate;
     self.tableView.dataSource = self.tableDelegate;
     [self.tableView reloadData];
-    [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+    [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
 }
 
 - (void)setUpBackground {
-    if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    if ([AWSAuthUIHelper isBackgroundColorFullScreen:self.config]) {
+        self.view.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
+        self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     }
     
     self.title = @"New Password Required";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
-    backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self.view insertSubview:backgroundImageView atIndex:0];
 }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolNewPasswordRequiredViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolNewPasswordRequiredViewController.m
@@ -62,7 +62,7 @@
     if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
         self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [UIColor whiteColor];
+        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
     }
     
     self.title = @"New Password Required";

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.h
@@ -25,7 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UIView *formView;
 @property (weak, nonatomic) IBOutlet UIView *tableFormView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+@property (weak, nonatomic) IBOutlet UIButton *signUpButton;
 @property (strong, nonatomic) id<AWSUIConfiguration> config;
+
 
 @end
 
@@ -33,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nonatomic) IBOutlet UIView *tableFormView;
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
+@property (weak, nonatomic) IBOutlet UIButton *requestCodeButton;
+@property (weak, nonatomic) IBOutlet UIButton *confirmButton;
 @property (strong, nonatomic) id<AWSUIConfiguration> config;
 
 @end

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.m
@@ -21,7 +21,7 @@
 #import "AWSFormTableCell.h"
 #import "AWSTableInputCell.h"
 #import "AWSFormTableDelegate.h"
-#import "AWSUserPoolsUIHelper.h"
+#import "AWSAuthUIHelper.h"
 #import <AWSAuthCore/AWSSignInManager.h>
 #import <AWSAuthCore/AWSUIConfiguration.h>
 
@@ -93,24 +93,24 @@ id<AWSUIConfiguration> config = nil;
     self.tableView.delegate = self.tableDelegate;
     self.tableView.dataSource = self.tableDelegate;
     [self.tableView reloadData];
-    [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+    [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
 
     // setup button background
-    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
-                                            toView:self.signUpButton];
+    [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
+                                          toView:self.signUpButton];
 }
 
 - (void)setUpBackground {
-    if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    if ([AWSAuthUIHelper isBackgroundColorFullScreen:self.config]) {
+        self.view.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
+        self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     }
     
     self.title = @"Sign Up";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
-    backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self.view insertSubview:backgroundImageView atIndex:0];
 }
@@ -239,22 +239,22 @@ id<AWSUIConfiguration> config = nil;
     self.tableView.delegate = self.tableDelegate;
     self.tableView.dataSource = self.tableDelegate;
     [self.tableView reloadData];
-    [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
+    [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
     
     // setup button background
-    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
-                                            toView:self.confirmButton];
-    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
-                                            toView:self.requestCodeButton
-                                        background:NO];
+    [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
+                                          toView:self.confirmButton];
+    [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
+                                          toView:self.requestCodeButton
+                                           background:NO];
 }
 
 - (void)setUpBackground {
-    self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
+    self.view.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
     self.title = @"Confirm";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
-    backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
+    backgroundImageView.backgroundColor = [AWSAuthUIHelper getBackgroundColor:self.config];
     backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     [self.view insertSubview:backgroundImageView atIndex:0];
 }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.m
@@ -13,6 +13,9 @@
 // permissions and limitations under the License.
 //
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 #import "AWSUserPoolSignUpViewController.h"
 #import <AWSUserPoolsSignIn/AWSUserPoolsSignIn.h>
 #import "AWSFormTableCell.h"
@@ -21,7 +24,6 @@
 #import "AWSUserPoolsUIHelper.h"
 #import <AWSAuthCore/AWSSignInManager.h>
 #import <AWSAuthCore/AWSUIConfiguration.h>
-
 
 @interface AWSSignInManager()
     
@@ -93,13 +95,17 @@ id<AWSUIConfiguration> config = nil;
     [self.tableView reloadData];
     [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
+
+    // setup button background
+    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
+                                            toView:self.signUpButton];
 }
 
 - (void)setUpBackground {
     if ([AWSUserPoolsUIHelper isBackgroundColorFullScreen:self.config]) {
         self.view.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];
     } else {
-        self.view.backgroundColor = [UIColor whiteColor];
+        self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
     }
     
     self.title = @"Sign Up";
@@ -235,10 +241,17 @@ id<AWSUIConfiguration> config = nil;
     [self.tableView reloadData];
     [AWSUserPoolsUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
+    
+    // setup button background
+    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
+                                            toView:self.confirmButton];
+    [AWSUserPoolsUIHelper applyTintColorFromConfig:self.config
+                                            toView:self.requestCodeButton
+                                        background:NO];
 }
 
 - (void)setUpBackground {
-    self.view.backgroundColor = [UIColor whiteColor];
+    self.view.backgroundColor = [AWSUserPoolsUIHelper getDefaultBackgroundColor];
     self.title = @"Confirm";
     UIImageView *backgroundImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.tableFormView.center.y)];
     backgroundImageView.backgroundColor = [AWSUserPoolsUIHelper getBackgroundColor:self.config];

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolSignUpViewController.m
@@ -119,6 +119,7 @@ id<AWSUIConfiguration> config = nil;
     if([@"SignUpConfirmSegue" isEqualToString:segue.identifier]){
         UserPoolSignUpConfirmationViewController *signUpConfirmationViewController = segue.destinationViewController;
         signUpConfirmationViewController.sentTo = self.sentTo;
+        signUpConfirmationViewController.config = self.config;
         NSString *userName = [self.tableDelegate getValueForCell:self.userNameRow forTableView:self.tableView];
         signUpConfirmationViewController.user = [self.pool getUser:userName];
     }
@@ -241,13 +242,13 @@ id<AWSUIConfiguration> config = nil;
     [self.tableView reloadData];
     [AWSAuthUIHelper setUpFormShadowForView:self.tableFormView];
     [self setUpBackground];
-    
+
     // setup button background
     [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
                                           toView:self.confirmButton];
     [AWSAuthUIHelper applyPrimaryColorFromConfig:self.config
                                           toView:self.requestCodeButton
-                                           background:NO];
+                                      background:NO];
 }
 
 - (void)setUpBackground {

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPools.storyboard
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPools.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SfA-Z0-41u">
-    <device id="retina4_0" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SfA-Z0-41u">
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,7 +13,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="SfA-Z0-41u" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="0b4-Wk-FS7">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -33,21 +31,21 @@
                         <viewControllerLayoutGuide type="bottom" id="FoP-6q-Q3y"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="sSU-fu-YjH">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rNd-yF-2B4">
-                                <rect key="frame" x="20" y="72" width="280" height="150"/>
+                                <rect key="frame" x="20" y="52" width="280" height="150"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="edb-ci-ykg">
                                         <rect key="frame" x="4" y="4" width="272" height="142"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="fwK-jt-Xtf" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="272" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fwK-jt-Xtf" id="obo-ab-0XQ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n5E-F6-uaf">
@@ -56,11 +54,10 @@
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7ja-4S-nQr">
                                                                     <rect key="frame" x="8" y="14" width="256" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="7ja-4S-nQr" firstAttribute="top" secondItem="n5E-F6-uaf" secondAttribute="top" constant="14" id="42a-tq-B49"/>
                                                                 <constraint firstItem="7ja-4S-nQr" firstAttribute="leading" secondItem="n5E-F6-uaf" secondAttribute="leadingMargin" id="QYi-kK-eal"/>
@@ -68,11 +65,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="blF-aZ-gDg">
-                                                            <rect key="frame" x="0.0" y="60" width="272" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="272" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="k9u-Wx-2M7">
                                                                     <rect key="frame" x="8" y="3" width="256" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -81,7 +77,6 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="k9u-Wx-2M7" firstAttribute="leading" secondItem="blF-aZ-gDg" secondAttribute="leadingMargin" id="sQC-1M-4nN"/>
                                                                 <constraint firstItem="k9u-Wx-2M7" firstAttribute="top" secondItem="blF-aZ-gDg" secondAttribute="top" constant="3" id="yxb-Dg-X3N"/>
@@ -89,16 +84,15 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ucJ-eD-Vnl">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XN1-C4-U1G">
-                                                                    <rect key="frame" x="13" y="28" width="251" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="251" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="XN1-C4-U1G" firstAttribute="trailing" secondItem="ucJ-eD-Vnl" secondAttribute="trailingMargin" id="1Wf-hL-h5M"/>
                                                                 <constraint firstItem="XN1-C4-U1G" firstAttribute="leading" secondItem="ucJ-eD-Vnl" secondAttribute="leadingMargin" constant="5" id="HmJ-ms-xGY"/>
@@ -107,6 +101,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="bottom" secondItem="ucJ-eD-Vnl" secondAttribute="bottom" id="2JG-nc-kMQ"/>
                                                         <constraint firstAttribute="bottomMargin" secondItem="blF-aZ-gDg" secondAttribute="bottom" constant="-9" id="4Vr-5T-CGv"/>
@@ -136,7 +131,7 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="edb-ci-ykg" firstAttribute="leading" secondItem="rNd-yF-2B4" secondAttribute="leading" constant="4" id="6uS-PA-PS7"/>
                                     <constraint firstAttribute="height" constant="150" id="78D-H4-0zE"/>
@@ -146,20 +141,19 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please enter the confirmation code and your new password" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dCa-0T-Vfu">
-                                <rect key="frame" x="20" y="28" width="280" height="36"/>
+                                <rect key="frame" x="20" y="8" width="280" height="36"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wON-mn-kGn">
-                                <rect key="frame" x="20" y="242" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="20" y="212" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="280" id="0vc-1G-glU"/>
-                                    <constraint firstAttribute="height" constant="35" id="nZH-yo-0I9"/>
+                                    <constraint firstAttribute="height" constant="40" id="nZH-yo-0I9"/>
                                 </constraints>
                                 <state key="normal" title="Update Password">
-                                    <color key="titleColor" red="0.9951923077" green="0.9903846154" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -175,7 +169,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="wON-mn-kGn" firstAttribute="trailing" secondItem="rNd-yF-2B4" secondAttribute="trailing" id="2PW-bi-tEd"/>
                             <constraint firstItem="dCa-0T-Vfu" firstAttribute="top" secondItem="FqQ-ca-9Q7" secondAttribute="bottom" constant="8" symbolic="YES" id="BiD-he-mnr"/>
@@ -186,12 +180,13 @@
                             <constraint firstItem="dCa-0T-Vfu" firstAttribute="centerX" secondItem="sSU-fu-YjH" secondAttribute="centerX" id="fb0-Da-5Lc"/>
                             <constraint firstItem="wON-mn-kGn" firstAttribute="centerX" secondItem="rNd-yF-2B4" secondAttribute="centerX" id="oM2-On-F43"/>
                             <constraint firstItem="dCa-0T-Vfu" firstAttribute="centerX" secondItem="rNd-yF-2B4" secondAttribute="centerX" id="u30-Hx-FMQ"/>
-                            <constraint firstItem="wON-mn-kGn" firstAttribute="top" secondItem="rNd-yF-2B4" secondAttribute="bottom" constant="20" id="vHz-O0-imV"/>
+                            <constraint firstItem="wON-mn-kGn" firstAttribute="top" secondItem="rNd-yF-2B4" secondAttribute="bottom" constant="10" id="vHz-O0-imV"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="tableFormView" destination="rNd-yF-2B4" id="gwo-OG-TXa"/>
                         <outlet property="tableView" destination="edb-ci-ykg" id="kEN-Om-5K2"/>
+                        <outlet property="updatePasswordButton" destination="wON-mn-kGn" id="gsl-kA-9nY"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="F6y-iP-DcK" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -213,33 +208,32 @@
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HJa-Cc-KSk">
                                 <rect key="frame" x="16" y="53" width="343" height="0.0"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ynd-Ed-kPb">
                                 <rect key="frame" x="20" y="46" width="280" height="300"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="tlm-ET-L8c">
                                         <rect key="frame" x="4" y="4" width="272" height="292"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="WTQ-Mh-Km6" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="272" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WTQ-Mh-Km6" id="YR1-zk-gsR">
-                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CWK-NZ-N7r">
                                                             <rect key="frame" x="0.0" y="0.0" width="272" height="37"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zwg-Dm-73n">
+                                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zwg-Dm-73n">
                                                                     <rect key="frame" x="8" y="14" width="256" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="zwg-Dm-73n" firstAttribute="top" secondItem="CWK-NZ-N7r" secondAttribute="top" constant="14" id="2jt-fb-5dX"/>
                                                                 <constraint firstItem="zwg-Dm-73n" firstAttribute="leading" secondItem="CWK-NZ-N7r" secondAttribute="leadingMargin" id="EGS-72-PzF"/>
@@ -247,11 +241,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pfl-7U-kPX">
-                                                            <rect key="frame" x="0.0" y="60" width="272" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="272" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="Pnn-K7-zl6">
                                                                     <rect key="frame" x="8" y="3" width="256" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -260,7 +253,6 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="Pnn-K7-zl6" firstAttribute="leading" secondItem="pfl-7U-kPX" secondAttribute="leadingMargin" id="Amw-WM-oNO"/>
                                                                 <constraint firstItem="Pnn-K7-zl6" firstAttribute="trailing" secondItem="pfl-7U-kPX" secondAttribute="trailingMargin" id="EJq-Wq-ycj"/>
@@ -268,16 +260,15 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lpJ-pv-szt">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="snq-o2-Nmi">
-                                                                    <rect key="frame" x="13" y="28" width="251" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="251" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="snq-o2-Nmi" firstAttribute="bottom" secondItem="lpJ-pv-szt" secondAttribute="bottomMargin" id="0Sb-g9-4se"/>
                                                                 <constraint firstItem="snq-o2-Nmi" firstAttribute="top" secondItem="lpJ-pv-szt" secondAttribute="topMargin" id="ChR-tg-snE"/>
@@ -286,6 +277,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstItem="CWK-NZ-N7r" firstAttribute="trailing" secondItem="lpJ-pv-szt" secondAttribute="trailing" id="0me-b8-x6B"/>
                                                         <constraint firstItem="lpJ-pv-szt" firstAttribute="leading" secondItem="CWK-NZ-N7r" secondAttribute="leading" id="6ik-G2-LIS"/>
@@ -315,7 +307,7 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="tlm-ET-L8c" firstAttribute="top" secondItem="ynd-Ed-kPb" secondAttribute="top" constant="4" id="a3v-Gq-Eeq"/>
                                     <constraint firstItem="tlm-ET-L8c" firstAttribute="leading" secondItem="ynd-Ed-kPb" secondAttribute="leading" constant="4" id="d8c-zH-HYo"/>
@@ -327,18 +319,17 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the following information to sign up" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eZY-Hq-j6H">
                                 <rect key="frame" x="19.5" y="16" width="281" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Db4-um-TSC">
-                                <rect key="frame" x="20" y="366" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="20" y="356" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="280" id="CI7-9s-lAA"/>
-                                    <constraint firstAttribute="height" constant="35" id="l0x-w3-nJr"/>
+                                    <constraint firstAttribute="height" constant="40" id="l0x-w3-nJr"/>
                                 </constraints>
                                 <state key="normal" title="Sign Up">
-                                    <color key="titleColor" red="0.9951923077" green="0.9903846154" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -352,7 +343,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Db4-um-TSC" firstAttribute="leading" secondItem="ynd-Ed-kPb" secondAttribute="leading" id="35k-rA-w8D"/>
                             <constraint firstItem="Db4-um-TSC" firstAttribute="width" secondItem="ynd-Ed-kPb" secondAttribute="width" id="D7R-HJ-Mr2"/>
@@ -361,12 +352,13 @@
                             <constraint firstItem="Db4-um-TSC" firstAttribute="centerX" secondItem="ynd-Ed-kPb" secondAttribute="centerX" id="L1r-dP-bGy"/>
                             <constraint firstItem="Db4-um-TSC" firstAttribute="centerX" secondItem="Z83-6q-CAy" secondAttribute="centerX" id="PWG-Vc-inN"/>
                             <constraint firstItem="ynd-Ed-kPb" firstAttribute="top" secondItem="Z83-6q-CAy" secondAttribute="top" constant="46" id="aR7-Rh-Mtf"/>
-                            <constraint firstItem="Db4-um-TSC" firstAttribute="top" secondItem="ynd-Ed-kPb" secondAttribute="bottom" constant="20" id="m8K-n6-NXS"/>
+                            <constraint firstItem="Db4-um-TSC" firstAttribute="top" secondItem="ynd-Ed-kPb" secondAttribute="bottom" constant="10" id="m8K-n6-NXS"/>
                             <constraint firstItem="Db4-um-TSC" firstAttribute="centerX" secondItem="eZY-Hq-j6H" secondAttribute="centerX" id="uOY-vb-a48"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="kSJ-Ps-4Hc"/>
                     <connections>
+                        <outlet property="signUpButton" destination="Db4-um-TSC" id="lyM-5i-WZQ"/>
                         <outlet property="tableFormView" destination="ynd-Ed-kPb" id="etq-aW-lWk"/>
                         <outlet property="tableView" destination="tlm-ET-L8c" id="lLm-sK-zAj"/>
                         <segue destination="oYn-kQ-Tog" kind="show" identifier="SignUpConfirmSegue" id="XMJ-lN-8F5"/>
@@ -385,38 +377,37 @@
                         <viewControllerLayoutGuide type="bottom" id="GCB-VV-q3w"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="bRf-kC-3Qf">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xwZ-Mm-Vlg">
-                                <rect key="frame" x="16" y="20" width="288" height="0.0"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="0.0" width="288" height="0.0"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uAg-Ox-Qjt">
-                                <rect key="frame" x="20" y="90" width="280" height="150"/>
+                                <rect key="frame" x="20" y="97" width="280" height="150"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="mxN-aX-IeO">
                                         <rect key="frame" x="4" y="4" width="272" height="142"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="83b-bV-L1j" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="272" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="83b-bV-L1j" id="pns-df-LDz">
-                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w29-2b-nnE">
                                                             <rect key="frame" x="0.0" y="0.0" width="272" height="37"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygh-VC-Dox">
+                                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ygh-VC-Dox">
                                                                     <rect key="frame" x="8" y="14" width="256" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="Ygh-VC-Dox" firstAttribute="trailing" secondItem="w29-2b-nnE" secondAttribute="trailingMargin" id="KQf-Je-N67"/>
                                                                 <constraint firstItem="Ygh-VC-Dox" firstAttribute="leading" secondItem="w29-2b-nnE" secondAttribute="leadingMargin" id="mrx-Y6-U3E"/>
@@ -424,11 +415,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fkr-M2-VIY">
-                                                            <rect key="frame" x="0.0" y="60" width="272" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="272" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="Ljf-HI-9BT">
                                                                     <rect key="frame" x="8" y="3" width="256" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -437,7 +427,6 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="Ljf-HI-9BT" firstAttribute="leading" secondItem="Fkr-M2-VIY" secondAttribute="leadingMargin" id="cxo-jf-0Y5"/>
                                                                 <constraint firstItem="Ljf-HI-9BT" firstAttribute="trailing" secondItem="Fkr-M2-VIY" secondAttribute="trailingMargin" id="d8Y-5w-uaw"/>
@@ -445,16 +434,15 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zsa-Fd-QbU">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ctc-ke-OQc">
-                                                                    <rect key="frame" x="13" y="28" width="251" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="251" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="Ctc-ke-OQc" firstAttribute="trailing" secondItem="zsa-Fd-QbU" secondAttribute="trailingMargin" id="3f6-cv-uUq"/>
                                                                 <constraint firstItem="Ctc-ke-OQc" firstAttribute="leading" secondItem="zsa-Fd-QbU" secondAttribute="leadingMargin" constant="5" id="XfN-72-5Y6"/>
@@ -463,6 +451,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="bottom" secondItem="zsa-Fd-QbU" secondAttribute="bottom" id="0pt-qN-dFr"/>
                                                         <constraint firstItem="w29-2b-nnE" firstAttribute="trailing" secondItem="Fkr-M2-VIY" secondAttribute="trailing" id="1Hk-Oz-Fb2"/>
@@ -492,7 +481,7 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="mxN-aX-IeO" firstAttribute="top" secondItem="uAg-Ox-Qjt" secondAttribute="top" constant="4" id="DMf-Vg-Ps3"/>
                                     <constraint firstAttribute="height" constant="150" id="HgW-84-hFA"/>
@@ -504,18 +493,17 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A confirmation code was sent." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PpT-bz-SXb">
                                 <rect key="frame" x="56.5" y="20" width="207" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JyM-ka-pB5">
-                                <rect key="frame" x="20" y="260" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="20" y="257" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="0bV-Tm-hLd"/>
+                                    <constraint firstAttribute="height" constant="40" id="0bV-Tm-hLd"/>
                                     <constraint firstAttribute="width" constant="280" id="Ec3-aR-jqm"/>
                                 </constraints>
                                 <state key="normal" title="Confirm">
-                                    <color key="titleColor" red="0.9951923077" green="0.9903846154" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -530,44 +518,49 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RJJ-nm-kxN">
-                                <rect key="frame" x="84" y="303" width="152" height="30"/>
-                                <state key="normal" title="Request another code"/>
+                                <rect key="frame" x="84" y="302" width="152" height="30"/>
+                                <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Request another code">
+                                    <color key="titleColor" systemColor="linkColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
                                 <connections>
                                     <action selector="onResendConfirmationCode:" destination="oYn-kQ-Tog" eventType="touchUpInside" id="PzT-yY-pgi"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please enter the code to confirm your account" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wpx-Bw-GDl">
-                                <rect key="frame" x="20" y="46" width="281" height="36"/>
+                                <rect key="frame" x="10" y="46" width="300" height="36"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="xwZ-Mm-Vlg" firstAttribute="leading" secondItem="bRf-kC-3Qf" secondAttribute="leadingMargin" id="5dH-cu-Yqa"/>
                             <constraint firstItem="JyM-ka-pB5" firstAttribute="centerX" secondItem="uAg-Ox-Qjt" secondAttribute="centerX" id="6Pf-Kw-3Rn"/>
-                            <constraint firstItem="RJJ-nm-kxN" firstAttribute="top" secondItem="JyM-ka-pB5" secondAttribute="bottom" constant="8" id="7Rp-qU-EMZ"/>
-                            <constraint firstItem="JyM-ka-pB5" firstAttribute="top" secondItem="uAg-Ox-Qjt" secondAttribute="bottom" constant="20" id="7fa-Mw-kYg"/>
+                            <constraint firstItem="RJJ-nm-kxN" firstAttribute="top" secondItem="JyM-ka-pB5" secondAttribute="bottom" constant="5" id="7Rp-qU-EMZ"/>
+                            <constraint firstItem="JyM-ka-pB5" firstAttribute="top" secondItem="uAg-Ox-Qjt" secondAttribute="bottom" constant="10" id="7fa-Mw-kYg"/>
                             <constraint firstItem="JyM-ka-pB5" firstAttribute="trailing" secondItem="uAg-Ox-Qjt" secondAttribute="trailing" id="7lF-lN-L6i"/>
                             <constraint firstItem="xwZ-Mm-Vlg" firstAttribute="bottom" secondItem="jca-3G-Q5u" secondAttribute="bottom" id="8lZ-d0-Zds"/>
                             <constraint firstItem="Wpx-Bw-GDl" firstAttribute="top" secondItem="PpT-bz-SXb" secondAttribute="bottom" constant="8" symbolic="YES" id="9RJ-CS-miU"/>
                             <constraint firstItem="JyM-ka-pB5" firstAttribute="leading" secondItem="uAg-Ox-Qjt" secondAttribute="leading" id="FMa-4E-FmL"/>
                             <constraint firstItem="RJJ-nm-kxN" firstAttribute="centerX" secondItem="JyM-ka-pB5" secondAttribute="centerX" id="Myp-Q6-WBX"/>
+                            <constraint firstAttribute="trailing" secondItem="Wpx-Bw-GDl" secondAttribute="trailing" constant="10" id="R2m-YV-d8b"/>
                             <constraint firstItem="Wpx-Bw-GDl" firstAttribute="centerX" secondItem="bRf-kC-3Qf" secondAttribute="centerX" id="Rav-TY-ddj"/>
                             <constraint firstItem="xwZ-Mm-Vlg" firstAttribute="top" secondItem="jca-3G-Q5u" secondAttribute="bottom" id="a3c-bo-c4p"/>
                             <constraint firstItem="PpT-bz-SXb" firstAttribute="centerX" secondItem="xwZ-Mm-Vlg" secondAttribute="centerX" id="dfa-Jq-ddC"/>
                             <constraint firstItem="JyM-ka-pB5" firstAttribute="width" secondItem="uAg-Ox-Qjt" secondAttribute="width" id="fjX-2C-A3F"/>
-                            <constraint firstItem="Wpx-Bw-GDl" firstAttribute="leading" secondItem="bRf-kC-3Qf" secondAttribute="leadingMargin" constant="4" id="l1z-gJ-qLZ"/>
-                            <constraint firstItem="uAg-Ox-Qjt" firstAttribute="top" secondItem="Wpx-Bw-GDl" secondAttribute="bottom" constant="8" symbolic="YES" id="p0W-Sw-rL0"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Wpx-Bw-GDl" secondAttribute="trailing" constant="3" id="pLa-5o-yTE"/>
+                            <constraint firstItem="uAg-Ox-Qjt" firstAttribute="top" secondItem="Wpx-Bw-GDl" secondAttribute="bottom" constant="15" id="p0W-Sw-rL0"/>
+                            <constraint firstItem="Wpx-Bw-GDl" firstAttribute="leading" secondItem="bRf-kC-3Qf" secondAttribute="leading" constant="10" id="rrM-JH-nOu"/>
                             <constraint firstItem="JyM-ka-pB5" firstAttribute="centerX" secondItem="PpT-bz-SXb" secondAttribute="centerX" id="tEs-fc-5IZ"/>
-                            <constraint firstItem="PpT-bz-SXb" firstAttribute="top" secondItem="xwZ-Mm-Vlg" secondAttribute="top" id="xt6-4H-Ahi"/>
+                            <constraint firstItem="PpT-bz-SXb" firstAttribute="top" secondItem="xwZ-Mm-Vlg" secondAttribute="top" constant="20" id="xt6-4H-Ahi"/>
                             <constraint firstItem="xwZ-Mm-Vlg" firstAttribute="trailing" secondItem="bRf-kC-3Qf" secondAttribute="trailingMargin" id="xwT-nw-48u"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="ze1-65-hn0"/>
                     <connections>
+                        <outlet property="confirmButton" destination="JyM-ka-pB5" id="NoE-ia-HtF"/>
+                        <outlet property="requestCodeButton" destination="RJJ-nm-kxN" id="mYd-SL-3Ub"/>
                         <outlet property="tableFormView" destination="uAg-Ox-Qjt" id="dRv-0q-62H"/>
                         <outlet property="tableView" destination="mxN-aX-IeO" id="yKg-JT-06c"/>
                     </connections>
@@ -589,37 +582,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P29-kN-brQ">
-                                <rect key="frame" x="16" y="28" width="288" height="0.0"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="15" width="288" height="0.0"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="Wad-Xv-3RG"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="an4-FD-ddq">
-                                <rect key="frame" x="20" y="58" width="280" height="75"/>
+                                <rect key="frame" x="20" y="53" width="280" height="75"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="eB4-yI-jcD">
                                         <rect key="frame" x="4" y="4" width="272" height="67"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="8Rm-Su-nQe" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="272" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8Rm-Su-nQe" id="XUr-lK-Zgp">
-                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OVG-EV-IW9">
                                                             <rect key="frame" x="0.0" y="0.0" width="272" height="37"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWV-t3-LWB">
+                                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWV-t3-LWB">
                                                                     <rect key="frame" x="8" y="14" width="256" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="zWV-t3-LWB" firstAttribute="top" secondItem="OVG-EV-IW9" secondAttribute="top" constant="14" id="0Jp-UK-0tA"/>
                                                                 <constraint firstItem="zWV-t3-LWB" firstAttribute="trailing" secondItem="OVG-EV-IW9" secondAttribute="trailingMargin" id="Khx-IW-NZC"/>
@@ -627,11 +619,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U3I-vS-suI">
-                                                            <rect key="frame" x="0.0" y="60" width="272" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="272" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="CkM-K8-q8T">
                                                                     <rect key="frame" x="8" y="3" width="256" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -640,24 +631,22 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="CkM-K8-q8T" firstAttribute="trailing" secondItem="U3I-vS-suI" secondAttribute="trailingMargin" id="GWL-Ou-Bw8"/>
                                                                 <constraint firstItem="CkM-K8-q8T" firstAttribute="top" secondItem="U3I-vS-suI" secondAttribute="top" constant="3" id="Sze-lb-DCb"/>
                                                                 <constraint firstItem="CkM-K8-q8T" firstAttribute="leading" secondItem="U3I-vS-suI" secondAttribute="leadingMargin" id="uBf-ne-0kg"/>
                                                             </constraints>
                                                         </view>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r7d-87-0f6">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                        <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r7d-87-0f6">
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ion-cp-n1v">
-                                                                    <rect key="frame" x="13" y="28" width="251" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="251" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="ion-cp-n1v" firstAttribute="bottom" secondItem="r7d-87-0f6" secondAttribute="bottomMargin" id="74a-3b-k9r"/>
                                                                 <constraint firstItem="ion-cp-n1v" firstAttribute="trailing" secondItem="r7d-87-0f6" secondAttribute="trailingMargin" id="A7a-Ga-R2i"/>
@@ -666,6 +655,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstItem="r7d-87-0f6" firstAttribute="centerY" secondItem="XUr-lK-Zgp" secondAttribute="centerY" id="0du-qo-chC"/>
                                                         <constraint firstAttribute="trailing" secondItem="OVG-EV-IW9" secondAttribute="trailing" id="4c5-PM-F9O"/>
@@ -695,7 +685,7 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="75" id="CIi-Vn-N9S"/>
                                     <constraint firstItem="eB4-yI-jcD" firstAttribute="top" secondItem="an4-FD-ddq" secondAttribute="top" constant="4" id="b1c-GJ-7h4"/>
@@ -705,20 +695,19 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your username to reset password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hM0-IG-47N">
-                                <rect key="frame" x="25.5" y="28" width="269" height="18"/>
+                                <rect key="frame" x="25.5" y="15" width="269" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e9P-Ga-w9L">
-                                <rect key="frame" x="20" y="153" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="20" y="138" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="Hvb-L3-sdP"/>
+                                    <constraint firstAttribute="height" constant="40" id="Hvb-L3-sdP"/>
                                     <constraint firstAttribute="width" constant="280" id="cZk-Pa-Gze"/>
                                 </constraints>
                                 <state key="normal" title="Forgot Password">
-                                    <color key="titleColor" red="0.9951923077" green="0.9903846154" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -733,24 +722,25 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="hM0-IG-47N" firstAttribute="top" secondItem="PN8-a0-H46" secondAttribute="bottom" constant="8" id="DF6-zW-Etw"/>
+                            <constraint firstItem="hM0-IG-47N" firstAttribute="top" secondItem="PN8-a0-H46" secondAttribute="bottom" constant="15" id="DF6-zW-Etw"/>
                             <constraint firstAttribute="trailingMargin" secondItem="P29-kN-brQ" secondAttribute="trailing" id="JYS-vP-qGb"/>
-                            <constraint firstItem="an4-FD-ddq" firstAttribute="top" secondItem="hM0-IG-47N" secondAttribute="bottom" constant="12" id="RtZ-fk-Gi6"/>
+                            <constraint firstItem="an4-FD-ddq" firstAttribute="top" secondItem="hM0-IG-47N" secondAttribute="bottom" constant="20" id="RtZ-fk-Gi6"/>
                             <constraint firstItem="e9P-Ga-w9L" firstAttribute="width" secondItem="an4-FD-ddq" secondAttribute="width" id="UBF-qz-cT1"/>
                             <constraint firstItem="P29-kN-brQ" firstAttribute="leading" secondItem="mvy-xA-fuB" secondAttribute="leadingMargin" id="WWc-nu-ei9"/>
                             <constraint firstItem="e9P-Ga-w9L" firstAttribute="centerX" secondItem="an4-FD-ddq" secondAttribute="centerX" id="ZxU-VH-0zq"/>
-                            <constraint firstItem="e9P-Ga-w9L" firstAttribute="top" secondItem="an4-FD-ddq" secondAttribute="bottom" constant="20" id="diF-is-6zq"/>
+                            <constraint firstItem="e9P-Ga-w9L" firstAttribute="top" secondItem="an4-FD-ddq" secondAttribute="bottom" constant="10" id="diF-is-6zq"/>
                             <constraint firstItem="e9P-Ga-w9L" firstAttribute="trailing" secondItem="an4-FD-ddq" secondAttribute="trailing" id="qqz-RM-3qq"/>
                             <constraint firstItem="hM0-IG-47N" firstAttribute="top" secondItem="P29-kN-brQ" secondAttribute="top" id="rt2-4l-1Sx"/>
                             <constraint firstItem="e9P-Ga-w9L" firstAttribute="centerX" secondItem="hM0-IG-47N" secondAttribute="centerX" id="sYO-ZW-kzJ"/>
                             <constraint firstItem="e9P-Ga-w9L" firstAttribute="leading" secondItem="an4-FD-ddq" secondAttribute="leading" id="wKV-Mq-YRy"/>
-                            <constraint firstItem="hM0-IG-47N" firstAttribute="centerX" secondItem="P29-kN-brQ" secondAttribute="centerX" id="zdj-rE-rCW"/>
+                            <constraint firstItem="hM0-IG-47N" firstAttribute="centerX" secondItem="mvy-xA-fuB" secondAttribute="centerX" id="zdj-rE-rCW"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="wcH-Ol-TbY"/>
                     <connections>
+                        <outlet property="forgotPasswordButton" destination="e9P-Ga-w9L" id="NFC-hX-elP"/>
                         <outlet property="tableFormView" destination="an4-FD-ddq" id="rTf-yH-sr1"/>
                         <outlet property="tableView" destination="eB4-yI-jcD" id="feu-wn-kRx"/>
                         <segue destination="Wwt-zD-yTe" kind="show" identifier="NewPasswordSegue" id="khP-zb-zjs"/>
@@ -773,37 +763,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l3H-DP-bnQ">
-                                <rect key="frame" x="16" y="28" width="288" height="0.0"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="8" width="288" height="0.0"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="MGy-As-fCb"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AYq-Iq-ulh">
-                                <rect key="frame" x="20" y="73" width="280" height="75"/>
+                                <rect key="frame" x="20" y="53" width="280" height="75"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uJN-zO-osp">
                                         <rect key="frame" x="4" y="4" width="272" height="67"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="ezE-hB-DJd" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="272" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ezE-hB-DJd" id="6bF-9s-Rvy">
-                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F5X-Td-vJC">
                                                             <rect key="frame" x="0.0" y="0.0" width="272" height="37"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f33-zV-QZN">
+                                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f33-zV-QZN">
                                                                     <rect key="frame" x="8" y="14" width="256" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="f33-zV-QZN" firstAttribute="trailing" secondItem="F5X-Td-vJC" secondAttribute="trailingMargin" id="1Xz-Qy-2GZ"/>
                                                                 <constraint firstItem="f33-zV-QZN" firstAttribute="top" secondItem="F5X-Td-vJC" secondAttribute="top" constant="14" id="QU3-zC-Of9"/>
@@ -811,11 +800,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eTd-hb-Uih">
-                                                            <rect key="frame" x="0.0" y="60" width="272" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="272" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="Hy5-Wf-qKF">
                                                                     <rect key="frame" x="8" y="3" width="256" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -824,7 +812,6 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="Hy5-Wf-qKF" firstAttribute="trailing" secondItem="eTd-hb-Uih" secondAttribute="trailingMargin" id="fPY-fS-eZz"/>
                                                                 <constraint firstItem="Hy5-Wf-qKF" firstAttribute="top" secondItem="eTd-hb-Uih" secondAttribute="top" constant="3" id="wZ9-Fq-Qyy"/>
@@ -832,16 +819,15 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EBK-Od-YuM">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mMW-AR-FEo">
-                                                                    <rect key="frame" x="13" y="28" width="251" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="251" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="mMW-AR-FEo" firstAttribute="leading" secondItem="EBK-Od-YuM" secondAttribute="leadingMargin" constant="5" id="PiY-lK-9qL"/>
                                                                 <constraint firstItem="mMW-AR-FEo" firstAttribute="bottom" secondItem="EBK-Od-YuM" secondAttribute="bottomMargin" id="XZx-rS-G9T"/>
@@ -850,6 +836,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="bottomMargin" secondItem="F5X-Td-vJC" secondAttribute="bottom" constant="27" id="6LP-WZ-lUY"/>
                                                         <constraint firstItem="F5X-Td-vJC" firstAttribute="leading" secondItem="6bF-9s-Rvy" secondAttribute="leading" id="AQ3-Av-UKn"/>
@@ -879,7 +866,7 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="uJN-zO-osp" firstAttribute="centerX" secondItem="AYq-Iq-ulh" secondAttribute="centerX" id="9ax-Hl-VU1"/>
                                     <constraint firstItem="uJN-zO-osp" firstAttribute="leading" secondItem="AYq-Iq-ulh" secondAttribute="leading" constant="4" id="A6y-r1-4v5"/>
@@ -889,14 +876,14 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yRX-z4-rvv">
-                                <rect key="frame" x="20" y="168" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="20" y="138" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="mo9-O9-pFi"/>
+                                    <constraint firstAttribute="height" constant="40" id="mo9-O9-pFi"/>
                                     <constraint firstAttribute="width" constant="280" id="uKw-Hh-ccP"/>
                                 </constraints>
                                 <state key="normal" title="Sign In">
-                                    <color key="titleColor" red="0.9951923077" green="0.9903846154" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -911,31 +898,29 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A confirmation code was sent." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T6p-9y-1RR">
-                                <rect key="frame" x="56.5" y="20" width="207" height="18"/>
+                                <rect key="frame" x="56.5" y="0.0" width="207" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Code Sent to: " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6s2-Vk-C1E">
-                                <rect key="frame" x="20" y="43" width="110" height="21"/>
+                                <rect key="frame" x="20" y="23" width="110" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="110" id="WaD-Io-nX5"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WzZ-Jn-oCi">
-                                <rect key="frame" x="138" y="43" width="162" height="22"/>
+                                <rect key="frame" x="138" y="23" width="162" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="eTR-ED-kb8"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="WzZ-Jn-oCi" firstAttribute="leading" secondItem="6s2-Vk-C1E" secondAttribute="trailing" constant="8" id="1c4-Zz-eWV"/>
                             <constraint firstItem="T6p-9y-1RR" firstAttribute="centerX" secondItem="AYq-Iq-ulh" secondAttribute="centerX" id="3Gc-Bq-SnF"/>
@@ -947,7 +932,7 @@
                             <constraint firstItem="AYq-Iq-ulh" firstAttribute="top" secondItem="WzZ-Jn-oCi" secondAttribute="bottom" constant="8" id="UO9-wM-4TS"/>
                             <constraint firstItem="yRX-z4-rvv" firstAttribute="trailing" secondItem="AYq-Iq-ulh" secondAttribute="trailing" id="WUr-hq-6CC"/>
                             <constraint firstItem="yRX-z4-rvv" firstAttribute="leading" secondItem="AYq-Iq-ulh" secondAttribute="leading" id="apL-Up-L71"/>
-                            <constraint firstItem="yRX-z4-rvv" firstAttribute="top" secondItem="AYq-Iq-ulh" secondAttribute="bottom" constant="20" id="atQ-2O-3UL"/>
+                            <constraint firstItem="yRX-z4-rvv" firstAttribute="top" secondItem="AYq-Iq-ulh" secondAttribute="bottom" constant="10" id="atQ-2O-3UL"/>
                             <constraint firstAttribute="trailingMargin" secondItem="l3H-DP-bnQ" secondAttribute="trailing" id="b0n-GC-yWQ"/>
                             <constraint firstItem="l3H-DP-bnQ" firstAttribute="leading" secondItem="3Ww-qO-xXn" secondAttribute="leadingMargin" id="c1x-jW-QDu"/>
                             <constraint firstItem="l3H-DP-bnQ" firstAttribute="top" secondItem="Hzm-Gk-RpR" secondAttribute="bottom" constant="8" symbolic="YES" id="ebK-7N-oZO"/>
@@ -961,6 +946,7 @@
                     <navigationItem key="navigationItem" id="AVt-Ff-IUk"/>
                     <connections>
                         <outlet property="codeSentTo" destination="WzZ-Jn-oCi" id="4nA-Af-D2p"/>
+                        <outlet property="signInButton" destination="yRX-z4-rvv" id="KqC-Dj-8iL"/>
                         <outlet property="tableFormView" destination="AYq-Iq-ulh" id="EdG-f5-3If"/>
                         <outlet property="tableView" destination="uJN-zO-osp" id="4yI-89-Nfo"/>
                     </connections>
@@ -982,37 +968,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eAG-Vm-tJL">
-                                <rect key="frame" x="16" y="28" width="288" height="0.0"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="8" width="288" height="0.0"/>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="65W-Xp-q2m"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9v8-wH-78z">
-                                <rect key="frame" x="20" y="91" width="280" height="75"/>
+                                <rect key="frame" x="20" y="71" width="280" height="75"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pLq-FM-ZZi">
                                         <rect key="frame" x="4" y="4" width="272" height="67"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AWSFormTableCell" rowHeight="75" id="Nvt-di-LtB" customClass="AWSTableInputCell">
                                                 <rect key="frame" x="0.0" y="28" width="272" height="75"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Nvt-di-LtB" id="CLA-U4-tSV">
-                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7zW-fJ-GdF">
                                                             <rect key="frame" x="0.0" y="0.0" width="272" height="37"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rXm-81-GOm">
+                                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rXm-81-GOm">
                                                                     <rect key="frame" x="8" y="14" width="256" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                    <color key="textColor" red="0.60328525639999997" green="0.60328525639999997" blue="0.60328525639999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="rXm-81-GOm" firstAttribute="top" secondItem="7zW-fJ-GdF" secondAttribute="top" constant="14" id="Gcf-wX-DwC"/>
                                                                 <constraint firstItem="rXm-81-GOm" firstAttribute="leading" secondItem="7zW-fJ-GdF" secondAttribute="leadingMargin" id="cWY-aX-kTk"/>
@@ -1020,11 +1005,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dCR-yv-EYo">
-                                                            <rect key="frame" x="0.0" y="60" width="272" height="13"/>
+                                                            <rect key="frame" x="0.0" y="40" width="272" height="33"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="14" translatesAutoresizingMaskIntoConstraints="NO" id="lRT-7W-9Mo">
                                                                     <rect key="frame" x="8" y="3" width="256" height="20"/>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                     <connections>
@@ -1033,7 +1017,6 @@
                                                                     </connections>
                                                                 </textField>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="lRT-7W-9Mo" firstAttribute="leading" secondItem="dCR-yv-EYo" secondAttribute="leadingMargin" id="Ofm-X1-UPM"/>
                                                                 <constraint firstItem="lRT-7W-9Mo" firstAttribute="trailing" secondItem="dCR-yv-EYo" secondAttribute="trailingMargin" id="X6c-n4-IwQ"/>
@@ -1041,16 +1024,15 @@
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kwV-Lf-8hh">
-                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="74.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="272" height="75"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p35-HU-ij1">
-                                                                    <rect key="frame" x="13" y="28" width="251" height="38.5"/>
+                                                                    <rect key="frame" x="13" y="8" width="251" height="59"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                                                    <color key="textColor" red="0.38810096150000001" green="0.38810096150000001" blue="0.38810096150000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    <color key="textColor" systemColor="placeholderTextColor" red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
-                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
                                                                 <constraint firstItem="p35-HU-ij1" firstAttribute="top" secondItem="kwV-Lf-8hh" secondAttribute="topMargin" id="4mf-7g-kOA"/>
                                                                 <constraint firstItem="p35-HU-ij1" firstAttribute="trailing" secondItem="kwV-Lf-8hh" secondAttribute="trailingMargin" id="Xbv-83-VTF"/>
@@ -1059,6 +1041,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
+                                                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstItem="kwV-Lf-8hh" firstAttribute="centerY" secondItem="CLA-U4-tSV" secondAttribute="centerY" id="0o5-a2-9VE"/>
                                                         <constraint firstItem="7zW-fJ-GdF" firstAttribute="trailing" secondItem="dCR-yv-EYo" secondAttribute="trailing" id="8uP-De-BTi"/>
@@ -1088,7 +1071,7 @@
                                         </prototypes>
                                     </tableView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="pLq-FM-ZZi" firstAttribute="centerX" secondItem="9v8-wH-78z" secondAttribute="centerX" id="ENz-l2-d2A"/>
                                     <constraint firstItem="pLq-FM-ZZi" firstAttribute="centerY" secondItem="9v8-wH-78z" secondAttribute="centerY" id="Nq5-aj-7mk"/>
@@ -1098,14 +1081,14 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dt2-QQ-w90">
-                                <rect key="frame" x="20" y="186" width="280" height="35"/>
-                                <color key="backgroundColor" red="0.2707115296" green="0.59983539500000005" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="20" y="166" width="280" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="5r9-PP-gLg"/>
+                                    <constraint firstAttribute="height" constant="40" id="5r9-PP-gLg"/>
                                     <constraint firstAttribute="width" constant="280" id="8oc-g1-y6F"/>
                                 </constraints>
                                 <state key="normal" title="Update Password">
-                                    <color key="titleColor" red="0.9951923077" green="0.9903846154" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
@@ -1120,31 +1103,28 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jVb-gh-d8l">
-                                <rect key="frame" x="20" y="61" width="110" height="21"/>
+                                <rect key="frame" x="20" y="41" width="110" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="110" id="HIx-wy-bk1"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q51-pw-zgO">
-                                <rect key="frame" x="138" y="61" width="162" height="22"/>
+                                <rect key="frame" x="138" y="41" width="162" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="Hj0-Fe-dMV"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please enter your new password below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BzB-cM-Tyh">
-                                <rect key="frame" x="27" y="38" width="266" height="18"/>
+                                <rect key="frame" x="27" y="18" width="266" height="18"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Dt2-QQ-w90" firstAttribute="leading" secondItem="9v8-wH-78z" secondAttribute="leading" id="AbH-7k-4NC"/>
                             <constraint firstItem="Q51-pw-zgO" firstAttribute="top" secondItem="BzB-cM-Tyh" secondAttribute="bottom" constant="5" id="B1D-ti-Xd5"/>

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.h
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.h
@@ -38,6 +38,22 @@ NS_ASSUME_NONNULL_BEGIN
 + (UIColor *) getBackgroundColor:(id<AWSUIConfiguration>)config;
 
 /**
+ Get the default background color. This is resilient to light/dark mode
+ setting on iOS 13.
+ */
++ (UIColor *) getDefaultBackgroundColor;
+
+/**
+ Apply button-like primary color to buttons and labels.
+ */
++ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
+                           toView:(UIView *) view
+                       background:(BOOL) background;
+
++ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
+                           toView:(UIView *) view;
+
+/**
  Retrieve the font set in the config or return nil
  
  @param config The object conforming to `AWSUIConfiguration` protocol

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.m
@@ -23,10 +23,10 @@ static id<AWSUIConfiguration> awsUIConfiguration;
 + (void) setUpFormShadowForView:(UIView *)view {
     view.layer.shadowColor = [UIColor blackColor].CGColor;
     view.layer.shadowOffset = CGSizeZero;
-    view.layer.shadowOpacity = 0.5;
-    view.layer.shadowRadius = 5;
+    view.layer.shadowOpacity = 0.25;
+    view.layer.shadowRadius = 6;
     view.layer.cornerRadius = 10.0;
-    view.layer.borderColor = [UIColor grayColor].CGColor;
+    view.layer.borderColor = [[UIColor grayColor] colorWithAlphaComponent:0.7].CGColor;
     view.layer.borderWidth = 0.5;
     view.layer.masksToBounds = NO;
 }
@@ -34,8 +34,33 @@ static id<AWSUIConfiguration> awsUIConfiguration;
 + (UIColor *) getBackgroundColor:(id<AWSUIConfiguration>)config {
     if (config != nil && config.backgroundColor != nil) {
         return config.backgroundColor;
-    } else {
-        return [UIColor darkGrayColor];
+    } else if (@available(iOS 13.0, *)) {
+        return [UIColor systemBackgroundColor];
+    }
+    return [UIColor darkGrayColor];
+}
+
++ (UIColor *) getDefaultBackgroundColor {
+    if (@available(iOS 13.0, *)) {
+        return [UIColor secondarySystemBackgroundColor];
+    }
+    return [UIColor whiteColor];
+}
+
++ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
+                           toView:(UIView *) view {
+    [self applyTintColorFromConfig:config toView:view background:YES];
+}
+
++ (void) applyTintColorFromConfig:(id<AWSUIConfiguration>)config
+                           toView:(UIView *) view
+                       background:(BOOL) background {
+    if (config.tintColor) {
+        if (background) {
+            view.backgroundColor = config.tintColor;
+        } else {
+            view.tintColor = config.tintColor;
+        }
     }
 }
 

--- a/AWSAuthUI.podspec
+++ b/AWSAuthUI.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
    s.requires_arc = true
    s.dependency 'AWSCore', '2.11.1'
    s.dependency 'AWSAuthCore', '2.11.1'
-   s.source_files = 'AWSAuthSDK/Sources/AWSAuthUI/*.{h,m}', 'AWSAuthSDK/Sources/AWSAuthUI/**/*.{h,m}', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.h'
+   s.source_files = 'AWSAuthSDK/Sources/AWSAuthUI/*.{h,m}', 'AWSAuthSDK/Sources/AWSAuthUI/**/*.{h,m}', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUI.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h'
-   s.private_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.h'
+   s.private_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h'
    s.resource_bundles = { 'AWSAuthUI' => ['AWSAuthSDK/Sources/AWSAuthUI/*.{storyboard}', 'AWSAuthSDK/Sources/AWSAuthUI/Images.xcassets'] }
  end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@
 
 - **AWSCognito**
   - Fix an issue where token is not refreshed after update attribute is invoked. See [Issue #1733](https://github.com/aws-amplify/aws-sdk-ios/issues/1733) and [PR #1734](https://github.com/aws-amplify/aws-sdk-ios/pull/1734) for details. Thanks @JesusMartinAlonso!
-  
+
+- **AWSMobileClient**
+  - Fixed an issue where the DropIn UI styles are inconsistent when dark mode is enabled on iOS 13. See [Issue #1953](https://github.com/aws-amplify/aws-sdk-ios/issues/1953) and [PR #1962](https://github.com/aws-amplify/aws-sdk-ios/pull/1962) for details. 
+
 - **Model updates for the following services**
   - Amazon EC2
   - Amazon Transcribe


### PR DESCRIPTION
*Issue #, if available:* #1953

*Notes:*

- removed hardcoded colors on every view
- replaced the colors with system-defined colors (they auto-adapt to the
dark mode)
- exposed two new customization options: `backgroundBottomColor` and
`tintColor`
- refactored some of the UI to use consistent spacing and colors across
different screens

*Testing:*

- tested the Auth flow with the Drop-in UI in the PhotoAlbum app
- tested on iOS 13.0 and 12.3

*Revision 2 notes:*

- renamed `backgroundBottomColor` to `secondaryBackgroundColor`
- renamed `tintColor` to `primaryColor`
- extracted Auth UI Helpers to AWSAuthCore so both AWSAuthUI and
AWSUserPoolsSignIn could use it (removed duplication and inconsistencies
between the Sign In and the other screens
- improved documentation

*Revision 3 notes:*

- moved the input cell label logic from `onTap` into its own helper
- fix typo
- fix indentation

*Revision 4 notes:*

- add changelog entry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
