### PR TITLE
Update Xcode image to 11.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ commands:
 jobs:
   build:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - checkout
@@ -258,7 +258,7 @@ jobs:
             xcodebuild build -project AWSAuthSDK/AWSAuthSDK.xcodeproj -scheme AWSAuthSDKAllTargets -sdk iphonesimulator -destination "${destination}"
   unittest:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - set_environment_variables
       - override_test_job
@@ -283,7 +283,7 @@ jobs:
           path: test_result
   pre_integrationtest:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     environment: 
       TERM: xterm-256color
     steps:
@@ -329,7 +329,7 @@ jobs:
             - build_result
   post_integrationtest:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       #TODO need check why multiple key does not work here
       - skip_job_unless_required
@@ -418,7 +418,7 @@ jobs:
         default: stable_testList
         type: string
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - set_environment_variables
       - override_test_job
@@ -461,7 +461,7 @@ jobs:
 
   release_tag:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - checkout
@@ -478,7 +478,7 @@ jobs:
 
   release_carthage:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - checkout
@@ -514,7 +514,7 @@ jobs:
 
   release_cocoapods:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - checkout
@@ -525,7 +525,7 @@ jobs:
 
   release_docs:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - checkout
@@ -555,7 +555,7 @@ jobs:
 
   add_doc_tag:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - checkout
@@ -569,7 +569,7 @@ jobs:
 
   bump_ios_sampleapp_version:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - set_environment_variables
@@ -613,7 +613,7 @@ jobs:
 
   bump_ios_amplifydocs_version:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     steps:
       - skip_job_unless_required
       - set_environment_variables
@@ -643,7 +643,7 @@ jobs:
 
   release_ios_s3:
     macos:
-      xcode: "11.2.1"
+      xcode: "11.4.0"
     environment:
       TERM: xterm-256color
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 --
 # AWS Mobile SDK for iOS CHANGELOG
 
+## Unreleased
+
+### Misc. Updates
+- Update CI/CD system to build with Xcode 11.4 See [issue #2365](https://github.com/aws-amplify/aws-sdk-ios/issues/2365).
+
 ## 2.13.1
 
 ### New features


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-ios/issues/2365

*Description of changes:*
Updated CircleCI config to build with Xcode 11.4.0, per https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
