### PR TITLE
IoT Integration test - Wait for subscription acknowledgement

### DIFF
--- a/AWSIoTTests/AWSIoTDataManagerTests.swift
+++ b/AWSIoTTests/AWSIoTDataManagerTests.swift
@@ -743,7 +743,7 @@ class AWSIoTDataManagerTests: XCTestCase {
         gotMessage.expectedFulfillmentCount = 5
 
         let subAckExpectation = self.expectation(description: "Subscription should be acknowledged")
-        let subAckCallback: AWSIoTMQTTAckBlock = {
+        let ackCallback: AWSIoTMQTTAckBlock = {
             subAckExpectation.fulfill()
         }
 
@@ -757,8 +757,8 @@ class AWSIoTDataManagerTests: XCTestCase {
                                                     XCTAssertEqual(testMessage, stringValue)
                                                     gotMessage.fulfill()
         },
-                                                 ackCallback: subAckCallback)
-        XCTAssertTrue(subStatus, "Subscription should be susccessful. Connection Status - \(iotDataManager.getConnectionStatus().rawValue)")
+                                                 ackCallback: ackCallback)
+        XCTAssertTrue(subStatus, "Subscription should be successful. Connection Status - \(iotDataManager.getConnectionStatus().rawValue)")
         wait(for:[subAckExpectation], timeout:10)
 
         //Publish to TestTopic 5 times
@@ -767,7 +767,7 @@ class AWSIoTDataManagerTests: XCTestCase {
                                                              onTopic:testTopic,
                                                              qoS:.messageDeliveryAttemptedAtLeastOnce,
                                                              ackCallback: {
-                                                                print("Message publised in topic \(testTopic))")
+                                                                print("Message published in topic \(testTopic))")
             })
             XCTAssertTrue(publishStatus, "Publish should be successful. Connection Status - \(iotDataManager.getConnectionStatus().rawValue)")
         }

