### PR TITLE
New region fixes; S3 test cleanup

### DIFF
--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -265,39 +265,39 @@ static NSString *const AWSServiceNameCloudWatch = @"monitoring";
 static NSString *const AWSServiceNameCognitoIdentity = @"cognito-identity";
 static NSString *const AWSServiceNameCognitoIdentityProvider = @"cognito-idp";
 static NSString *const AWSServiceNameCognitoSync = @"cognito-sync";
+static NSString *const AWSServiceNameComprehend = @"comprehend";
 static NSString *const AWSServiceNameConnect = @"connect";
 static NSString *const AWSServiceNameConnectParticipant = @"connectparticipant";
 static NSString *const AWSServiceNameDynamoDB = @"dynamodb";
 static NSString *const AWSServiceNameEC2 = @"ec2";
 static NSString *const AWSServiceNameElasticLoadBalancing = @"elasticloadbalancing";
+static NSString *const AWSServiceNameFirehose = @"firehose";
 static NSString *const AWSServiceNameIoT = @"execute-api";
 static NSString *const AWSServiceNameIoTData = @"iotdata";
-static NSString *const AWSServiceNameFirehose = @"firehose";
-static NSString *const AWSServiceNameKinesis = @"kinesis";
 static NSString *const AWSServiceNameKMS = @"kms";
+static NSString *const AWSServiceNameKinesis = @"kinesis";
+static NSString *const AWSServiceNameKinesisVideo = @"kinesisvideo";
+static NSString *const AWSServiceNameKinesisVideoArchivedMedia = @"kinesisvideo";
+static NSString *const AWSServiceNameKinesisVideoSignaling = @"kinesisvideo";
 static NSString *const AWSServiceNameLambda = @"lambda";
 static NSString *const AWSServiceNameLexRuntime = @"runtime.lex";
 static NSString *const AWSServiceNameLogs = @"logs";
 static NSString *const AWSServiceNameMachineLearning = @"machinelearning";
 static NSString *const AWSServiceNameMobileAnalytics = @"mobileanalytics";
-static NSString *const AWSServiceNamePolly = @"polly";
 static NSString *const AWSServiceNameMobileTargeting = @"mobiletargeting";
+static NSString *const AWSServiceNamePolly = @"polly";
 static NSString *const AWSServiceNameRekognition = @"rekognition";
 static NSString *const AWSServiceNameS3 = @"s3";
 static NSString *const AWSServiceNameSES = @"email";
-static NSString *const AWSServiceNameSimpleDB = @"sdb";
 static NSString *const AWSServiceNameSNS = @"sns";
 static NSString *const AWSServiceNameSQS = @"sqs";
 static NSString *const AWSServiceNameSTS = @"sts";
+static NSString *const AWSServiceNameSageMakerRuntime = @"sagemaker";
+static NSString *const AWSServiceNameSimpleDB = @"sdb";
 static NSString *const AWSServiceNameTextract = @"textract";
 static NSString *const AWSServiceNameTranscribe = @"transcribe";
-static NSString *const AWSServiceNameTranslate = @"translate";
-static NSString *const AWSServiceNameComprehend = @"comprehend";
-static NSString *const AWSServiceNameKinesisVideo = @"kinesisvideo";
-static NSString *const AWSServiceNameKinesisVideoArchivedMedia = @"kinesisvideo";
-static NSString *const AWSServiceNameKinesisVideoSignaling = @"kinesisvideo";
-static NSString *const AWSServiceNameSageMakerRuntime = @"sagemaker";
 static NSString *const AWSServiceNameTranscribeStreaming = @"transcribe";
+static NSString *const AWSServiceNameTranslate = @"translate";
 
 @interface AWSEndpoint()
 
@@ -622,8 +622,6 @@ static NSString *const AWSServiceNameTranscribeStreaming = @"transcribe";
             || regionType == AWSRegionSAEast1
             || regionType == AWSRegionUSGovWest1
             || regionType == AWSRegionMESouth1
-            || regionType == AWSRegionAFSouth1
-            || regionType == AWSRegionEUSouth1
             )) {
             separator = @"-";
         }

--- a/AWSCoreTests/AWSTestUtility.h
+++ b/AWSCoreTests/AWSTestUtility.h
@@ -25,9 +25,17 @@ FOUNDATION_EXPORT NSString *const AWSTestUtilityCognitoIdentityServiceKey;
 + (void)setupCredentialsViaFile;
 + (void)setupFakeCognitoCredentialsProvider;
 + (void)setupCognitoCredentialsProvider;
++ (void)setupCognitoCredentialsProviderForRegion:(AWSRegionType)region;
 + (void)setupSTS;
 + (void)setupCognitoIdentityService;
