### PR TITLE
Increased the timeout for s3 upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,6 +679,7 @@ jobs:
           command: |
             aws s3api put-object --bucket "$release_bucket" --key "$sdkNameWithVersion.zip" --body "$sdkNameWithVersion.zip" --content-disposition "attachment;filename=$sdkNameWithVersion.zip" --acl public-read --profile sdk_s3_release
             aws s3api put-object --bucket "$release_bucket" --key "latest/$sdkName.zip" --body "$sdkNameWithVersion.zip" --content-disposition "attachment;filename=$sdkNameWithVersion.zip" --acl public-read --profile sdk_s3_release
+          no_output_timeout: 30m
       - run:
           name: Invalidate cloudfront
           command: |


### PR DESCRIPTION
Upload to S3 step was failing in circleCi because of the following error:

```
Too long with no output (exceeded 10m0s): context deadline exceeded
```

This fix should increase the timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
