### PR TITLE
Remove AWSTranscribeStreaming subspec

### DIFF
--- a/AWSiOSSDKv2.podspec
+++ b/AWSiOSSDKv2.podspec
@@ -149,9 +149,8 @@ Pod::Spec.new do |s|
     sub.dependency 'AWSTranscribe', '2.12.7'
   end
 
-  s.subspec 'AWSTranscribeStreaming' do |sub|
-    sub.dependency 'AWSTranscribeStreaming', '2.12.7'
-  end
+  # note that AWSTranscribeStreaming requires iOS 9.0 or higher, and is
+  # therefore not included as a subspec
 
   s.subspec 'AWSTranslate' do |sub|
     sub.dependency 'AWSTranslate', '2.12.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 ### Note for CocoaPods users
 
-The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes a [subspec for AWSTranscribeStreaming](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2.
+The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes a [subspec for AWSTranscribeStreaming](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual 2.12.7 release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2.
   
 ## 2.12.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 ### Note for CocoaPods users
 
-The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes a [subspec for AWSTranscribeStreaming](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual 2.12.7 release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2.
+The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes a [subspec for AWSTranscribeStreaming](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual 2.12.7 release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2. Note that we don’t recommend using the AWSiOSSDKv2 pod, but rather importing individual pods.
   
 ## 2.12.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   - Amazon IoT
   - AWS KMS
   - AWS Lambda
+
+### Note for CocoaPods users
+
+The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes an [AWSTranscribeStreaming subspec](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2.
   
 ## 2.12.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 ### Note for CocoaPods users
 
-The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes an [AWSTranscribeStreaming subspec](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2.
+The source code of the AWSiOSSDKV2.podspec at the 2.12.7 release tag includes a [subspec for AWSTranscribeStreaming](https://github.com/aws-amplify/aws-sdk-ios/blob/2.12.7/AWSiOSSDKv2.podspec#L152-L154). However, that subspec is not in the actual release of the AWSiOSSDKv2 pod, since it requires iOS 9.0 or higher. Future releases will properly reflect that AWSTranscribeStreaming is not packaged as a subspec of AWSiOSSDKv2.
   
 ## 2.12.6
 


### PR DESCRIPTION
The AWSTranscribeStreaming module requires iOS 9+, which makes it incompatible with AWSiOSSDKv2.podspec's declaration of 8.0.

This change reverts the addition of AWSTranscribeStreaming to the aggregate podspec I performed in https://github.com/aws-amplify/aws-sdk-ios/commit/d9e1d0a2bbd7426b494134b3082ac124abfc982e. 

Longer term, our options are:

1. Upgrade platform support to be consistently iOS 9 or higher
2. Remove the AWSiOSSDKv2 podspec, since our instructions no longer recommend that people use that spec, but rather import individual specs

Either one is a breaking change, but the 2nd option is likely the cleanest. However, for now, we can continue to publish the aggregate podspec without subspecs like AWSTranscribeStreaming, that require iOS 9+.