### PR TITLE
Add customDemographic field for pinpoint to override default demographic 

### DIFF
--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -76,6 +76,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) AWSPinpointEndpointProfileDemographic *_Nullable demographic;
 
 /**
+ The AWSPinpointEndpointProfileDemographic facet that, if it is set, will overwrite the default demographic
+ for subsequent requests to Pinpoint
+ @returns demographic
+ */
+@property (nonatomic, strong) AWSPinpointEndpointProfileDemographic *_Nullable customDemographic;
+
+/**
  The AWSPinpointEndpointProfileUser facet of the endpoint profile
  @returns user
  */

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -109,7 +109,7 @@ NSString *DEBUG_CHANNEL_TYPE = @"APNS_SANDBOX";
         
         //this updates demograhpic information.
         _location = [AWSPinpointEndpointProfileLocation new];
-        _demographic = [AWSPinpointEndpointProfileDemographic defaultAWSPinpointEndpointProfileDemographic];
+        _demographic = self.customDemographic ?: [AWSPinpointEndpointProfileDemographic defaultAWSPinpointEndpointProfileDemographic];
         _effectiveDate = [AWSPinpointDateUtils utcTimeMillisNow];
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # AWS Mobile SDK for iOS CHANGELOG
+## Unreleased Changes
+- Added support for adding custom demographic to pinpoint [PR: #2410](https://github.com/aws-amplify/aws-sdk-ios/pull/2410)
 
 ## 2.13.2
 


### PR DESCRIPTION
Prior to moving forward with this PR, I want to verify that this will resolve the customer's request.

In this prototype, the customer should be able to do something like:
```
//Setup custom fields that will be used in subsequent events that are sent to pinpoint:
let customDemographic: AWSPinpointEndpointProfileDemographic! = AWSPinpointEndpointProfileDemographic.default()
customDemographic.appVersion = "1.0.1.2.3.4.5.6"
customDemographic.platform = "MyCustomPlatform"
customDemographic.model = "MyCustomDeviceModel"

//No longer going with static variable named customDemographic
//AWSPinpointEndpointProfile.setCustomDemographic(customDemographic)

//Then initialize pinpoint as normal, perhaps something like this:
let pinpointConfiguration = AWSPinpointConfiguration.defaultPinpointConfiguration(launchOptions: launchOptions)
let pinpoint = AWSPinpoint(configuration: pinpointConfiguration)
//Overrides default demographic:
pinpoint.targetingClient.currentEndpointProfile().customDemographic = customDemographic

//Create some events:
analyticsClient.createEvent(withEventType: "UserPushedButton")

//Submit some events:
analyticsClient.submitEvents(completionBlock: {...})
```

And as  result, we'd expect to see the request to pinpoint being sent as:
```
{
...........
   "Demographic" : 
 {"Locale":"en_US",
"Timezone":"America\/Los_Angeles",
"PlatformVersion":"13.3",
"AppVersion":"1.0.1.2.3.4.5.6",
"Model":"MyCustomDeviceModel",
"Make":"apple",
"Platform":"MyCustomPlatform"},
........
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
