### PR TITLE
Pass clientMetaData to Cognito Triggers

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -368,16 +368,28 @@ extension AWSMobileClient {
     ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
     ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when a result is available.
-    public func confirmSignUp(username: String, confirmationCode: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+    public func confirmSignUp(username: String,
+                              confirmationCode: String,
+                              clientMetaData: [String:String] = [:],
+                              completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
         if let uname = self.userpoolOpsHelper.signUpUser?.username, uname == username {
-            confirmSignUp(user: self.userpoolOpsHelper.signUpUser!, confirmationCode: confirmationCode, clientMetaData: clientMetaData, completionHandler: completionHandler)
+            confirmSignUp(user: self.userpoolOpsHelper.signUpUser!,
+                          confirmationCode: confirmationCode,
+                          clientMetaData: clientMetaData,
+                          completionHandler: completionHandler)
         } else {
             let user = self.userPoolClient?.getUser(username)
-            confirmSignUp(user: user!, confirmationCode: confirmationCode,clientMetaData: clientMetaData, completionHandler: completionHandler)
+            confirmSignUp(user: user!,
+                          confirmationCode: confirmationCode,
+                          clientMetaData: clientMetaData,
+                          completionHandler: completionHandler)
         }
     }
     
-    internal func confirmSignUp(user: AWSCognitoIdentityUser, confirmationCode: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+    internal func confirmSignUp(user: AWSCognitoIdentityUser,
+                                confirmationCode: String,
+                                clientMetaData: [String:String] = [:],
+                                completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
         user.confirmSignUp(confirmationCode, clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
@@ -426,7 +438,9 @@ extension AWSMobileClient {
     ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
     ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when result is available.
-    public func forgotPassword(username: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
+    public func forgotPassword(username: String,
+                               clientMetaData: [String:String] = [:],
+                               completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
         let user = self.userPoolClient?.getUser(username)
         user!.forgotPassword(clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
@@ -451,7 +465,11 @@ extension AWSMobileClient {
     ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
     ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when a result is available.
-    public func confirmForgotPassword(username: String, newPassword: String, confirmationCode: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
+    public func confirmForgotPassword(username: String,
+                                      newPassword: String,
+                                      confirmationCode: String,
+                                      clientMetaData: [String:String] = [:],
+                                      completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
         let user = self.userPoolClient?.getUser(username)
         user!.confirmForgotPassword(confirmationCode, password: newPassword, clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -313,11 +313,14 @@ extension AWSMobileClient {
     ///   - password: password of the user
     ///   - userAttributes: user attributes which contain attributes like phone_number, email, etc.
     ///   - validationData: validation data for the user.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when a sign up result is available.
     public func signUp(username: String,
                        password: String,
                        userAttributes: [String: String] = [:],
                        validationData: [String: String] = [:],
+                       clientMetaData: [String:String] = [:],
                        completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
         
         if (self.userPoolClient == nil) { completionHandler(nil, AWSMobileClientError.userPoolNotConfigured(message: "Cognito User Pools is not configured in `awsconfiguration.json`. Please add Cognito User Pools before using this API."))}
@@ -327,7 +330,8 @@ extension AWSMobileClient {
         
         self.userPoolClient?.signUp(username, password: password,
                                    userAttributes: userAttributesTransformed.count == 0 ? nil : userAttributesTransformed,
-                                   validationData: validationDataTransformed.count == 0 ? nil : validationDataTransformed).continueWith { (task) -> Any? in
+                                   validationData: validationDataTransformed.count == 0 ? nil : validationDataTransformed,
+                                   clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let result = task.result {
@@ -361,18 +365,20 @@ extension AWSMobileClient {
     /// - Parameters:
     ///   - username: username of the user.
     ///   - confirmationCode: confirmation code sent to the user.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when a result is available.
-    public func confirmSignUp(username: String, confirmationCode: String, completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+    public func confirmSignUp(username: String, confirmationCode: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
         if let uname = self.userpoolOpsHelper.signUpUser?.username, uname == username {
-            confirmSignUp(user: self.userpoolOpsHelper.signUpUser!, confirmationCode: confirmationCode, completionHandler: completionHandler)
+            confirmSignUp(user: self.userpoolOpsHelper.signUpUser!, confirmationCode: confirmationCode, clientMetaData: clientMetaData, completionHandler: completionHandler)
         } else {
             let user = self.userPoolClient?.getUser(username)
-            confirmSignUp(user: user!, confirmationCode: confirmationCode, completionHandler: completionHandler)
+            confirmSignUp(user: user!, confirmationCode: confirmationCode,clientMetaData: clientMetaData, completionHandler: completionHandler)
         }
     }
     
-    internal func confirmSignUp(user: AWSCognitoIdentityUser, confirmationCode: String, completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
-        user.confirmSignUp(confirmationCode).continueWith { (task) -> Any? in
+    internal func confirmSignUp(user: AWSCognitoIdentityUser, confirmationCode: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+        user.confirmSignUp(confirmationCode, clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let _ = task.result {
@@ -417,10 +423,12 @@ extension AWSMobileClient {
     ///
     /// - Parameters:
     ///   - username: username of the user who forgot the password.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when result is available.
-    public func forgotPassword(username: String, completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
+    public func forgotPassword(username: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
         let user = self.userPoolClient?.getUser(username)
-        user!.forgotPassword().continueWith { (task) -> Any? in
+        user!.forgotPassword(clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let result = task.result {
@@ -440,10 +448,12 @@ extension AWSMobileClient {
     ///   - username: username of the user who forgot the password
     ///   - newPassword: the new password which the user wants to set
     ///   - confirmationCode: the confirmation code sent to the user
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when a result is available.
-    public func confirmForgotPassword(username: String, newPassword: String, confirmationCode: String, completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
+    public func confirmForgotPassword(username: String, newPassword: String, confirmationCode: String, clientMetaData: [String:String] = [:], completionHandler: @escaping ((ForgotPasswordResult?, Error?) -> Void)) {
         let user = self.userPoolClient?.getUser(username)
-        user!.confirmForgotPassword(confirmationCode, password: newPassword).continueWith { (task) -> Any? in
+        user!.confirmForgotPassword(confirmationCode, password: newPassword, clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let _ = task.result {

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
@@ -23,6 +23,21 @@ class AWSMobileClientPasswordTests: AWSMobileClientTestBase {
         wait(for: [forgotPasswordExpection], timeout: 5)
     }
     
+    func testForgotPasswordWithNilClientMetaData() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        forgotPasswordWithClientMetaData(username: username, clientMetaData: nil)
+    }
+    
+    func testForgotPasswordWithValidClientMetaData() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        forgotPasswordWithClientMetaData(username: username, clientMetaData: ["customKey":"customValue"])
+    }
+    
+    
     func testChangePassword() {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -17,6 +17,19 @@ class AWSMobileClientTests: AWSMobileClientTestBase {
         adminVerifyUser(username: username)
     }
     
+    func testSignUpWithNilClientMetaData() {
+        let username = "testUser" + UUID().uuidString
+        signUpWithClientMetaData(username: username)
+        adminVerifyUser(username: username)
+    }
+    
+    func testSignUpWithValidClientMetaData() {
+        let username = "testUser" + UUID().uuidString
+        signUpWithClientMetaData(username: username,
+                                 clientMetaData: ["customKey":"cutomValue"])
+        adminVerifyUser(username: username)
+    }
+    
     func testResendSignUpCode() {
         let username = "testUser" + UUID().uuidString
         signUpUser(username: username)

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -17,16 +17,10 @@ class AWSMobileClientTests: AWSMobileClientTestBase {
         adminVerifyUser(username: username)
     }
     
-    func testSignUpWithNilClientMetaData() {
-        let username = "testUser" + UUID().uuidString
-        signUpWithClientMetaData(username: username)
-        adminVerifyUser(username: username)
-    }
-    
     func testSignUpWithValidClientMetaData() {
         let username = "testUser" + UUID().uuidString
-        signUpWithClientMetaData(username: username,
-                                 clientMetaData: ["customKey":"cutomValue"])
+        signUpUser(username: username,
+                   clientMetaData: ["customKey":"cutomValue"])
         adminVerifyUser(username: username)
     }
     

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -84,14 +84,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Confirm a users' sign up with the confirmation code.  If forceAliasCreation is set, if another user is aliased to the same email/phone this code was sent to, reassign alias to this user.
  */
--(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode forceAliasCreation:(BOOL)forceAliasCreation;
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
+                                                       forceAliasCreation:(BOOL)forceAliasCreation;
 
 -(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
-                                                            clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+                                                           clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
 
 -(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
-                                                            forceAliasCreation:(BOOL)forceAliasCreation
-                                                            clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+                                                       forceAliasCreation:(BOOL)forceAliasCreation
+                                                           clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
 /**
  Resend the confirmation code sent during sign up
  */
@@ -131,8 +132,8 @@ NS_ASSUME_NONNULL_BEGIN
  Conclude the forgot password flow by providing the forgot password code and new password.
  */
 - (AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *)confirmForgotPassword:(NSString *)confirmationCode
-                                                                    password:(NSString *)password
-                                                                    clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+                                                                                 password:(NSString *)password
+                                                                           clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
 
 
 - (AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *)confirmForgotPassword:(NSString *)confirmationCode

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -86,6 +86,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 -(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode forceAliasCreation:(BOOL)forceAliasCreation;
 
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
+                                                            clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
+                                                            forceAliasCreation:(BOOL)forceAliasCreation
+                                                            clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
 /**
  Resend the confirmation code sent during sign up
  */
@@ -116,13 +122,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Send a code to this user to initiate the forgot password flow
  */
+- (AWSTask<AWSCognitoIdentityUserForgotPasswordResponse *> *)forgotPassword:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
 - (AWSTask<AWSCognitoIdentityUserForgotPasswordResponse *> *)forgotPassword;
+
 
 /**
  Conclude the forgot password flow by providing the forgot password code and new password.
  */
 - (AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *)confirmForgotPassword:(NSString *)confirmationCode
+                                                                    password:(NSString *)password
+                                                                    clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
+
+- (AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *)confirmForgotPassword:(NSString *)confirmationCode
                                                                                  password:(NSString *)password;
+
 
 /**
  Change this user's password

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -45,8 +45,8 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 
 
 -(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
-                                                            forceAliasCreation:(BOOL)forceAliasCreation
-                                                            clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
+                                                       forceAliasCreation:(BOOL)forceAliasCreation
+                                                           clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     AWSCognitoIdentityProviderConfirmSignUpRequest *request = [AWSCognitoIdentityProviderConfirmSignUpRequest new];
     request.clientId = self.pool.userPoolConfiguration.clientId;
     request.username = self.username;
@@ -72,13 +72,13 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 
 
 -(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
-                                                            forceAliasCreation:(BOOL)forceAliasCreation {
+                                                       forceAliasCreation:(BOOL)forceAliasCreation {
     return [self confirmSignUp:confirmationCode forceAliasCreation:forceAliasCreation clientMetaData:nil];
 }
 
 
 -(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
-                                                            clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
+                                                           clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     return [self confirmSignUp:confirmationCode forceAliasCreation:NO clientMetaData:clientMetaData];
 }
 
@@ -110,7 +110,9 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 }
 
 
--(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode password:(NSString *) password clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
+-(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode
+                                                                                 password:(NSString *) password
+                                                                           clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     AWSCognitoIdentityProviderConfirmForgotPasswordRequest *request = [AWSCognitoIdentityProviderConfirmForgotPasswordRequest new];
     request.clientId = self.pool.userPoolConfiguration.clientId;
     request.username = self.username;
@@ -128,7 +130,8 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     }];
 }
 
--(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode password:(NSString *) password {
+-(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode
+                                                                                 password:(NSString *) password {
     return [self confirmForgotPassword:confirmationCode
                               password:password
                               clientMetaData:nil];

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -43,11 +43,10 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     return self;
 }
 
--(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode {
-    return [self confirmSignUp:confirmationCode forceAliasCreation:NO];
-}
 
--(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode forceAliasCreation:(BOOL)forceAliasCreation {
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
+                                                            forceAliasCreation:(BOOL)forceAliasCreation
+                                                            clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     AWSCognitoIdentityProviderConfirmSignUpRequest *request = [AWSCognitoIdentityProviderConfirmSignUpRequest new];
     request.clientId = self.pool.userPoolConfiguration.clientId;
     request.username = self.username;
@@ -56,6 +55,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     request.forceAliasCreation = (forceAliasCreation?@(YES):@(NO));
     request.analyticsMetadata = [self.pool analyticsMetadata];
     request.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
+    request.clientMetadata = clientMetaData;
     
     return [[self.pool.client confirmSignUp:request] continueWithBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderConfirmSignUpResponse *> * _Nonnull task) {
         if (task.error) {
@@ -70,13 +70,32 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     }];
 }
 
--(AWSTask<AWSCognitoIdentityUserForgotPasswordResponse *> *) forgotPassword {
+
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
+                                                            forceAliasCreation:(BOOL)forceAliasCreation {
+    return [self confirmSignUp:confirmationCode forceAliasCreation:forceAliasCreation clientMetaData:nil];
+}
+
+
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode
+                                                            clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
+    return [self confirmSignUp:confirmationCode forceAliasCreation:NO clientMetaData:clientMetaData];
+}
+
+
+-(AWSTask<AWSCognitoIdentityUserConfirmSignUpResponse *> *) confirmSignUp:(NSString *) confirmationCode {
+    return [self confirmSignUp:confirmationCode forceAliasCreation:NO clientMetaData:nil];
+}
+
+
+-(AWSTask<AWSCognitoIdentityUserForgotPasswordResponse *> *) forgotPassword:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData {
     AWSCognitoIdentityProviderForgotPasswordRequest *request = [AWSCognitoIdentityProviderForgotPasswordRequest new];
     request.clientId = self.pool.userPoolConfiguration.clientId;
     request.username = self.username;
     request.secretHash = [self.pool calculateSecretHash:self.username];
     request.analyticsMetadata = [self.pool analyticsMetadata];
     request.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
+    request.clientMetadata = clientMetaData;
     
     return [[self.pool.client forgotPassword:request] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderForgotPasswordResponse *> * _Nonnull task) {
         AWSCognitoIdentityUserForgotPasswordResponse * response = [AWSCognitoIdentityUserForgotPasswordResponse new];
@@ -86,7 +105,12 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 
 }
 
--(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode password:(NSString *) password {
+-(AWSTask<AWSCognitoIdentityUserForgotPasswordResponse *> *) forgotPassword {
+    return [self forgotPassword:nil];
+}
+
+
+-(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode password:(NSString *) password clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     AWSCognitoIdentityProviderConfirmForgotPasswordRequest *request = [AWSCognitoIdentityProviderConfirmForgotPasswordRequest new];
     request.clientId = self.pool.userPoolConfiguration.clientId;
     request.username = self.username;
@@ -95,6 +119,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     request.confirmationCode = confirmationCode;
     request.analyticsMetadata = [self.pool analyticsMetadata];
     request.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
+    request.clientMetadata = clientMetaData;
     
     return [[self.pool.client confirmForgotPassword:request] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderConfirmForgotPasswordResponse *> * _Nonnull task) {
         AWSCognitoIdentityUserConfirmForgotPasswordResponse * response = [AWSCognitoIdentityUserConfirmForgotPasswordResponse new];
@@ -102,6 +127,13 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
         return [AWSTask taskWithResult:response];
     }];
 }
+
+-(AWSTask<AWSCognitoIdentityUserConfirmForgotPasswordResponse *> *) confirmForgotPassword: (NSString *)confirmationCode password:(NSString *) password {
+    return [self confirmForgotPassword:confirmationCode
+                              password:password
+                              clientMetaData:nil];
+}
+
 
 -(AWSTask<AWSCognitoIdentityUserResendConfirmationCodeResponse *> *) resendConfirmationCode {
     AWSCognitoIdentityProviderResendConfirmationCodeRequest *request = [AWSCognitoIdentityProviderResendConfirmationCodeRequest new];

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -64,10 +64,10 @@ NS_ASSUME_NONNULL_BEGIN
  Sign up a new user
  */
 - (AWSTask<AWSCognitoIdentityUserPoolSignUpResponse *> *)signUp:(NSString *)username
-                                                         password:(NSString *)password
-                                                         userAttributes:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)userAttributes
-                                                         validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData
-                                                         clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+                                                       password:(NSString *)password
+                                                 userAttributes:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)userAttributes
+                                                 validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData
+                                                 clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
 
 
 - (AWSTask<AWSCognitoIdentityUserPoolSignUpResponse *> *)signUp:(NSString *)username

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -64,9 +64,17 @@ NS_ASSUME_NONNULL_BEGIN
  Sign up a new user
  */
 - (AWSTask<AWSCognitoIdentityUserPoolSignUpResponse *> *)signUp:(NSString *)username
+                                                         password:(NSString *)password
+                                                         userAttributes:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)userAttributes
+                                                         validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData
+                                                         clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
+
+- (AWSTask<AWSCognitoIdentityUserPoolSignUpResponse *> *)signUp:(NSString *)username
                                                        password:(NSString *)password
                                                  userAttributes:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)userAttributes
                                                  validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData;
+
 
 /**
  Return the user who last authenticated.  Username may be nil if current user is unknown.

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -183,10 +183,12 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     _delegate = nil;
 }
 
+
 - (AWSTask<AWSCognitoIdentityUserPoolSignUpResponse *>*) signUp: (NSString*) username
                                      password: (NSString*) password
                                userAttributes: (NSArray<AWSCognitoIdentityUserAttributeType *> *) userAttributes
-                               validationData: (NSArray<AWSCognitoIdentityUserAttributeType *> *) validationData {
+                               validationData: (NSArray<AWSCognitoIdentityUserAttributeType *> *) validationData
+                               clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     AWSCognitoIdentityProviderSignUpRequest* request = [AWSCognitoIdentityProviderSignUpRequest new];
     request.clientId = self.userPoolConfiguration.clientId;
     request.username = username;
@@ -197,6 +199,7 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     request.analyticsMetadata = [self analyticsMetadata];
     AWSCognitoIdentityUser *contextUser = [[AWSCognitoIdentityUser alloc] initWithUsername:username pool:self];
     request.userContextData = [self userContextData:username deviceId:[contextUser asfDeviceId]];
+    request.clientMetadata = clientMetaData;
     
     return [[self.client signUp:request] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderSignUpResponse *> * _Nonnull task) {
         AWSCognitoIdentityUser * user = [[AWSCognitoIdentityUser alloc] initWithUsername:username pool:self];
@@ -211,6 +214,14 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
         return [AWSTask taskWithResult:signupResponse];
     }];
 }
+
+- (AWSTask<AWSCognitoIdentityUserPoolSignUpResponse *>*) signUp: (NSString*) username
+                                     password: (NSString*) password
+                               userAttributes: (NSArray<AWSCognitoIdentityUserAttributeType *> *) userAttributes
+                               validationData: (NSArray<AWSCognitoIdentityUserAttributeType *> *) validationData {
+    return [self signUp:username password:password userAttributes:userAttributes validationData:validationData clientMetaData:nil];
+}
+
 
 - (AWSCognitoIdentityUser*) currentUser {
     return [[AWSCognitoIdentityUser alloc] initWithUsername:[self currentUsername] pool: self];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
+## 2.13.1
+
+### Misc. Updates
+
+- Added an optional parameter `clientMetaData` to `signUp`, `confirmSignUp`, `forgotPassword` and `confirmForgotPassword`. Should not break existing calls to these functions.
+
 ## 2.13.0
 
 ### Bug Fixes


### PR DESCRIPTION
ClientMetaData is added as an optional parameter for signUp, confirmSignUp, forgotPassword and confirmForgotPassword. This data is passed to the cognito api.
Reference api: [here](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SignUp.html)
This PR address this [issue](https://github.com/aws-amplify/aws-sdk-ios/issues/2299)

Testing:
In addition to integration tests, tested using custom lambda triggers(pre-singup, post-confirmation and custom-message)from a sample app and verifying that the event received in the lambda has the passed clientMetaData intact.

![image](https://user-images.githubusercontent.com/55896475/75713312-7530f980-5c7e-11ea-9f69-dd3557f4b403.png)
![image](https://user-images.githubusercontent.com/55896475/75713335-7e21cb00-5c7e-11ea-8dc1-b773a6ff4aaf.png)
![image](https://user-images.githubusercontent.com/55896475/75713354-8548d900-5c7e-11ea-96ed-9546f3bd5e3f.png)
![image](https://user-images.githubusercontent.com/55896475/75713367-8974f680-5c7e-11ea-8844-65e99a0e1797.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
