### PR TITLE
Copy x86_64-apple-ios-simulator swiftmodule files for AWSMobileClient…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
 # AWS Mobile SDK for iOS CHANGELOG
-## Unreleased
-- Fixed issue 2274 where we were not packaging x86_64-apple-ios-simulator.swiftmodule files for binary releases
 
 ## 2.12.7
 
@@ -14,6 +12,7 @@
   - Fix crash on NewPasswordRequired flow when UIAlertView is presented on service error
 - **AWSMobileClient**
   - Fixed issue where custom auth challenge task completion wasn't being reset to nil if user logged out before completing it (See [#2261](https://github.com/aws-amplify/aws-sdk-ios/issues/2261))
+- Include x86_64-apple-ios-simulator.swiftmodule files for binary releases (See [#2274](https://github.com/aws-amplify/aws-sdk-ios/issues/2274))
 
 ### Misc. Updates
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # AWS Mobile SDK for iOS CHANGELOG
+## Unreleased
+- Fixed issue 2274 where we were not packaging x86_64-apple-ios-simulator.swiftmodule files for binary releases
 
 ## 2.12.7
 

--- a/CircleciScripts/package_sdk.sh
+++ b/CircleciScripts/package_sdk.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-set -u
-
+set -u -v
 # Helper function to exit on nonzero code
 function exitOnFailureCode() {
     if [ $1 -ne 0 ]
@@ -72,7 +71,6 @@ FRAMEWORK_DIR=$FRAMEWORK_BUILD_PATH/$FRAMEWORK_NAME.framework
 mkdir -p $FRAMEWORK_DIR
 # rm -rf $FRAMEWORK_DIR
 echo "copy framework"
-echo "builtFramework/Release-iphoneos/${project_name}.framework $FRAMEWORK_DIR"
 cp -aR "builtFramework/Release-iphoneos/${project_name}.framework/" "$FRAMEWORK_DIR"
 cp -aR "builtFramework/Debug-iphonesimulator/${project_name}.framework/" "$FRAMEWORK_DIR"
 # The trick for creating a fully usable library is

--- a/CircleciScripts/package_sdk.sh
+++ b/CircleciScripts/package_sdk.sh
@@ -74,6 +74,7 @@ mkdir -p $FRAMEWORK_DIR
 echo "copy framework"
 echo "builtFramework/Release-iphoneos/${project_name}.framework $FRAMEWORK_DIR"
 cp -aR "builtFramework/Release-iphoneos/${project_name}.framework/" "$FRAMEWORK_DIR"
+cp -aR "builtFramework/Debug-iphonesimulator/${project_name}.framework/" "$FRAMEWORK_DIR"
 # The trick for creating a fully usable library is
 # to use lipo to glue the different library
 # versions together into one file. When an


### PR DESCRIPTION
Tested locally on my box by importing in generated build artifacts into a new project file.  Made sure to compile and run code that was calling into the AWSMobileClient.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
