### PR TITLE
Filter out non-mutable attribute "email_verified" for new password required flow (#2203)

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -32,6 +32,7 @@ static const NSString * AWSCognitoIdentityUserAsfDeviceId = @"asf.device.id";
 static const NSString * AWSCognitoIdentityUserDeviceSecret = @"device.secret";
 static const NSString * AWSCognitoIdentityUserDeviceGroup = @"device.group";
 static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttributes.";
+static const NSString * AWSCognitoIdentityUserEmailVerifiedKey = @"email_verified";
 
 -(instancetype) initWithUsername: (NSString *)username pool:(AWSCognitoIdentityUserPool *)pool {
     self = [super init];
@@ -363,6 +364,9 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
         
         if(userAttributes){
             [userAttributesDict addEntriesFromDictionary:[NSJSONSerialization JSONObjectWithData:[userAttributes dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil]];
+            // Service responds with "Cannot modify the non-mutable attribute email_verified", if this value isn't taken out.
+            // https://github.com/aws-amplify/aws-sdk-ios/issues/2203
+            [userAttributesDict removeObjectForKey:AWSCognitoIdentityUserEmailVerifiedKey];
         }
         if(requiredAttributes) {
             NSArray * requiredAttributesArray = [NSJSONSerialization JSONObjectWithData:[requiredAttributes dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug Fixes
   - **Amazon IoT**
     - Fixed a crash in AWSIoTManager when importing PKCS12 data with an incorrect passphrase. (See [#1166](https://github.com/aws-amplify/aws-sdk-ios/issues/1166))
+  - **AWSCognitoIdentityProvider**
+    - Fixed issue where users in a FORCE_CHANGE_PASSWORD flow are unable to update their password (See [#2203](https://github.com/aws-amplify/aws-sdk-ios/issues/2203))
 
 ### Misc. Updates
 


### PR DESCRIPTION
Regarding:
https://github.com/aws-amplify/aws-sdk-ios/issues/2203

Server seems to be throwing an error when sending email_verified as part of the request.  In this context, I don't see how sending this field is relevant, so it seems to make sense to filter this field out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
