### PR TITLE
 Remove all user attributes for new password required flow

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -32,7 +32,6 @@ static const NSString * AWSCognitoIdentityUserAsfDeviceId = @"asf.device.id";
 static const NSString * AWSCognitoIdentityUserDeviceSecret = @"device.secret";
 static const NSString * AWSCognitoIdentityUserDeviceGroup = @"device.group";
 static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttributes.";
-static const NSString * AWSCognitoIdentityUserEmailVerifiedKey = @"email_verified";
 
 -(instancetype) initWithUsername: (NSString *)username pool:(AWSCognitoIdentityUserPool *)pool {
     self = [super init];
@@ -359,15 +358,9 @@ static const NSString * AWSCognitoIdentityUserEmailVerifiedKey = @"email_verifie
         id<AWSCognitoIdentityNewPasswordRequired> newPasswordRequiredDelegate = [self.pool.delegate startNewPasswordRequired];
         NSString * userAttributes = lastChallenge.challengeParameters[@"userAttributes"];
         NSString * requiredAttributes = lastChallenge.challengeParameters[@"requiredAttributes"];
-        NSMutableDictionary<NSString*, NSString *> *userAttributesDict = [NSMutableDictionary new];
+        NSDictionary<NSString*, NSString *> *userAttributesDict = [NSMutableDictionary new];
         NSMutableSet<NSString*> *requiredAttributesSet = [NSMutableSet new];
         
-        if(userAttributes){
-            [userAttributesDict addEntriesFromDictionary:[NSJSONSerialization JSONObjectWithData:[userAttributes dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil]];
-            // Service responds with "Cannot modify the non-mutable attribute email_verified", if this value isn't taken out.
-            // https://github.com/aws-amplify/aws-sdk-ios/issues/2203
-            [userAttributesDict removeObjectForKey:AWSCognitoIdentityUserEmailVerifiedKey];
-        }
         if(requiredAttributes) {
             NSArray * requiredAttributesArray = [NSJSONSerialization JSONObjectWithData:[requiredAttributes dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil];
             for (NSString * requiredAttribute in requiredAttributesArray) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - **Amazon IoT**
     - Fixed a crash in AWSIoTManager when importing PKCS12 data with an incorrect passphrase. (See [#1166](https://github.com/aws-amplify/aws-sdk-ios/issues/1166))
   - **AWSMobileClient, Amazon Cognito Identity Provider**
-    - Fixed issue where users in a FORCE_CHANGE_PASSWORD flow are unable to update their password (See [#2203](https://github.com/aws-amplify/aws-sdk-ios/issues/2203))
+    - Fixed issue where users in a FORCE_CHANGE_PASSWORD flow are unable to update their password.  We confirmed with the service team that we should not be sending back these parameters, and instead be sending an empty dictionary. (See [#2203](https://github.com/aws-amplify/aws-sdk-ios/issues/2203))
   - **AWSMobileClient**
     - Fixed issue where custom auth challenge task completion wasn't being reset to nil if user logged out before completing it (See [#2261](https://github.com/aws-amplify/aws-sdk-ios/issues/2261))
 


### PR DESCRIPTION
While testing w/ an account that was created w/ phone_number_verified, I noticed that we are experiencing the same problem with the phone_number_verified attribute during the password change required workflow

Related:
(#2203) (#2240)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
