### PR TITLE
Pass clientMetaData in respondAuthChallenge

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -570,9 +570,12 @@ extension AWSMobileClient {
     /// - Parameters:
     ///   - challengeResponse: confirmation code or TOTP token which is available to the user.
     ///   - userAttributes: user attributes required for the operation.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when result is available.
     public func confirmSignIn(challengeResponse: String,
                               userAttributes: [String:String] = [:],
+                              clientMetaData: [String:String] = [:],
                               completionHandler: @escaping ((SignInResult?, Error?) -> Void)) {
         if (self.userpoolOpsHelper.mfaCodeCompletionSource != nil) {
             self.userpoolOpsHelper.currentConfirmSignInHandlerCallback = completionHandler
@@ -581,10 +584,12 @@ extension AWSMobileClient {
             self.userpoolOpsHelper.currentConfirmSignInHandlerCallback = completionHandler
             let passwordDetails = AWSCognitoIdentityNewPasswordRequiredDetails.init(proposedPassword: challengeResponse,
                                                                                     userAttributes: userAttributes)
+            passwordDetails.clientMetaData = clientMetaData
             self.userpoolOpsHelper.newPasswordRequiredTaskCompletionSource?.set(result: passwordDetails)
         } else if (self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource != nil) {
             self.userpoolOpsHelper.currentConfirmSignInHandlerCallback = completionHandler
             let customAuthDetails = AWSCognitoIdentityCustomChallengeDetails.init(challengeResponses: ["ANSWER": challengeResponse])
+            customAuthDetails.clientMetaData = clientMetaData
             self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(result: customAuthDetails)
             self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = nil
         }

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -184,6 +184,11 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
  */
 @property(nonatomic, strong) NSDictionary<NSString*,NSString*>* challengeResponses;
 
+/**
+ A map of custom key-value pairs that you can provide as input for any custom workflows that this action triggers.
+ */
+@property(nonatomic, copy, nullable) NSDictionary<NSString*, NSString*> *clientMetaData;
+
 -(instancetype) initWithChallengeResponses: (NSDictionary<NSString*,NSString*> *) challengeResponses;
 
 @end
@@ -202,6 +207,11 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
  required attributes.  Any other attributes are optional.
  */
 @property(nonatomic, strong, nullable) NSArray<AWSCognitoIdentityUserAttributeType*> *userAttributes;
+
+/**
+ A map of custom key-value pairs that you can provide as input for any custom workflows that this action triggers.
+ */
+@property(nonatomic, copy, nullable) NSDictionary<NSString*, NSString*> *clientMetaData;
 
 /**
  Initializer given a new password and map of user attributes to set 


### PR DESCRIPTION
- ClientMetaData is added as an optional parameter for confirmSignIn. This data is passed to the cognito api.
- Reference [api](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html#CognitoUserPools-RespondToAuthChallenge-request-ClientMetadata)

# Testing

Manually tested it by passing the metadata as shown below:
```
 AWSMobileClient.default().confirmSignIn(challengeResponse: "1133", clientMetaData: ["key": "testValue"]) 
```
This was logged in the lambda function in verify auth challenge.
```
console.info('clientMetadata ' + event.request.clientMetadata['key']);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