+
 + (NSDictionary<NSString *, NSString *> *)getCredentialsJsonAsDictionary;
++ (AWSRegionType)getDefaultRegionType;
++ (AWSCognitoCredentialsProvider *)getCognitoCredentialsProviderFromFileForRegion:(AWSRegionType)region;
++ (AWSStaticCredentialsProvider *)getStaticCredentialsProviderFromFile;
+
++ (BOOL)isCognitoSupportedInDefaultRegion;
++ (BOOL)isCognitoSupportedInRegion:(AWSRegionType)region;
 
 - (NSDate *)mockDateSwizzle;
 + (void)setMockDate:(NSDate *)aMockDate;

--- a/AWSCoreTests/AWSTestUtility.m
+++ b/AWSCoreTests/AWSTestUtility.m
@@ -68,90 +68,81 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
 + (void)setupCredentialsViaFile {
     if (![AWSServiceManager defaultServiceManager].defaultServiceConfiguration) {
 #if AWS_TEST_BJS_INSTEAD
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials" ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
+        NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
         AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKeyBJS"]
                                                                                                           secretKey:credentialsJson[@"secretKeyBJS"]];
 
         AWSServiceConfiguration *configuration = [AWSServiceConfiguration  configurationWithRegion:AWSRegionCNNorth1
                                                                                credentialsProvider:credentialsProvider];
-
 #else
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
-        AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                          secretKey:credentialsJson[@"secretKey"]];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+        AWSRegionType region = [AWSTestUtility getDefaultRegionType];
+        AWSStaticCredentialsProvider *credentialsProvider = [AWSTestUtility getStaticCredentialsProviderFromFile];
+        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:region
                                                                              credentialsProvider:credentialsProvider];
 #endif
         [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
     }
 }
 
++ (AWSStaticCredentialsProvider *)getStaticCredentialsProviderFromFile {
+    NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
+    AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
+                                                                                                      secretKey:credentialsJson[@"secretKey"]];
+    return credentialsProvider;
+}
+
 + (void)setupFakeCognitoCredentialsProvider {
+    AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
+                                                                                                    identityPoolId:@"fakeIdentityPoolId"];
 
-    AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1 identityPoolId:@"fakeIdentityPoolId"];
-
-    
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
                                                                          credentialsProvider:credentialsProvider];
+    
     [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
-
 }
 
 + (void)setupCognitoCredentialsProvider {
+    [AWSTestUtility setupCognitoCredentialsProviderForRegion:[AWSTestUtility getDefaultRegionType]];
+}
+
++ (void)setupCognitoCredentialsProviderForRegion:(AWSRegionType)region {
 #if AWS_TEST_BJS_INSTEAD
     //since BJS doesn't support Cognito, we are using STS instead
     [self setupSTS];
     [self runServiceWithStsCredential];
-
 #else
     if (![AWSServiceManager defaultServiceManager].defaultServiceConfiguration) {
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
-
-        AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSEast1
-                                                                                                        identityPoolId:credentialsJson[@"identityPoolId"]
-                                                                                                         unauthRoleArn:credentialsJson[@"unauthRoleArn"]
-                                                                                                           authRoleArn:credentialsJson[@"authRoleArn"]
-                                                                                               identityProviderManager:nil];
-
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+        AWSCognitoCredentialsProvider *credentialsProvider = [AWSTestUtility getCognitoCredentialsProviderFromFileForRegion:region];
+        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:region
                                                                              credentialsProvider:credentialsProvider];
         [AWSServiceManager defaultServiceManager].defaultServiceConfiguration = configuration;
     }
 #endif
