### PR TITLE
Update Jazzy docs gen to use next release (2.12.7)

### DIFF
--- a/CircleciScripts/generate_documentation.sh
+++ b/CircleciScripts/generate_documentation.sh
@@ -6,7 +6,7 @@
 
 set -x
 
-SDK_VERSION="2.12.3"
+SDK_VERSION="2.12.7"
 
 GITHUB_DOC_ROOT=https://aws-amplify.github.io
 GITHUB_SOURCE_ROOT=https://github.com/aws-amplify/aws-sdk-ios


### PR DESCRIPTION
I saw from https://github.com/aws-amplify/aws-sdk-ios/pull/2150 that we aren't sure if this scriptwill run successfully in circle CI workflow. I'm updating it here to make sure that the SDK version used is at least correct for the next release workflow.

Some of my open questions are
- Need to figure out how to avoid having to update the SDK version hard coded in this file
- How does jazzy docs generated make its way to the gh-pages branch's docs directory?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
