### PR TITLE
Phani/integtest updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ AWS*.framework
 
 # Stuff that can't be committed #
 ######################
+testconfiguration.json
 credentials.json
 Pods
 Podfile.lock

--- a/AWSAPIGatewayTests/AWSAPIGatewayInvokeTest.swift
+++ b/AWSAPIGatewayTests/AWSAPIGatewayInvokeTest.swift
@@ -24,7 +24,7 @@ class TestAPIGatewayInvoke: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
         client = AWSLambdaMicroserviceClient.default()
         
         headerParameters = [

--- a/AWSAPIGatewayTests/AWSAPIGatewayInvokeTest.swift
+++ b/AWSAPIGatewayTests/AWSAPIGatewayInvokeTest.swift
@@ -25,7 +25,8 @@ class TestAPIGatewayInvoke: XCTestCase {
     override func setUp() {
         super.setUp()
         AWSTestUtility.setupSessionCredentialsProvider()
-        client = AWSLambdaMicroserviceClient.default()
+        let testConfig = AWSTestUtility.getIntegrationTestConfiguration(forPackageId: "apigateway")
+        client = AWSLambdaMicroserviceClient.defaultClient(testConfig!["endpointURL"] as! String)
         
         headerParameters = [
             "Content-Type": "application/json",

--- a/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.h
+++ b/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return The default service client.
  */
-+ (instancetype)defaultClient;
++ (instancetype)defaultClient: (NSString *)endpointURL;
 
 /**
  Creates a service client with the given service configuration and registers it for the key.

--- a/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.m
+++ b/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.m
@@ -64,7 +64,7 @@ static NSString *const AWSInfoClientKey = @"AWSLambdaMicroserviceClient";
 
 static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 
-+ (instancetype)defaultClient {
++ (instancetype)defaultClient:(NSString *)endpointURL {
     AWSServiceConfiguration *serviceConfiguration = nil;
     AWSServiceInfo *serviceInfo = [[AWSInfo defaultAWSInfo] defaultServiceInfo:AWSInfoClientKey];
     if (serviceInfo) {
@@ -76,6 +76,14 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         serviceConfiguration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUnknown
                                                            credentialsProvider:nil];
     }
+    
+    if ([endpointURL hasSuffix:@"/"]) {
+        endpointURL = [endpointURL substringToIndex:[endpointURL length] - 1];
+    }
+    serviceConfiguration.endpoint = [[AWSEndpoint alloc] initWithRegion:serviceConfiguration.regionType
+                                                                service:AWSServiceAPIGateway
+                                                                    URL:[NSURL URLWithString:endpointURL]];
+
 
     static AWSLambdaMicroserviceClient *_defaultClient = nil;
     static dispatch_once_t onceToken;
@@ -129,18 +137,8 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 - (instancetype)initWithConfiguration:(AWSServiceConfiguration *)configuration {
     if (self = [super init]) {
         _configuration = [configuration copy];
-
-        NSString *URLString = @"https://yjzm4utpcl.execute-api.us-east-1.amazonaws.com/prod";
-        if ([URLString hasSuffix:@"/"]) {
-            URLString = [URLString substringToIndex:[URLString length] - 1];
-        }
-        _configuration.endpoint = [[AWSEndpoint alloc] initWithRegion:_configuration.regionType
-                                                              service:AWSServiceAPIGateway
-                                                                  URL:[NSURL URLWithString:URLString]];
-
         AWSSignatureV4Signer *signer =  [[AWSSignatureV4Signer alloc] initWithCredentialsProvider:_configuration.credentialsProvider
                                                                                          endpoint:_configuration.endpoint];
-
         _configuration.baseURL = _configuration.endpoint.URL;
         _configuration.requestInterceptors = @[[AWSNetworkingRequestInterceptor new], signer];
     }

--- a/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.m
+++ b/AWSAPIGatewayTests/AWSLambdaMicroserviceClient.m
@@ -130,7 +130,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
     if (self = [super init]) {
         _configuration = [configuration copy];
 
-        NSString *URLString = @"https://mykov6r7rh.execute-api.us-east-1.amazonaws.com/prod";
+        NSString *URLString = @"https://yjzm4utpcl.execute-api.us-east-1.amazonaws.com/prod";
         if ([URLString hasSuffix:@"/"]) {
             URLString = [URLString substringToIndex:[URLString length] - 1];
         }

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -128,6 +128,11 @@
 		17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1786CA4D1F2BEDB8003421FF /* Images.xcassets */; };
 		17F4F75021F6B0750068B553 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		17F4F75121F6B0750068B553 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */; };
+		43B25DB22457D7B600C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
+		43B25DB32457D7EC00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
+		43B25DB42457D7EE00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
+		43B25DB52457D7F000C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
+		43B25DB62457D7F100C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
 		6BB7BFAF23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB7BF2E23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h */; };
 		B4031B79230F044A009EB524 /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4031B78230F044A009EB524 /* AWSMobileClientUserDetails.swift */; };
 		B4031BE623105727009EB524 /* AWSMobileClientSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */; };
@@ -1370,6 +1375,7 @@
 		17D61FA6216BBC59009B2B9C /* AWSMobileClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClient.swift; sourceTree = "<group>"; };
 		17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
 		17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
+		43B25D3E2457D7B600C40F76 /* testconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = testconfiguration.json; path = ../../../AWSCoreTests/Resources/testconfiguration.json; sourceTree = "<group>"; };
 		6BB7BF2E23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-Mixed-Swift.h"; sourceTree = "<group>"; };
 		B4031B78230F044A009EB524 /* AWSMobileClientUserDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSMobileClientUserDetails.swift; sourceTree = "<group>"; };
 		B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientSignInTests.swift; sourceTree = "<group>"; };
@@ -1754,6 +1760,7 @@
 			isa = PBXGroup;
 			children = (
 				177B8AD521DFF12A0051068F /* awsconfiguration.json */,
+				43B25D3E2457D7B600C40F76 /* testconfiguration.json */,
 				17CD4B5521826BA100953483 /* credentials-mc.json */,
 				17CD4AA8218241AD00953483 /* Info.plist */,
 				B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */,
@@ -3308,6 +3315,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25DB42457D7EE00C40F76 /* testconfiguration.json in Resources */,
 				1773B1D922029DAE00356909 /* credentials-mc.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3325,6 +3333,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B412F5DA23341E9600F1AC69 /* awsconfiguration.json in Resources */,
+				43B25DB22457D7B600C40F76 /* testconfiguration.json in Resources */,
 				17CD4B5621826BA100953483 /* credentials-mc.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3337,6 +3346,7 @@
 				17CD4B2D218244EC00953483 /* LaunchScreen.storyboard in Resources */,
 				17CD4B2A218244EC00953483 /* Assets.xcassets in Resources */,
 				17CD4B28218244EA00953483 /* Main.storyboard in Resources */,
+				43B25DB52457D7F000C40F76 /* testconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3345,6 +3355,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B412F5ED233477BF00F1AC69 /* credentials-mc.json in Resources */,
+				43B25DB32457D7EC00C40F76 /* testconfiguration.json in Resources */,
 				B412F5EC2334755B00F1AC69 /* awsconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3354,6 +3365,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B412F65623347FBD00F1AC69 /* Main.storyboard in Resources */,
