### PR TITLE
Link testconfiguration.json file during build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ commands:
 
   update_brew:
     description: >-
-      update brew
+      Update Homebrew
     steps:
       - run:
-          name: update brew
+          name: Update Homebrew
           command: |
             HOMEBREW_LOGS=~/homebrew-logs
             HOMEBREW_TEMP=~/homebrew-temp
@@ -31,10 +31,10 @@ commands:
 
   set_environment_variables:
     description: >-
-      set environment variables
+      Set environment variables
     steps:
       - run:
-          name: set environment variables
+          name: Set environment variables
           command: |
             sdkName=aws-ios-sdk
             echo "export sdkName=$sdkName" >> $BASH_ENV
@@ -60,7 +60,7 @@ commands:
       If current release is not a minor version bump, stop executing the current job and return success.
     steps:
       - run:
-          name: skip left steps and return immediately from current job if current release is not a minor version bump
+          name: Skip remaining steps if current release is not a minor version bump
           command: |
             echo $release_version
             maintenance=$(echo $release_version | sed "s/[0-9]*.[0-9]*.\([0-9]*\)/\1/")
@@ -72,10 +72,10 @@ commands:
 
   bump_version_pre:
     description: >-
-      prepare bump version
+      Prepare bump version
     steps:
       - run:
-          name: checkout repository for bump version
+          name: Checkout repository for bump version
           command: |
             if [ -z "$target_branch" ]
             then
@@ -103,10 +103,10 @@ commands:
 
   bump_version_post:
     description: >-
-      check in bump version change
+      Check in bump version change
     steps:
       - run:
-          name: stage changes
+          name: Stage changes
           command: |
             cd ${bumpversion_repo_name}
             git config --local user.name "${GITHUB_BUMPVERSION_USER}"
@@ -119,7 +119,7 @@ commands:
               circleci step halt
             fi
       - run:
-          name: check in changes
+          name: Check in changes
           command: |
             if [ -z "$target_branch" ]
             then
@@ -135,36 +135,36 @@ commands:
             echo "title:$title"
             echo "content:$content"
             python3 ../CircleciScripts/create_pullrequest.py "${GITHUB_BUMPVERSION_USER}" "${GITHUB_BUMPVERSION_TOKEN}" "$title" "$content" "$target_branch" "${GITHUB_BUMPVERSION_USER}:bump_version" ${bumpversion_repo_user} ${bumpversion_repo_name}
+
   configure_aws:
     description: >-
-      install aws cli and configure android aws release profile
+      Install aws cli and configure android aws release profile
     steps:
       - run:
-          name: install aws cli
+          name: Install AWS cli
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
       - run:
-          name: configure aws profile
+          name: Configure AWS profiles
           command: |
-            aws configure --profile build_resources set region us-east-1
-            echo -e "[build_resources]\naws_access_key_id=${BUILD_RESOURCES_AWS_ACCESS_KEY_ID}\naws_secret_access_key=${BUILD_RESOURCES_AWS_SECRET_ACCESS_KEY}\n" >> ~/.aws/credentials
-
             aws configure --profile sdk_s3_release set region us-east-1
             echo -e "[sdk_s3_release]\naws_access_key_id=${S3_RELEASE_AWS_ACCESS_KEY_ID}\naws_secret_access_key=${S3_RELEASE_AWS_SECRET_ACCESS_KEY}\n" >> ~/.aws/credentials
+
   pre_start_simulator:
     description: >-
-      pre start simulator, build may fail is simulator is not started
+      Pre-start iOS Simulator, as the build may fail if it takes too long to start up during that step
     steps:
       - run:
-          name: pre-start simulator
+          name: Pre-start iOS Simulator
           command: |
             bash CircleciScripts/pre_start_simulator.sh
+
   skip_test_job:
     description: >-
-      check if the test job can be skipped
+      Check if the test job can be skipped
     steps:
       - run:
-          name: skip the test job if commit message require skipping tests
+          name: Skip the test job if commit message require skipping tests
           command: |
             commitmessage=$(git log --format=%B -n 1 ${CIRCLE_SHA1})
             if [[ "$commitmessage" =~ .*"[skip test]".* ]]
@@ -173,7 +173,7 @@ commands:
                circleci step halt
             fi
       - run:
-          name: skip the test job if the release process is triggered by circleci
+          name: Skip the test job if the release process was triggered by CircleCI
           command: |
             skipflag=$(echo "${SKIPTEST_FOR_RELEASE}") | tr '[:upper:]' '[:lower:]'
             if ! [ -z "${CIRCLE_TAG}" ] && [ "$skipflag" == "true" ]
@@ -182,38 +182,37 @@ commands:
               echo $tagmessage
               if [[ "$tagmessage" =~ .*"Trigger release from circleci".* ]]
               then
-                 echo "The release is triggered by circleci. skip the job"
+                 echo "The release was triggered by CircleCI. Skip the job"
                  circleci step halt
               fi
             fi
       - run:
-          name: skip the test job if this is merged from develop by circleci
+          name: Skip the test job if this was merged from develop by CircleCI
           command: |
             skipflag=$(echo "${SKIPTEST_FOR_MASTER}") | tr '[:upper:]' '[:lower:]'
             commitmessage=$(git log --format=%B -n 1 ${CIRCLE_SHA1})
             if [ "$skipflag" == "true" ] && [[ "$commitmessage" =~ .*"[Merge develop to master by circleci]".* ]]
             then
