### PR TITLE
Add Sign in with Apple to IdentityProviders

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
@@ -145,6 +145,7 @@ public enum IdentityProvider: String {
     case twitter = "api.twitter.com"
     case amazon = "www.amazon.com"
     case developer = "cognito-identity.amazonaws.com"
+    case apple = "appleid.apple.com"
     
     func getHostedUIIdentityProvider() -> String? {
         switch self {
@@ -154,6 +155,8 @@ public enum IdentityProvider: String {
             return "Google"
         case .amazon:
             return "LoginWithAmazon"
+        case .apple:
+            return "SignInWithApple"
         default:
             return nil
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
+## Unreleased
+
+### New features
+- **AWSMobileClient** Added IdentityProvider strings for Sign in with Apple: `IdentityProvider.apple`. See [Issue #1809](https://github.com/aws-amplify/aws-sdk-ios/issues/1809)) and [PR #2425](https://github.com/aws-amplify/aws-sdk-ios/pull/2425).
+
 ## 2.13.2
 
 ### Bug Fixes


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-ios/issues/1809

*Description of changes:*
Now that Cognito supports Sign in with Apple as an Authentication Provider for IdentityPools, as well as a federated provider for UserPools via HostedUI, we can add the final provider strings to `AWSMobileClient.IdentityProviders`.

This will be accompanied by separate updates:
* To the Android AWSMobileClient
* To the legacy (SDK) Authentication documentation
* To the new preview Authentication documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
