### PR TITLE
Clear CustomAuthChallenge Task on SignOut

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -519,6 +519,7 @@ extension AWSMobileClient {
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
         }
         self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
+        self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = nil
         invokeSignInCallback(signResult: nil, error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
         self.userPoolClient?.clearAll()
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     - Fixed a crash in AWSIoTManager when importing PKCS12 data with an incorrect passphrase. (See [#1166](https://github.com/aws-amplify/aws-sdk-ios/issues/1166))
   - **AWSCognitoIdentityProvider**
     - Fixed issue where users in a FORCE_CHANGE_PASSWORD flow are unable to update their password (See [#2203](https://github.com/aws-amplify/aws-sdk-ios/issues/2203))
+  - **AWSMobileClient**
+    - Fixed issue where custom auth challenge task completion wasn't being reset to nil if user logged out before completing it (See [#2261](https://github.com/aws-amplify/aws-sdk-ios/issues/2261))
 
 ### Misc. Updates
 


### PR DESCRIPTION
*Issue #, if available:* Providing a fix for #2261 

*Description of changes:*
CustomAuthChallengeTask does not clear on sign out so if sign in challenge wasn't completed and sign out was called first, you receive an error of "Missing required parameter ANSWER"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