-               echo "This is merged from develop by circleci. skip the test job"
+               echo "This is merged from develop by CircleCI. Skip the test job"
                circleci step halt
             fi
 
   override_test_job:
     description: >-
-      skip the test job is project variable OVERRIDE_TEST is set with TRUE
+      Skip the test job if previously tested, or if the environment variable OVERRIDE_TEST is TRUE
     steps:
-
       - run:
-          name: skip test if the commit is already tested
+          name: Skip test if the commit is already tested
           command: |
             echo "${TESTED_COMMITID}:${CIRCLE_SHA1}"
             skipflag=$(echo "${SKIPTESTEDCHANGE}" | tr '[:upper:]' '[:lower:]')
             if [ "${TESTED_COMMITID}" == "${CIRCLE_SHA1}" ] && [ "${skipflag}" != "true" ]
             then
-              echo "skip test as the change ${CIRCLE_SHA1} is already tested"
+              echo "Skipping test as the change ${CIRCLE_SHA1} has already been tested"
               circleci step halt
             fi
       - run:
-          name: check_for_test_override
+          name: Skip test if OVERRIDE_TEST flag is set
           command: |
               echo "override_test_variable_name=$override_test_variable_name"
               override_test_value=$(eval "echo $"${override_test_variable_name}"")
@@ -222,83 +221,85 @@ commands:
                 echo "project environment variable OVERRIDE_TEST is set with TRUE, skip all tests"
                 circleci step halt
               fi
+
   skip_job_unless_required:
     description: >-
-      skip job unless required
+      Skip job unless required
     steps:
       - run:
-          name: skip_job_from_environment_variable
+          name: Skip job if SKIP_JOB flag is set
           command: |
               variable_name=SKIP_JOB_${CIRCLE_JOB}
-
               skipjob_flag=$(eval "echo $"${variable_name}"")
               skipjob_flag=$(echo "${skipjob_flag}" | tr '[:upper:]' '[:lower:]')
               if [ "${skipjob_flag}" == "true" ]
               then
-                echo "skip current job as ${variable_name} is set in project environment variables"
+                echo "Skipping current job as ${variable_name} environment variable is set"
                 circleci step halt
               fi
 
 jobs:
   build:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - checkout
       - set_environment_variables
       - run:
-          name: create credentials
+          name: Create empty placeholder credentials files
           command: |
             touch AWSCoreTests/Resources/credentials.json
             touch AWSAuthSDK/Tests/AWSMobileClientTests/awsconfiguration.json
             touch AWSAuthSDK/Tests/AWSMobileClientTests/credentials-mc.json
       - pre_start_simulator
       - run:
-          name: build sdk
+          name: Build sdk
           command: |
             xcodebuild build -project AWSiOSSDKv2.xcodeproj -scheme AWSAllTests -sdk iphonesimulator -destination "${destination}"
             xcodebuild build -project AWSAuthSDK/AWSAuthSDK.xcodeproj -scheme AWSAuthSDKAllTargets -sdk iphonesimulator -destination "${destination}"
+
   unittest:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - set_environment_variables
       - override_test_job
       - skip_job_unless_required
       - checkout
       - skip_test_job
-      - run:
-          name: create credentials
-          command: |
-            touch AWSCoreTests/Resources/credentials.json
       - pre_start_simulator
       - run:
-          name: build sdk
+          name: Create empty credentials.json placeholder
+          command: |
+            touch AWSCoreTests/Resources/credentials.json
+      - run:
+          name: Build SDK
           command: xcodebuild build-for-testing -project AWSiOSSDKv2.xcodeproj -scheme AWSAllTests -sdk iphonesimulator -destination "${destination}"
       - run :
-          name: run unit tests
+          name: Run unit tests
           command: bash CircleciScripts/run_unittests.sh "test_result" "${destination}"
       - run:
-          name : check unit test result
+          name : Check unit test result
           command : bash CircleciScripts/check_test_result.sh "test_result"
       - store_artifacts:
           path: test_result
+
   pre_integrationtest:
     macos:
-      xcode: "11.4.0"
-    environment: 
+      xcode: "11.4.1"
+    environment:
       TERM: xterm-256color
     steps:
       - skip_job_unless_required
       - set_environment_variables
       - override_test_job
       - run:
-          name: get override test variable name
+          name: Get override test variable name
           command: |
             echo "override_test_variable_name=$override_test_variable_name"
       - run:
-          name: reset OVERRIDE_TEST environment variable
+          name: Reset OVERRIDE_TEST environment variable
           command: |
             override_test_value=$(eval "echo $"${override_test_variable_name}"")
             if ! [ -z "$override_test_value" ]
@@ -313,16 +314,21 @@ jobs:
             fi
       - checkout
       - set_environment_variables
-      - configure_aws
       - run:
-          name: create credentials
+          name: Create credentials
           command: |
             echo ${IOS_TESTS_CREDENTIALS_JSON} | base64 --decode > AWSCoreTests/Resources/credentials.json
-            aws --profile build_resources s3 cp s3://ios-circleci-payload/awsconfiguration.json AWSAuthSDK/Tests/AWSMobileClientTests/awsconfiguration.json
-            aws --profile build_resources s3 cp s3://ios-circleci-payload/credentials-mc.json AWSAuthSDK/Tests/AWSMobileClientTests/credentials-mc.json
+      - run:
+          name: Create empty placeholder credentials files
+          command: |
+            touch AWSAuthSDK/Tests/AWSMobileClientTests/awsconfiguration.json
+            touch AWSAuthSDK/Tests/AWSMobileClientTests/credentials-mc.json
+      - run:
+          name: Generate testconfiguration.json
+          command: echo "PWD=$PWD" ; ls Scripts/ ; bash Scripts/generate-test-config.sh -p ios -v
       - pre_start_simulator
       - run:
