### PR TITLE
patch config.yml with xterm environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,6 +642,8 @@ jobs:
   release_ios_s3:
     macos:
       xcode: "11.2.1"
+    environment: 
+      TERM: xterm-256color
     steps:
       - skip_job_unless_required
       - checkout


### PR DESCRIPTION
*Issue #, if available:*
Issue with the release pipeline with error
```
WARNING: terminal is not fully functional
-  (press RETURN)

```

Looks like this is the possible fix

ref https://discuss.circleci.com/t/on-macos-runners-warning-terminal-is-not-fully-functional/33656/5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