+				43B25DB62457D7F100C40F76 /* testconfiguration.json in Resources */,
 				B412F65423347FBD00F1AC69 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -22,16 +22,20 @@ class AWSMobileClientTestBase: XCTestCase {
     let sharedPassword: String = "Abc123@@!!"
     
     override class func setUp() {
-        let credentialsJson = loadCredentialsFromFile()
-        userPoolId = (credentialsJson["mc-userpool_id"] as! String)
-        sharedEmail = (credentialsJson["mc-email"] as! String)
-        identityPoolId = (credentialsJson["mc-pool_id_dev_auth"] as! String)
+        let testConfigurationJSON = loadTestConfigurationFromFile()
+        let credentialsTestConfiguration = testConfigurationJSON["Credentials"] as! [String: Any]
+        let allPackagesTestConfiguration = testConfigurationJSON["Packages"] as! [String: Any]
+        let mobileClientTesConfiguration = allPackagesTestConfiguration["mobileclient"] as! [String: Any]
         
-        let credentialsProvider = AWSBasicSessionCredentialsProvider(accessKey: credentialsJson["accessKey"] as! String,
-                                                                     secretKey: credentialsJson["secretKey"] as! String,
-                                                                     sessionToken: credentialsJson["sessionToken"] as! String)
+        userPoolId = (mobileClientTesConfiguration["mc-userpool_id"] as! String)
+        sharedEmail = (mobileClientTesConfiguration["mc-email"] as! String)
+        identityPoolId = (mobileClientTesConfiguration["mc-pool_id_dev_auth"] as! String)
         
-        let region = (credentialsJson["mc-region"] as! String).aws_regionTypeValue()
+        let credentialsProvider = AWSBasicSessionCredentialsProvider(accessKey: credentialsTestConfiguration["accessKey"] as! String,
+                                                                     secretKey: credentialsTestConfiguration["secretKey"] as! String,
+                                                                     sessionToken: credentialsTestConfiguration["sessionToken"] as! String)
+        
+        let region = (credentialsTestConfiguration["region"] as! String).aws_regionTypeValue()
         let configuration = AWSServiceConfiguration(region: region, credentialsProvider: credentialsProvider)!
         
         AWSCognitoIdentityProvider.register(with: configuration, forKey: "TEST")
@@ -50,11 +54,11 @@ class AWSMobileClientTestBase: XCTestCase {
     
     //MARK: Helper methods
     
-    static func loadCredentialsFromFile() -> [String: Any] {
-        let filePath = Bundle(for: AWSMobileClientTestBase.self).path(forResource: "credentials-mc", ofType: "json")!
+    static func loadTestConfigurationFromFile() -> [String: Any] {
+        let filePath = Bundle(for: AWSMobileClientTestBase.self).path(forResource: "testconfiguration", ofType: "json")!
         let fileData = try! NSData(contentsOfFile: filePath) as Data
-        let credentialsJson = try! JSONSerialization.jsonObject(with: fileData, options: .mutableContainers) as! [String: Any]
-        return credentialsJson
+        let testConfigurationJSON = try! JSONSerialization.jsonObject(with: fileData, options: .mutableContainers) as! [String: Any]
+        return testConfigurationJSON
     }
     
     static func initializeMobileClient() {

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -27,8 +27,9 @@ class AWSMobileClientTestBase: XCTestCase {
         sharedEmail = (credentialsJson["mc-email"] as! String)
         identityPoolId = (credentialsJson["mc-pool_id_dev_auth"] as! String)
         
-        let credentialsProvider = AWSStaticCredentialsProvider(accessKey: credentialsJson["accessKey"] as! String,
-                                                               secretKey: credentialsJson["secretKey"] as! String)
+        let credentialsProvider = AWSBasicSessionCredentialsProvider(accessKey: credentialsJson["accessKey"] as! String,
+                                                                     secretKey: credentialsJson["secretKey"] as! String,
+                                                                     sessionToken: credentialsJson["sessionToken"] as! String)
         
         let region = (credentialsJson["mc-region"] as! String).aws_regionTypeValue()
         let configuration = AWSServiceConfiguration(region: region, credentialsProvider: credentialsProvider)!

--- a/AWSAutoScalingTests/AWSAutoScalingTests.m
+++ b/AWSAutoScalingTests/AWSAutoScalingTests.m
@@ -26,8 +26,7 @@
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSAutoScalingTests/AWSAutoScalingTests.m
+++ b/AWSAutoScalingTests/AWSAutoScalingTests.m
@@ -26,7 +26,8 @@
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSCloudWatchTests/AWSCloudWatchTests.m
+++ b/AWSCloudWatchTests/AWSCloudWatchTests.m
@@ -26,8 +26,7 @@
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSCloudWatchTests/AWSCloudWatchTests.m
+++ b/AWSCloudWatchTests/AWSCloudWatchTests.m
@@ -26,7 +26,8 @@
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSCognitoTests/AWSCognitoClientTest.m
+++ b/AWSCognitoTests/AWSCognitoClientTest.m
@@ -92,10 +92,10 @@ Method _mockMethod;
 
 @implementation AWSCognitoClientTest
 + (void)setUp {
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:[CognitoTestUtils region]
                                                                                          identityPoolId:[CognitoTestUtils identityPoolId]];
 
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:provider];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:[CognitoTestUtils region] credentialsProvider:provider];
 
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }

--- a/AWSCognitoTests/AWSCognitoSyncServiceTests.m
+++ b/AWSCognitoTests/AWSCognitoSyncServiceTests.m
@@ -18,6 +18,7 @@
 #import <AWSCore/AWSCore.h>
 #import "AWSCognito.h"
 #import "CognitoTestUtils.h"
+#import "AWSTestUtility.h"
 
 @interface AWSCognitoSyncTests : XCTestCase
 
@@ -28,14 +29,14 @@ NSString *_identityId;
 @implementation AWSCognitoSyncTests
 
 + (void)setUp {
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:[CognitoTestUtils region]
                                                                                          identityPoolId:[CognitoTestUtils identityPoolId]
                                                                                           unauthRoleArn:[CognitoTestUtils unauthRoleArn]
                                                                                             authRoleArn:[CognitoTestUtils authRoleArn]
                                                                                 identityProviderManager:nil];
     [[provider getIdentityId] waitUntilFinished];
     _identityId = provider.identityId;
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:[CognitoTestUtils region]
                                                                          credentialsProvider:provider];
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 
@@ -58,13 +59,8 @@ NSString *_identityId;
 }
 
 - (void)testInvalidDatasetNameFails {
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials" ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    AWSStaticCredentialsProvider *provider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                           secretKey:credentialsJson[@"secretKey"]];
-    AWSServiceConfiguration * configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:provider];
+    [AWSTestUtility setupSessionCredentialsProvider];
+    AWSServiceConfiguration *configuration = [AWSServiceManager defaultServiceManager].defaultServiceConfiguration;
     [AWSCognitoSync registerCognitoSyncWithConfiguration:configuration forKey:@"testExampleFailed"];
     AWSCognitoSync *client = [AWSCognitoSync CognitoSyncForKey:@"testExampleFailed"];
 

--- a/AWSCognitoTests/CognitoTestUtils.h
+++ b/AWSCognitoTests/CognitoTestUtils.h
@@ -15,6 +15,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <AWSCore/AWSCore.h>
 
 @interface CognitoTestUtils : NSObject
 
@@ -23,5 +24,6 @@
 + (NSString *) authRoleArn;
 + (NSString *) identityPoolId;
 + (NSString *) facebookToken;
++ (AWSRegionType) region;
 
 @end

--- a/AWSCognitoTests/CognitoTestUtils.m
+++ b/AWSCognitoTests/CognitoTestUtils.m
@@ -15,6 +15,7 @@
 
 #import "CognitoTestUtils.h"
 #import <AWSCore/AWSCore.h>
+#import "AWSTestUtility.h"
 
 NSString * AWSCognitoClientTestsAccountID = nil;
 NSString * AWSCognitoClientTestsFacebookAppID = nil;
@@ -22,23 +23,22 @@ NSString * AWSCognitoClientTestsFacebookAppSecret = nil;
 NSString * AWSCognitoClientTestsUnauthRoleArn = nil;
 NSString * AWSCognitoClientTestsAuthRoleArn = nil;
 NSString * AWSCognitoClientTestsIdentityPoolId = nil;
+AWSRegionType region = nil;
 
 @implementation CognitoTestUtils
 
 + (void)loadConfig {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
-        AWSCognitoClientTestsAccountID = credentialsJson[@"accountId"];
-        AWSCognitoClientTestsFacebookAppID = credentialsJson[@"facebookAppId"];
-        AWSCognitoClientTestsFacebookAppSecret = credentialsJson[@"facebookAppSecret"];
-        AWSCognitoClientTestsUnauthRoleArn = credentialsJson[@"unauthRoleArn"];
-        AWSCognitoClientTestsAuthRoleArn = credentialsJson[@"authRoleArn"];
-        AWSCognitoClientTestsIdentityPoolId = credentialsJson[@"identityPoolId"];
+        NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"core"];
+        
+        AWSCognitoClientTestsAccountID = [AWSTestUtility getAccountIdFromTestConfiguration];
+        region = [AWSTestUtility getRegionFromTestConfiguration];
+        AWSCognitoClientTestsFacebookAppID = testConfig[@"facebookAppId"];
+        AWSCognitoClientTestsFacebookAppSecret = testConfig[@"facebookAppSecret"];
+        AWSCognitoClientTestsUnauthRoleArn = testConfig[@"unauthRoleArn"];
+        AWSCognitoClientTestsAuthRoleArn = testConfig[@"authRoleArn"];
+        AWSCognitoClientTestsIdentityPoolId = testConfig[@"identityPoolId"];
     });
 }
 
@@ -60,6 +60,11 @@ NSString * AWSCognitoClientTestsIdentityPoolId = nil;
 + (NSString *) identityPoolId {
     [CognitoTestUtils loadConfig];
     return AWSCognitoClientTestsIdentityPoolId;
+}
+
++ (AWSRegionType) region {
+    [CognitoTestUtils loadConfig];
+    return region;
 }
 
 @end

--- a/AWSComprehendTests/AWSComprehendTests.swift
+++ b/AWSComprehendTests/AWSComprehendTests.swift
@@ -20,8 +20,8 @@ class AWSComprehendTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup cognito credentials to use for tests.
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        // Setup session based credentials to use for tests.
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
     }
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.

--- a/AWSComprehendTests/AWSComprehendTests.swift
+++ b/AWSComprehendTests/AWSComprehendTests.swift
@@ -20,8 +20,7 @@ class AWSComprehendTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup session based credentials to use for tests.
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
     }
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.

--- a/AWSCore/Service/AWSService.h
+++ b/AWSCore/Service/AWSService.h
@@ -113,9 +113,6 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
 
 - (void)addUserAgentProductToken:(NSString *)productToken;
 
-- (instancetype)initWithRegionName:(NSString *)regionName
-               credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider;
-
 @end
 
 #pragma mark - AWSEndpoint
@@ -132,7 +129,6 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
 @property (nonatomic, readonly) NSNumber *portNumber;
 
 + (NSString *)regionNameFromType:(AWSRegionType)regionType;
-+ (AWSRegionType)regionTypeFromName:(NSString *)regionName;
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
                        service:(AWSServiceType)serviceType

--- a/AWSCore/Service/AWSService.h
+++ b/AWSCore/Service/AWSService.h
@@ -113,6 +113,9 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
 
 - (void)addUserAgentProductToken:(NSString *)productToken;
 
+- (instancetype)initWithRegionName:(NSString *)regionName
+               credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider;
+
 @end
 
 #pragma mark - AWSEndpoint
@@ -129,6 +132,7 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
 @property (nonatomic, readonly) NSNumber *portNumber;
 
 + (NSString *)regionNameFromType:(AWSRegionType)regionType;
++ (AWSRegionType)regionTypeFromName:(NSString *)regionName;
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
                        service:(AWSServiceType)serviceType

--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -155,16 +155,6 @@ static NSString *const AWSServiceConfigurationUnknown = @"Unknown";
     return self;
 }
 
-- (instancetype)initWithRegionName:(NSString *)regionName
-               credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
-    
-    AWSRegionType regionType = [AWSEndpoint regionTypeFromName: regionName];
-    self = [self initWithRegion:regionType credentialsProvider:credentialsProvider];
-    
-    return self;
-}
-
-
 + (NSString *)baseUserAgent {
     static NSString *_userAgent = nil;
     static dispatch_once_t onceToken;
@@ -487,55 +477,6 @@ static NSString *const AWSServiceNameTranscribeStreaming = @"transcribe";
             return nil;
     }
 }
-
-+ (AWSRegionType)regionTypeFromName:(NSString *)regionName {
-    if ([regionName isEqualToString:(AWSRegionNameUSEast1)])
-        return AWSRegionUSEast1;
-    else if ([regionName isEqualToString:(AWSRegionNameUSEast2)])
-        return AWSRegionUSEast2;
-    else if ([regionName isEqualToString:(AWSRegionNameUSWest1)])
-         return AWSRegionUSWest1;
-    else if ([regionName isEqualToString:(AWSRegionNameUSWest2)])
-         return AWSRegionUSWest2;
-    else if ([regionName isEqualToString:(AWSRegionNameEUWest1)])
-         return AWSRegionEUWest1;
-    else if ([regionName isEqualToString:(AWSRegionNameEUWest2)])
-         return AWSRegionEUWest2;
-    else if ([regionName isEqualToString:(AWSRegionNameEUCentral1)])
-         return AWSRegionEUCentral1;
-    else if ([regionName isEqualToString:(AWSRegionNameAPSoutheast1)])
-         return AWSRegionAPSoutheast1;
-    else if ([regionName isEqualToString:(AWSRegionNameAPSoutheast2)])
-         return AWSRegionAPSoutheast2;
-    else if ([regionName isEqualToString:(AWSRegionNameAPNortheast1)])
-         return AWSRegionAPNortheast1;
-    else if ([regionName isEqualToString:(AWSRegionNameAPNortheast2)])
-         return AWSRegionAPNortheast2;
-    else if ([regionName isEqualToString:(AWSRegionNameAPSouth1)])
-         return AWSRegionAPSouth1;
-    else if ([regionName isEqualToString:(AWSRegionNameSAEast1)])
-         return AWSRegionSAEast1;
-    else if ([regionName isEqualToString:(AWSRegionNameCNNorth1)])
-         return AWSRegionCNNorth1;
-    else if ([regionName isEqualToString:(AWSRegionNameCACentral1)])
-         return AWSRegionCACentral1;
-    else if ([regionName isEqualToString:(AWSRegionNameUSGovWest1)])
-         return AWSRegionUSGovWest1;
-    else if ([regionName isEqualToString:(AWSRegionNameCNNorthWest1)])
-         return AWSRegionCNNorthWest1;
-    else if ([regionName isEqualToString:(AWSRegionNameEUWest3)])
-         return AWSRegionEUWest3;
-    else if ([regionName isEqualToString:(AWSRegionNameUSGovEast1)])
-         return AWSRegionUSGovEast1;
-    else if ([regionName isEqualToString:(AWSRegionNameEUNorth1)])
-         return AWSRegionEUNorth1;
-    else if ([regionName isEqualToString:(AWSRegionNameAPEast1)])
-         return AWSRegionAPEast1;
-    else if ([regionName isEqualToString:(AWSRegionNameMESouth1)])
-         return AWSRegionMESouth1;
-    else return AWSRegionUnknown;
-}
-
 
 - (NSString *)serviceNameFromType:(AWSServiceType)serviceType {
     switch (serviceType) {

--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -147,13 +147,23 @@ static NSString *const AWSServiceConfigurationUnknown = @"Unknown";
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
                       endpoint:(AWSEndpoint *)endpoint
-           credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider{
+           credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
     if(self = [self initWithRegion:regionType credentialsProvider:credentialsProvider]){
         _endpoint = endpoint;
     }
     
     return self;
 }
+
+- (instancetype)initWithRegionName:(NSString *)regionName
+               credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
+    
+    AWSRegionType regionType = [AWSEndpoint regionTypeFromName: regionName];
+    self = [self initWithRegion:regionType credentialsProvider:credentialsProvider];
+    
+    return self;
+}
+
 
 + (NSString *)baseUserAgent {
     static NSString *_userAgent = nil;
@@ -477,6 +487,55 @@ static NSString *const AWSServiceNameTranscribeStreaming = @"transcribe";
             return nil;
     }
 }
