### PR TITLE
[Polly] Allow specifying 'engine' in URL builder.

### DIFF
--- a/AWSPolly/AWSPollySynthesizeSpeechURLBuilder.h
+++ b/AWSPolly/AWSPollySynthesizeSpeechURLBuilder.h
@@ -79,6 +79,12 @@ typedef NS_ENUM(NSInteger, AWSPollySynthesizeSpeechURLBuilderErrorType) {
  */
 @property (nonatomic, strong) NSDate *expires;
 
+/**
+ Specifies the engine (standard or neural) for Amazon Polly to use when processing input text for speech synthesis.
+ Using a voice that is not supported for the engine selected will result in an error.
+ */
+@property (nonatomic, assign) AWSPollyEngine engine;
+
 @end
 
 

--- a/AWSPollyTests/AWSPollyTests.m
+++ b/AWSPollyTests/AWSPollyTests.m
@@ -170,6 +170,10 @@ static NSDictionary<NSString *,NSString *> *lexicons;
     [request setVoiceId:AWSPollyVoiceIdSalli];
     [request setLexiconNames:@[w3cLexiconName, w2cLexiconName]]; // W3C will be spoken as World Wide Web Consortium.
     [request setExpires:[NSDate dateWithTimeIntervalSinceNow:10*60]];
+
+    // Note: Specifying an engine for an unsupported language will cause an error.
+    // https://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html#polly-SynthesizeSpeech-request-Engine
+    [request setEngine:AWSPollyEngineNeural];
     
     AWSPollySynthesizeSpeechURLBuilder *builder = [AWSPollySynthesizeSpeechURLBuilder defaultPollySynthesizeSpeechURLBuilder];
     __block NSString *filePath;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2.12.1
 
+### New Features
+
+- **Amazon Polly**
+  - `AWSPollySynthesizeSpeechURLBuilder` now supports the ability to specify the engine (standard or neural) for a request.
+    See [the Amazon Polly documentation](https://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html#polly-SynthesizeSpeech-request-Engine)
+    for a discussion of the Engine. See [Issue #1973](https://github.com/aws-amplify/aws-sdk-ios/issues/1973).
+
 ### Bug Fixes
 - **AWS AuthUI**
   - Present sign-in modal fullscreen to avoid undesirable gap. See issue [#1963](https://github.com/aws-amplify/aws-sdk-ios/issues/1963). Thanks @BillBunting!


### PR DESCRIPTION
*Issue #, if available:*
#1973 

*Description of changes:*

Adds `engine` support to the hand-written Polly presigned URL builder.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
