### PR TITLE
Fixed readme for cocopod and framework installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ You should use one of these three ways to import the AWS Mobile SDK but not mult
 
 2. In your project directory (the directory where your `*.xcodeproj` file is), create a plain text file named `Podfile` (without any file extension) and add the lines below. Replace `YourTarget` with your actual target name.
 
-        source 'https://github.com/CocoaPods/Specs.git'
-        
         platform :ios, '8.0'
         use_frameworks!
         
@@ -147,7 +145,7 @@ You should use one of these three ways to import the AWS Mobile SDK but not mult
 
 ### Frameworks
 
-1. Download the SDK from our [AWS Mobile SDK](http://aws.amazon.com/mobile/sdk) page. The SDK is stored in a compressed file archive named `aws-ios-sdk-#.#.#` (where `#.#.#` represents the version number, so for version 2.7.0, the filename is `aws-ios-sdk-2.7.0`).
+1. Download the [latest SDK](https://sdk-for-ios.amazonwebservices.com/latest/aws-ios-sdk.zip). Older SDK versions can be downloaded from `https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-#.#.#.zip`, where `#.#.#` represents the version number. So for version 2.10.2, the download link is [https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-2.10.2.zip](https://sdk-for-ios.amazonwebservices.com/aws-ios-sdk-2.10.2.zip).
 
 2. With your project open in Xcode, select your **Target**. Under **General** tab, find **Embedded Binaries** and then click the **+** button.
 


### PR DESCRIPTION
*Issue [#2370](https://github.com/aws-amplify/aws-sdk-ios/issues/2370)

*Description of changes:*
- Our documentation was pointing to the old way of fetching spec repo, instead it now default to CDN. So removed the line that point to the git based repo.

- Fixed the link for accessing the framework file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