+
++ (AWSRegionType)regionTypeFromName:(NSString *)regionName {
+    if ([regionName isEqualToString:(AWSRegionNameUSEast1)])
+        return AWSRegionUSEast1;
+    else if ([regionName isEqualToString:(AWSRegionNameUSEast2)])
+        return AWSRegionUSEast2;
+    else if ([regionName isEqualToString:(AWSRegionNameUSWest1)])
+         return AWSRegionUSWest1;
+    else if ([regionName isEqualToString:(AWSRegionNameUSWest2)])
+         return AWSRegionUSWest2;
+    else if ([regionName isEqualToString:(AWSRegionNameEUWest1)])
+         return AWSRegionEUWest1;
+    else if ([regionName isEqualToString:(AWSRegionNameEUWest2)])
+         return AWSRegionEUWest2;
+    else if ([regionName isEqualToString:(AWSRegionNameEUCentral1)])
+         return AWSRegionEUCentral1;
+    else if ([regionName isEqualToString:(AWSRegionNameAPSoutheast1)])
+         return AWSRegionAPSoutheast1;
+    else if ([regionName isEqualToString:(AWSRegionNameAPSoutheast2)])
+         return AWSRegionAPSoutheast2;
+    else if ([regionName isEqualToString:(AWSRegionNameAPNortheast1)])
+         return AWSRegionAPNortheast1;
+    else if ([regionName isEqualToString:(AWSRegionNameAPNortheast2)])
+         return AWSRegionAPNortheast2;
+    else if ([regionName isEqualToString:(AWSRegionNameAPSouth1)])
+         return AWSRegionAPSouth1;
+    else if ([regionName isEqualToString:(AWSRegionNameSAEast1)])
+         return AWSRegionSAEast1;
+    else if ([regionName isEqualToString:(AWSRegionNameCNNorth1)])
+         return AWSRegionCNNorth1;
+    else if ([regionName isEqualToString:(AWSRegionNameCACentral1)])
+         return AWSRegionCACentral1;
+    else if ([regionName isEqualToString:(AWSRegionNameUSGovWest1)])
+         return AWSRegionUSGovWest1;
+    else if ([regionName isEqualToString:(AWSRegionNameCNNorthWest1)])
+         return AWSRegionCNNorthWest1;
+    else if ([regionName isEqualToString:(AWSRegionNameEUWest3)])
+         return AWSRegionEUWest3;
+    else if ([regionName isEqualToString:(AWSRegionNameUSGovEast1)])
+         return AWSRegionUSGovEast1;
+    else if ([regionName isEqualToString:(AWSRegionNameEUNorth1)])
+         return AWSRegionEUNorth1;
+    else if ([regionName isEqualToString:(AWSRegionNameAPEast1)])
+         return AWSRegionAPEast1;
+    else if ([regionName isEqualToString:(AWSRegionNameMESouth1)])
+         return AWSRegionMESouth1;
+    else return AWSRegionUnknown;
+}
+
 
 - (NSString *)serviceNameFromType:(AWSServiceType)serviceType {
     switch (serviceType) {

--- a/AWSCoreTests/AWSClockSkewTests.m
+++ b/AWSCoreTests/AWSClockSkewTests.m
@@ -27,7 +27,7 @@ static NSString *AWSClockSkewTestsSTSKey = @"AWSClockSkewTestsSTSKey";
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupSessionCredentialsProvider];
+    [AWSTestUtility setupCognitoIdentityService];
 }
 
 - (void)setUp {
@@ -104,8 +104,8 @@ static NSString *AWSClockSkewTestsSTSKey = @"AWSClockSkewTestsSTSKey";
 
 }
 #endif
-*/
-//STS Test
+ // Disabling this test which needs static long term credentials
+STS Test
 -(void)testClockSkewSTS
 {
     XCTAssertFalse([NSDate aws_getRuntimeClockSkew], @"current RunTimeClockSkew is not zero!");
@@ -134,6 +134,7 @@ static NSString *AWSClockSkewTestsSTSKey = @"AWSClockSkewTestsSTSKey";
     }] waitUntilFinished];
 
 }
+*/
 
 //Cognito Identity Service Test
 #if !AWS_TEST_BJS_INSTEAD

--- a/AWSCoreTests/AWSClockSkewTests.m
+++ b/AWSCoreTests/AWSClockSkewTests.m
@@ -27,23 +27,15 @@ static NSString *AWSClockSkewTestsSTSKey = @"AWSClockSkewTestsSTSKey";
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoIdentityService];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 
     if (![AWSSTS STSForKey:AWSClockSkewTestsSTSKey]) {
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
-        AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                          secretKey:credentialsJson[@"secretKey"]];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
-                                                                             credentialsProvider:credentialsProvider];
+        AWSServiceConfiguration *configuration = [AWSServiceManager defaultServiceManager].defaultServiceConfiguration;
         [AWSSTS registerSTSWithConfiguration:configuration
                                       forKey:AWSClockSkewTestsSTSKey];
     }

--- a/AWSCoreTests/AWSCognitoCredentialsProviderTests.m
+++ b/AWSCoreTests/AWSCognitoCredentialsProviderTests.m
@@ -26,6 +26,7 @@ NSString * AWSCognitoCredentialsProviderTestsFacebookAppID = nil;
 NSString * AWSCognitoCredentialsProviderTestsFacebookAppSecret = nil;
 NSString * AWSCognitoCredentialsProviderTestsUnauthRoleArn = nil;
 NSString * AWSCognitoCredentialsProviderTestsAuthRoleArn = nil;
+NSString * WICProviderTestRoleArn = nil;
 
 NSString *_facebookToken;
 NSString *_facebookAppToken;
@@ -113,15 +114,8 @@ BOOL _identityChanged;
                           identityPoolId:identityPoolId
                          useEnhancedFlow:NO
                  identityProviderManager:[AWSTestFakeIdentityProvider new]]) {
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
-        AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                          secretKey:credentialsJson[@"secretKey"]];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
-                                                                             credentialsProvider:credentialsProvider];
+        [AWSTestUtility setupSessionCredentialsProvider];
+        AWSServiceConfiguration *configuration = [AWSServiceManager defaultServiceManager].defaultServiceConfiguration;
 
         [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration
                                                               forKey:@"Default"];
@@ -171,7 +165,7 @@ BOOL _identityChanged;
 @end
 
 @interface AWSCognitoCredentialsProviderTests : XCTestCase
-
+@property AWSRegionType region;
 @end
 
 @implementation AWSCognitoCredentialsProviderTests
@@ -180,28 +174,21 @@ BOOL _identityChanged;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
-
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                      secretKey:credentialsJson[@"secretKey"]];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
-                                                                         credentialsProvider:credentialsProvider];
-    // Static cib client that uses long term credentials
+    [AWSTestUtility setupSessionCredentialsProvider];
+    AWSServiceConfiguration *configuration = [AWSServiceManager defaultServiceManager].defaultServiceConfiguration;
     [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration
-                                                          forKey:@"Static"];
+                                                          forKey:@"Session"];
     
-    AWSCognitoCredentialsProviderTestsIdentityPoolId = credentialsJson[@"identityPoolId"];
-    AWSCognitoCredentialsProviderTestsUnauthIdentityPoolId = credentialsJson[@"unauthIdentityPoolId"];
-    AWSCognitoCredentialsProviderTestsAccountID = credentialsJson[@"accountId"];
-    AWSCognitoCredentialsProviderTestsFacebookAppID = credentialsJson[@"facebookAppId"];
-    AWSCognitoCredentialsProviderTestsFacebookAppSecret = credentialsJson[@"facebookAppSecret"];
-    AWSCognitoCredentialsProviderTestsUnauthRoleArn = credentialsJson[@"unauthRoleArn"];
-    AWSCognitoCredentialsProviderTestsAuthRoleArn = credentialsJson[@"authRoleArn"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"core"];
+    AWSCognitoCredentialsProviderTestsIdentityPoolId = testConfig[@"identityPoolId"];
+    AWSCognitoCredentialsProviderTestsUnauthIdentityPoolId = testConfig[@"unauthIdentityPoolId"];
+    AWSCognitoCredentialsProviderTestsFacebookAppID = testConfig[@"facebookAppId"];
+    AWSCognitoCredentialsProviderTestsFacebookAppSecret = testConfig[@"facebookAppSecret"];
+    AWSCognitoCredentialsProviderTestsUnauthRoleArn = testConfig[@"unauthRoleArn"];
+    AWSCognitoCredentialsProviderTestsAuthRoleArn = testConfig[@"authRoleArn"];
+    WICProviderTestRoleArn = testConfig[@"WICProviderTestRoleArn"];
+    
+    AWSCognitoCredentialsProviderTestsAccountID = [AWSTestUtility getAccountIdFromTestConfiguration];
 
     [AWSCognitoCredentialsProviderTests createFBAccount];
 }
@@ -213,11 +200,12 @@ BOOL _identityChanged;
                                                  name:AWSCognitoIdentityIdChangedNotification
                                                object:nil];
     _identityChanged = NO;
