### PR TITLE
adding xterm and changelog updates for 2.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,8 @@ jobs:
   pre_integrationtest:
     macos:
       xcode: "11.2.1"
+    environment: 
+      TERM: xterm-256color
     steps:
       - skip_job_unless_required
       - set_environment_variables
@@ -642,6 +644,8 @@ jobs:
   release_ios_s3:
     macos:
       xcode: "11.2.1"
+    environment:
+      TERM: xterm-256color
     steps:
       - skip_job_unless_required
       - checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- **Breaking Change** Updated nullability flags for the `AWSSignatureSignerUtility`, `AWSSignatureV4Signer`, `AWSSignatureV2Signer` and `AWSS3ChunkedEncodingInputStream` classes. Methods in these classes will have new signatures in Swift code, and may require code changes in your app to consume. 
+- **Breaking Change** Updated nullability flags for the `AWSSignatureSignerUtility`, `AWSSignatureV4Signer`, `AWSSignatureV2Signer` and `AWSS3ChunkedEncodingInputStream` classes. Methods in these classes will have new signatures in Swift code, and may require code changes in your app to consume. See [PR #2235](https://github.com/aws-amplify/aws-sdk-ios/pull/2235) for more details.
 
 - **Amazon S3**
   - TransferUtility now properly cancels waiting parts when canceling a multipart upload. See [Issue #2280](https://github.com/aws-amplify/aws-sdk-ios/issues/2280), [PR #2288](https://github.com/aws-amplify/aws-sdk-ios/pull/2288/). Thanks, [@colinhumber](https://github.com/colinhumber)!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## 2.13.0
 
-### Misc. Updates
+### Bug Fixes
 
 - **Breaking Change** Updated nullability flags for the `AWSSignatureSignerUtility`, `AWSSignatureV4Signer`, `AWSSignatureV2Signer` and `AWSS3ChunkedEncodingInputStream` classes. Methods in these classes will have new signatures in Swift code, and may require code changes in your app to consume. 
-
-## 2.12.8
-
-### Bug Fixes
 
 - **Amazon S3**
   - TransferUtility now properly cancels waiting parts when canceling a multipart upload. See [Issue #2280](https://github.com/aws-amplify/aws-sdk-ios/issues/2280), [PR #2288](https://github.com/aws-amplify/aws-sdk-ios/pull/2288/). Thanks, [@colinhumber](https://github.com/colinhumber)!
@@ -25,6 +21,10 @@
   - AWS Lambda
   - Amazon Pinpoint
   - Amazon Rekognition
+
+## 2.12.8
+
+This version has been deprecated. Please use the latest release.
 
 ## 2.12.7
 


### PR DESCRIPTION
this adds the `TERM: xterm-256color` environment for places which is using `configure_aws` step that installs aws cli. we noticed this was installing 2.0.0 that started breaking in a later step with

```
WARNING: terminal is not fully functional
-  (press RETURN)
```

Looks like this is the possible fix

ref https://discuss.circleci.com/t/on-macos-runners-warning-terminal-is-not-fully-functional/33656/5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
