### PR TITLE
Added af-south-1, eu-south-1 regions

### DIFF
--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -256,6 +256,8 @@ static NSString *const AWSRegionNameCACentral1 = @"ca-central-1";
 static NSString *const AWSRegionNameUSGovWest1 = @"us-gov-west-1";
 static NSString *const AWSRegionNameUSGovEast1 = @"us-gov-east-1";
 static NSString *const AWSRegionNameMESouth1 = @"me-south-1";
+static NSString *const AWSRegionNameAFSouth1 = @"af-south-1";
+static NSString *const AWSRegionNameEUSouth1 = @"eu-south-1";
 
 static NSString *const AWSServiceNameAPIGateway = @"execute-api";
 static NSString *const AWSServiceNameAutoScaling = @"autoscaling";
@@ -473,6 +475,10 @@ static NSString *const AWSServiceNameTranscribeStreaming = @"transcribe";
             return AWSRegionNameAPEast1;
         case AWSRegionMESouth1:
             return AWSRegionNameMESouth1;
+        case AWSRegionAFSouth1:
+            return AWSRegionNameAFSouth1;
+        case AWSRegionEUSouth1:
+            return AWSRegionNameEUSouth1;
         default:
             return nil;
     }
@@ -615,7 +621,10 @@ static NSString *const AWSServiceNameTranscribeStreaming = @"transcribe";
             || regionType == AWSRegionAPSouth1
             || regionType == AWSRegionSAEast1
             || regionType == AWSRegionUSGovWest1
-            || regionType == AWSRegionMESouth1)) {
+            || regionType == AWSRegionMESouth1
+            || regionType == AWSRegionAFSouth1
+            || regionType == AWSRegionEUSouth1
+            )) {
             separator = @"-";
         }
 

--- a/AWSCore/Service/AWSServiceEnum.h
+++ b/AWSCore/Service/AWSServiceEnum.h
@@ -115,6 +115,14 @@ typedef NS_ENUM(NSInteger, AWSRegionType) {
      *  Middle East South (Bahrain)
      */
     AWSRegionMESouth1 NS_SWIFT_NAME(MESouth1),
+    /**
+     *  Africa (Cape Town)
+     */
+    AWSRegionAFSouth1 NS_SWIFT_NAME(AFSouth1),
+    /**
+     *  Europe (Milan)
+     */
+    AWSRegionEUSouth1 NS_SWIFT_NAME(EUSouth1),
 };
 
 /**

--- a/AWSCore/Utility/AWSCategory.m
+++ b/AWSCore/Utility/AWSCategory.m
@@ -602,6 +602,18 @@ static NSTimeInterval _clockskew = 0.0;
         return AWSRegionMESouth1;
     }
 
+    if ([self isEqualToString:@"AWSRegionAFSouth1"]
+        || [self isEqualToString:@"AFSouth1"]
+        || [self isEqualToString:@"af-south-1"]) {
+        return AWSRegionAFSouth1;
+    }
+
+    if ([self isEqualToString:@"AWSRegionEUSouth1"]
+        || [self isEqualToString:@"EUSouth1"]
+        || [self isEqualToString:@"eu-south-1"]) {
+        return AWSRegionEUSouth1;
+    }
+
     return AWSRegionUnknown;
 }
 

--- a/AWSS3/AWSS3Model.h
+++ b/AWSS3/AWSS3Model.h
@@ -75,7 +75,9 @@ typedef NS_ENUM(NSInteger, AWSS3BucketLocationConstraint) {
     AWSS3BucketLocationConstraintUSGovEast1,
     AWSS3BucketLocationConstraintEUNorth1,
     AWSS3BucketLocationConstraintAPEast1,
-    AWSS3BucketLocationConstraintMESouth1
+    AWSS3BucketLocationConstraintMESouth1,
+    AWSS3BucketLocationConstraintAFSouth1,
+    AWSS3BucketLocationConstraintEUSouth1,
 };
 
 typedef NS_ENUM(NSInteger, AWSS3BucketLogsPermission) {

--- a/AWSS3/AWSS3Model.m
+++ b/AWSS3/AWSS3Model.m
@@ -1089,6 +1089,12 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
         if ([value caseInsensitiveCompare:@"me-south-1"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintMESouth1);
         }
+        if ([value caseInsensitiveCompare:@"af-south-1"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintAFSouth1);
+        }
+        if ([value caseInsensitiveCompare:@"eu-south-1"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintEUSouth1);
+        }
         return @(AWSS3BucketLocationConstraintUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
@@ -1138,6 +1144,10 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
                 return @"ap-east-1";
             case AWSS3BucketLocationConstraintMESouth1:
                 return @"me-south-1";
+            case AWSS3BucketLocationConstraintAFSouth1:
+                return @"af-south-1";
+            case AWSS3BucketLocationConstraintEUSouth1:
+                return @"eu-south-1";
             default:
                 return nil;
         }
@@ -2342,6 +2352,12 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
         if ([value caseInsensitiveCompare:@"me-south-1"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintMESouth1);
         }
+        if ([value caseInsensitiveCompare:@"af-south-1"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintAFSouth1);
+        }
+        if ([value caseInsensitiveCompare:@"eu-south-1"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintEUSouth1);
+        }
         return @(AWSS3BucketLocationConstraintUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
@@ -2391,6 +2407,10 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
                 return @"ap-east-1";
             case AWSS3BucketLocationConstraintMESouth1:
                 return @"me-south-1";
+            case AWSS3BucketLocationConstraintAFSouth1:
+                return @"af-south-1";
+            case AWSS3BucketLocationConstraintEUSouth1:
+                return @"eu-south-1";
             default:
                 return nil;
         }

--- a/AWSS3/AWSS3Resources.m
+++ b/AWSS3/AWSS3Resources.m
@@ -1299,7 +1299,9 @@
         \"us-gov-east-1\",\
         \"eu-north-1\",\
         \"ap-east-1\",\
-        \"me-south-1\"\
+        \"me-south-1\",\
+        \"af-south-1\",\
+        \"eu-south-1\"\
       ]\
     },\
     \"BucketLoggingStatus\":{\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New features
+- **AWS Core**
+  - Added support for `af-south-1` - Africa (Cape Town) region
+  - Added support for `eu-south-1` - Europe (Milan) region
+
 ### Bug Fixes
 - **Amazon Pinpoint**
   - Fix Missing address issue related to apps which have enabled push notifications, is using the pinpoint SDK, but is not registering the token with the endpoint [PR: #2455](https://github.com/aws-amplify/aws-sdk-ios/pull/2455)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,11 @@
 - **Amazon Pinpoint**
   - Fix Missing address issue related to apps which have enabled push notifications, is using the pinpoint SDK, but is not registering the token with the endpoint [PR: #2455](https://github.com/aws-amplify/aws-sdk-ios/pull/2455)
 
-## 2.13.2
-
 ### Misc. Updates
 - Model updates for the following services
   - Amazon EC2
   - Amazon Transcribe
+  - AWS Lambda
   
 ## 2.13.2
 


### PR DESCRIPTION
- Add 'Africa (Cape Town)' (af-south-1, CPT) region
- Add 'Europe (Milan)' (eu-south-1, MXP) region

*Issue #, if available:*

*Description of changes:*
Change approved offline, no review required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