+    self.region = [AWSTestUtility getRegionFromTestConfiguration];
 }
 
 - (void)tearDown {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
     [provider clearKeychain];
     [super tearDown];
@@ -230,9 +218,9 @@ BOOL _identityChanged;
 #pragma mark - Tests
 
 - (void)testWICProvider {
-    AWSWebIdentityCredentialsProvider *provider = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSWebIdentityCredentialsProvider *provider = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:self.region
                                                                                                      providerId:@"graph.facebook.com"
-                                                                                                        roleArn:@"arn:aws:iam::335750469596:role/WICProviderTestRole"
+                                                                                                        roleArn:WICProviderTestRoleArn
                                                                                                 roleSessionName:@"iOSTest-WICProvider"
                                                                                                webIdentityToken:_facebookToken];
     
@@ -256,18 +244,18 @@ BOOL _identityChanged;
 }
 
 - (void)testWICProviderKeychain{
-    AWSWebIdentityCredentialsProvider *provider1 = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSWebIdentityCredentialsProvider *provider1 = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:self.region
                                                                                                      providerId:@"graph.facebook.com"
-                                                                                                        roleArn:@"arn:aws:iam::335750469596:role/WICProviderTestRole"
+                                                                                                        roleArn:WICProviderTestRoleArn
                                                                                                 roleSessionName:@"iOSTest-WICProvider"
                                                                                                webIdentityToken:_facebookToken];
     
     __block AWSWebIdentityCredentialsProvider *provider2 = nil;
 
     [[[[provider1 credentials] continueWithBlock:^id _Nullable(AWSTask<AWSCredentials *> * _Nonnull task) {
-        provider2 = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+        provider2 = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:self.region
                                                                        providerId:@"graph.facebook.com"
-                                                                          roleArn:@"arn:aws:iam::335750469596:role/WICProviderTestRole"
+                                                                          roleArn:WICProviderTestRoleArn
                                                                   roleSessionName:@"iOSTest-WICProvider"
                                                                  webIdentityToken:_facebookToken];
         
@@ -286,7 +274,7 @@ BOOL _identityChanged;
 
 - (void)testProvider {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                           unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                             authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
@@ -316,7 +304,7 @@ BOOL _identityChanged;
 
 - (void)testProviderEnhancedFlow {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                 identityProviderManager:identityProvider];
     [[[[provider credentials] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCredentials *> * _Nonnull task) {
@@ -345,7 +333,7 @@ BOOL _identityChanged;
 - (void)testProviderNotification {
     AWSTestFacebookIdentityProvider *identityProvider1 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSTestFacebookIdentityProvider *identityProvider2 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
-    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                           identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                            unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                              authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
@@ -359,7 +347,7 @@ BOOL _identityChanged;
         provider1IdentityId = provider1.identityId;
 
         [provider1 clearKeychain];
-        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                 unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                   authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
@@ -389,7 +377,7 @@ BOOL _identityChanged;
 
 - (void)testProviderKeychain {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
-    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                           identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                            unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                              authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
@@ -402,7 +390,7 @@ BOOL _identityChanged;
         XCTAssertNil(task.error);
         XCTAssertNotNil(provider1.identityId, @"Unable to get identityId");
 
-        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                 unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                   authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
@@ -423,7 +411,7 @@ BOOL _identityChanged;
 
 - (void)testProviderFailure {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsUnauthIdentityPoolId
                                                                                           unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                             authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
@@ -447,7 +435,7 @@ BOOL _identityChanged;
 #pragma mark - Enhanced Flow
 - (void)testEnhancedProvider {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                 identityProviderManager:identityProvider];
 
@@ -478,7 +466,7 @@ BOOL _identityChanged;
 - (void)testEnhancedProviderNotification {
     AWSTestFacebookIdentityProvider *identityProvider1 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
     AWSTestFacebookIdentityProvider *identityProvider2 = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:NO];
-    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                           identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                  identityProviderManager:identityProvider1];
 
@@ -490,7 +478,7 @@ BOOL _identityChanged;
         provider1IdentityId = provider1.identityId;
 
         [provider1 clearKeychain];
-        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                       identityProviderManager:identityProvider2];
         return [provider2 getIdentityId];
@@ -517,7 +505,7 @@ BOOL _identityChanged;
 }
 
 - (void)testEnhancedProviderKeychain {
-    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider1 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                           identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId
                                                                                  identityProviderManager:[AWSTestFacebookIdentityProvider new]];
 
@@ -527,7 +515,7 @@ BOOL _identityChanged;
         XCTAssertNil(task.error);
         XCTAssertNotNil(provider1.identityId, @"Unable to get identityId");
 
-        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+        provider2 = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
         return [provider2 getIdentityId];
     }] continueWithSuccessBlock:^id _Nullable(AWSTask * _Nonnull task) {
@@ -551,7 +539,7 @@ BOOL _identityChanged;
 
 - (void)testEnhancedProviderFailure {
     AWSTestFacebookIdentityProvider *identityProvider = [[AWSTestFacebookIdentityProvider alloc] initWithLoggedIn:YES];
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                          identityPoolId:AWSCognitoCredentialsProviderTestsUnauthIdentityPoolId
                                                                                 identityProviderManager:identityProvider];
 
@@ -574,10 +562,10 @@ BOOL _identityChanged;
 #pragma mark - BYOI
 
 - (void)testBYOIProvider {
-    AWSFakeCognitoIdentityProvider *fakeIdentityProvider = [[AWSFakeCognitoIdentityProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSFakeCognitoIdentityProvider *fakeIdentityProvider = [[AWSFakeCognitoIdentityProvider alloc] initWithRegionType:self.region
                                                                                                        identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
 
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                           unauthRoleArn:AWSCognitoCredentialsProviderTestsUnauthRoleArn
                                                                                             authRoleArn:AWSCognitoCredentialsProviderTestsAuthRoleArn
                                                                                        identityProvider:fakeIdentityProvider];
@@ -595,10 +583,10 @@ BOOL _identityChanged;
 }
 
 - (void)testBYOIProviderWithEnhancedFlow {
-    AWSFakeCognitoIdentityProvider *fakeIdentityProvider = [[AWSFakeCognitoIdentityProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSFakeCognitoIdentityProvider *fakeIdentityProvider = [[AWSFakeCognitoIdentityProvider alloc] initWithRegionType:self.region
                                                                                                        identityPoolId:AWSCognitoCredentialsProviderTestsIdentityPoolId];
 
-    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSCognitoCredentialsProvider *provider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:self.region
                                                                                        identityProvider:fakeIdentityProvider];
 
     [[[provider credentials] continueWithBlock:^id(AWSTask *task) {

--- a/AWSCoreTests/AWSCognitoCredentialsProviderTests.m
+++ b/AWSCoreTests/AWSCognitoCredentialsProviderTests.m
@@ -179,7 +179,7 @@ BOOL _identityChanged;
     [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration
                                                           forKey:@"Session"];
     
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"core"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"core"];
     AWSCognitoCredentialsProviderTestsIdentityPoolId = testConfig[@"identityPoolId"];
     AWSCognitoCredentialsProviderTestsUnauthIdentityPoolId = testConfig[@"unauthIdentityPoolId"];
     AWSCognitoCredentialsProviderTestsFacebookAppID = testConfig[@"facebookAppId"];

--- a/AWSCoreTests/AWSCognitoIdentityServiceTests.m
+++ b/AWSCoreTests/AWSCognitoIdentityServiceTests.m
@@ -134,7 +134,7 @@
         AWSCognitoIdentityIdentityPool *identityPool = task.result;
 
         AWSCognitoIdentityGetIdInput *getId = [AWSCognitoIdentityGetIdInput new];
-        getId.accountId = @"335750469596";
+        getId.accountId = [AWSTestUtility getAccountIdFromTestConfiguration];
         identityPoolId = identityPool.identityPoolId;
         getId.identityPoolId = identityPool.identityPoolId;
 

--- a/AWSCoreTests/AWSCredentialsProviderTests.m
+++ b/AWSCoreTests/AWSCredentialsProviderTests.m
@@ -22,6 +22,7 @@
 
 @property (nonatomic) NSString *dummyAccessKey;
 @property (nonatomic) NSString *dummySecretKey;
+@property AWSRegionType region;
 
 @end
 
@@ -32,7 +33,7 @@
     // Put setup code here. This method is called before the invocation of each test method in the class.
     _dummyAccessKey = @"dummyAccessKey";
     _dummySecretKey = @"dummySecretKey";
-
+    self.region = [AWSTestUtility getRegionFromTestConfiguration];
 }
 
 - (void)tearDown {
@@ -74,7 +75,7 @@
     NSString *roleSessionName = @"testSession";
     NSString *webIdentityToken = @"OauthToken";
 
-    AWSWebIdentityCredentialsProvider *provider = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+    AWSWebIdentityCredentialsProvider *provider = [[AWSWebIdentityCredentialsProvider alloc] initWithRegionType:self.region
                                                                                                      providerId:providerId
                                                                                                         roleArn:roleArn
                                                                                                 roleSessionName:roleSessionName

--- a/AWSCoreTests/AWSSTSTests.m
+++ b/AWSCoreTests/AWSSTSTests.m
@@ -25,7 +25,7 @@
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupSTS];
+//    [AWSTestUtility setupSTS];
 }
 
 - (void)setUp {
@@ -35,6 +35,9 @@
 - (void)tearDown {
     [super tearDown];
 }
+
+/*
+// Disabling this test which needs static long term credentials
 
 - (void)testGetSessionToken {
     AWSSTS *sts = [AWSSTS STSForKey:AWSTestUtilitySTSKey];
@@ -58,6 +61,7 @@
         return nil;
     }] waitUntilFinished];
 }
+*/
 
 
 @end

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -23,6 +23,7 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 @interface AWSTestUtility : NSObject
 
 + (void)setupSessionCredentialsProvider;
++ (NSDictionary *)getIntegrationTestConfigurationFor:(NSString *) packageId;
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProvider;

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -24,6 +24,10 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 
 + (void)setupSessionCredentialsProvider;
 + (NSDictionary *)getIntegrationTestConfigurationFor:(NSString *) packageId;
++ (AWSRegionType)getRegionFromTestConfiguration;
++ (NSDictionary *) getTestConfigurationJSON;
++ (NSString *) getAccountIdFromTestConfiguration;
+
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProvider;

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -27,7 +27,6 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 + (AWSRegionType)getRegionFromTestConfiguration;
 + (NSDictionary *) getTestConfigurationJSON;
 + (NSString *) getAccountIdFromTestConfiguration;
-+ (NSDictionary *) getCredentialsFromTestConfiguration;
 
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -22,6 +22,7 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 
 @interface AWSTestUtility : NSObject
 
++ (void)setupSTSBasedSessionCredentialsProvider;
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProvider;

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -27,13 +27,14 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 + (AWSRegionType)getRegionFromTestConfiguration;
 + (NSDictionary *) getTestConfigurationJSON;
 + (NSString *) getAccountIdFromTestConfiguration;
++ (NSDictionary *) getCredentialsFromTestConfiguration;
++ (void)setupCognitoIdentityService;
 
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProviderForRegion:(AWSRegionType)region;
 + (void)setupSTS;
-+ (void)setupCognitoIdentityService;
 
 + (NSDictionary<NSString *, NSString *> *)getCredentialsJsonAsDictionary;
 + (AWSRegionType)getDefaultRegionType;

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -22,7 +22,7 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 
 @interface AWSTestUtility : NSObject
 
-+ (void)setupSTSBasedSessionCredentialsProvider;
++ (void)setupSessionCredentialsProvider;
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProvider;

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -23,10 +23,11 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 @interface AWSTestUtility : NSObject
 
 + (void)setupSessionCredentialsProvider;
-+ (NSDictionary *)getIntegrationTestConfigurationFor:(NSString *) packageId;
++ (NSDictionary *)getIntegrationTestConfigurationForPackageId:(NSString *) packageId;
 + (AWSRegionType)getRegionFromTestConfiguration;
 + (NSDictionary *) getTestConfigurationJSON;
 + (NSString *) getAccountIdFromTestConfiguration;
++ (NSDictionary *) getCredentialsFromTestConfiguration;
 
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -65,7 +65,7 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
     [super initialize];
 }
 
-+ (void) setupSTSBasedSessionCredentialsProvider {
++ (void) setupSessionCredentialsProvider {
     NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
                                                                           ofType:@"json"];
     NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
@@ -75,8 +75,8 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
                                                                initWithAccessKey:credentialsJson[@"accessKey"]
                                                                        secretKey:credentialsJson[@"secretKey"]
                                                                     sessionToken:credentialsJson[@"sessionToken"]];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
-                                                                         credentialsProvider:credentialsProvider];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegionName: credentialsJson[@"region"]
+                                                                             credentialsProvider:credentialsProvider];
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }
 

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -77,20 +77,24 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }
 
-+ (NSDictionary *) getIntegrationTestConfigurationFor:(NSString *) packageId {
++ (NSDictionary *) getIntegrationTestConfigurationForPackageId:(NSString *) packageId {
     NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
     return testConfigurationJson[@"Packages"][packageId];
 }
 
 + (AWSRegionType) getRegionFromTestConfiguration {
-    NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
-    return [testConfigurationJson[@"Credentials"][@"region"] aws_regionTypeValue];
+    return [[self getCredentialsFromTestConfiguration][@"region"] aws_regionTypeValue];
 }
 
 + (NSString *) getAccountIdFromTestConfiguration {
-    NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
-    return testConfigurationJson[@"Credentials"][@"accountId"];
+    return [self getCredentialsFromTestConfiguration][@"accountId"];
 }
+
++ (NSDictionary *) getCredentialsFromTestConfiguration {
+    NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
+    return testConfigurationJson[@"Credentials"];
+}
+
 
 + (NSDictionary *) getTestConfigurationJSON {
     NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"testconfiguration"

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -65,6 +65,21 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
     [super initialize];
 }
 
++ (void) setupSTSBasedSessionCredentialsProvider {
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
+                                                                          ofType:@"json"];
+    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
+                                                                    options:NSJSONReadingMutableContainers
+                                                                      error:nil];
+    AWSBasicSessionCredentialsProvider *credentialsProvider = [[AWSBasicSessionCredentialsProvider alloc]
+                                                               initWithAccessKey:credentialsJson[@"accessKey"]
+                                                                       secretKey:credentialsJson[@"secretKey"]
+                                                                    sessionToken:credentialsJson[@"sessionToken"]];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+                                                                         credentialsProvider:credentialsProvider];
+    [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
+}
+
 + (void)setupCredentialsViaFile {
     if (![AWSServiceManager defaultServiceManager].defaultServiceConfiguration) {
 #if AWS_TEST_BJS_INSTEAD

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -66,13 +66,12 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
 }
 
 + (void) setupSessionCredentialsProvider {
-    
-    NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
+    NSDictionary *credentialsFromTestConfigurationJson = [self getCredentialsFromTestConfiguration];
     AWSBasicSessionCredentialsProvider *credentialsProvider = [[AWSBasicSessionCredentialsProvider alloc]
-                                                               initWithAccessKey:testConfigurationJson[@"credentials"][@"accessKey"]
-                                                                       secretKey:testConfigurationJson[@"credentials"][@"secretKey"]
-                                                                    sessionToken:testConfigurationJson[@"credentials"][@"sessionToken"]];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion: [testConfigurationJson[@"credentials"][@"region"] aws_regionTypeValue]
+                                                               initWithAccessKey:credentialsFromTestConfigurationJson[@"accessKey"]
+                                                                       secretKey:credentialsFromTestConfigurationJson[@"secretKey"]
+                                                                    sessionToken:credentialsFromTestConfigurationJson[@"sessionToken"]];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion: [self getRegionFromTestConfiguration]
                                                                          credentialsProvider:credentialsProvider];
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }
@@ -82,14 +81,17 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
     return testConfigurationJson[@"packages"][packageId];
 }
 
++ (NSDictionary *) getCredentialsFromTestConfiguration {
+    return [self getTestConfigurationJSON][@"credentials"];
+}
+
 + (AWSRegionType) getRegionFromTestConfiguration {
-    NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
-    return [testConfigurationJson[@"credentials"][@"region"] aws_regionTypeValue];
+    return [[self getIntegrationTestConfigurationForPackageId: @"common"][@"region"] aws_regionTypeValue];
 }
 
 + (NSString *) getAccountIdFromTestConfiguration {
-    NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
-    return testConfigurationJson[@"credentials"][@"accountId"];
+    NSDictionary *credentialsFromTestConfigurationJson = [self getCredentialsFromTestConfiguration];
+    return credentialsFromTestConfigurationJson[@"identityId"];
 }
 
 + (NSDictionary *) getTestConfigurationJSON {
@@ -103,19 +105,79 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
 
 + (void)setupCognitoIdentityService {
     if (![AWSCognitoIdentity CognitoIdentityForKey:AWSTestUtilityCognitoIdentityServiceKey]) {
-        NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
+        NSDictionary *credentialsFromTestConfigurationJson = [self getCredentialsFromTestConfiguration];
         AWSBasicSessionCredentialsProvider *credentialsProvider = [[AWSBasicSessionCredentialsProvider alloc]
-                                                                   initWithAccessKey:testConfigurationJson[@"credentials"][@"accessKey"]
-                                                                           secretKey:testConfigurationJson[@"credentials"][@"secretKey"]
-                                                                        sessionToken:testConfigurationJson[@"credentials"][@"sessionToken"]];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion: [testConfigurationJson[@"credentials"][@"region"] aws_regionTypeValue]
+                                                                   initWithAccessKey:credentialsFromTestConfigurationJson[@"accessKey"]
+                                                                           secretKey:credentialsFromTestConfigurationJson[@"secretKey"]
+                                                                        sessionToken:credentialsFromTestConfigurationJson[@"sessionToken"]];
+        
+        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion: [self getRegionFromTestConfiguration]
                                                                              credentialsProvider:credentialsProvider];
         [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration
                                                               forKey:AWSTestUtilityCognitoIdentityServiceKey];
     }
 }
 
+// un-comment and delete the old version from below for migration to use temporary credentials
+//+ (void)setupCognitoCredentialsProvider {
+//    if (![AWSServiceManager defaultServiceManager].defaultServiceConfiguration) {
+//        NSDictionary *commonTestConfiguration = [self getIntegrationTestConfigurationForPackageId: @"common"];
+//        if ([[commonTestConfiguration[@"cognito_support_in_region"] lowercaseString] isEqualToString: @"false"]) {
+//            NSException *exception = [NSException exceptionWithName:@"IntegrationTestSetupExeception"
+//                                                             reason:[NSString stringWithFormat:@"Cognito not supported in region :  %@",commonTestConfiguration[@"region"]]
+//                                                           userInfo:nil];
+//            @throw exception;
+//        }
+//
+//        AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:[self getRegionFromTestConfiguration]
+//                                                                                                        identityPoolId:commonTestConfiguration[@"identityPoolId"]
+//                                                                                                         unauthRoleArn:commonTestConfiguration[@"unauthRoleArn"]
+//                                                                                                           authRoleArn:commonTestConfiguration[@"authRoleArn"]
+//                                                                                               identityProviderManager:nil];
+//
+//        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:[self getRegionFromTestConfiguration]
+//                                                                             credentialsProvider:credentialsProvider];
+//        [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
+//    }
+//}
 
+
+Method _originalDateMethod;
+Method _mockDateMethod;
+static char mockDateKey;
+
+// Mock Method, replaces [NSDate date]
+- (NSDate *)mockDateSwizzle {
+    return objc_getAssociatedObject([NSDate class], &mockDateKey);
+}
+
+// Convenience method so tests can set what they want [NSDate date] to return
++ (void)setMockDate:(NSDate *)aMockDate {
+    objc_setAssociatedObject([NSDate class], &mockDateKey, aMockDate, OBJC_ASSOCIATION_RETAIN);
+}
+
++ (void)setupSwizzling {
+    // Start by having the mock return the test startup date
+    [self setMockDate:[NSDate date]];
+
+    // Save these as instance variables so test teardown can swap the implementation back
+    _originalDateMethod = class_getClassMethod([NSDate class], @selector(date));
+    _mockDateMethod = class_getInstanceMethod([self class], @selector(mockDateSwizzle));
+    method_exchangeImplementations(_originalDateMethod, _mockDateMethod);
+
+    //make sure current runTimeClockSkew is 0
+    [NSDate aws_setRuntimeClockSkew:0];
+}
+
++ (void)revertSwizzling {
+    // Revert the swizzle
+    method_exchangeImplementations(_mockDateMethod, _originalDateMethod);
+    //reset RunTimeClockSkew
+    [NSDate aws_setRuntimeClockSkew:0];
+}
+
+
+// Methods from here need to be deprecated
 + (void)setupCredentialsViaFile {
     if (![AWSServiceManager defaultServiceManager].defaultServiceConfiguration) {
 #if AWS_TEST_BJS_INSTEAD
@@ -265,40 +327,6 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
             return false;
             break;
     }
-}
-
-Method _originalDateMethod;
-Method _mockDateMethod;
-static char mockDateKey;
-
-// Mock Method, replaces [NSDate date]
-- (NSDate *)mockDateSwizzle {
-    return objc_getAssociatedObject([NSDate class], &mockDateKey);
-}
-
-// Convenience method so tests can set what they want [NSDate date] to return
-+ (void)setMockDate:(NSDate *)aMockDate {
-    objc_setAssociatedObject([NSDate class], &mockDateKey, aMockDate, OBJC_ASSOCIATION_RETAIN);
-}
-
-+ (void)setupSwizzling {
-    // Start by having the mock return the test startup date
-    [self setMockDate:[NSDate date]];
-
-    // Save these as instance variables so test teardown can swap the implementation back
-    _originalDateMethod = class_getClassMethod([NSDate class], @selector(date));
-    _mockDateMethod = class_getInstanceMethod([self class], @selector(mockDateSwizzle));
-    method_exchangeImplementations(_originalDateMethod, _mockDateMethod);
-
-    //make sure current runTimeClockSkew is 0
-    [NSDate aws_setRuntimeClockSkew:0];
-}
-
-+ (void)revertSwizzling {
-    // Revert the swizzle
-    method_exchangeImplementations(_mockDateMethod, _originalDateMethod);
-    //reset RunTimeClockSkew
-    [NSDate aws_setRuntimeClockSkew:0];
 }
 
 @end

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -75,8 +75,8 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
                                                                initWithAccessKey:credentialsJson[@"accessKey"]
                                                                        secretKey:credentialsJson[@"secretKey"]
                                                                     sessionToken:credentialsJson[@"sessionToken"]];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegionName: credentialsJson[@"region"]
-                                                                             credentialsProvider:credentialsProvider];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion: [credentialsJson[@"region"] aws_regionTypeValue]
+                                                                         credentialsProvider:credentialsProvider];
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }
 

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -80,6 +80,15 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }
 
