### PR TITLE
Mark waiting upload parts as cancelled when canceling a multipart upload

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -2191,7 +2191,12 @@ didCompleteWithError:(NSError *)error {
                     AWSS3TransferUtilityUploadSubTask *subTask = [transferUtilityMultiPartUploadTask.inProgressPartsDictionary objectForKey:key];
                     [subTask.sessionTask cancel];
                 }
-                
+
+                for (NSNumber *key in [transferUtilityMultiPartUploadTask.waitingPartsDictionary allKeys]) {
+                    AWSS3TransferUtilityUploadSubTask *subTask = [transferUtilityMultiPartUploadTask.waitingPartsDictionary objectForKey:key];
+                    [subTask.sessionTask cancel];
+                }
+
                 //Abort the request, so the server can clean up any partials.
                 [self callAbortMultiPartForUploadTask:transferUtilityMultiPartUploadTask];
                 

--- a/AWSS3/AWSS3TransferUtilityTasks.m
+++ b/AWSS3/AWSS3TransferUtilityTasks.m
@@ -261,7 +261,12 @@
         AWSS3TransferUtilityUploadSubTask *subTask = [self.inProgressPartsDictionary objectForKey:key];
         [subTask.sessionTask cancel];
     }
-    
+
+    for (NSNumber *key in [self.waitingPartsDictionary allKeys]) {
+        AWSS3TransferUtilityUploadSubTask *subTask = [self.waitingPartsDictionary objectForKey:key];
+        [subTask.sessionTask cancel];
+    }
+
     [AWSS3TransferUtilityDatabaseHelper deleteTransferRequestFromDB:_transferID databaseQueue:self.databaseQueue];
 }
 


### PR DESCRIPTION
An NSURLSession that has been marked as invalidated via `finishTasksAndInvalidate` will only fully invalidate when all tasks associated with it have been completed. Currently, only in-progress parts
are being cancelled and thus marked as completed. Any waiting tasks remain in the `NSURLSessionTaskStateSuspended` state. As per the documentation, the session will only be flagged as invalidated, calling
the `[NSURLSession session:didBecomeInvalidWithError:]` when all tasks have a state of `NSURLSessionTaskStateCompleted`.