### PR TITLE
fixed failing integ tests with clientMetaData

### DIFF
--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
@@ -23,18 +23,15 @@ class AWSMobileClientPasswordTests: AWSMobileClientTestBase {
         wait(for: [forgotPasswordExpection], timeout: 5)
     }
     
-    func testForgotPasswordWithNilClientMetaData() {
-        let username = "testUser" + UUID().uuidString
-        signUpAndVerifyUser(username: username)
-        signIn(username: username)
-        forgotPasswordWithClientMetaData(username: username, clientMetaData: nil)
-    }
-    
     func testForgotPasswordWithValidClientMetaData() {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
-        signIn(username: username)
-        forgotPasswordWithClientMetaData(username: username, clientMetaData: ["customKey":"customValue"])
+        let forgotPasswordExpection = expectation(description: "Expecting code to be sent for forgot password.")
+        AWSMobileClient.default().forgotPassword(username: username) { (forgotPasswordResult, error) in
+            XCTAssertNotNil(error, "should get error which mentions there is no verified email or phone.")
+            forgotPasswordExpection.fulfill()
+        }
+        wait(for: [forgotPasswordExpection], timeout: 5)
     }
     
     

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientPasswordTests.swift
@@ -27,7 +27,8 @@ class AWSMobileClientPasswordTests: AWSMobileClientTestBase {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username)
         let forgotPasswordExpection = expectation(description: "Expecting code to be sent for forgot password.")
-        AWSMobileClient.default().forgotPassword(username: username) { (forgotPasswordResult, error) in
+        AWSMobileClient.default().forgotPassword(username: username,
+                                                 clientMetaData: ["customKey":"cutomValue"]) { (forgotPasswordResult, error) in
             XCTAssertNotNil(error, "should get error which mentions there is no verified email or phone.")
             forgotPasswordExpection.fulfill()
         }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -131,7 +131,7 @@ class AWSMobileClientTestBase: XCTestCase {
             username: username,
             password: sharedPassword,
             userAttributes: userAttributes,
-            clientMetaData: clientMetaData) { (signUpResult, error) in
+            clientMetaData: clientMetaData ?? [:]) { (signUpResult, error) in
                 if let error = error {
                     var errorMessage: String
                     if let mobileClientError = error as? AWSMobileClientError {
@@ -211,46 +211,6 @@ class AWSMobileClientTestBase: XCTestCase {
         let namespace = "\(AWSMobileClient.default().userPoolClient!.userPoolConfiguration.clientId).\(username)"
         let key = "\(namespace).tokenExpiration"
         keychain.removeItem(forKey: key)
-    }
-    
-    func forgotPasswordWithClientMetaData(username: String,
-                                          clientMetaData: [String: String]? = nil,
-                                          forgotPasswordState: ForgotPasswordState = .confirmationCodeSent) {
-        let forgotPasswordExpectation = expectation(description: "successful forgot password with clientMetaData expectation.")
-        AWSMobileClient.default().forgotPassword(username: username,
-                                                 clientMetaData: clientMetaData
-                                                ) { (forgotPasswordResult, error) in
-                if let error = error {
-                    var errorMessage: String
-                    if let mobileClientError = error as? AWSMobileClientError {
-                        errorMessage = mobileClientError.message
-                    } else {
-                        errorMessage = error.localizedDescription
-                    }
-                    XCTFail("Unexpected failure: \(errorMessage)")
-                    return
-                }
-                
-                guard let forgotPasswordResult = forgotPasswordResult else {
-                    XCTFail("Forgot Password with ClientMetaData unexpectedly nil")
-                    return
-                }
-                                                    
-                switch(forgotPasswordResult.forgotPasswordState) {
-                case .confirmationCodeSent:
-                    print("Confirmation code sent via \(forgotPasswordResult.codeDeliveryDetails!.deliveryMedium) to: \(forgotPasswordResult.codeDeliveryDetails!.destination!)")
-                default:
-                    print("Error: Invalid case.")
-                }
-                
-                XCTAssertTrue(forgotPasswordResult.forgotPasswordState == forgotPasswordState,
-                              "User is expected to be marked as \(forgotPasswordState).")
-                
-                forgotPasswordExpectation.fulfill()
-        }
-        
-        wait(for: [forgotPasswordExpectation], timeout: 5)
-        
     }
     
 }


### PR DESCRIPTION
Issue: 
ClientMetaData is added as an optional parameter for signUp, confirmSignUp, forgotPassword and confirmForgotPassword. This data is passed to the cognito api.

Description of changes:
changes introduced by this [PR](https://github.com/aws-amplify/aws-sdk-ios/pull/2328)
had a couple of AWSMobileClient integration tests failing. This PR would fix them. Refer to the above PR for additional info.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
