### PR TITLE
Fix NSInternalInconsistencyException on NewPasswordRequired flow

### DIFF
--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/AWSUserPoolsUIOperations.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/AWSUserPoolsUIOperations.m
@@ -119,9 +119,16 @@ completionHandler:(nonnull void (^)(id _Nullable, NSError * _Nullable))completio
 
     AWSUserPoolNewPasswordRequiredViewController *viewController = (AWSUserPoolNewPasswordRequiredViewController *)[self getUserPoolsViewControllerWithIdentifier:@"NewPasswordRequired"];
     viewController.config = self.config;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.navigationController pushViewController:viewController
-                                             animated:YES];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        if ([self.navigationController.topViewController isKindOfClass:[AWSUserPoolNewPasswordRequiredViewController class]] &&
+            self.navigationController.topViewController != viewController) {
+            [self.navigationController popViewControllerAnimated:NO];
+            [self.navigationController pushViewController:viewController
+                                                 animated:NO];
+        } else{
+            [self.navigationController pushViewController:viewController
+                                                 animated:YES];
+        }
     });
     
     return viewController;


### PR DESCRIPTION
*Description of changes:*
Here's what seems to be happening:
When we get an error back, we are attempting to push a replacement AWSUserPoolNewPasswordRequiredViewController  onto the nav stack at the same time we are presenting a UIAlertView.  The UIAlertView is preventing the new AWSUserPoolNewPasswordRequiredViewController from appearing on the stack. The ViewControllers and (Bolts)Tasks are currently coupled together, so we are crashing because we are attempting to re-run the completed task that was attached to the stale view controller.

Instead, we should, seems like the right thing to do is the following three items (which I have pushed into the PR):
1.  Remove that old `AWSUserPoolNewPasswordRequiredViewController` (and therefore the completed task will also be removed) from the navigation stack
2.  Present the new AWSUserPoolNewPasswordRequiredViewController (with the old config) in place of the old `AWSUserPoolNewPasswordRequiredViewController` that is being removed
3.  Presenting the alert view off of the newly created AWSUserPoolNewPasswordRequiredViewController (which becomes the top view controller)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
