### PR TITLE
Fix nullability warnings in AWSSignature

### DIFF
--- a/AWSCore/Authentication/AWSSignature.h
+++ b/AWSCore/Authentication/AWSSignature.h
@@ -25,11 +25,11 @@ FOUNDATION_EXPORT NSString * _Nonnull const AWSSignatureV4Terminator;
 
 @interface AWSSignatureSignerUtility : NSObject
 
-+ (NSData * _Nonnull)sha256HMacWithData:(NSData * _Nullable)data withKey:(NSData * _Nullable)key;
++ (NSData * _Nonnull)sha256HMacWithData:(NSData * _Nullable)data withKey:(NSData * _Nonnull)key;
 + (NSString * _Nonnull)hashString:(NSString * _Nullable)stringToHash;
-+ (NSData * _Nullable)hash:(NSData * _Nullable)dataToHash;
-+ (NSString * _Nullable)hexEncode:(NSString * _Nullable)string;
-+ (NSString * _Nullable)HMACSign:(NSData * _Nullable)data withKey:(NSString * _Nullable)key usingAlgorithm:(uint32_t)algorithm;
++ (NSData * _Nonnull)hash:(NSData * _Nullable)dataToHash;
++ (NSString * _Nonnull)hexEncode:(NSString * _Nullable)string;
++ (NSString * _Nullable)HMACSign:(NSData * _Nullable)data withKey:(NSString * _Nonnull)key usingAlgorithm:(uint32_t)algorithm;
 
 @end
 

--- a/AWSCore/Authentication/AWSSignature.h
+++ b/AWSCore/Authentication/AWSSignature.h
@@ -16,8 +16,8 @@
 #import <Foundation/Foundation.h>
 #import "AWSNetworking.h"
 
-FOUNDATION_EXPORT NSString *const AWSSignatureV4Algorithm;
-FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
+FOUNDATION_EXPORT NSString * _Nonnull const AWSSignatureV4Algorithm;
+FOUNDATION_EXPORT NSString * _Nonnull const AWSSignatureV4Terminator;
 
 @class AWSEndpoint;
 
@@ -25,20 +25,20 @@ FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
 
 @interface AWSSignatureSignerUtility : NSObject
 
-+ (NSData *)sha256HMacWithData:(NSData *)data withKey:(NSData *)key;
-+ (NSString *)hashString:(NSString *)stringToHash;
-+ (NSData *)hash:(NSData *)dataToHash;
-+ (NSString *)hexEncode:(NSString *)string;
-+ (NSString *)HMACSign:(NSData *)data withKey:(NSString *)key usingAlgorithm:(uint32_t)algorithm;
++ (NSData * _Nonnull)sha256HMacWithData:(NSData * _Nullable)data withKey:(NSData * _Nullable)key;
++ (NSString * _Nonnull)hashString:(NSString * _Nullable)stringToHash;
++ (NSData * _Nullable)hash:(NSData * _Nullable)dataToHash;
++ (NSString * _Nullable)hexEncode:(NSString * _Nullable)string;
++ (NSString * _Nullable)HMACSign:(NSData * _Nullable)data withKey:(NSString * _Nullable)key usingAlgorithm:(uint32_t)algorithm;
 
 @end
 
 @interface AWSSignatureV4Signer : NSObject <AWSNetworkingRequestInterceptor>
 
-@property (nonatomic, strong, readonly) id<AWSCredentialsProvider> credentialsProvider;
+@property (nonatomic, strong, readonly) id<AWSCredentialsProvider> _Nonnull credentialsProvider;
 
-- (instancetype)initWithCredentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
-                                   endpoint:(AWSEndpoint *)endpoint;
+- (instancetype _Nonnull)initWithCredentialsProvider:(id<AWSCredentialsProvider> _Nonnull)credentialsProvider
+                                   endpoint:(AWSEndpoint * _Nonnull)endpoint;
 
 /**
  Returns a URL signed using the SigV4 algorithm, using the current date, and including the session token (if any) as
@@ -54,14 +54,14 @@ FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
  @param signBody if true and the httpMethod is GET, sign an empty string as part of the signature content
  @return a task containing the signed URL
  */