++ (NSDictionary *) getIntegrationTestConfigurationFor:(NSString *) packageId {
+    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
+                                                                          ofType:@"json"];
+    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
+                                                                    options:NSJSONReadingMutableContainers
+                                                                      error:nil];
+    return credentialsJson[@"packages"][packageId];
+}
+
 + (void)setupCredentialsViaFile {
     if (![AWSServiceManager defaultServiceManager].defaultServiceConfiguration) {
 #if AWS_TEST_BJS_INSTEAD

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -77,7 +77,7 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
 }
 
-+ (NSDictionary *) getIntegrationTestConfigurationFor:(NSString *) packageId {
++ (NSDictionary *) getIntegrationTestConfigurationForPackageId:(NSString *) packageId {
     NSDictionary *testConfigurationJson = [self getTestConfigurationJSON];
     return testConfigurationJson[@"packages"][packageId];
 }

--- a/AWSDynamoDBTests/AWSDynamoDBObjectMapperSwiftTests.swift
+++ b/AWSDynamoDBTests/AWSDynamoDBObjectMapperSwiftTests.swift
@@ -67,8 +67,7 @@ class TestObjectV2: AWSDynamoDBObjectModel, AWSDynamoDBModeling {
 class AWSDynamoDBObjectMapperSwiftTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        // Setup session based credentials to use for tests.
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
 
         let timeIntervalSinceReferenceDate = Int(Date().timeIntervalSinceReferenceDate)
         tableName = "DynamoDBOMTestSwift-\(timeIntervalSinceReferenceDate)"

--- a/AWSDynamoDBTests/AWSDynamoDBObjectMapperSwiftTests.swift
+++ b/AWSDynamoDBTests/AWSDynamoDBObjectMapperSwiftTests.swift
@@ -67,7 +67,8 @@ class TestObjectV2: AWSDynamoDBObjectModel, AWSDynamoDBModeling {
 class AWSDynamoDBObjectMapperSwiftTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        // Setup session based credentials to use for tests.
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
 
         let timeIntervalSinceReferenceDate = Int(Date().timeIntervalSinceReferenceDate)
         tableName = "DynamoDBOMTestSwift-\(timeIntervalSinceReferenceDate)"

--- a/AWSDynamoDBTests/AWSDynamoDBObjectMapperTests.m
+++ b/AWSDynamoDBTests/AWSDynamoDBObjectMapperTests.m
@@ -318,7 +318,8 @@ static NSString *tableNameKeyOnly = nil;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     tableName = [NSString stringWithFormat:@"%@-%f", AWSDynamoDBObjectMapperTestTable, timeIntervalSinceReferenceDate];

--- a/AWSDynamoDBTests/AWSDynamoDBObjectMapperTests.m
+++ b/AWSDynamoDBTests/AWSDynamoDBObjectMapperTests.m
@@ -318,8 +318,7 @@ static NSString *tableNameKeyOnly = nil;
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     tableName = [NSString stringWithFormat:@"%@-%f", AWSDynamoDBObjectMapperTestTable, timeIntervalSinceReferenceDate];

--- a/AWSDynamoDBTests/AWSDynamoDBTests.m
+++ b/AWSDynamoDBTests/AWSDynamoDBTests.m
@@ -33,8 +33,7 @@ static NSString *table2Name = nil;
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     table1Name = [NSString stringWithFormat:@"%@-%f", AWSDynamoDBTestTable1, timeIntervalSinceReferenceDate];

--- a/AWSDynamoDBTests/AWSDynamoDBTests.m
+++ b/AWSDynamoDBTests/AWSDynamoDBTests.m
@@ -33,7 +33,8 @@ static NSString *table2Name = nil;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     table1Name = [NSString stringWithFormat:@"%@-%f", AWSDynamoDBTestTable1, timeIntervalSinceReferenceDate];

--- a/AWSEC2Tests/AWSEC2Tests.m
+++ b/AWSEC2Tests/AWSEC2Tests.m
@@ -28,8 +28,7 @@
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSEC2Tests/AWSEC2Tests.m
+++ b/AWSEC2Tests/AWSEC2Tests.m
@@ -28,7 +28,8 @@
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSElasticLoadBalancingTests/AWSElasticLoadBalancingTests.m
+++ b/AWSElasticLoadBalancingTests/AWSElasticLoadBalancingTests.m
@@ -26,8 +26,7 @@
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSElasticLoadBalancingTests/AWSElasticLoadBalancingTests.m
+++ b/AWSElasticLoadBalancingTests/AWSElasticLoadBalancingTests.m
@@ -26,7 +26,8 @@
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSKMSTests/AWSKMSTests.m
+++ b/AWSKMSTests/AWSKMSTests.m
@@ -31,8 +31,7 @@
     
     _sharedKeyMetadata = nil;
     
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
     self.kms = [AWSKMS defaultKMS];
 
     _sharedKeyMetadata = [self createKey];

--- a/AWSKMSTests/AWSKMSTests.m
+++ b/AWSKMSTests/AWSKMSTests.m
@@ -31,7 +31,8 @@
     
     _sharedKeyMetadata = nil;
     
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
     self.kms = [AWSKMS defaultKMS];
 
     _sharedKeyMetadata = [self createKey];

--- a/AWSKinesisTests/AWSFirehoseRecorderTests.m
+++ b/AWSKinesisTests/AWSFirehoseRecorderTests.m
@@ -30,7 +30,8 @@ NSString *const AWSFirehoseRecorderTestStream = @"test-permanent-firehose";
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 + (void)tearDown {

--- a/AWSKinesisTests/AWSFirehoseRecorderTests.m
+++ b/AWSKinesisTests/AWSFirehoseRecorderTests.m
@@ -30,8 +30,7 @@ NSString *const AWSFirehoseRecorderTestStream = @"test-permanent-firehose";
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 + (void)tearDown {

--- a/AWSKinesisTests/AWSFirehoseTests.m
+++ b/AWSKinesisTests/AWSFirehoseTests.m
@@ -29,7 +29,8 @@ NSString *const AWSFirehoseTestStream = @"test-permanent-firehose";
 
 - (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)tearDown {

--- a/AWSKinesisTests/AWSFirehoseTests.m
+++ b/AWSKinesisTests/AWSFirehoseTests.m
@@ -29,8 +29,7 @@ NSString *const AWSFirehoseTestStream = @"test-permanent-firehose";
 
 - (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)tearDown {

--- a/AWSKinesisTests/AWSKinesisRecorderTests.m
+++ b/AWSKinesisTests/AWSKinesisRecorderTests.m
@@ -32,8 +32,7 @@ static NSString *testStreamName = nil;
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testStreamName = [NSString stringWithFormat:@"%@-%f", AWSKinesisRecorderTestStream, timeIntervalSinceReferenceDate];

--- a/AWSKinesisTests/AWSKinesisRecorderTests.m
+++ b/AWSKinesisTests/AWSKinesisRecorderTests.m
@@ -32,7 +32,8 @@ static NSString *testStreamName = nil;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testStreamName = [NSString stringWithFormat:@"%@-%f", AWSKinesisRecorderTestStream, timeIntervalSinceReferenceDate];

--- a/AWSKinesisTests/AWSKinesisTests.m
+++ b/AWSKinesisTests/AWSKinesisTests.m
@@ -31,7 +31,8 @@ static NSString *testStreamName = nil;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testStreamName = [NSString stringWithFormat:@"%@-%f", AWSKinesisTestStream, timeIntervalSinceReferenceDate];

--- a/AWSKinesisTests/AWSKinesisTests.m
+++ b/AWSKinesisTests/AWSKinesisTests.m
@@ -31,8 +31,7 @@ static NSString *testStreamName = nil;
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testStreamName = [NSString stringWithFormat:@"%@-%f", AWSKinesisTestStream, timeIntervalSinceReferenceDate];

--- a/AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests.swift
+++ b/AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests.swift
@@ -23,8 +23,8 @@ class AWSKinesisVideoArchivedMediaTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup cognito credentials to use for tests.
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        // Setup session based credentials to use for tests.
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
     }
     
     override func setUp() {

--- a/AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests.swift
+++ b/AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests.swift
@@ -23,8 +23,7 @@ class AWSKinesisVideoArchivedMediaTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup session based credentials to use for tests.
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
     }
     
     override func setUp() {

--- a/AWSKinesisVideoSignalingTests/AWSKinesisVideoSignalingIntegrationTests.swift
+++ b/AWSKinesisVideoSignalingTests/AWSKinesisVideoSignalingIntegrationTests.swift
@@ -21,8 +21,8 @@ class AWSKinesisVideoSignalingIntegrationTests: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-        // Setup cognito credentials to use for tests.
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        // Setup session based credentials to use for tests.
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
     }
 
     override func tearDown() {

--- a/AWSKinesisVideoSignalingTests/AWSKinesisVideoSignalingIntegrationTests.swift
+++ b/AWSKinesisVideoSignalingTests/AWSKinesisVideoSignalingIntegrationTests.swift
@@ -21,8 +21,7 @@ class AWSKinesisVideoSignalingIntegrationTests: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-        // Setup session based credentials to use for tests.
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
     }
 
     override func tearDown() {

--- a/AWSKinesisVideoTests/AWSKinesisVideoTests.swift
+++ b/AWSKinesisVideoTests/AWSKinesisVideoTests.swift
@@ -22,8 +22,7 @@ class AWSKinesisVideoTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup session based credentials to use for tests.
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
     }
     
     override func setUp() {

--- a/AWSKinesisVideoTests/AWSKinesisVideoTests.swift
+++ b/AWSKinesisVideoTests/AWSKinesisVideoTests.swift
@@ -22,8 +22,8 @@ class AWSKinesisVideoTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup cognito credentials to use for tests.
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        // Setup session based credentials to use for tests.
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
     }
     
     override func setUp() {

--- a/AWSLambdaTests/AWSLambdaTests.m
+++ b/AWSLambdaTests/AWSLambdaTests.m
@@ -30,7 +30,7 @@
 - (void)setUp {
     [super setUp];
     [AWSTestUtility setupSessionCredentialsProvider];
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"lambda"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"lambda"];
     self.echo_function_name = testConfig[@"echo_function_name"];
     self.echo2_function_name = testConfig[@"echo2_function_name"];
 }

--- a/AWSLambdaTests/AWSLambdaTests.m
+++ b/AWSLambdaTests/AWSLambdaTests.m
@@ -20,18 +20,22 @@
 
 @interface AWSLambdaTests : XCTestCase
 
+@property NSString *echo_function_name;
+@property NSString *echo2_function_name;
+
 @end
 
 @implementation AWSLambdaTests
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"lambda"];
+    self.echo_function_name = testConfig[@"echo_function_name"];
+    self.echo2_function_name = testConfig[@"echo2_function_name"];
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
 
@@ -53,7 +57,7 @@
     AWSLambda *lambda = [AWSLambda defaultLambda];
 
     AWSLambdaGetFunctionRequest *getFunctionsRequest = [AWSLambdaGetFunctionRequest new];
-    getFunctionsRequest.functionName = @"echo";
+    getFunctionsRequest.functionName = [self echo_function_name];
 
     [[[lambda getFunction:getFunctionsRequest] continueWithBlock:^id(AWSTask *task) {
         if (task.error) {
@@ -110,7 +114,7 @@
 - (void)testInvoke {
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"echo";
+    invocationRequest.functionName = [self echo_function_name];
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
                                  @"key2" : @"value2",
@@ -142,7 +146,7 @@
     
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"echo";
+    invocationRequest.functionName = [self echo_function_name];
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
                                  @"key2" : @"value2",
@@ -172,7 +176,7 @@
     AWSLambda *lambda = [AWSLambda defaultLambda];
 
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"echo-2";
+    invocationRequest.functionName = [self echo2_function_name];
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"firstName" : @"testInvokeFunction2",
                                  @"isError" : @NO};
@@ -196,7 +200,7 @@
 - (void)testInvokeWithVersion {
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"echo";
+    invocationRequest.functionName = [self echo_function_name];
     invocationRequest.qualifier = @"2";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",
@@ -221,7 +225,7 @@
 - (void)testInvokeWithVersionAlias {
     AWSLambda *lambda = [AWSLambda defaultLambda];
     AWSLambdaInvocationRequest *invocationRequest = [AWSLambdaInvocationRequest new];
-    invocationRequest.functionName = @"echo";
+    invocationRequest.functionName = [self echo_function_name];
     invocationRequest.qualifier = @"Version2Alias";
     invocationRequest.invocationType = AWSLambdaInvocationTypeRequestResponse;
     NSDictionary *parameters = @{@"key1" : @"value1",

--- a/AWSMobileAnalyticsTests/AWSMobileAnalyticsERSTests.m
+++ b/AWSMobileAnalyticsTests/AWSMobileAnalyticsERSTests.m
@@ -30,8 +30,7 @@
 - (void)setUp
 {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)tearDown

--- a/AWSMobileAnalyticsTests/AWSMobileAnalyticsERSTests.m
+++ b/AWSMobileAnalyticsTests/AWSMobileAnalyticsERSTests.m
@@ -30,7 +30,8 @@
 - (void)setUp
 {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)tearDown

--- a/AWSPinpointTests/AWSPinpointAnalyticsClientTests.m
+++ b/AWSPinpointTests/AWSPinpointAnalyticsClientTests.m
@@ -24,7 +24,7 @@ NSString *const AWSPinpointAnalyticsClientErrorDomain = @"com.amazonaws.AWSPinpo
 @interface AWSPinpointAnalyticsClientTests : XCTestCase
 @property (nonatomic, strong) AWSPinpoint *pinpoint;
 @property (nonatomic, strong) NSUserDefaults *userDefaults;
-
+@property  NSString *pinpointAppId;
 @end
 
 
@@ -38,15 +38,12 @@ NSString *const AWSPinpointAnalyticsClientErrorDomain = @"com.amazonaws.AWSPinpo
     [super setUp];
     [[NSUserDefaults standardUserDefaults] removeSuiteNamed:@"AWSPinpointAnalyticsClientTests"];
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"AWSPinpointAnalyticsClientTests"];
-
-    [AWSTestUtility setupCognitoCredentialsProvider];
     
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    AWSPinpointConfiguration *configuration = [[AWSPinpointConfiguration alloc] initWithAppId:credentialsJson[@"pinpointAppId"] launchOptions:@{}];
+    [AWSTestUtility setupSessionCredentialsProvider];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    self.pinpointAppId = testConfig[@"pinpointAppId"];
+
+    AWSPinpointConfiguration *configuration = [[AWSPinpointConfiguration alloc] initWithAppId:self.pinpointAppId launchOptions:@{}];
     configuration.userDefaults = self.userDefaults;
     
     self.pinpoint = [AWSPinpoint pinpointWithConfiguration:configuration];

--- a/AWSPinpointTests/AWSPinpointAnalyticsClientTests.m
+++ b/AWSPinpointTests/AWSPinpointAnalyticsClientTests.m
@@ -40,7 +40,7 @@ NSString *const AWSPinpointAnalyticsClientErrorDomain = @"com.amazonaws.AWSPinpo
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"AWSPinpointAnalyticsClientTests"];
     
     [AWSTestUtility setupSessionCredentialsProvider];
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"pinpoint"];
     self.pinpointAppId = testConfig[@"pinpointAppId"];
 
     AWSPinpointConfiguration *configuration = [[AWSPinpointConfiguration alloc] initWithAppId:self.pinpointAppId launchOptions:@{}];

--- a/AWSPinpointTests/AWSPinpointBackgroundBehaviorTests.m
+++ b/AWSPinpointTests/AWSPinpointBackgroundBehaviorTests.m
@@ -244,7 +244,7 @@ static id _mockNSBundle;
 
 + (AWSPinpoint *)makeTestPinpointEnablingAutoSessionRecording:(BOOL)enableAutoSessionRecording {
     [AWSTestUtility setupSessionCredentialsProvider];
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"pinpoint"];
     NSString *appID = testConfig[@"pinpointAppId"];
     
     AWSPinpointConfiguration *config = [[AWSPinpointConfiguration alloc] initWithAppId:appID

--- a/AWSPinpointTests/AWSPinpointBackgroundBehaviorTests.m
+++ b/AWSPinpointTests/AWSPinpointBackgroundBehaviorTests.m
@@ -243,16 +243,10 @@ static id _mockNSBundle;
 }
 
 + (AWSPinpoint *)makeTestPinpointEnablingAutoSessionRecording:(BOOL)enableAutoSessionRecording {
-    [AWSTestUtility setupCognitoCredentialsProvider];
-
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-
-    NSString *appID = credentialsJson[@"pinpointAppId"];
-
+    [AWSTestUtility setupSessionCredentialsProvider];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    NSString *appID = testConfig[@"pinpointAppId"];
+    
     AWSPinpointConfiguration *config = [[AWSPinpointConfiguration alloc] initWithAppId:appID
                                                                          launchOptions:nil
                                                                         maxStorageSize:5 * 1024 * 1024

--- a/AWSPinpointTests/AWSPinpointEventRecorderTestBase.m
+++ b/AWSPinpointTests/AWSPinpointEventRecorderTestBase.m
@@ -60,7 +60,7 @@ int const AWSPinpointClientBatchRecordByteLimitDefault = 512 * 1024;
     [[NSUserDefaults standardUserDefaults] removeSuiteNamed:@"AWSPinpointEventRecorderTests"];
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"AWSPinpointEventRecorderTests"];
 
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"pinpoint"];
     
     [self initializePinpointIAD:testConfig[@"pinpointAppId"]];
     [[AWSDDLog sharedInstance] setLogLevel:AWSDDLogLevelVerbose];

--- a/AWSPinpointTests/AWSPinpointEventRecorderTestBase.m
+++ b/AWSPinpointTests/AWSPinpointEventRecorderTestBase.m
@@ -56,21 +56,18 @@ int const AWSPinpointClientBatchRecordByteLimitDefault = 512 * 1024;
 - (void)setUp {
     [super setUp];
 
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
     [[NSUserDefaults standardUserDefaults] removeSuiteNamed:@"AWSPinpointEventRecorderTests"];
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"AWSPinpointEventRecorderTests"];
 
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    [self initializePinpointIAD:credentialsJson];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    
+    [self initializePinpointIAD:testConfig[@"pinpointAppId"]];
     [[AWSDDLog sharedInstance] setLogLevel:AWSDDLogLevelVerbose];
 }
 
-- (void) initializePinpointIAD:(NSDictionary *) credentialsJson {
-    self.appIdIAD = credentialsJson[@"pinpointAppId"];
+- (void) initializePinpointIAD:(NSString *) pinpointAppId {
+    self.appIdIAD = pinpointAppId;
     self.configIAD = [[AWSPinpointConfiguration alloc] initWithAppId:self.appIdIAD
                                                        launchOptions:nil
                                                       maxStorageSize:AWSPinpointClientByteLimitDefault

--- a/AWSPinpointTests/AWSPinpointSessionClientTests.m
+++ b/AWSPinpointTests/AWSPinpointSessionClientTests.m
@@ -50,7 +50,7 @@ static NSString *const AWSPinpointSessionKey = @"com.amazonaws.AWSPinpointSessio
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"AWSPinpointSessionClientTests"];
     
     [AWSTestUtility setupSessionCredentialsProvider];
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"pinpoint"];
     self.appId = testConfig[@"pinpointAppId"];
 }
 

--- a/AWSPinpointTests/AWSPinpointSessionClientTests.m
+++ b/AWSPinpointTests/AWSPinpointSessionClientTests.m
@@ -48,14 +48,10 @@ static NSString *const AWSPinpointSessionKey = @"com.amazonaws.AWSPinpointSessio
     [super setUp];
     [[NSUserDefaults standardUserDefaults] removeSuiteNamed:@"AWSPinpointSessionClientTests"];
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"AWSPinpointSessionClientTests"];
-    [AWSTestUtility setupCognitoCredentialsProvider];
     
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    self.appId = credentialsJson[@"pinpointAppId"];
+    [AWSTestUtility setupSessionCredentialsProvider];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    self.appId = testConfig[@"pinpointAppId"];
 }
 
 - (void)tearDown {

--- a/AWSPinpointTests/AWSPinpointTargetingClientTests.m
+++ b/AWSPinpointTests/AWSPinpointTargetingClientTests.m
@@ -55,13 +55,14 @@ static NSString *userId;
 - (void)setUp {
     [super setUp];
 
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
     [[NSUserDefaults standardUserDefaults] removeSuiteNamed:AWSPinpointTargetingClientTestsName];
     self.userDefaults = [[NSUserDefaults alloc] initWithSuiteName:AWSPinpointTargetingClientTestsName];
     [self.userDefaults removeObjectForKey:AWSPinpointEndpointAttributesKey];
     [self.userDefaults removeObjectForKey:AWSPinpointEndpointMetricsKey];
     [self.userDefaults removeObjectForKey:AWSDeviceTokenKey];
     [self.userDefaults synchronize];
+    
 }
 
 - (void)tearDown {
@@ -69,13 +70,9 @@ static NSString *userId;
 }
 
 - (AWSPinpointConfiguration *)getDefaultAWSPinpointConfiguration {
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
 
-    return [[AWSPinpointConfiguration alloc] initWithAppId:credentialsJson[@"pinpointAppId"] launchOptions:@{}];
+    return [[AWSPinpointConfiguration alloc] initWithAppId:testConfig[@"pinpointAppId"] launchOptions:@{}];
 }
 
 - (AWSPinpointConfiguration *)getAWSPinpointConfigurationWithOptOut:(BOOL)optOut {

--- a/AWSPinpointTests/AWSPinpointTargetingClientTests.m
+++ b/AWSPinpointTests/AWSPinpointTargetingClientTests.m
@@ -70,7 +70,7 @@ static NSString *userId;
 }
 
 - (AWSPinpointConfiguration *)getDefaultAWSPinpointConfiguration {
-    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationFor: @"pinpoint"];
+    NSDictionary *testConfig = [AWSTestUtility getIntegrationTestConfigurationForPackageId: @"pinpoint"];
 
     return [[AWSPinpointConfiguration alloc] initWithAppId:testConfig[@"pinpointAppId"] launchOptions:@{}];
 }

--- a/AWSPinpointTests/AWSPinpointTests.m
+++ b/AWSPinpointTests/AWSPinpointTests.m
@@ -30,7 +30,7 @@
 
 - (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)tearDown {

--- a/AWSSNSTests/AWSSNSTests.m
+++ b/AWSSNSTests/AWSSNSTests.m
@@ -26,8 +26,7 @@
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSSNSTests/AWSSNSTests.m
+++ b/AWSSNSTests/AWSSNSTests.m
@@ -26,7 +26,8 @@
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 }
 
 - (void)setUp {

--- a/AWSSimpleDBTests/AWSSimpleDBTests.m
+++ b/AWSSimpleDBTests/AWSSimpleDBTests.m
@@ -31,8 +31,7 @@ static NSString *_testDomainName = nil;
 
 + (void)setUp {
     [super setUp];
-    // Setup session based credentials to use for tests.
-    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
+    [AWSTestUtility setupSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     _testDomainName = [NSString stringWithFormat:@"%@%lld", AWSSimpleDBTestDomainNamePrefix, (int64_t)timeIntervalSinceReferenceDate];

--- a/AWSSimpleDBTests/AWSSimpleDBTests.m
+++ b/AWSSimpleDBTests/AWSSimpleDBTests.m
@@ -31,8 +31,8 @@ static NSString *_testDomainName = nil;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
-    //[AWSTestUtility setupCrdentialsViaFile];
+    // Setup session based credentials to use for tests.
+    [AWSTestUtility setupSTSBasedSessionCredentialsProvider];
 
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     _testDomainName = [NSString stringWithFormat:@"%@%lld", AWSSimpleDBTestDomainNamePrefix, (int64_t)timeIntervalSinceReferenceDate];

--- a/AWSTranscribeStreamingTests/AWSTranscribeStreamingSwiftTests.swift
+++ b/AWSTranscribeStreamingTests/AWSTranscribeStreamingSwiftTests.swift
@@ -29,7 +29,7 @@ class AWSTranscribeStreamingSwiftTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
 
         guard let config = AWSServiceManager.default().defaultServiceConfiguration else {
             XCTFail("Can't get default service configuration")

--- a/AWSTranscribeStreamingTests/AWSTranscribeStreamingSwiftTests.swift
+++ b/AWSTranscribeStreamingTests/AWSTranscribeStreamingSwiftTests.swift
@@ -29,7 +29,7 @@ class AWSTranscribeStreamingSwiftTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
 
         guard let config = AWSServiceManager.default().defaultServiceConfiguration else {
             XCTFail("Can't get default service configuration")

--- a/AWSTranslateTests/AWSTranslateTests.swift
+++ b/AWSTranslateTests/AWSTranslateTests.swift
@@ -20,8 +20,8 @@ class AWSTranslateTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup cognito credentials to use for tests.
-        AWSTestUtility.setupCognitoCredentialsProvider()
+        // Setup session based credentials to use for tests.
+        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
     }
     
     override func tearDown() {

--- a/AWSTranslateTests/AWSTranslateTests.swift
+++ b/AWSTranslateTests/AWSTranslateTests.swift
@@ -20,8 +20,7 @@ class AWSTranslateTests: XCTestCase {
     
     override class func setUp() {
         super.setUp()
-        // Setup session based credentials to use for tests.
-        AWSTestUtility.setupSTSBasedSessionCredentialsProvider()
+        AWSTestUtility.setupSessionCredentialsProvider()
     }
     
     override func tearDown() {

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -393,6 +393,45 @@
 		211167392399D25000902FC1 /* AWSGeneralKinesisVideoSignalingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 211167382399D25000902FC1 /* AWSGeneralKinesisVideoSignalingTests.m */; };
 		2111673C2399D82100902FC1 /* AWSKinesisVideoSignalingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2111673B2399D82100902FC1 /* AWSKinesisVideoSignalingIntegrationTests.swift */; };
 		21BBD1EB239D556B00DDF1F7 /* AWSKinesisVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1778554320F9A72800D083BB /* AWSKinesisVideo.framework */; };
+		43B25D162456187000C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D17245619DE00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D18245619E000C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D19245619E300C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D1A245619E600C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D1B245619EC00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D1C245619EF00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D1D245619F100C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D1E245619F300C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D1F245619F600C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D20245619F800C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D21245619FD00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2224561A0000C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2324561A0200C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2424561A0400C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2524561A0500C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2624561A0700C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2724561A0900C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2824561A0B00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2924561A0E00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2A24561A0F00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2B24561A1100C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2C24561A1600C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2D24561A1800C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2E24561A1B00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D2F24561A1F00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3024561A2000C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3124561A2200C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3224561A2400C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3324561A2700C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3424561A2800C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3524561A2D00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3624561A2F00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3724561A3100C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3824561A3200C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3924561A3300C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3A24561A3500C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3B24561A3700C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
+		43B25D3C24561A8300C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D152456187000C40F76 /* testconfiguration.json */; };
 		95CEF9F423BFF67D006D4663 /* AWSTranscribeStreamingClientWebSocketProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEF9F323BFF67D006D4663 /* AWSTranscribeStreamingClientWebSocketProviderTests.swift */; };
 		95CEF9F623BFFCB4006D4663 /* AWSSRWebSocket+TranscribeStreaming.h in Headers */ = {isa = PBXBuildFile; fileRef = 95CEF9F223BEC583006D4663 /* AWSSRWebSocket+TranscribeStreaming.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		95CEF9F723C0054C006D4663 /* credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF3E1C6A69AB0098B15B /* credentials.json */; };
@@ -3772,6 +3811,7 @@
 		211167372399CE8400902FC1 /* AWSKinesisVideoSignalingTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSKinesisVideoSignalingTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		211167382399D25000902FC1 /* AWSGeneralKinesisVideoSignalingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralKinesisVideoSignalingTests.m; sourceTree = "<group>"; };
 		2111673B2399D82100902FC1 /* AWSKinesisVideoSignalingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSKinesisVideoSignalingIntegrationTests.swift; sourceTree = "<group>"; };
+		43B25D152456187000C40F76 /* testconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = testconfiguration.json; sourceTree = "<group>"; };
 		95CEF9F223BEC583006D4663 /* AWSSRWebSocket+TranscribeStreaming.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSSRWebSocket+TranscribeStreaming.h"; sourceTree = "<group>"; };
 		95CEF9F323BFF67D006D4663 /* AWSTranscribeStreamingClientWebSocketProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSTranscribeStreamingClientWebSocketProviderTests.swift; sourceTree = "<group>"; };
 		95DED98F23B1ACD500F7D354 /* AWSTranscribeStreamingWebSocketProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSTranscribeStreamingWebSocketProvider.h; sourceTree = "<group>"; };
@@ -8024,6 +8064,7 @@
 		CEB8EF3D1C6A69AB0098B15B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				43B25D152456187000C40F76 /* testconfiguration.json */,
 				CEB8EF3E1C6A69AB0098B15B /* credentials.json */,
 			);
 			path = Resources;
@@ -11926,6 +11967,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2824561A0B00C40F76 /* testconfiguration.json in Resources */,
 				FA41B39322C652E300142F8D /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -11950,6 +11992,7 @@
 			files = (
 				FA41B39422C652E700142F8D /* credentials.json in Resources */,
 				17F389C520F9B51400DADF5B /* AWSCore.framework in Resources */,
+				43B25D2724561A0900C40F76 /* testconfiguration.json in Resources */,
 				17F389C420F9B50E00DADF5B /* AWSKinesisVideo.framework in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -11966,6 +12009,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FABD9ED422D6661300BD4441 /* hello_world.wav in Resources */,
+				43B25D3A24561A3500C40F76 /* testconfiguration.json in Resources */,
 				FA53332422D4110900BD88AF /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -11974,6 +12018,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3924561A3300C40F76 /* testconfiguration.json in Resources */,
 				17ADAEA3209BD24500FF7598 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12028,6 +12073,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2B24561A1100C40F76 /* testconfiguration.json in Resources */,
 				183BD93D1D8A406F004B2659 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12043,6 +12089,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2F24561A1F00C40F76 /* testconfiguration.json in Resources */,
 				18798FFB1DEFCB1B00BC419B /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12079,6 +12126,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3024561A2000C40F76 /* testconfiguration.json in Resources */,
 				18E2F59D1DED370300BD4608 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12108,6 +12156,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2924561A0E00C40F76 /* testconfiguration.json in Resources */,
 				211167362399CD2000902FC1 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12151,6 +12200,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D1D245619F100C40F76 /* testconfiguration.json in Resources */,
 				9A7ACD0B20B1CF7C00DDBEC1 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12159,6 +12209,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3B24561A3700C40F76 /* testconfiguration.json in Resources */,
 				9A7ACD0420B12E5B00DDBEC1 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12171,6 +12222,7 @@
 				9AD5842A20F63E9B00042041 /* city_thumb.jpg in Resources */,
 				9AC4C4EE20F4F18300B1ECF4 /* credentials.json in Resources */,
 				9AD5842820F63E6700042041 /* singleface.jpg in Resources */,
+				43B25D3124561A2200C40F76 /* testconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12185,6 +12237,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3324561A2700C40F76 /* testconfiguration.json in Resources */,
 				B4A4E04122B4282000379396 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12214,6 +12267,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D1F245619F600C40F76 /* testconfiguration.json in Resources */,
 				B4D61D03232867A5007E7A12 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12236,6 +12290,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3824561A3200C40F76 /* testconfiguration.json in Resources */,
 				B5A0263522F022F4001C75CE /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12251,6 +12306,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D1E245619F300C40F76 /* testconfiguration.json in Resources */,
 				B5DD454822C9B49E003871AE /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12274,6 +12330,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D162456187000C40F76 /* testconfiguration.json in Resources */,
 				CEB8EF491C6A69AB0098B15B /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12427,6 +12484,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D18245619E000C40F76 /* testconfiguration.json in Resources */,
 				CE9DE5691C6A74FC0060793F /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12442,6 +12500,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D20245619F800C40F76 /* testconfiguration.json in Resources */,
 				CEFE06591C6AA24D007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12459,6 +12518,7 @@
 			files = (
 				18DD79BF1D67BC2A00845EBD /* ec2-input.json in Resources */,
 				18DD79C01D67BC2A00845EBD /* ec2-output.json in Resources */,
+				43B25D21245619FD00C40F76 /* testconfiguration.json in Resources */,
 				CEFE065A1C6AA24E007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12474,6 +12534,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2224561A0000C40F76 /* testconfiguration.json in Resources */,
 				CEFE065B1C6AA24F007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12490,6 +12551,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FAAB43DE23D279EF00F7BCBB /* test-identity-password-is-abc123.p12 in Resources */,
+				43B25D2324561A0200C40F76 /* testconfiguration.json in Resources */,
 				CEFE065C1C6AA24F007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12505,6 +12567,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2624561A0700C40F76 /* testconfiguration.json in Resources */,
 				CEFE065D1C6AA250007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12520,6 +12583,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2A24561A0F00C40F76 /* testconfiguration.json in Resources */,
 				CEFE065E1C6AA251007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12535,6 +12599,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2C24561A1600C40F76 /* testconfiguration.json in Resources */,
 				CEFE065F1C6AA252007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12551,6 +12616,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CEFE06601C6AA253007A42E4 /* credentials.json in Resources */,
+				43B25D2E24561A1B00C40F76 /* testconfiguration.json in Resources */,
 				CE9DE9AB1C6A7BDC0060793F /* AWSiOSSDKv2AnalyticsTests-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12566,6 +12632,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3224561A2400C40F76 /* testconfiguration.json in Resources */,
 				CEFE06611C6AA254007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12581,6 +12648,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3424561A2800C40F76 /* testconfiguration.json in Resources */,
 				CEFE06621C6AA256007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12596,6 +12664,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3524561A2D00C40F76 /* testconfiguration.json in Resources */,
 				CEFE06631C6AA257007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12611,6 +12680,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3624561A2F00C40F76 /* testconfiguration.json in Resources */,
 				CEFE06641C6AA257007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12626,6 +12696,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3724561A3100C40F76 /* testconfiguration.json in Resources */,
 				CEFE06651C6AA258007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12641,6 +12712,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D1C245619EF00C40F76 /* testconfiguration.json in Resources */,
 				CEFE06581C6AA24D007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12656,6 +12728,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D17245619DE00C40F76 /* testconfiguration.json in Resources */,
 				CEFE06561C6AA249007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12671,6 +12744,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D19245619E300C40F76 /* testconfiguration.json in Resources */,
 				CEFE06571C6AA24A007A42E4 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12679,6 +12753,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2D24561A1800C40F76 /* testconfiguration.json in Resources */,
 				CE9E509A1C72C3B500B60FD7 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12694,6 +12769,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D1B245619EC00C40F76 /* testconfiguration.json in Resources */,
 				CEA316CD1C93A468002A9F58 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12723,6 +12799,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D2524561A0500C40F76 /* testconfiguration.json in Resources */,
 				E4E1DA5D1E5F5C080080F769 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12747,6 +12824,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D1A245619E600C40F76 /* testconfiguration.json in Resources */,
 				EFDE85F21ED2050C008841EC /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12762,6 +12840,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				43B25D3C24561A8300C40F76 /* testconfiguration.json in Resources */,
 				95CEF9F723C0054C006D4663 /* credentials.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12771,6 +12850,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FAFE10D8234D3F2E00BD2DCA /* credentials.json in Resources */,
+				43B25D2424561A0400C40F76 /* testconfiguration.json in Resources */,
 				FAFE10C2234D3E2500BD2DCA /* ota_integ_test.bin in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 ### New features
-- **Integration Tests Refactor** 
-  - Change the integration test suites to use temporary session credentials
+- **Integration Tests** 
+   - AWS Mobile SDK for iOS integration tests are now provisioned from a CloudFormation stack created by [the new amplify-ci-support package](LINK TBD). See [the README](LINK TBD) for details on how to provision your account to run integration tests.
 
 ### Bug Fixes
 - **Amazon Pinpoint**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 ### New features
-- **Integration Tests** 
-   - AWS Mobile SDK for iOS integration tests are now provisioned from a CloudFormation stack created by [the new amplify-ci-support package](LINK TBD). See [the README](LINK TBD) for details on how to provision your account to run integration tests.
+- **Integration tests**
+    - AWS Mobile SDK for iOS integration tests are now provisioned from a CloudFormation stack created by [the new amplify-ci-support package](LINK TBD). See [the README](LINK TBD) for details on how to provision your account to run integration tests.
 
 ### Bug Fixes
 - **Amazon Pinpoint**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
+### New features
+- **Integration Tests Refactor** 
+  - Change the integration test suites to use temporary session credentials
 
 ### Bug Fixes
 - **Amazon Pinpoint**


### PR DESCRIPTION
*Issue #, if available:*
Update Integration Test suite to use session based temporary credentials

*Description of changes:*
Refactor integration tests of first bunch of packages to use Session based temporary credentials.
These test suites now read from testconfiguration.json instead of credentials.json.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
