### PR TITLE
Release process refactoring & fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,7 +738,7 @@ jobs:
 
             bump_version_message="[bump version $release_version]"
             bump_version_pr_title="bump iOS sdk version to ${release_version}"
-            target_branch=test_develop
+            target_branch=develop
             echo "export bumpversion_repo_user=$bumpversion_repo_user" >> $BASH_ENV
             echo "export bumpversion_repo_name=$bumpversion_repo_name" >> $BASH_ENV
             echo "export release_version=$release_version" >> $BASH_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ src/aws-ios-sdk-*.zip
 xcuserdata
 *.xccheckout
 
+# Other IDEs
+.idea
+
 # Patched code #
 ######################
 *.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
+## Unreleased
+
 ## 2.13.3
 
 ### New features

--- a/CircleciScripts/bump_sdk_version.py
+++ b/CircleciScripts/bump_sdk_version.py
@@ -1,171 +1,208 @@
-from functions import replacefiles
-import sys
-import os
 import glob
+import os
 import re
+import sys
+
+from functions import replacefiles
 from lxml import etree
 
-def bump_plist(filename, newsdkversion):
-    tree = etree.parse(filename)
-    root = tree.getroot()
-    namespaces = root.nsmap
-    dictnode = root.find("./dict", namespaces)
-    setversion = False
-    for child in dictnode:
-        if child.tag == 'key' and child.text == 'CFBundleShortVersionString':
-            setversion = True
-        else:
-            if setversion:
-                print("old version:", child.text)
-                child.text=newsdkversion
-                break
 
-    plist_string = format_plist(tree)
-    plist = open(filename, "w")
-    plist.write(plist_string)
-    plist.close()
+class VersionBumper:
 
-# Adjusts lxml's pretty-printed XML format to match Xcode's default and avoid
-# semantically uninteresting diffs
-def format_plist(tree):
-    plist_string = tree_to_string(tree)
+    module_list = [
+        "AWSAPIGateway",
+        "AWSAutoScaling",
+        "AWSCloudWatch",
+        "AWSCognito",
+        "AWSCognitoAuth",
+        "AWSCognitoIdentityProvider",
+        "AWSComprehend",
+        "AWSConnect",
+        "AWSConnectParticipant",
+        "AWSCore",
+        "AWSDynamoDB",
+        "AWSEC2",
+        "AWSElasticLoadBalancing",
+        "AWSIoT",
+        "AWSKMS",
+        "AWSKinesis",
+        "AWSKinesisVideo",
+        "AWSKinesisVideoArchivedMedia",
+        "AWSKinesisVideoSignaling",
+        "AWSLambda",
+        "AWSLex",
+        "AWSLogs",
+        "AWSMachineLearning",
+        "AWSMobileAnalytics",
+        "AWSPinpoint",
+        "AWSPolly",
+        "AWSRekognition",
+        "AWSS3",
+        "AWSSES",
+        "AWSSNS",
+        "AWSSQS",
+        "AWSSageMakerRuntime",
+        "AWSSimpleDB",
+        "AWSTextract",
+        "AWSTranscribe",
+        "AWSTranscribeStreaming",
+        "AWSTranslate",
+        "AWSAuthSDK/Sources/AWSAuthCore",
+        "AWSAuthSDK/Sources/AWSAuthUI",
+        "AWSAuthSDK/Sources/AWSFacebookSignIn",
+        "AWSAuthSDK/Sources/AWSGoogleSignIn",
+        "AWSAuthSDK/Sources/AWSMobileClient",
+        "AWSAuthSDK/Sources/AWSUserPoolsSignIn",
+    ]
 
-    flags = re.MULTILINE | re.IGNORECASE
+    def __init__(self, root, new_sdk_version):
+        self._root = root
+        self._new_sdk_version = new_sdk_version
 
-    # Prepend XML prolog. This could be partially done with `lxml.tostring`'s
-    # xml_declaration option, but that returns single-quoted attributes
-    formatted_plist = '<?xml version="1.0" encoding="UTF-8"?>\n' + plist_string
+    def bump_sdk_version(self):
+        self.bump_plists()
+        self.bump_services()
+        self.bump_podspecs()
+        self.bump_changelog()
+        self.bump_generate_docs()
 
-    # Replace self-closing '<string/>' tags with explicitly closed tags
-    formatted_plist = re.sub(r'<string/>', '<string></string>', formatted_plist, flags=flags)
+    def bump_plists(self):
+        for module in VersionBumper.module_list:
+            filename = os.path.join(root, module, "Info.plist")
+            self.bump_plist(filename)
 