-          name: build sdk
+          name: Build SDK
           command: |
             xcodebuild build-for-testing -project AWSiOSSDKv2.xcodeproj -scheme AWSAllTests -sdk iphonesimulator -destination "${destination}" -derivedDataPath ./build_result/AWSiOSSDKv2
             xcodebuild build-for-testing -project AWSAuthSDK/AWSAuthSDK.xcodeproj -scheme AWSMobileClient -sdk iphonesimulator -destination "${destination}" -derivedDataPath ./build_result/AWSAuthSDK
@@ -330,9 +336,10 @@ jobs:
           key: build_result-{{ .Revision }}
           paths:
             - build_result
+
   post_integrationtest:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       #TODO need check why multiple key does not work here
       - skip_job_unless_required
@@ -350,7 +357,7 @@ jobs:
       - restore_cache:
           key: test_result-{{ .Revision }}-Comprehend
       - restore_cache:
-          key: test_result-{{ .Revision }}-Connect  
+          key: test_result-{{ .Revision }}-Connect
       - restore_cache:
           key: test_result-{{ .Revision }}-ConnectParticipant
       - restore_cache:
@@ -413,15 +420,14 @@ jobs:
               -d "$parameters" \
               "https://circleci.com/api/v1.1/project/github/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/envvar?circle-token=${CIRCLE_API_USER_TOKEN}"
 
-
   integrationtest:
-    description: run integration tests
+    description: Run integration tests
     parameters:
       groupname:
         default: stable_testList
         type: string
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - set_environment_variables
       - override_test_job
@@ -433,19 +439,19 @@ jobs:
       - restore_cache:
           key: build_result-{{ .Revision }}
       - run:
-          name: install json parser
+          name: Install JSON parser
           command: pip3 install demjson
       - run:
-          name: create credentials
+          name: Create credentials
           command: |
             echo ${IOS_TESTS_CREDENTIALS_JSON} | base64 --decode > AWSCoreTests/Resources/credentials.json
       - run :
-          name: run integration tests
+          name: Run integration tests
           command: |
             mkdir integration_test_result
             python3 CircleciScripts/run_integrationtests.py CircleciScripts/IntegrationTestsConfiguration.json "integration_test_result" "<< parameters.groupname >>" "${destination}" "./build_result"
       - run:
-          name : check integration test result
+          name : Check integration test result
           command : |
             echo "testresult=$testresult"
             if [ "$testresult" == "0" ]
@@ -464,16 +470,16 @@ jobs:
 
   release_tag:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - checkout
       - update_brew
       - run:
-          name: install github-release
+          name: Install github-release
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install github-release
       - run:
-          name: release the tag
+          name: Release the tag to GitHub
           command: |
             tagdescription=$(sed -n '/## '${CIRCLE_TAG}'/,/## [0-9]*\.[0-9]*\.[0-9]/p' CHANGELOG.md | sed '1d' | sed '$d')
             tagname="AWS SDK for iOS "${CIRCLE_TAG}
@@ -481,25 +487,25 @@ jobs:
 
   release_carthage:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - checkout
       - pre_start_simulator
       - update_brew
       - run:
-          name: install github-release
+          name: Install github-release
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install github-release
       - run:
-          name: install aws cli
+          name: Install AWS CLI
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
       - run:
-          name: upgrade carthage
+          name: Upgrade Carthage
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade carthage
       - run:
-          name: build
+          name: Build SDK for Carthage release
           command: |
             xcodebuild -project AWSiOSSDKv2.xcodeproj -scheme AWSCore -sdk iphonesimulator -destination "${destination}" build
       - run:
@@ -508,27 +514,27 @@ jobs:
             carthage build --no-skip-current | tee buildout.txt
           no_output_timeout: 100m
       - run:
-          name: Create Carthage Archive
+          name: Create Carthage archive
           command: python3 ./CircleciScripts/create_carthage_archive.py
           no_output_timeout: 20m
       - run:
-          name: upload file to git release
+          name: Upload Carthage archive to GitHub release
           command: github-release upload -s ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -t ${CIRCLE_TAG} -f aws-sdk-ios-carthage.framework.zip -n aws-sdk-ios-carthage.framework.zip
 
   release_cocoapods:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - checkout
       - run:
-          name: Release cocoapods
+          name: Release CocoaPods
           command: python3 ./CircleciScripts/cocoapods_release.py
           no_output_timeout: 20m
 
   release_docs:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - checkout
@@ -537,17 +543,17 @@ jobs:
           command: |
             sudo gem install jazzy --source http://rubygems.org
       - run:
-          name: generate documents
+          name: Generate documents
           command: bash ./CircleciScripts/generate_documentation.sh
       - run:
-          name: copy documents
+          name: Copy documents
           command: |
             git config --local user.name "AWS"
             git checkout gh-pages
             rm -rf docs/reference
             mv docs_tmp docs/reference
       - run:
-          name: checkin documents
+          name: Checkin documents
           command: |
             for dirPath in docs/reference/* ; do
               sdkName=$( basename "$dirPath" )
@@ -558,7 +564,7 @@ jobs:
 
   add_doc_tag:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - checkout
@@ -572,28 +578,28 @@ jobs:
 
   bump_ios_sampleapp_version:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - set_environment_variables
       - quit_for_nominorversion
       - checkout
       - run:
-          name: checkout repository for bump version
+          name: Checkout repository for bump version
           command: |
             SAMPLE_APPS_REPO_ACCOUNT=awslabs
             echo "export SAMPLE_APPS_REPO_ACCOUNT=$SAMPLE_APPS_REPO_ACCOUNT" >> $BASH_ENV
             git clone "https://github.com/${SAMPLE_APPS_REPO_ACCOUNT}/aws-sdk-ios-samples.git"
       - run:
-          name: update version
+          name: Update version
           command:
             python3 CircleciScripts/bump_iossample_version.py "$(pwd)/aws-sdk-ios-samples" $release_version
       - run:
-          name: build projects
+          name: Build projects
           command:
             python3 CircleciScripts/build_iossample.py "$(pwd)/aws-sdk-ios-samples"
       - run:
-          name: stage changes
+          name: Stage changes
           command: |
             cd aws-sdk-ios-samples
             git config --local user.name "AWS"
@@ -606,7 +612,7 @@ jobs:
               circleci step halt
             fi
       - run:
-          name: check in changes
+          name: Check in changes
           command: |
             cd aws-sdk-ios-samples
             git status
@@ -616,14 +622,14 @@ jobs:
 
   bump_ios_amplifydocs_version:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     steps:
       - skip_job_unless_required
       - set_environment_variables
       - quit_for_nominorversion
       - checkout
       - run:
-          name: set_bumpversion_environment
+          name: Set environment variables
           command: |
             bumpversion_repo_user=aws-amplify
             bumpversion_repo_name=docs
@@ -639,14 +645,14 @@ jobs:
             echo "bump_version_pr_title:$bump_version_pr_title"
       - bump_version_pre
       - run:
-          name: bump version
+          name: Bump docs version
           command:
             python3 CircleciScripts/bump_iosdocs_version.py "$(pwd)/${bumpversion_repo_name}/ios" $release_version
       - bump_version_post
 
   release_ios_s3:
     macos:
-      xcode: "11.4.0"
+      xcode: "11.4.1"
     environment:
       TERM: xterm-256color
     steps:
@@ -690,6 +696,7 @@ jobs:
           name: Invalidate cloudfront
           command: |
             python3 CircleciScripts/cloudfront_invalidate.py sdk_s3_release "${S3_RELEASE_DISTRIBUTION_ID}" "latest/$sdkName.zip"
+
   bump_sdk_version:
     docker:
       - image: circleci/android:api-27-alpha
@@ -700,19 +707,19 @@ jobs:
       - set_environment_variables
       - checkout
       - run:
-          name: install python3-pip
+          name: Install python3-pip
           command: |
             echo "${newsdkversion}"
             sudo apt-get update
             sudo apt-get -y install python3-pip
       - run:
-          name: Install json parser
+          name: Install JSON parser
           command: sudo pip3 install demjson
       - run:
           name: Install lxml
           command: sudo pip3 install lxml
       - run:
-          name: set_bumpversion_environment
+          name: Set environment variables
           command: |
             git config --local user.name AWS
 
@@ -748,11 +755,12 @@ jobs:
             echo "bump_version_pr_title:$bump_version_pr_title"
       - bump_version_pre
       - run:
-          name: bump version
+          name: Bump SDK version
           command: |
             cp -R ${bumpversion_repo_name}/CircleciScripts/ CircleciScripts/
             python3 CircleciScripts/bump_sdk_version.py "$(pwd)/${bumpversion_repo_name}" $release_version
       - bump_version_post
+
   merge_to_master:
     docker:
       - image: circleci/android:api-27-alpha
@@ -763,7 +771,7 @@ jobs:
       - checkout
       - set_environment_variables
       - run:
-          name: merge change to master
+          name: Merge change to master
           command: |
             git config --local user.name AWS
             git checkout master
@@ -787,6 +795,7 @@ jobs:
               echo "push change"
               git push -q https://${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git
             fi
+
   prepare_release_sdk:
     docker:
       - image: circleci/android:api-27-alpha
@@ -797,9 +806,10 @@ jobs:
       - checkout
       - set_environment_variables
       - run:
-          name: trigger release_sdk if curremt commit is a bump version
+          name: Trigger release_sdk if current commit is a bump version
           command: |
             bash CircleciScripts/prepare_release_sdk.sh
+
   create_pullrequest_for_modelupdate:
     docker:
       - image: circleci/android:api-27-alpha
@@ -810,13 +820,12 @@ jobs:
       - set_environment_variables
       - checkout
       - run:
-          name: create pull request
+          name: Create pull request
           command: |
             target_branch="develop"
             title=${CIRCLE_BRANCH}
             content="${CIRCLE_BRANCH}"
             python3 ./CircleciScripts/create_pullrequest.py "${GITHUB_USER}" "${GITHUB_TOKEN}" "$title" "$content" "$target_branch" "${CIRCLE_PROJECT_USERNAME}:${CIRCLE_BRANCH}" ${CIRCLE_PROJECT_USERNAME} ${CIRCLE_PROJECT_REPONAME}
-
 
 workflows:
   version: 2
@@ -1191,6 +1200,7 @@ workflows:
               only:
                 - master
                 - develop
+
       - post_integrationtest:
           requires:
             - APIGateway
@@ -1229,6 +1239,7 @@ workflows:
               only:
                 - master
                 - develop
+
       - merge_to_master:
           requires:
             - build

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -128,11 +128,6 @@
 		17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1786CA4D1F2BEDB8003421FF /* Images.xcassets */; };
 		17F4F75021F6B0750068B553 /* AWSCognitoAuth+Extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		17F4F75121F6B0750068B553 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */; };