+}
+
++ (AWSCognitoCredentialsProvider *)getCognitoCredentialsProviderFromFileForRegion:(AWSRegionType)region {
+    NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
+    AWSCognitoCredentialsProvider *credentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:region
+                                                                                                    identityPoolId:credentialsJson[@"identityPoolId"]
+                                                                                                     unauthRoleArn:credentialsJson[@"unauthRoleArn"]
+                                                                                                       authRoleArn:credentialsJson[@"authRoleArn"]
+                                                                                           identityProviderManager:nil];
+    return credentialsProvider;
 }
 
 + (void)setupSTS {
     if (![AWSSTS STSForKey:AWSTestUtilitySTSKey]) {
 #if AWS_TEST_BJS_INSTEAD
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials" ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
+        NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
         AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKeyBJS"]
                                                                                                           secretKey:credentialsJson[@"secretKeyBJS"]];
 
         AWSServiceConfiguration *configuration = [AWSServiceConfiguration  configurationWithRegion:AWSRegionCNNorth1
                                                                                credentialsProvider:credentialsProvider];
 #else
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
-        AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                          secretKey:credentialsJson[@"secretKey"]];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+        AWSRegionType region = [AWSTestUtility getDefaultRegionType];
+        AWSStaticCredentialsProvider *credentialsProvider = [AWSTestUtility getStaticCredentialsProviderFromFile];
+        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:region
                                                                              credentialsProvider:credentialsProvider];
 #endif
         [AWSSTS registerSTSWithConfiguration:configuration
@@ -160,11 +151,7 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
 }
 
 + (NSString *) getIoTEndPoint:(NSString *) endpointName {
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary<NSString *, NSString*> *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
+    NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
     if ([credentialsJson objectForKey:endpointName]) {
         return [credentialsJson valueForKey:endpointName];
     } else {
@@ -183,63 +170,65 @@ NSString *const AWSTestUtilityCognitoIdentityServiceKey = @"test-cib";
 
 + (void)setupCognitoIdentityService {
     if (![AWSCognitoIdentity CognitoIdentityForKey:AWSTestUtilityCognitoIdentityServiceKey]) {
-        NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                              ofType:@"json"];
-        NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                        options:NSJSONReadingMutableContainers
-                                                                          error:nil];
+        NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
+        AWSRegionType region = [AWSTestUtility getDefaultRegionType];
+
         AWSStaticCredentialsProvider *credentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
                                                                                                           secretKey:credentialsJson[@"secretKey"]];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
+        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:region
                                                                              credentialsProvider:credentialsProvider];
         [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration
                                                               forKey:AWSTestUtilityCognitoIdentityServiceKey];
     }
 }
 
-/* TODO: currently not used. Should clean this up.
-+ (void)runServiceWithStsCredential {
-    AWSTestCredentialsProvider *testCredentialProvider = [AWSTestCredentialsProvider new];
-
-    AWSSTS *sts = [AWSSTS STSForKey:AWSTestUtilitySTSKey];
-
-    AWSSTSGetSessionTokenRequest *getSessionTokenRequest = [AWSSTSGetSessionTokenRequest new];
-    getSessionTokenRequest.durationSeconds = @900;
-
-    [[[sts getSessionToken:getSessionTokenRequest] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            //XCTFail(@"Error: [%@]", task.error);
-        }
-
-        if (task.result) {
-            AWSSTSGetSessionTokenResponse *getSessionTokenResponse = task.result;
-            //XCTAssertTrue([getSessionTokenResponse.credentials.accessKeyId length] > 0);
-            testCredentialProvider.accessKey = getSessionTokenResponse.credentials.accessKeyId;
-
-            //XCTAssertTrue([getSessionTokenResponse.credentials.secretAccessKey length] > 0);
-            testCredentialProvider.secretKey = getSessionTokenResponse.credentials.secretAccessKey;
-
-            //XCTAssertTrue([getSessionTokenResponse.credentials.sessionToken length] > 0);
-            testCredentialProvider.sessionKey = getSessionTokenResponse.credentials.sessionToken;
-
-            //XCTAssertTrue([getSessionTokenResponse.credentials.expiration isKindOfClass:[NSDate class]]);
-        }
-
-        return nil;
-    }] waitUntilFinished];
-#if AWS_TEST_BJS_INSTEAD
-    AWSServiceConfiguration *configuration = [AWSServiceConfiguration  configurationWithRegion:AWSRegionCNNorth1
-                                                                           credentialsProvider:testCredentialProvider];
-#else
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1
-                                                                         credentialsProvider:testCredentialProvider];
-
-#endif
-    [[AWSServiceManager defaultServiceManager] setDefaultServiceConfiguration:configuration];
-    
-    
++ (AWSRegionType)getDefaultRegionType {
+    NSDictionary<NSString *, NSString*> *credentialsJson = [AWSTestUtility getCredentialsJsonAsDictionary];
+    NSString *regionString = credentialsJson[@"region"] ?: @"us-east-1";
+    AWSRegionType region = [regionString aws_regionTypeValue];
+    return region;
 }
-*/
+
++ (BOOL)isCognitoSupportedInDefaultRegion {
+    return [AWSTestUtility isCognitoSupportedInRegion:[AWSTestUtility getDefaultRegionType]];
+}
+
+// TODO: This is brittle. Implement a lookup by service like the Java SDK's isServiceSupported method
+// https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html
++ (BOOL)isCognitoSupportedInRegion:(AWSRegionType)region {
+    switch (region) {
+        case AWSRegionAPNortheast1:
+        case AWSRegionAPNortheast2:
+        case AWSRegionAPSouth1:
+        case AWSRegionAPSoutheast1:
+        case AWSRegionAPSoutheast2:
+        case AWSRegionCACentral1:
+        case AWSRegionEUCentral1:
+        case AWSRegionEUWest1:
+        case AWSRegionEUWest2:
+        case AWSRegionUSEast1:
+        case AWSRegionUSEast2:
+        case AWSRegionUSWest2:
+            return true;
+            break;
+
+        case AWSRegionAFSouth1:
+        case AWSRegionAPEast1:
+        case AWSRegionCNNorth1:
+        case AWSRegionCNNorthWest1:
+        case AWSRegionEUNorth1:
+        case AWSRegionEUSouth1:
+        case AWSRegionEUWest3:
+        case AWSRegionMESouth1:
+        case AWSRegionSAEast1:
+        case AWSRegionUSGovEast1:
+        case AWSRegionUSGovWest1:
+        case AWSRegionUSWest1:
+        case AWSRegionUnknown:
+            return false;
+            break;
+    }
+}
 
 Method _originalDateMethod;
 Method _mockDateMethod;

