### PR TITLE
Remove custom carthage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,12 +504,9 @@ jobs:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
       - run:
-          name: download custom carthage
+          name: install carthage
           command: |
-            aws s3 cp s3://custom-carthage/customcarthage.zip customcarthage.zip
-            unzip -a customcarthage.zip
-            ls customcarthage
-            chmod 111 customcarthage/carthage
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install carthage
       - run:
           name: build
           command: |
@@ -517,7 +514,7 @@ jobs:
       - run:
           name: Build Carthage
           command: |
-            customcarthage/carthage build --no-skip-current | tee buildout.txt
+            carthage build --no-skip-current | tee buildout.txt
           no_output_timeout: 100m
       - run:
           name: Create Carthage Archive


### PR DESCRIPTION
*Issue #, if available:*

Building Carthage is faililng because the custom version of Carthage we built is not compatible with Xcode 11's `simctl` output. I ran the job manually using a homebrew-installed version of the latest Carthage, and it worked fine. My recollection is that we only used the custom Carthage because it was taking too long to build previously, and I don't think it's necessary any more.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