-		43B25DB22457D7B600C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
-		43B25DB32457D7EC00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
-		43B25DB42457D7EE00C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
-		43B25DB52457D7F000C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
-		43B25DB62457D7F100C40F76 /* testconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = 43B25D3E2457D7B600C40F76 /* testconfiguration.json */; };
 		6BB7BFAF23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB7BF2E23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h */; };
 		B4031B79230F044A009EB524 /* AWSMobileClientUserDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4031B78230F044A009EB524 /* AWSMobileClientUserDetails.swift */; };
 		B4031BE623105727009EB524 /* AWSMobileClientSignInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */; };
@@ -1237,6 +1232,41 @@
 			remoteGlobalIDString = EFDE85E11FC5DD3D00D281A2;
 			remoteInfo = AWSCognitoIdentityProviderASF;
 		};
+		FA4A694C2462317A00230849 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
+			remoteInfo = AWSTestResources;
+		};
+		FA4A69C12462317A00230849 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FAD9DD1F245CD135003F84D0;
+			remoteInfo = AWSTestResources;
+		};
+		FA4A69C32462319A00230849 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
+			remoteInfo = AWSTestResources;
+		};
+		FA4A69C5246231A800230849 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
+			remoteInfo = AWSTestResources;
+		};
+		FA4A69C72462329900230849 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
+			remoteInfo = AWSTestResources;
+		};
 		FAF1B87C2339175B007F1435 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
