### PR TITLE
Mac catalyst support.

### DIFF
--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -952,7 +952,7 @@ static NSString *_defaultService;
 
 #pragma mark -
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)sharedPasswordWithCompletion:(void (^)(NSString *account, NSString *password, NSError *error))completion
 {
     NSString *domain = self.server.host;


### PR DESCRIPTION
Using AppSync on Mac Catalyst applications is currently not working as AppSync has a dependency on AWSCore's `AWSUICKeyChainStore` which only checks for `#if TARGET_OS_IOS`

Adding an extra check for `!TARGET_OS_MACCATALYST` fixes the problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.