-+ (AWSTask<NSURL *> *)generateQueryStringForSignatureV4WithCredentialProvider:(id<AWSCredentialsProvider>)credentialsProvider
-                                                                   httpMethod:(AWSHTTPMethod)httpMethod
-                                                               expireDuration:(int32_t)expireDuration
-                                                                     endpoint:(AWSEndpoint *)endpoint
-                                                                      keyPath:(NSString *)keyPath
-                                                               requestHeaders:(NSDictionary<NSString *, NSString *> *)requestHeaders
-                                                            requestParameters:(NSDictionary<NSString *, id> *)requestParameters
-                                                                     signBody:(BOOL)signBody;
++ (AWSTask<NSURL *> * _Nonnull)generateQueryStringForSignatureV4WithCredentialProvider:(id<AWSCredentialsProvider> _Nonnull)credentialsProvider
+                                                                            httpMethod:(AWSHTTPMethod)httpMethod
+                                                                        expireDuration:(int32_t)expireDuration
+                                                                              endpoint:(AWSEndpoint * _Nonnull)endpoint
+                                                                               keyPath:(NSString * _Nullable)keyPath
+                                                                        requestHeaders:(NSDictionary<NSString *, NSString *> * _Nullable)requestHeaders
+                                                                     requestParameters:(NSDictionary<NSString *, id> * _Nullable)requestParameters
+                                                                              signBody:(BOOL)signBody;
 
 /**
  Returns a URL signed using the SigV4 algorithm.
@@ -83,41 +83,39 @@ FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
         If false, appends the X-AMZ-Security-Token to the end of the signed URL request parameters
  @return a task containing the signed URL
  */
-+ (AWSTask<NSURL *> *)sigV4SignedURLWithRequest:(NSURLRequest * _Nonnull)request
-                             credentialProvider:(id<AWSCredentialsProvider> _Nonnull)credentialsProvider
-                                     regionName:(NSString * _Nonnull)regionName
-                                    serviceName:(NSString * _Nonnull)serviceName
-                                           date:(NSDate * _Nonnull)date
-                                 expireDuration:(int32_t)expireDuration
-                                       signBody:(BOOL)signBody
-                               signSessionToken:(BOOL)signSessionToken;
++ (AWSTask<NSURL *> * _Nonnull)sigV4SignedURLWithRequest:(NSURLRequest * _Nonnull)request
+                                      credentialProvider:(id<AWSCredentialsProvider> _Nonnull)credentialsProvider
+                                              regionName:(NSString * _Nonnull)regionName
+                                             serviceName:(NSString * _Nonnull)serviceName
+                                                    date:(NSDate * _Nonnull)date
+                                          expireDuration:(int32_t)expireDuration
+                                                signBody:(BOOL)signBody
+                                        signSessionToken:(BOOL)signSessionToken;
 
-+ (NSString *)getCanonicalizedQueryStringForDate:(NSDate *)currentDate;
++ (NSString * _Nonnull)getCanonicalizedRequest:(NSString * _Nonnull)method
+                                 path:(NSString * _Nonnull)path
+                                query:(NSString * _Nullable)query
+                              headers:(NSDictionary * _Nullable)headers
+                        contentSha256:(NSString * _Nullable)contentSha256;
 
-+ (NSString *)getCanonicalizedRequest:(NSString *)method
-                                 path:(NSString *)path
-                                query:(NSString *)query
-                              headers:(NSDictionary *)headers
-                        contentSha256:(NSString *)contentSha256;
++ (NSData * _Nonnull)getV4DerivedKey:(NSString * _Nullable)secret
+                       date:(NSString * _Nullable)dateStamp
+                     region:(NSString * _Nullable)regionName
+                    service:(NSString * _Nullable)serviceName;
 
-+ (NSData *)getV4DerivedKey:(NSString *)secret
-                       date:(NSString *)dateStamp
-                     region:(NSString *)regionName
-                    service:(NSString *)serviceName;
-
-+ (NSString *)getSignedHeadersString:(NSDictionary *)headers;
++ (NSString * _Nonnull)getSignedHeadersString:(NSDictionary * _Nullable)headers;
 
 @end
 
 @interface AWSSignatureV2Signer : NSObject <AWSNetworkingRequestInterceptor>
 
-@property (nonatomic, strong, readonly) id<AWSCredentialsProvider> credentialsProvider;
+@property (nonatomic, strong, readonly) id<AWSCredentialsProvider> _Nullable credentialsProvider;
 