@@ -1843,6 +1873,7 @@
 			isa = PBXGroup;
 			children = (
 				B55D57AE1F44EC3F005A0E56 /* AWSAllTestsHost.app */,
+				FA4A69C22462317A00230849 /* AWSTestResources.framework */,
 				B55D57121F44EC3F005A0E56 /* AWSCore.framework */,
 				B55D57141F44EC3F005A0E56 /* AWSCoreTests.xctest */,
 				B55D57161F44EC3F005A0E56 /* AWSCoreUnitTests.xctest */,
@@ -2136,9 +2167,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1750D00C1F2D4DFA006D915E /* Build configuration list for PBXNativeTarget "AWSUserPoolsSignIn" */;
 			buildPhases = (
+				1750D0041F2D4DFA006D915E /* Headers */,
 				1750D0021F2D4DFA006D915E /* Sources */,
 				1750D0031F2D4DFA006D915E /* Frameworks */,
-				1750D0041F2D4DFA006D915E /* Headers */,
 				1750D0051F2D4DFA006D915E /* Resources */,
 			);
 			buildRules = (
@@ -2156,9 +2187,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 176375451F328D210086588B /* Build configuration list for PBXNativeTarget "AWSFacebookSignIn" */;
 			buildPhases = (
+				1763753D1F328D210086588B /* Headers */,
 				1763753B1F328D210086588B /* Sources */,
 				1763753C1F328D210086588B /* Frameworks */,
-				1763753D1F328D210086588B /* Headers */,
 				1763753E1F328D210086588B /* Resources */,
 			);
 			buildRules = (
@@ -2182,6 +2213,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FA4A69C6246231A800230849 /* PBXTargetDependency */,
 				177B8AEC21E81B7D0051068F /* PBXTargetDependency */,
 				B412F65B2334803A00F1AC69 /* PBXTargetDependency */,
 			);
@@ -2194,9 +2226,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1786CA391F2BED3C003421FF /* Build configuration list for PBXNativeTarget "AWSGoogleSignIn" */;
 			buildPhases = (
+				1786CA311F2BED3C003421FF /* Headers */,
 				1786CA2F1F2BED3C003421FF /* Sources */,
 				1786CA301F2BED3C003421FF /* Frameworks */,
-				1786CA311F2BED3C003421FF /* Headers */,
 				1786CA321F2BED3C003421FF /* Resources */,
 			);
 			buildRules = (
@@ -2220,6 +2252,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FA4A694D2462317A00230849 /* PBXTargetDependency */,
 				17CD4B152182428F00953483 /* PBXTargetDependency */,
 				17CD4B132182428800953483 /* PBXTargetDependency */,
 				17CD4B112182428200953483 /* PBXTargetDependency */,
@@ -2244,6 +2277,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FA4A69C82462329900230849 /* PBXTargetDependency */,
 				B41F67DF233D56A80060FDEE /* PBXTargetDependency */,
 				B41F67E3233D56A80060FDEE /* PBXTargetDependency */,
 				173A454121E92A0200F9C579 /* PBXTargetDependency */,
@@ -2268,6 +2302,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				FA4A69C42462319A00230849 /* PBXTargetDependency */,
 				B412F5E6233445A500F1AC69 /* PBXTargetDependency */,
 				B412F65D2334805400F1AC69 /* PBXTargetDependency */,
 			);
@@ -2297,9 +2332,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B5170D9D1F466CE5008FD811 /* Build configuration list for PBXNativeTarget "AWSAuthCore" */;
 			buildPhases = (
+				B5170D951F466CE5008FD811 /* Headers */,
 				B5170D931F466CE5008FD811 /* Sources */,
 				B5170D941F466CE5008FD811 /* Frameworks */,
-				B5170D951F466CE5008FD811 /* Headers */,
 				B5170D961F466CE5008FD811 /* Resources */,
 			);
 			buildRules = (
@@ -2316,9 +2351,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B5345D731F366AFA009C1041 /* Build configuration list for PBXNativeTarget "AWSAuthUI" */;
 			buildPhases = (
+				B5345D0C1F366AFA009C1041 /* Headers */,
 				B5345D0A1F366AFA009C1041 /* Sources */,
 				B5345D0B1F366AFA009C1041 /* Frameworks */,
-				B5345D0C1F366AFA009C1041 /* Headers */,
 				B5345D0D1F366AFA009C1041 /* Resources */,
 			);
 			buildRules = (
@@ -2335,9 +2370,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B5FC69061FAFA1AA004790CB /* Build configuration list for PBXNativeTarget "AWSMobileClient" */;
 			buildPhases = (
+				B5FC68FE1FAFA1AA004790CB /* Headers */,
 				B5FC68FC1FAFA1AA004790CB /* Sources */,
 				B5FC68FD1FAFA1AA004790CB /* Frameworks */,
-				B5FC68FE1FAFA1AA004790CB /* Headers */,
 				B5FC68FF1FAFA1AA004790CB /* Resources */,
 			);
 			buildRules = (
@@ -3278,6 +3313,13 @@
 			remoteRef = E496D9411FDB0632000CF290 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		FA4A69C22462317A00230849 /* AWSTestResources.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = AWSTestResources.framework;
+			remoteRef = FA4A69C12462317A00230849 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		FAF1B87D2339175B007F1435 /* AWSCoreConfigurationTest.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
@@ -3315,7 +3357,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43B25DB42457D7EE00C40F76 /* testconfiguration.json in Resources */,
 				1773B1D922029DAE00356909 /* credentials-mc.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3333,7 +3374,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B412F5DA23341E9600F1AC69 /* awsconfiguration.json in Resources */,
-				43B25DB22457D7B600C40F76 /* testconfiguration.json in Resources */,
 				17CD4B5621826BA100953483 /* credentials-mc.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3346,7 +3386,6 @@
 				17CD4B2D218244EC00953483 /* LaunchScreen.storyboard in Resources */,
 				17CD4B2A218244EC00953483 /* Assets.xcassets in Resources */,
 				17CD4B28218244EA00953483 /* Main.storyboard in Resources */,
-				43B25DB52457D7F000C40F76 /* testconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3355,7 +3394,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B412F5ED233477BF00F1AC69 /* credentials-mc.json in Resources */,
-				43B25DB32457D7EC00C40F76 /* testconfiguration.json in Resources */,
 				B412F5EC2334755B00F1AC69 /* awsconfiguration.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3365,7 +3403,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B412F65623347FBD00F1AC69 /* Main.storyboard in Resources */,
-				43B25DB62457D7F100C40F76 /* testconfiguration.json in Resources */,
 				B412F65423347FBD00F1AC69 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3708,6 +3745,26 @@
 			isa = PBXTargetDependency;
 			target = B5FC69001FAFA1AA004790CB /* AWSMobileClient */;
 			targetProxy = B92BA3CC2318859D007C1175 /* PBXContainerItemProxy */;
+		};
+		FA4A694D2462317A00230849 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSTestResources;
+			targetProxy = FA4A694C2462317A00230849 /* PBXContainerItemProxy */;
+		};
+		FA4A69C42462319A00230849 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSTestResources;
+			targetProxy = FA4A69C32462319A00230849 /* PBXContainerItemProxy */;
+		};
+		FA4A69C6246231A800230849 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSTestResources;
+			targetProxy = FA4A69C5246231A800230849 /* PBXContainerItemProxy */;
+		};
+		FA4A69C82462329900230849 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AWSTestResources;
+			targetProxy = FA4A69C72462329900230849 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -8,6 +8,7 @@ import XCTest
 @testable import AWSMobileClient
 import AWSAuthCore
 import AWSCognitoIdentityProvider
+import AWSTestResources
 
 class AWSMobileClientTestBase: XCTestCase {
 
@@ -23,11 +24,12 @@ class AWSMobileClientTestBase: XCTestCase {
     
     override class func setUp() {
         let testConfigurationJSON = loadTestConfigurationFromFile()
-        let credentialsTestConfiguration = testConfigurationJSON["Credentials"] as! [String: Any]
-        let allPackagesTestConfiguration = testConfigurationJSON["Packages"] as! [String: Any]
+        let credentialsTestConfiguration = testConfigurationJSON["credentials"] as! [String: Any]
+        let allPackagesTestConfiguration = testConfigurationJSON["packages"] as! [String: Any]
         let mobileClientTesConfiguration = allPackagesTestConfiguration["mobileclient"] as! [String: Any]
-        
-        userPoolId = (mobileClientTesConfiguration["mc-userpool_id"] as! String)
+        let commonTestConfiguration = allPackagesTestConfiguration["common"] as! [String: Any]
+
+        userPoolId = (mobileClientTesConfiguration["userpool_id"] as! String)
         sharedEmail = (mobileClientTesConfiguration["mc-email"] as! String)
         identityPoolId = (mobileClientTesConfiguration["mc-pool_id_dev_auth"] as! String)
         
@@ -35,7 +37,7 @@ class AWSMobileClientTestBase: XCTestCase {
                                                                      secretKey: credentialsTestConfiguration["secretKey"] as! String,
                                                                      sessionToken: credentialsTestConfiguration["sessionToken"] as! String)
         
-        let region = (credentialsTestConfiguration["region"] as! String).aws_regionTypeValue()
+        let region = (commonTestConfiguration["region"] as! String).aws_regionTypeValue()
         let configuration = AWSServiceConfiguration(region: region, credentialsProvider: credentialsProvider)!
         
         AWSCognitoIdentityProvider.register(with: configuration, forKey: "TEST")
@@ -55,10 +57,7 @@ class AWSMobileClientTestBase: XCTestCase {
     //MARK: Helper methods
     
     static func loadTestConfigurationFromFile() -> [String: Any] {
-        let filePath = Bundle(for: AWSMobileClientTestBase.self).path(forResource: "testconfiguration", ofType: "json")!
-        let fileData = try! NSData(contentsOfFile: filePath) as Data
-        let testConfigurationJSON = try! JSONSerialization.jsonObject(with: fileData, options: .mutableContainers) as! [String: Any]
-        return testConfigurationJSON
+        return AWSTestConfiguration.getTestConfiguration() as! [String: Any]
     }
     
     static func initializeMobileClient() {

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -11316,6 +11316,7 @@
 				FAD9DD1B245CD135003F84D0 /* Sources */,
 				FAD9DD1C245CD135003F84D0 /* Frameworks */,
 				FAD9DD1D245CD135003F84D0 /* Resources */,
+				FAFC5902245CEA4A00D415DB /* Copy testconfiguration.json */,
 			);
 			buildRules = (
 			);
@@ -12880,6 +12881,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "${SRCROOT}/Scripts/GenerateAppleDocs.sh";
+		};
+		FAFC5902245CEA4A00D415DB /* Copy testconfiguration.json */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy testconfiguration.json";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "TEMP_FILE=$HOME/.aws-amplify/aws-sdk-ios/testconfiguration.json\nDEST_PATH=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/testconfiguration.json\"\nif [[ ! -f $TEMP_FILE ]] ; then\n    echo \"${TEMP_FILE} does not exist. Using empty configuration.\"\n    exit 0\nfi\n\nif [[ -f $DEST_PATH ]] ; then\n    rm $DEST_PATH\nfi\n\nln -s $TEMP_FILE $DEST_PATH\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Scripts/generate-test-config.sh
+++ b/Scripts/generate-test-config.sh
@@ -1,14 +1,269 @@
 #!/bin/bash
 
-DESTINATION=$1
+# vim: set ts=2 sw=2 sts=2 et:
 
-if [[ -z $DESTINATION ]] ; then
-  echo "Destination not specified" >&2
+##################################################
+# SCRIPT METADATA
+
+SCRIPT_NAME=$(basename $0)
+SUMMARY="Generates a testconfiguration.json file for use in Amplify and AWS mobile SDK integration tests"
+SYNOPSIS="${SCRIPT_NAME} <android|ios> [options]"
+
+
+##################################################
+# DEFAULTS & DECLARATIONS
+##################################################
+LOG_LEVEL_INFO=0
+LOG_LEVEL_DEBUG=1
+LOG_LEVEL_TRACE=2
+LOG_LEVEL=0
+
+
+##################################################
+# FUNCTIONS
+##################################################
+
+# Logging. Note that all logging output goes to STDERR
+
+function log {
+  msg="$(date) $*"
+  echo $msg >&2
+}
+
+function log_debug {
+  if [[ $LOG_LEVEL -lt LOG_LEVEL_DEBUG ]] ; then
+    return
+  fi
+
+  log "[D]:: $*"
+}
+
+# Always logged
+function log_error {
+  log "[E]:: $*"
+}
+
+# Always logged, except in quiet mode
+function log_info {
+  if [[ $LOG_LEVEL -lt LOG_LEVEL_INFO ]] ; then
+    return
+  fi
+
+  log "[I]:: $*"
+}
+
+function log_trace {
+  if [[ $LOG_LEVEL -lt LOG_LEVEL_TRACE ]] ; then
+    return
+  fi
+
+  log "[T]:: $*"
+}
+
+function die {
+  log_error $*
   exit 1
+}
+
+# Usage & help
+
+function print_usage {
+  echo "usage: ${SYNOPSIS}"
+}
+
+function print_help {
+  usage=$(print_usage)
+  cat <<EOF
+${usage}
+
+SYNOPSIS
+    ${SYNOPSIS}
+
+$SCRIPT_NAME generates a test configuration file for AWS SDK and
+Amplify integration tests.
+
+REQUIREMENTS
+    $SCRIPT_NAME requires the following utilities to be installed
+    and available on your PATH:
+        - Python - v3.7 or higher, accessible as 'python3'
+          (https://www.python.org/)
+    
+    If you use the -a option to assume the test execution role prior to
+    generating the test configuration file, you must also have the following
+    utilities installed:
+        - jq - A JSON parsing utility
+          (https://stedolan.github.io/jq/)
+        - AWS CLI - for retrieving secret values from STS
+          (https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+
+OPTIONS:
+    -a
+        Assume the test execution role before generating the test configuration
+        file. Requires your environment to have exported credentials for a role
+        or user that has 'sts:AssumeRole' permissions for the integration test
+        execution role. If not specified, temporary role credentials must be
+        exported into the environment variables 'AWS_ACCESS_KEY_ID',
+        'AWS_SECRET_ACCESS_KEY', and 'AWS_SESSION_TOKEN'.
+
+    -p <android|ios>
+        Generate configuration file for platform="<val>"
+
+    -r <region>
+        Look for resources in <region>. If not present, use the value of the
+        environment variable AWS_DEFAULT_REGION. Either the environment
+        variable or this flag must be specified.
+
+    STANDARD OPTIONS:
+    -h
+        Print this help message
+    -q
+        Quiet mode, only errors will be logged
+    -v
+        Verbose output. Specify up to 2 times for more debugging output
+EOF
+}
+
+
+##################################################
+# PARSE ARGUMENTS
+
+assume_role=""
+platform=""
+region=${AWS_DEFAULT_REGION}
+
+while getopts "ap:qvh" optchar ; do
+  case "$optchar" in
+    a)
+      assume_role=1
+      ;;
+    p)
+      platform=$OPTARG
+      ;;
+    r)
+      region=$OPTARG
+      ;;
+
+    q)
+      LOG_LEVEL=-1
+      ;;
+    v)
+      LOG_LEVEL+=1
+      ;;
+    h)
+      print_help
+      exit 0
+      ;;
+    *)
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+
+##################################################
+# VALIDATIONS AND ASSIGNMENTS
+
+cmd_quiet_flag="--quiet"
+if [[ $LOG_LEVEL -gt 1 ]] ; then
+  cmd_quiet_flag=""
 fi
 