--- a/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
+++ b/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
@@ -55,8 +55,11 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
     [super setUp];
     bucketNameArray = @[@"ios-v2-s3-tm-testdata", @"ios-v2-s3.periods", @"ios-v2-s3-eu-central", @"ios-v2-s3-eu-c.periods"];
 
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-    [AWSTestUtility setupCognitoCredentialsProvider];
+    if ([AWSTestUtility isCognitoSupportedInDefaultRegion]) {
+        [AWSTestUtility setupCognitoCredentialsProvider];
+    } else {
+        [AWSTestUtility setupCredentialsViaFile];
+    }
 
     id<AWSCredentialsProvider> credentialProvider = [AWSServiceManager defaultServiceManager].defaultServiceConfiguration.credentialsProvider;
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionEUCentral1
@@ -64,13 +67,7 @@ static NSString *testS3PresignedURLEUCentralStaticKey = @"testS3PresignedURLEUCe
     [AWSS3PreSignedURLBuilder registerS3PreSignedURLBuilderWithConfiguration:configuration forKey:testS3PresignedURLEUCentralKey];
     [AWSS3 registerS3WithConfiguration:configuration forKey:testS3EUCentralKey];
 
-    NSString *filePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"credentials"
-                                                                          ofType:@"json"];
-    NSDictionary *credentialsJson = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:filePath]
-                                                                    options:NSJSONReadingMutableContainers
-                                                                      error:nil];
-    AWSStaticCredentialsProvider *staticCredentialsProvider = [[AWSStaticCredentialsProvider alloc] initWithAccessKey:credentialsJson[@"accessKey"]
-                                                                                                            secretKey:credentialsJson[@"secretKey"]];
+    AWSStaticCredentialsProvider *staticCredentialsProvider = [AWSTestUtility getStaticCredentialsProviderFromFile];
     AWSServiceConfiguration *staticConfig = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionEUCentral1
                                                                         credentialsProvider:staticCredentialsProvider];
     [AWSS3PreSignedURLBuilder registerS3PreSignedURLBuilderWithConfiguration:staticConfig forKey:testS3PresignedURLEUCentralStaticKey];

--- a/AWSS3Tests/AWSS3TestHelper.h
+++ b/AWSS3Tests/AWSS3TestHelper.h
@@ -23,9 +23,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)createBucketWithName:(NSString *)bucketName
                    andRegion:(AWSRegionType)regionType;
 
++ (BOOL)createBucketWithName:(NSString *)bucketName;
+
 + (void)deleteAllObjectsFromBucket:(NSString *)bucketName;
 
 + (BOOL)deleteBucketWithName:(NSString *)bucketName;