-+ (instancetype)signerWithCredentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
-                                     endpoint:(AWSEndpoint *)endpoint;
++ (instancetype _Nonnull)signerWithCredentialsProvider:(id<AWSCredentialsProvider> _Nonnull)credentialsProvider
+                                     endpoint:(AWSEndpoint * _Nonnull)endpoint;
 
-- (instancetype)initWithCredentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
-                                   endpoint:(AWSEndpoint *)endpoint;
+- (instancetype _Nonnull)initWithCredentialsProvider:(id<AWSCredentialsProvider> _Nonnull)credentialsProvider
+                                   endpoint:(AWSEndpoint * _Nonnull)endpoint;
 
 @end
 
@@ -132,11 +130,11 @@ FOUNDATION_EXPORT NSString *const AWSSignatureV4Terminator;
  * Initialize the input stream with date, scope, signing key and signature
  * of request headers.
  **/
-- (instancetype)initWithInputStream:(NSInputStream *)stream
-                               date:(NSDate *)date
-                              scope:(NSString *)scope
-                           kSigning:(NSData *)kSigning
-                    headerSignature:(NSString *)headerSignature;
+- (instancetype _Nonnull )initWithInputStream:(NSInputStream * _Nonnull)stream
+                                         date:(NSDate * _Nullable)date
+                                        scope:(NSString * _Nullable)scope
+                                     kSigning:(NSData * _Nullable)kSigning
+                              headerSignature:(NSString * _Nullable)headerSignature;
 
 /**
  * Computes new content length after data being chunked encoded.

--- a/AWSCoreTests/AWSSignatureNullabilityTests.m
+++ b/AWSCoreTests/AWSSignatureNullabilityTests.m
@@ -1,0 +1,65 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWSSignature.h"
+
+@interface AWSSignatureNullabilityTests : XCTestCase
+
+@end
+
+@implementation AWSSignatureNullabilityTests
+
+
+- (void)testsha256HMACWithNilData {
+    NSData *secretKey = [@"aKey" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *signature = [AWSSignatureSignerUtility sha256HMacWithData:nil
+                                                              withKey:secretKey];
+    XCTAssertNotNil(signature);
+}
+
+- (void)testhashWithNilData {
+    NSData *hash = [AWSSignatureSignerUtility hash:nil];
+    XCTAssertNotNil(hash);
+}
+
+- (void)testhashStringWithNilData {
+    NSString *hash = [AWSSignatureSignerUtility hashString:nil];
+    XCTAssertNotNil(hash);
+}
+
+- (void)testhexEncodeWithNilData {
+    NSString *hex = [AWSSignatureSignerUtility hexEncode:nil];
+    XCTAssertNotNil(hex);
+}
+
+- (void)testHMACSignWithNilData {
+    NSString *secretKey = @"aKey";
+    NSString *signature = [AWSSignatureSignerUtility HMACSign:nil
+                                                      withKey:secretKey
+                                               usingAlgorithm:0];
+    XCTAssertNotNil(signature);
+}
+
+- (void)testHMACSignWithInvalidAlgorithm {
+    NSString *secretKey = @"aKey";
+    NSString *signature = [AWSSignatureSignerUtility HMACSign:nil
+                                                      withKey:secretKey
+                                               usingAlgorithm:1];
+    XCTAssertNil(signature);
+}
+
+
+@end

--- a/AWSCoreUnitTests/SigV4Tests/SigV4Tests.swift
+++ b/AWSCoreUnitTests/SigV4Tests/SigV4Tests.swift
@@ -51,7 +51,7 @@ class SigV4Tests: XCTestCase {
             date: SigV4TestCredentials.testDate,
             expireDuration: SigV4TestCredentials.expiry,
             signBody: testCase.shouldSignBody,
-            signSessionToken: testCase.shouldSignSecurityToken)?.continueWith { task in
+            signSessionToken: testCase.shouldSignSecurityToken).continueWith { task in
                 defer {
                     taskIsComplete.fulfill()
                 }

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -448,6 +448,7 @@
 		9AD5842820F63E6700042041 /* singleface.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 9AD5842620F63E6700042041 /* singleface.jpg */; };
 		9AD5842A20F63E9B00042041 /* city_thumb.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 9AD5842920F63E9B00042041 /* city_thumb.jpg */; };
 		B434294122F0FA0E00567E83 /* AWSTextract.h in Headers */ = {isa = PBXBuildFile; fileRef = B434294022F0FA0D00567E83 /* AWSTextract.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B44FBC4823F4B27D008EA8D2 /* AWSSignatureNullabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B44FBC4723F4B27D008EA8D2 /* AWSSignatureNullabilityTests.m */; };
 		B47FAF4322C577CE00014548 /* AWSS3TransferUtilityUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */; };
 		B482E84722EEA9F20075A0A3 /* AWSS3TestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B482E84622EEA9F20075A0A3 /* AWSS3TestHelper.m */; };
 		B4A4DFFE22B4201400379396 /* AWSSageMakerRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4A4DFF522B4201300379396 /* AWSSageMakerRuntime.framework */; };