-TEMP_FILE=$(mktemp aws-sdk-ios.testconfiguration.json)
-echo '{"credentials":{"accessKey":"EMPTY","secretKey":"EMPTY","sessionToken":"EMPTY"},"packages":{"common":{"region":"us-west-2"}}}' > $TEMP_FILE
-cp $TEMP_FILE $DESTINATION
-rm $TEMP_FILE
+if [[ -z $platform ]] ; then
+  die "'platform' not specified"
+fi
+
+if [[ -z $region ]] ; then
+  die "'region' not specified"
+fi
+
+python_cmd=$(which python3)
+if [[ -z $python_cmd ]] ; then
+  die "Cannot find 'python3' in PATH"
+fi
+
+if [[ $assume_role ]] ; then
+  aws_cli_cmd=$(which aws)
+  if [[ -z $aws_cli_cmd ]] ; then
+    die "Cannot find 'aws' in PATH"
+  fi
+
+  jq_cmd=$(which jq)
+  if [[ -z $jq_cmd ]] ; then
+    die "Cannot find 'jq' in PATH"
+  fi
+fi
+
+
+##################################################
+# MAIN
+
+# Exit if any command fails. Don't set this flag until after argument and
+# environment validation, or commands like `which foo` that test for
+# dependencies will cause an immediate failure with no error message
+set -e
+
+trap exit SIGINT
+
+log_info "Generating configuration file for ${platform}"
+
+starting_dir=$PWD
+
+# Set up output paths
+dest_dir=$HOME/.aws-amplify/aws-sdk-${platform}
+dest_file=${dest_dir}/testconfiguration.json
+mkdir -p $dest_dir
+
+# Set up support repo
+support_repo_name=amplify-ci-support
+support_repo_branch=palpatim/build_testconfig
+support_repo_url=https://github.com/aws-amplify/${support_repo_name}.git
+
+cd $dest_dir
+
+# Install CI support repo
+
+if [[ -d ${dest_dir}/${support_repo_name} ]] ; then
+  log_debug "Support repo exists at '${dest_dir}/${support_repo_name}. Fetching latest version."
+  cd $support_repo_name
+  git fetch origin $cmd_quiet_flag
+  git checkout -B $support_repo_branch $cmd_quiet_flag
+else
+  log_debug "Cloning support repo into '${dest_dir}/${support_repo_name}"
+  git clone $support_repo_url --branch $support_repo_branch $support_repo_name $cmd_quiet_flag
+  cd $support_repo_name
+fi
+
+# Install dependencies
+cd ./src/integ_test_resources/common/scripts
+log_debug "Setting up and activating python virtual environment"
+$python_cmd -m venv .env
+source ./.env/bin/activate $cmd_quiet_flag
+
+log_debug "Installing python requirements"
+pip3 install --upgrade pip $cmd_quiet_flag
+pip3 install -r requirements.txt $cmd_quiet_flag
+
+# Assume test execution role and export those values so the builder script can pick them up from the environment
+if [[ $assume_role ]] ; then
+  log_debug "Assuming test execution IAM role"
+  circleci_execution_role_arn=$(aws ssm get-parameter --name '/mobile-sdk/ios/common/circleci_execution_role' | jq -r .Parameter.Value)
+  assume_role_creds=$(aws sts assume-role --duration-seconds 3600 --role-arn "${circleci_execution_role_arn}" --role-session-name "IntegTest-$(date +%Y%m%d%H%M%S)")
+  export AWS_ACCESS_KEY_ID=$(echo $assume_role_creds | jq -r '.Credentials.AccessKeyId')
+  export AWS_SECRET_ACCESS_KEY=$(echo $assume_role_creds | jq -r '.Credentials.SecretAccessKey')
+  export AWS_SESSION_TOKEN=$(echo $assume_role_creds | jq -r '.Credentials.SessionToken')
+fi
+
+export AWS_DEFAULT_REGION=${region}
+
+# Write config file content
+log_debug "Generating configuration file"
+python3 device_config_builder.py ${platform} > $dest_file
+
+# Clean up
+log_debug "Cleaning up"
+deactivate
+cd $starting_dir
+
+log_info "Generated configuration file at ${dest_file}"
 


### PR DESCRIPTION
- Script to generate test configuration in user's HOME directory
- Update Xcode image to 11.4.1
- Minor CircleCI config file cleanup
- Remove testconfiguration.json references from AuthSDK tests
- Update some mobile client test keys to use testconfiguration.json

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