-    # Adjust lxml's default space-based indentation to Xcode's tab-based. Use the
-    # multiline flag and match beginning of each line.
-    formatted_plist = re.sub(r'^\s+<', '\t<', formatted_plist, flags=flags)
+    def bump_plist(self, filename):
+        tree = etree.parse(filename)
+        root_node = tree.getroot()
+        namespaces = root_node.nsmap
+        dict_node = root_node.find("./dict", namespaces)
+        set_version = False
+        for child in dict_node:
+            if child.tag == "key" and child.text == "CFBundleShortVersionString":
+                set_version = True
+            else:
+                if set_version:
+                    child.text = self._new_sdk_version
+                    break
 
-    return formatted_plist
+        plist_string = VersionBumper.format_plist(tree)
+        plist = open(filename, "w")
+        plist.write(plist_string)
+        plist.close()
 
-def tree_to_string(tree):
-    plist_bytes = etree.tostring(tree, pretty_print = True, xml_declaration = False, encoding='UTF-8')
-    plist_string = plist_bytes.decode('utf-8')
-    return plist_string
+    @staticmethod
+    def format_plist(tree):
+        """
+        Adjusts lxml's pretty-printed XML format to match Xcode's default and avoid
+        semantically uninteresting diffs
+
+        :param tree: the lxml tree to format
+        :return: a pretty-printed string matching Xcode's plist format
+        """
+        plist_string = VersionBumper.tree_to_string(tree)
+
+        flags = re.MULTILINE | re.IGNORECASE
+
+        # Prepend XML prolog. This could be partially done with `lxml.tostring`'s
+        # xml_declaration option, but that returns single-quoted attributes
+        formatted_plist = '<?xml version="1.0" encoding="UTF-8"?>\n' + plist_string
+
+        # Replace self-closing '<string/>' tags with explicitly closed tags
+        formatted_plist = re.sub(
+            r"<string/>", "<string></string>", formatted_plist, flags=flags
+        )
+
+        # Adjust lxml's default space-based indentation to Xcode's tab-based. Use the
+        # multiline flag and match beginning of each line.
+        formatted_plist = re.sub(r"^\s+<", "\t<", formatted_plist, flags=flags)
+
+        return formatted_plist
+
+    @staticmethod
+    def tree_to_string(tree):
+        plist_bytes = etree.tostring(
+            tree, pretty_print=True, xml_declaration=False, encoding="UTF-8"
+        )
+        plist_string = plist_bytes.decode("utf-8")
+        return plist_string
+
+    def bump_services(self):
+        service_pattern = {
+            "match": r'(NSString[[:space:]]+\*const[[:space:]]+AWS.+SDKVersion[[:space:]]*=[[:space:]]+@")[0-9]+\.[0-9]+\.[0-9]+"',
+            "replace": r'\1{version}"'.format(version=self._new_sdk_version),
+            "files": [],
+        }
+
+        # Add files for each module
+        for module in VersionBumper.module_list:
+            path = "{0}/{0}Service.m".format(module)
+            if os.path.isfile(os.path.join(root, path)):
+                service_pattern["files"].append(path)
+
+        # Add files for special modules
+        service_pattern["files"].extend([
+            "AWSAPIGateway/AWSAPIGatewayClient.m",
+            "AWSCognito/CognitoSync/AWSCognitoSyncService.m",
+            "AWSCognitoAuth/AWSCognitoAuth.m",
+            "AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m",
+            "AWSCore/Service/AWSService.m",
+            "AWSIoT/AWSIoTDataService.m",
+            "AWSKinesis/AWSFirehoseService.m",
+            "AWSLex/AWSLexInteractionKit.m",
+            "AWSMobileAnalytics/AWSMobileAnalyticsERS/AWSMobileAnalyticsERSService.m",
+            "AWSPinpoint/AWSPinpointTargeting/AWSPinpointTargetingService.m",
+            "AWSPolly/AWSPollySynthesizeSpeechURLBuilder.m",
+            "AWSS3/AWSS3PreSignedURL.m",
+        ])
+        replacefiles(self._root, service_pattern)
+
+    def bump_podspecs(self):
+        podspec_pattern1 = {
+            "enclosemark": "double",
+            "exclude": "AWSCognitoIdentityProviderASF",
+            "match": r"(dependency[[:space:]]+'AWS.+'[[:space:]]*,[[:space:]]*')[0-9]+\.[0-9]+\.[0-9]+(')",
+            "replace": r"\1{version}\2".format(version=self._new_sdk_version),
+            "files": [],
+        }
+
+        podspec_pattern2 = {
+            "enclosemark": "double",
+            "exclude": "AWSCognitoIdentityProviderASF",
+            "match": r"(s\.version[[:space:]]+=[[:space:]]*')[0-9]+\.[0-9]+\.[0-9]+(')",
+            "replace": r"\1{version}\2".format(version=self._new_sdk_version),
+            "files": [],
+        }
+
+        for file in glob.glob(os.path.join(root, "*.podspec")):
+            if file.endswith("AWSCognitoIdentityProviderASF.podspec"):
+                continue
+            podspec_pattern1["files"].append(file)
+            podspec_pattern2["files"].append(file)
+
+        replacefiles(self._root, podspec_pattern1)
+        replacefiles(self._root, podspec_pattern2)
+
+    def bump_changelog(self):
+        changelog_pattern = {
+            "match": r"## Unreleased",
+            "replace": "## Unreleased\\\n-Features for next release\\\n\\\n## {version}".format(
+                version=self._new_sdk_version
+            ),
+            "files": ["CHANGELOG.md"],
+        }
+        replacefiles(self._root, changelog_pattern)
+
+    def bump_generate_docs(self):
+        generate_documentation_pattern = {
+            "match": r'VERSION="[0-9]+\.[0-9]+\.[0-9]+"',
+            "replace": r'VERSION="{version}"'.format(version=self._new_sdk_version),
+            "files": ["CircleciScripts/generate_documentation.sh"],
+        }
+        replacefiles(self._root, generate_documentation_pattern)
 
 
-root = sys.argv[1]
-newsdkversion = sys.argv[2]
-modulelist = [
-    "AWSAPIGateway",
-    "AWSAutoScaling",
-    "AWSCloudWatch",
-    "AWSCognito",
-    "AWSCognitoAuth",
-    "AWSCognitoIdentityProvider",
-    "AWSComprehend",
-    "AWSConnect",
-    "AWSConnectParticipant",
-    "AWSCore",
-    "AWSDynamoDB",
-    "AWSEC2",
-    "AWSElasticLoadBalancing",
-    "AWSIoT",
-    "AWSKMS",
-    "AWSKinesis",
-    "AWSKinesisVideo",
-    "AWSKinesisVideoArchivedMedia",
-    "AWSKinesisVideoSignaling",
-    "AWSLambda",
-    "AWSLex",
-    "AWSLogs",
-    "AWSMachineLearning",
-    "AWSMobileAnalytics",
-    "AWSPinpoint",
-    "AWSPolly",
-    "AWSRekognition",
-    "AWSS3",
-    "AWSSES",
-    "AWSSNS",
-    "AWSSQS",
-    "AWSSageMakerRuntime",
-    "AWSSimpleDB",
-    "AWSTextract",
-    "AWSTranscribe",
-    "AWSTranscribeStreaming",
-    "AWSTranslate",
-    'AWSAutoScaling',
-    'AWSAuthSDK/Sources/AWSAuthCore',
-    'AWSAuthSDK/Sources/AWSFacebookSignIn',
-    'AWSAuthSDK/Sources/AWSGoogleSignIn',
-    'AWSAuthSDK/Sources/AWSMobileClient',
-    'AWSAuthSDK/Sources/AWSUserPoolsSignIn',
-    'AWSAuthSDK/Sources/AWSAuthUI'
-]
-
-for module in modulelist:
-    filename = os.path.join(root, module, "Info.plist")
-    bump_plist(filename,newsdkversion)
-
-podspec_pattern1 = {
-    "enclosemark" : "double",
-    'exclude':'AWSCognitoIdentityProviderASF',
-    "match" : r"(dependency[[:space:]]+'AWS.+'[[:space:]]*,[[:space:]]*')[0-9]+\.[0-9]+\.[0-9]+(')", 
-    "replace" : r"\1[version]\2",
-    "files" : []       
-}
-
-podspec_pattern2 = {
-    "enclosemark" : "double",
-    'exclude':'AWSCognitoIdentityProviderASF',
-    "match" : r"(s\.version[[:space:]]+=[[:space:]]*')[0-9]+\.[0-9]+\.[0-9]+(')", 
-    "replace" : r"\1[version]\2",
-    "files" : []       
-}
-
-
-for file in glob.glob(os.path.join(root,"*.podspec")):
-    if (file.endswith('AWSCognitoIdentityProviderASF.podspec')):
-        continue
-    podspec_pattern1["files"].append(file)
-    podspec_pattern2["files"].append(file)
-
-service_pattern = {
-        "match" : r'(NSString[[:space:]]+\*const[[:space:]]+AWS.+SDKVersion[[:space:]]*=[[:space:]]+@")[0-9]+\.[0-9]+\.[0-9]+"', 
-        "replace" : r'\1[version]"',
-        "files" : []
-}
-
-#add file for each module 
-for module in modulelist:
-    filepath = "{0}/{0}Service.m".format(module)
-    if os.path.isfile(os.path.join(root, filepath)):
-        print("add service pattern file", filepath)
-        service_pattern["files"].append(filepath)
-#add file for special module
-service_pattern["files"].append("AWSCognito/CognitoSync/AWSCognitoSyncService.m")
-service_pattern["files"].append("AWSCognitoIdentityProvider/CognitoIdentityProvider/AWSCognitoIdentityProviderService.m")
-service_pattern["files"].append("AWSCore/Service/AWSService.m")
-service_pattern["files"].append("AWSIoT/AWSIoTDataService.m")
-service_pattern["files"].append("AWSKinesis/AWSFirehoseService.m")
-service_pattern["files"].append("AWSLex/AWSLexInteractionKit.m")
-service_pattern["files"].append("AWSPolly/AWSPollySynthesizeSpeechURLBuilder.m")
-service_pattern["files"].append("AWSS3/AWSS3PreSignedURL.m")
-service_pattern["files"].append("AWSAPIGateway/AWSAPIGatewayClient.m")
-service_pattern["files"].append("AWSCognitoAuth/AWSCognitoAuth.m")
-service_pattern["files"].append("AWSMobileAnalytics/AWSMobileAnalyticsERS/AWSMobileAnalyticsERSService.m")
-service_pattern["files"].append("AWSPinpoint/AWSPinpointTargeting/AWSPinpointTargetingService.m")
-
-replaces = [
-    {
-        # "enclosemark" : "double",
-        "match" : r'VERSION="[0-9]+\.[0-9]+\.[0-9]+"', 
-        "replace" : r'VERSION="[version]"',
-        "files" : [
-            'CircleciScripts/generate_documentation.sh'
-        ]
-    }
-]
-replaces.append(podspec_pattern1)
-replaces.append(podspec_pattern2)
-replaces.append(service_pattern)
-for replaceaction in replaces:
-    replaceaction["replace"] = replaceaction["replace"].replace("[version]", newsdkversion)
-replacefiles(root, replaces)
+if __name__ == "__main__":
+    root = sys.argv[1]
+    new_sdk_version = sys.argv[2]
+    bumper = VersionBumper(root, new_sdk_version)
+    bumper.bump_sdk_version()