@@ -3823,6 +3824,7 @@
 		9AD5842620F63E6700042041 /* singleface.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = singleface.jpg; sourceTree = "<group>"; };
 		9AD5842920F63E9B00042041 /* city_thumb.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = city_thumb.jpg; sourceTree = "<group>"; };
 		B434294022F0FA0D00567E83 /* AWSTextract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSTextract.h; sourceTree = "<group>"; };
+		B44FBC4723F4B27D008EA8D2 /* AWSSignatureNullabilityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSSignatureNullabilityTests.m; sourceTree = "<group>"; };
 		B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSS3TransferUtilityUnitTests.m; sourceTree = "<group>"; };
 		B482E84522EEA9F10075A0A3 /* AWSS3TestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSS3TestHelper.h; sourceTree = "<group>"; };
 		B482E84622EEA9F20075A0A3 /* AWSS3TestHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSS3TestHelper.m; sourceTree = "<group>"; };
@@ -6711,6 +6713,7 @@
 				CEB8EF281C6A69A00098B15B /* AWSNetworkingTests.m */,
 				CEB8EF291C6A69A00098B15B /* AWSSerializationTests.m */,
 				CEB8EF2B1C6A69A00098B15B /* AWSSignatureTests.m */,
+				B44FBC4723F4B27D008EA8D2 /* AWSSignatureNullabilityTests.m */,
 				CEB8EF2C1C6A69A00098B15B /* AWSSTSTests.m */,
 				CEB8EF2D1C6A69A00098B15B /* AWSTestUtility.h */,
 				CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */,
@@ -13363,6 +13366,7 @@
 				CEB8EF301C6A69A00098B15B /* AWSClockSkewTests.m in Sources */,
 				CEB8EF3C1C6A69A00098B15B /* AWSUtilityTests.m in Sources */,
 				CEB8EF321C6A69A00098B15B /* AWSCognitoIdentityServiceTests.m in Sources */,
+				B44FBC4823F4B27D008EA8D2 /* AWSSignatureNullabilityTests.m in Sources */,
 				CEB8EF361C6A69A00098B15B /* AWSNetworkingTests.m in Sources */,
 				CEB8EF391C6A69A00098B15B /* AWSSignatureTests.m in Sources */,
 				CEB8EF3B1C6A69A00098B15B /* AWSTestUtility.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Misc. Updates
 
-- **Breaking Change** Updated nullability flag for the `AWSSignatureSignerUtility`, `AWSSignatureV4Signer`, `AWSSignatureV2Signer` and `AWSS3ChunkedEncodingInputStream` classes. If you are using any of these classes in `swift` code base you might want to add the right specifier for the return values. 
+- **Breaking Change** Updated nullability flags for the `AWSSignatureSignerUtility`, `AWSSignatureV4Signer`, `AWSSignatureV2Signer` and `AWSS3ChunkedEncodingInputStream` classes. Methods in these classes will have new signatures in Swift code, and may require code changes in your app to consume. 
 
 ## 2.12.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
+## 2.13.0
+
+### Misc. Updates
+
+- **Breaking Change** Updated nullability flag for the `AWSSignatureSignerUtility`, `AWSSignatureV4Signer`, `AWSSignatureV2Signer` and `AWSS3ChunkedEncodingInputStream` classes. If you are using any of these classes in `swift` code base you might want to add the right specifier for the return values. 
+
 ## 2.12.8
 
 ### Bug Fixes


### PR DESCRIPTION
*Issue #, if available:*
Projects that depend on our sdk are seeing a lot of compiler warning due to the missing nullability flags in the objc code base.

*Description of changes:*
I am adding flags based on the fact that the method that the parameters passed into the function have the right flag based on the methods functionality. Also made sure that the method class wont crash.

*Testing*
Add few unit test cases around the updated methods

https://github.com/aws-amplify/aws-sdk-ios/issues/2001

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