--- a/AWSIoTTests/AWSIoTDataManagerTests.swift
+++ b/AWSIoTTests/AWSIoTDataManagerTests.swift
@@ -741,7 +741,7 @@ class AWSIoTDataManagerTests: XCTestCase {
         let testMessage = "Test Message"
         let testTopic = "TestTopic"
         gotMessage.expectedFulfillmentCount = 5
-
+        gotMessage.assertForOverFulfill = false
         let subAckExpectation = self.expectation(description: "Subscription should be acknowledged")
         let ackCallback: AWSIoTMQTTAckBlock = {
             subAckExpectation.fulfill()
@@ -803,7 +803,9 @@ class AWSIoTDataManagerTests: XCTestCase {
         for i in 1...numberOfAttempts  {
             hasConnected.add(self.expectation(description: "MQTT connection\(i) has been established"))
             hasDisconnected.add(self.expectation(description: "Disconnected\(i)"))
-            gotMessages.add(self.expectation(description: "Got message on subscription \(i)"))
+            let expectation = self.expectation(description: "Got message on subscription \(i)")
+            expectation.assertForOverFulfill = false
+            gotMessages.add(expectation)
             subConfirmed.add(self.expectation(description: "Subscription \(i) confirmed"))
         }
 
@@ -928,7 +930,9 @@ class AWSIoTDataManagerTests: XCTestCase {
         for i in 1...numberOfAttempts  {
             hasConnected.add(self.expectation(description: "MQTT connection\(i) has been established"))
             hasDisconnected.add(self.expectation(description: "Disconnected\(i)"))
-            gotMessages.add(self.expectation(description: "Got message on subscription \(i)"))
+            let expectation = self.expectation(description: "Got message on subscription \(i)")
+            expectation.assertForOverFulfill = false
+            gotMessages.add(expectation)
             subConfirmed.add(self.expectation(description: "Subscription \(i) confirmed"))
         }
 
@@ -1312,6 +1316,8 @@ class AWSIoTDataManagerTests: XCTestCase {
 
         let gotMessage = self.expectation(description: "Got message on subscription")
         gotMessage.expectedFulfillmentCount = 5
+        gotMessage.assertForOverFulfill = false
+
         func mqttEventCallback( _ status: AWSIoTMQTTStatus )
         {
             print("connection status = \(status.rawValue)")
@@ -1410,7 +1416,9 @@ class AWSIoTDataManagerTests: XCTestCase {
         for i in 1...numberOfAttempts  {
             hasConnected.add(self.expectation(description: "MQTT connection\(i) has been established"))
             hasDisconnected.add(self.expectation(description: "Disconnected\(i)"))
-            gotMessages.add(self.expectation(description: "Got message on subscription \(i)"))
+            let expectation = self.expectation(description: "Got message on subscription \(i)")
+            expectation.assertForOverFulfill = false
+            gotMessages.add(expectation)
             subConfirmed.add(self.expectation(description: "Subscription \(i) confirmed"))
         }
 


### PR DESCRIPTION
The integration test starts publishing to the topic before the subscription is properly setup. This change makes the `publishString` to wait for subscription to complete. 

This issue looks like the problem with CircleCI integration test failing. See the logs below from CircleCI:
```
connection status = 2
Connected
2020-04-10 22:00:30:658 AWSAllTestsHost[1294:65633] MQTT session connected.
2020-04-10 22:00:30:658 AWSAllTestsHost[1294:65633] Auto-resubscribe is enabled. Resubscribing to topics.
2020-04-10 22:00:30:658 AWSAllTestsHost[1294:65223] Subscribing to topic TestTopic with messageCallback
2020-04-10 22:00:30:659 AWSAllTestsHost[1294:65223] messageId sending now 2
2020-04-10 22:00:30:659 AWSAllTestsHost[1294:65223] Published message 3 for QOS 1
2020-04-10 22:00:30:659 AWSAllTestsHost[1294:65223] Published message 4 for QOS 1
2020-04-10 22:00:30:659 AWSAllTestsHost[1294:65223] Published message 5 for QOS 1
2020-04-10 22:00:30:660 AWSAllTestsHost[1294:65223] Published message 6 for QOS 1
2020-04-10 22:00:30:660 AWSAllTestsHost[1294:65223] Published message 7 for QOS 1
2020-04-10 22:00:30:714 AWSAllTestsHost[1294:65633] Removing msgID 5 from internal store for QOS1 gaurantee
2020-04-10 22:00:30:715 AWSAllTestsHost[1294:65633] Removing msgID 3 from internal store for QOS1 gaurantee
2020-04-10 22:00:30:716 AWSAllTestsHost[1294:65633] Removing msgID 4 from internal store for QOS1 gaurantee
2020-04-10 22:00:30:716 AWSAllTestsHost[1294:65633] Removing msgID 6 from internal store for QOS1 gaurantee
2020-04-10 22:00:30:716 AWSAllTestsHost[1294:65633] Removing msgID 7 from internal store for QOS1 gaurantee
/Users/distiller/project/AWSIoTTests/AWSIoTDataManagerTests.swift:758: error: -[AWSIoTTests.AWSIoTDataManagerTests testPublishSubscribeWithCert] : Asynchronous wait failed: Exceeded timeout of 30 seconds, with unfulfilled expectations: "Got message on subscription".
2020-04-10 22:01:00:790 AWSAllTestsHost[1294:65223] AWSIoTMQTTClient: Disconnect message issued.
2020-04-10 22:01:00:790 AWSAllTestsHost[1294:65633] closing encoder stream.
2020-04-10 22:01:00:790 AWSAllTestsHost[1294:65633] closing decoder stream.
connection status = 3
Disconnected
```

And the corresponding Cloudwatch logs:

```
22:00:30
{"timestamp":"2020-04-10 22:00:30.637","logLevel":"INFO","traceId":"xx","accountId":"xxx","status":"Success","eventType":"Connect","protocol":"MQTT","clientId":"xx","principalId":"xx","sourceIp":"xx","sourcePort":xx}
22:00:30
{"timestamp":"2020-04-10 22:00:30.693","logLevel":"INFO","traceId":"xx","accountId":"xxx","status":"Success","eventType":"Publish-In","protocol":"MQTT","topicName":"TestTopic","clientId":"xx","principalId":"xx","sourceIp":"xx","sourcePort":xx}
22:00:30
{"timestamp":"2020-04-10 22:00:30.694","logLevel":"INFO","traceId":"xx","accountId":"xxx","status":"Success","eventType":"Publish-In","protocol":"MQTT","topicName":"TestTopic","clientId":"xx","principalId":"xx","sourceIp":"xx","sourcePort":xx}
22:00:30
{"timestamp":"2020-04-10 22:00:30.701","logLevel":"INFO","traceId":"xx","accountId":"xxx","status":"Success","eventType":"Subscribe","protocol":"MQTT","topicName":"TestTopic","clientId":"xx","principalId":"xx","sourceIp":"xx","sourcePort":xx}
22:01:00
{"timestamp":"2020-04-10 22:01:00.823","logLevel":"INFO","traceId":"xx","accountId":"xxx","status":"Success","eventType":"Disconnect","protocol":"MQTT","clientId":"xx","principalId":"xx","sourceIp":"xx","sourcePort":xx}

```
As you can see in cloudwatch log, the subscription message was received after the publish.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