--- a/CircleciScripts/framework_list.py
+++ b/CircleciScripts/framework_list.py
@@ -15,7 +15,7 @@ grouped_frameworks = [
 
     [
         # Depends only on AWSCognitoIdentityProviderASF
-        'AWSCognitoAuth'
+        'AWSCognitoAuth',
 
         # Depends on AWSCore and AWSCognitoIdentityProviderASF
         'AWSCognitoIdentityProvider',
@@ -62,7 +62,7 @@ grouped_frameworks = [
 
     [
         # Depends only on AWSCognito service-api package
-        'AWSCognitoSync'
+        'AWSCognitoSync',
 
         # Depends on AWSCore and AWSAuthCore
         'AWSAuthUI',
@@ -79,7 +79,7 @@ grouped_frameworks = [
 
     [
         # Depends on most previous packages except auth
-        'AWSiOSSDKv2'
+        'AWSiOSSDKv2',
 
         # Depends on AWSAuthCore, AWSFacebookSignIn, AWSGoogleSignIn,
         # AWSUserPoolsSignIn and AWSAuthUI

--- a/CircleciScripts/framework_list.py
+++ b/CircleciScripts/framework_list.py
@@ -3,6 +3,9 @@
 # consume for the release process. Packages toward the bottom of the list
 # depend on packages toward the top of the list.
 
+# Note that this list isn't a comprehensive list of Xcode schemas or targets
+# that need to be built and tested, only a model of dependencies for cocoapods.
+
 grouped_frameworks = [
     # No dependencies
     [
@@ -10,17 +13,17 @@ grouped_frameworks = [
         'AWSCognitoIdentityProviderASF',
     ],
 
-    # Depends only on AWSCognitoIdentityProviderASF
-    ['AWSCognitoAuth'],
-
-    # Depends on AWSCore and AWSCognitoIdentityProviderASF
-    ['AWSCognitoIdentityProvider'],
-
-    # Depends only on AWSCore
-    ['AWSAuthCore'],
-
-    # Service-API packages depend only on AWSCore
     [
+        # Depends only on AWSCognitoIdentityProviderASF
+        'AWSCognitoAuth'
+
+        # Depends on AWSCore and AWSCognitoIdentityProviderASF
+        'AWSCognitoIdentityProvider',
+
+        # Depends only on AWSCore
+        'AWSAuthCore',
+
+        # Service-API packages depend only on AWSCore
         'AWSAPIGateway',
         'AWSAutoScaling',
         'AWSCloudWatch',
@@ -57,31 +60,31 @@ grouped_frameworks = [
         'AWSTranslate',
     ],
 
-    # Depends only on AWSCognito service-api package
-    ['AWSCognitoSync'],
-
-    # Depends on AWSCore and AWSAuthCore
-    ['AWSAuthUI'],
-
-    # Depends only on AWSAuthCore (and possibly external Pods, but nothing else
-    # built locally)
     [
+        # Depends only on AWSCognito service-api package
+        'AWSCognitoSync'
+
+        # Depends on AWSCore and AWSAuthCore
+        'AWSAuthUI',
+
+        # Depends only on AWSAuthCore (and possibly external Pods, but nothing else
+        # built locally)
         'AWSFacebookSignIn',
         'AWSGoogleSignIn',
-    ],
 
-    # Depends only on AWSAuthCore and AWSCognitoIdentityProvider
-    [
+        # Depends only on AWSAuthCore and AWSCognitoIdentityProvider
         'AWSMobileClient',
         'AWSUserPoolsSignIn',
     ],
 
-    # Depends on most previous packages except auth
-    ['AWSiOSSDKv2'],
+    [
+        # Depends on most previous packages except auth
+        'AWSiOSSDKv2'
 
-    # Depends on AWSAuthCore, AWSFacebookSignIn, AWSGoogleSignIn,
-    # AWSUserPoolsSignIn and AWSAuthUI
-    ['AWSAuth'],
+        # Depends on AWSAuthCore, AWSFacebookSignIn, AWSGoogleSignIn,
+        # AWSUserPoolsSignIn and AWSAuthUI
+        'AWSAuth',
+    ],
 
 ]
 

--- a/CircleciScripts/functions.py
+++ b/CircleciScripts/functions.py
@@ -1,9 +1,8 @@
 import os
 import platform
-import subprocess
 
 from datetime import datetime
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 
 
 def runcommand(
@@ -23,7 +22,7 @@ def runcommand(
     while True:
         try:
             process.communicate(timeout=10)
-        except subprocess.TimeoutExpired:
+        except TimeoutExpired:
             # tell circleci I am still alive, don't kill me
             if wait_times % 30 == 0:
                 print(str(datetime.now()) + ": I am still alive")

--- a/CircleciScripts/functions.py
+++ b/CircleciScripts/functions.py
@@ -1,68 +1,79 @@
-import sys
-from subprocess import Popen, PIPE
-import subprocess
-import xml.etree.ElementTree as ET
 import os
-from datetime import datetime
-from enum import Enum
-from collections import namedtuple
-import re
 import platform
+import subprocess
+
+from datetime import datetime
+from subprocess import Popen
 
 
-def runcommand(command, timeout=0,pipein=None, pipeout =  None, logcommandline = True,  workingdirectory=None):
+def runcommand(
+    command,
+    timeout=0,
+    pipein=None,
+    pipeout=None,
+    logcommandline=True,
+    workingdirectory=None,
+):
     if logcommandline:
         print("running command: ", command, "......")
-    process = Popen(command, shell=True, stdin=pipein, stdout = pipeout, cwd = workingdirectory)
-    wait_times = 0 
+    process = Popen(
+        command, shell=True, stdin=pipein, stdout=pipeout, cwd=workingdirectory
+    )
+    wait_times = 0
     while True:
         try:
-            process.communicate(timeout = 10)
-        except subprocess.TimeoutExpired:        
-            #tell circleci I am still alive, don't kill me
-            if wait_times % 30 == 0 :
-                print(str(datetime.now())+ ": I am still alive")
+            process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            # tell circleci I am still alive, don't kill me
+            if wait_times % 30 == 0:
+                print(str(datetime.now()) + ": I am still alive")
             # if time costed exceed timeout, quit
-            if timeout >0 and wait_times > timeout * 6 :
-                print(str(datetime.now())+ ": time out")
+            if timeout > 0 and wait_times > timeout * 6:
+                print(str(datetime.now()) + ": time out")
                 return 1
-            wait_times+=1 
+            wait_times += 1
 
             continue
         break
-    exit_code = process.wait()    
+    exit_code = process.wait()
     return exit_code
 
 
- #replace is a dictionary. it has a format 
- #{
- # "exclude:string"
- # "match":string,
- # "replace":string 
- # "files" : [
- # string,
- # ]
- # match and replace will be used by sed command like  sed -E 's/{match}/{replace}/'
- # please check with sed document to see how to handle escape characaters in match and replace
- #}
-def replacefiles(root, replaces):
+# replace is a dictionary. it has a format
+# {
+# "exclude:string"
+# "match":string,
+# "replace":string
+# "files" : [
+# string,
+# ]
+# match and replace will be used by sed command like  sed -E 's/{match}/{replace}/'
+# please check with sed document to see how to handle escape characaters in match and replace
+# }
+def replacefiles(root, *replaces):
     for replaceaction in replaces:
         match = replaceaction["match"]
         replace = replaceaction["replace"]
         files = replaceaction["files"]
         enclosemark = "'"
-        if "enclosemark" in replaceaction and replaceaction['enclosemark'] == "double" :
+        if "enclosemark" in replaceaction and replaceaction["enclosemark"] == "double":
             enclosemark = '"'
-        paramters = "-r -i''"
+        sed_params = "-r -i''"
         if platform.system() == "Darwin":
-            paramters = "-E -i ''"
-        exclude=""
-        if 'exclude' in replaceaction:
-            exclude = "/{0}/ ! ".format(replaceaction['exclude'])       
+            sed_params = "-E -i ''"
+        exclude = ""
+        if "exclude" in replaceaction:
+            exclude = "/{0}/ ! ".format(replaceaction["exclude"])
         for file in files:
-            targetfile = os.path.join(root, file)           
-            runcommand(command = "sed {4}   {5}{3}s/{0}/{1}/{5}  '{2}'".format(match, replace, targetfile, exclude, paramters, enclosemark), logcommandline = True) 
-
-
-
-
+            targetfile = os.path.join(root, file)
+            runcommand(
+                command="sed {sed_params} {enclosemark}{exclude}s/{match}/{replace}/{enclosemark} '{targetfile}'".format(
+                    match=match,
+                    replace=replace,
+                    targetfile=targetfile,
+                    exclude=exclude,
+                    sed_params=sed_params,
+                    enclosemark=enclosemark,
+                ),
+                logcommandline=True,
+            )


### PR DESCRIPTION
- ci: Add CHANGELOG bump during bump_sdk_version
- ci: Refactor bump_sdk_version
- ci: Regroup framework list into less granular tranches
- ci: Remove duplicate AWSAutoScaling entry from framework list
- docs: Add 'Unreleased' section to CHANGELOG
- fix: Change bump_sdk target branch to develop instead of test_develop
- style: Reformatted bump_sdk_version and functions

*Issue #, if available:*

*Description of changes:*
In addition to refactoring the `bump_sdk_version` script, the big changes that I’d like you to focus on are:
- My reorganization/regrouping of the framework list -- I grouped these into less granular groups to reduce the number of hardcoded waits in the cocoapods release. These groups are based on the dependencies noted in the framework list itself.
- My change of the bump_sdk_version branch from `test_develop` to `develop`. This stopped working with the 2.13.2 release, for reasons we can't quite identify. There appears to have been a change that caused the `test_develop` and `develop` branches to stay un-synchronized; and PRs were no longer being posted to the `develop` branch. My investigation didn't reveal any changes to either the CircleCI config or the support scripts that seemed suspicious, so all I can figure is that the change was an unintended side effect of some of the reordering of release steps to put the cocoapods & carthage releases at the end of the process. My evaluation of this change is that it's innocuous, but obviously we'll want to keep pretty close eye on the generated bump-version PR during the next release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