+
++ (AWSS3CreateBucketRequest *)getCreateBucketRequest;
+
++ (AWSS3BucketLocationConstraint)getLocationConstraintForRegionType:(AWSRegionType)regionType;
 
 /**
 Check if the given object is present inside the bucket. This is a blocking call.

--- a/AWSS3Tests/AWSS3TestHelper.m
+++ b/AWSS3Tests/AWSS3TestHelper.m
@@ -14,6 +14,7 @@
 //
 
 #import "AWSS3TestHelper.h"
+#import "AWSTestUtility.h"
 
 @interface AWSS3CreateBucketConfiguration()
 
@@ -29,24 +30,18 @@
 
 @implementation AWSS3TestHelper
 
++ (BOOL)createBucketWithName:(NSString *)bucketName {
+    return [AWSS3TestHelper createBucketWithName:bucketName
+                                       andRegion:[AWSTestUtility getDefaultRegionType]];
+}
+
 + (BOOL)createBucketWithName:(NSString *)bucketName
                    andRegion:(AWSRegionType)regionType {
     
     AWSS3 *s3 = [AWSS3 defaultS3];
     
-    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
+    AWSS3CreateBucketRequest *createBucketReq = [AWSS3TestHelper getCreateBucketRequest];
     createBucketReq.bucket = bucketName;
-    
-    if (regionType != AWSRegionUSEast1) {
-        NSString *regionName = [AWSEndpoint regionNameFromType:regionType];
-        NSValueTransformer *locationConstraintTransformer = [AWSS3CreateBucketConfiguration locationConstraintJSONTransformer];
-        NSNumber *constraint = [locationConstraintTransformer transformedValue:regionName];
-        AWSS3BucketLocationConstraint dupcon = constraint.integerValue;
-        AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
-        createBucketConfiguration.locationConstraint = dupcon;
-        createBucketReq.createBucketConfiguration = createBucketConfiguration;
-    }
-
     
     __block BOOL success = NO;
     [[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
@@ -61,6 +56,33 @@
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
     
     return success;
+}
+
++ (AWSS3CreateBucketRequest *)getCreateBucketRequest {
+    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
+    AWSRegionType regionType = [AWSTestUtility getDefaultRegionType];
+    AWSS3BucketLocationConstraint locationConstraint = [AWSS3TestHelper getLocationConstraintForRegionType:regionType];
+    
+    if (locationConstraint == AWSS3BucketLocationConstraintBlank) {
+        return createBucketReq;
+    }
+
+    AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
+    createBucketConfiguration.locationConstraint = locationConstraint;
+    createBucketReq.createBucketConfiguration = createBucketConfiguration;
+
+    return createBucketReq;
+}
+
++ (AWSS3BucketLocationConstraint) getLocationConstraintForRegionType:(AWSRegionType)regionType {
+    if (regionType == AWSRegionUSEast1) {
+        return AWSS3BucketLocationConstraintBlank;
+    }
+    NSString *regionName = [AWSEndpoint regionNameFromType:regionType];
+    NSValueTransformer *locationConstraintTransformer = [AWSS3CreateBucketConfiguration locationConstraintJSONTransformer];
+    NSNumber *constraintInt = [locationConstraintTransformer transformedValue:regionName];
+    AWSS3BucketLocationConstraint constraint = constraintInt.integerValue;
+    return constraint;
 }
 
 + (BOOL)deleteBucketWithName:(NSString *)bucketName {

--- a/AWSS3Tests/AWSS3Tests.m
+++ b/AWSS3Tests/AWSS3Tests.m
@@ -14,6 +14,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import "AWSService.h"
 #import "AWSS3.h"
 #import "AWSTestUtility.h"
 #import "AWSS3TestHelper.h"
@@ -36,24 +37,27 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 
 + (void)setUp {
     [super setUp];
-    [AWSTestUtility setupCognitoCredentialsProvider];
-    //[AWSTestUtility setupCrdentialsViaFile];
     
+    if ([AWSTestUtility isCognitoSupportedInDefaultRegion]) {
+        [AWSTestUtility setupCognitoCredentialsProvider];
+    } else {
+        [AWSTestUtility setupCredentialsViaFile];
+    }
+
     testBucketsCreated = [NSMutableArray new];
-    
     
     //Create bucketName
     NSTimeInterval timeIntervalSinceReferenceDate = [NSDate timeIntervalSinceReferenceDate];
     testBucketNameGeneral = [NSString stringWithFormat:@"%@%lld", AWSS3TestBucketNamePrefix, (int64_t)timeIntervalSinceReferenceDate];
 
-    [AWSS3TestHelper createBucketWithName:testBucketNameGeneral andRegion:AWSRegionUSEast1];
+    [AWSS3TestHelper createBucketWithName:testBucketNameGeneral];
     [testBucketsCreated addObject:testBucketNameGeneral];
     
     //Create a large temporary file for uploading & downloading test
     tempLargeURL = [NSURL fileURLWithPath:[[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-s3tmTestTempLarge",testBucketNameGeneral]]];
     NSError *error = nil;
     if (![[NSFileManager defaultManager] createFileAtPath:tempLargeURL.path contents:nil attributes:nil]) {
-        AWSDDLogError(@"Error: Can not create file with file path:%@",tempLargeURL.path);
+        AWSDDLogError(@"Error: Can not create file with file path:%@", tempLargeURL.path);
     }
     error = nil;
     NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingToURL:tempLargeURL error:&error];
@@ -77,7 +81,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         [fileHandle closeFile];
         
         if (true) {
-            //Create a smal temporary file for uploading & downloading test
+            //Create a small temporary file for uploading & downloading test
             tempSmallURL = [NSURL fileURLWithPath:[[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0] stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-s3tmTestTempSmall",testBucketNameGeneral]]];
             NSError *error = nil;
             if (![[NSFileManager defaultManager] createFileAtPath:tempSmallURL.path contents:nil attributes:nil]) {
@@ -139,8 +143,6 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 }
 
 -(void)testCreateEmptyFolder {
-    
-    
     AWSS3 *s3 = [AWSS3 defaultS3];
     
     AWSS3PutObjectRequest *putObjectRequest = [AWSS3PutObjectRequest new];
@@ -164,9 +166,8 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         XCTAssertTrue([task.result isKindOfClass:[AWSS3DeleteObjectOutput class]],@"The response object is not a class of [%@], got: %@", NSStringFromClass([AWSS3DeleteObjectOutput class]),[task.result description]);
         return nil;
     }] waitUntilFinished];
-    
-    
 }
+
 - (void)testClockSkewS3 {
     [AWSTestUtility setupSwizzling];
 
@@ -207,15 +208,8 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     AWSS3 *s3 = [AWSS3 defaultS3];
     XCTAssertNotNil(s3);
 
-    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
-    createBucketReq.ACL = AWSS3BucketCannedACLAuthenticatedRead;
+    AWSS3CreateBucketRequest *createBucketReq = [AWSS3TestHelper getCreateBucketRequest];
     createBucketReq.bucket = bucketNameTest2;
-
-#if AWS_TEST_BJS_INSTEAD
-    AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
-    createBucketConfiguration.locationConstraint = AWSS3BucketLocationConstraintCNNorth1;
-    createBucketReq.createBucketConfiguration = createBucketConfiguration;
-#endif
     
     [[[[[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error, @"The request failed. error: [%@]", task.error);
@@ -253,17 +247,10 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     
     AWSS3 *s3 = [AWSS3 defaultS3];
     XCTAssertNotNil(s3);
-    
-    AWSS3CreateBucketRequest *createBucketReq = [AWSS3CreateBucketRequest new];
-    createBucketReq.ACL = AWSS3BucketCannedACLAuthenticatedRead;
+
+    AWSS3CreateBucketRequest *createBucketReq = [AWSS3TestHelper getCreateBucketRequest];
     createBucketReq.bucket = bucketNameTest2;
-    
-#if AWS_TEST_BJS_INSTEAD
-    AWSS3CreateBucketConfiguration *createBucketConfiguration = [AWSS3CreateBucketConfiguration new];
-    createBucketConfiguration.locationConstraint = AWSS3BucketLocationConstraintCNNorth1;
-    createBucketReq.createBucketConfiguration = createBucketConfiguration;
-#endif
-    
+
     [[[[[[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error, @"The request failed. error: [%@]", task.error);
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
@@ -310,12 +297,22 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 }
 
 - (void)testBucketCustomEndpoint {
+    AWSRegionType region = [AWSTestUtility getDefaultRegionType];
+
+    id<AWSCredentialsProvider> credentialsProvider;
+    if ([AWSTestUtility isCognitoSupportedInDefaultRegion]) {
+        credentialsProvider = [AWSTestUtility getCognitoCredentialsProviderFromFileForRegion:region];
+    } else {
+        credentialsProvider = [AWSTestUtility getStaticCredentialsProviderFromFile];
+    }
+
+    NSString *regionName = [AWSEndpoint regionNameFromType:region];
+    NSString *urlString = [NSString stringWithFormat:@"https://s3.dualstack.%@.amazonaws.com", regionName];
+    AWSEndpoint *customEndpoint = [[AWSEndpoint alloc]initWithURLString:urlString];
     
-    id<AWSCredentialsProvider> credentialsProvider = [[[AWSServiceManager defaultServiceManager] defaultServiceConfiguration] credentialsProvider];
-    
-    AWSEndpoint *customEndpoint = [[AWSEndpoint alloc]initWithURLString:@"https://s3.dualstack.us-east-1.amazonaws.com"];
-    
-    AWSServiceConfiguration *serviceConfiguration = [[AWSServiceConfiguration alloc]initWithRegion:AWSRegionUSEast1 endpoint:customEndpoint credentialsProvider:credentialsProvider];
+    AWSServiceConfiguration *serviceConfiguration = [[AWSServiceConfiguration alloc]initWithRegion:region
+                                                                                          endpoint:customEndpoint
+                                                                               credentialsProvider:credentialsProvider];
     
     [AWSS3 registerS3WithConfiguration:serviceConfiguration forKey:@"customendpoint"];
     
@@ -388,12 +385,30 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 
 
 - (void)testPutBucketWithGrants {
-    NSString *grantBucketName = [testBucketNameGeneral stringByAppendingString:@"-grant"];
-    [testBucketsCreated addObject:grantBucketName];
-    XCTAssertTrue([AWSS3TestHelper createBucketWithName:grantBucketName andRegion:AWSRegionUSEast1]);
-
     AWSS3 *s3 = [AWSS3 defaultS3];
     XCTAssertNotNil(s3);
+
+    // S3 listBuckets response is the only way to programmatically get an owner:
+    // https://forums.aws.amazon.com/thread.jspa?threadID=260661
+    __block AWSS3Owner *owner;
+    [[[s3 listBuckets:[AWSRequest new]] continueWithBlock:^id _Nullable(AWSTask<AWSS3ListBucketsOutput *> * _Nonnull t) {
+        if (!t.result || !t.result.owner) {
+            XCTFail(@"ListBuckets owner unexpectedly empty");
+            return nil;
+        }
+        owner = t.result.owner;
+        return nil;
+    }] waitUntilFinished];
+    
+    if (!owner) {
+        XCTFail(@"Could not get owner");
+        return;
+    }
+    
+    NSString *grantBucketName = [testBucketNameGeneral stringByAppendingString:@"-grant"];
+    [testBucketsCreated addObject:grantBucketName];
+    XCTAssertTrue([AWSS3TestHelper createBucketWithName:grantBucketName
+                                              andRegion:[AWSTestUtility getDefaultRegionType]]);
 
     AWSS3Grantee *granteeOne = [AWSS3Grantee new];
     granteeOne.identifier = @"154b2f3550127d0439dfe1e89a03a7a4178048cc05c6fdaeb40796841a5cfcef";
@@ -406,13 +421,9 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 
     NSArray *grantsList = [NSArray arrayWithObjects:grantOne, nil];
 
-    AWSS3Owner *s3Owner = [AWSS3Owner new];
-    s3Owner.displayName = @"aws-dr-mobile-test-ios@amazon.com";
-    s3Owner.identifier = @"0d822d37be4e6e24e50d96c88fefa5d3b2e8cd5661a759d6a07596306c41f52d";
-
     AWSS3AccessControlPolicy *accessControlPolicy = [AWSS3AccessControlPolicy new];
     accessControlPolicy.grants = grantsList;
-    accessControlPolicy.owner = s3Owner;
+    accessControlPolicy.owner = owner;
 
     AWSS3PutBucketAclRequest *putBucketAclReq = [AWSS3PutBucketAclRequest new];
     putBucketAclReq.bucket = grantBucketName;
@@ -421,8 +432,6 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 #else
     putBucketAclReq.accessControlPolicy = accessControlPolicy;
 #endif
-    
-    
     
     [[[s3 putBucketAcl:putBucketAclReq] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNil(task.error, @"The request failed. error: [%@]", task.error);
@@ -692,7 +701,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     AWSS3PutObjectRequest *putObjectRequest = [AWSS3PutObjectRequest new];
     putObjectRequest.bucket = testBucketNameGeneral;
     putObjectRequest.key = keyName;
-    putObjectRequest.body = [NSURL fileURLWithPath:getObjectFilePath];;
+    putObjectRequest.body = [NSURL fileURLWithPath:getObjectFilePath];
     putObjectRequest.contentLength = [NSNumber numberWithUnsignedLongLong:fileSize];
     putObjectRequest.contentType = @"video/mpeg";
     
@@ -807,19 +816,37 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 }
 
 -(void)testGetObjectByFilePathCanceled {
+    NSString * keyName = @"testGetObjectByFilePathCanceled.bin";
     
     AWSS3 *s3 = [AWSS3 defaultS3];
     
+    // Upload test file for subsequent download
+    NSString *localFilePath = tempSmallURL.path;
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:localFilePath]);
+    unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:localFilePath error:nil] fileSize];
+
+    AWSS3PutObjectRequest *putObjectRequest = [AWSS3PutObjectRequest new];
+    putObjectRequest.bucket = testBucketNameGeneral;
+    putObjectRequest.key = keyName;
+    putObjectRequest.body = [NSURL fileURLWithPath:localFilePath];
+    putObjectRequest.contentLength = [NSNumber numberWithUnsignedLongLong:fileSize];
+    putObjectRequest.contentType = @"video/mpeg";
+
+    [[[s3 putObject:putObjectRequest] continueWithBlock:^id _Nullable(AWSTask<AWSS3PutObjectOutput *> * _Nonnull t) {
+        XCTAssertNil(t.error);
+        return nil;
+    }] waitUntilFinished];
+
+    // Prepare a download request (which will be subsequently cancelled prior to completion)
     AWSS3GetObjectRequest *getObjectRequest = [AWSS3GetObjectRequest new];
-    getObjectRequest.bucket = @"ios-v2-s3-tm-testdata";
-    getObjectRequest.key = @"temp.txt";
+    getObjectRequest.bucket = testBucketNameGeneral;
+    getObjectRequest.key = keyName;
     
     //assign the file path to be written.
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsPath = [paths objectAtIndex:0]; //Get the docs directory
     NSString *filePath = [documentsPath stringByAppendingPathComponent:@"s3TestCanceled.txt"];
     getObjectRequest.downloadingFileURL = [NSURL fileURLWithPath:filePath];
-    
     
     AWSTask *getObjTask = [[s3 getObject:getObjectRequest] continueWithBlock:^id(AWSTask *task) {
         //Should return Cancelled Task Error
@@ -835,16 +862,13 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         return nil;
     }];
     
-    
-    //wait few sec then cancel this job
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+    // wait few sec then cancel this job
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     [getObjectRequest cancel];
     
-    
     [getObjTask waitUntilFinished];
-
-    
 }
+
 - (void)testPutGetAndDeleteObjectByFilePathWithProgressFeedback {
     NSString *keyName = @"ios-v2-do-not-delete-s3test-put-get-delete-obj";
     NSString *getObjectFilePath = tempSmallURL.path;
@@ -1036,7 +1060,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     rule2.allowedHeaders = @[@"*"];
     [corsRules addObject:rule2];
     
-    AWSS3CORSConfiguration *cors = [AWSS3CORSConfiguration new];;
+    AWSS3CORSConfiguration *cors = [AWSS3CORSConfiguration new];
     cors.CORSRules = corsRules;
     
     AWSS3PutBucketCorsRequest *putBucketCorsReq = [AWSS3PutBucketCorsRequest new];
@@ -1374,6 +1398,9 @@ static NSMutableArray<NSString *> *testBucketsCreated;
     AWSS3 *s3 = [AWSS3 defaultS3];
     AWSS3GetBucketLocationRequest *getBucketLocationRequest = [AWSS3GetBucketLocationRequest new];
     getBucketLocationRequest.bucket = testBucketNameGeneral;
+    
+    AWSRegionType regionType = [AWSTestUtility getDefaultRegionType];
+    AWSS3BucketLocationConstraint expectedConstraint = [AWSS3TestHelper getLocationConstraintForRegionType:regionType];
 
     [[[s3 getBucketLocation:getBucketLocationRequest] continueWithBlock:^id(AWSTask *task) {
         if(task.error != nil){
@@ -1381,11 +1408,9 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         }
         
         AWSS3GetBucketLocationOutput *getBucketLocationOutput = task.result;
-#if AWS_TEST_BJS_INSTEAD
-        XCTAssertEqual(getBucketLocationOutput.locationConstraint, AWSS3BucketLocationConstraintCNNorth1);
-#else
-        XCTAssertEqual(getBucketLocationOutput.locationConstraint, AWSS3BucketLocationConstraintBlank);
-#endif
+
+        XCTAssertEqual(getBucketLocationOutput.locationConstraint, expectedConstraint);
+
         return nil;
     }] waitUntilFinished];
 }
@@ -1461,12 +1486,16 @@ static NSMutableArray<NSString *> *testBucketsCreated;
 }
 
 - (void)testInventorySetupOnBucket {
-    NSString *sourceBucketName = @"ios-v2-do-not-delete-s3test-inventory-source";
-
-    NSString *destinationBucketName = @"ios-v2-do-not-delete-s3test-inventory";
-
     AWSS3 *s3 = [AWSS3 defaultS3];
     XCTAssertNotNil(s3);
+
+    NSString *sourceBucketName = [testBucketNameGeneral stringByAppendingString:@"-inventory-source"];
+    [AWSS3TestHelper createBucketWithName:sourceBucketName];
+    [testBucketsCreated addObject:sourceBucketName];
+
+    NSString *destinationBucketName = [testBucketNameGeneral stringByAppendingString:@"-inventory-destination"];
+    [AWSS3TestHelper createBucketWithName:destinationBucketName];
+    [testBucketsCreated addObject:destinationBucketName];
 
     AWSS3PutBucketInventoryConfigurationRequest *putBucketInventoryRequest = [AWSS3PutBucketInventoryConfigurationRequest new];
     putBucketInventoryRequest.bucket = sourceBucketName;


### PR DESCRIPTION
- fix: Remove CPT and MXP from S3 URL special handling
- test: Test utility refactoring to allow S3 integ tests to run in regions
        other than USEast1, using credential providers other than Cognito
- style: Sort service name list

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
