### PR TITLE
bug: [Pinpoint] persist explicit set for optOut over default behavior

### DIFF
--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -135,6 +135,7 @@ NSString *DEBUG_CHANNEL_TYPE = @"APNS_SANDBOX";
 
     _optOutBackingVariable = optOut;
 }
+
 - (NSString *)optOut {
     return _optOutBackingVariable;
 }

--- a/AWSPinpointTests/AWSPinpointTargetingClientTests.m
+++ b/AWSPinpointTests/AWSPinpointTargetingClientTests.m
@@ -27,6 +27,7 @@ NSString *const AWSPinpointEndpointAttributesKey = @"AWSPinpointEndpointAttribut
 NSString *const AWSPinpointEndpointMetricsKey = @"AWSPinpointEndpointMetricsKey";
 NSString *const AWSPinpointEndpointProfileKey = @"AWSPinpointEndpointProfileKey";
 NSString *const AWSDeviceToken = @"com.amazonaws.AWSDeviceTokenKey";
+NSString *const AWSPinpointOverrideDefaultOptOutKey = @"com.amazonaws.AWSPinpointOverrideDefaultOptOutKey";
 static NSString *userId;
 
 @interface AWSPinpointTargetingClientTests : XCTestCase
@@ -61,6 +62,7 @@ static NSString *userId;
     [self.userDefaults removeObjectForKey:AWSPinpointEndpointAttributesKey];
     [self.userDefaults removeObjectForKey:AWSPinpointEndpointMetricsKey];
     [self.userDefaults removeObjectForKey:AWSDeviceTokenKey];
+    [self.userDefaults removeObjectForKey:AWSPinpointOverrideDefaultOptOutKey];
     [self.userDefaults synchronize];
     
 }
@@ -254,10 +256,29 @@ static NSString *userId;
     XCTAssertTrue([profile.optOut isEqualToString:@"ALL"]);
 }
 
+- (void)testCurrentProfileReturnsOptOutAllWhenNotificationsEnabledAndDeviceTokenNotSetAndOverrideIsSetToNone {
+    [self initializePinpointWithConfiguration:[self getAWSPinpointConfigurationWithOptOut:NO] forceCreate:YES];
+    [self initializeMockApplicationWithRemoteNotifications:YES];
+    self.pinpoint.targetingClient.currentEndpointProfile.optOut = @"NONE";
+
+    AWSPinpointEndpointProfile *profile = [self.pinpoint.targetingClient currentEndpointProfile];
+    XCTAssertTrue([profile.optOut isEqualToString:@"ALL"]);
+}
+
 - (void)testCurrentProfileReturnsOptOutAllWhenNotificationsDisabledAndDeviceTokenSet {
     [self initializePinpointWithConfiguration:[self getAWSPinpointConfigurationWithOptOut:NO] forceCreate:YES];
     [self initializeMockApplicationWithRemoteNotifications:NO];
     [self setDeviceTokenInUserDefaults];
+    
+    AWSPinpointEndpointProfile *profile = [self.pinpoint.targetingClient currentEndpointProfile];
+    XCTAssertTrue([profile.optOut isEqualToString:@"ALL"]);
+}
+
+- (void)testCurrentProfileReturnsOptOutAllWhenNotificationsDisabledAndDeviceTokenSetAndOverrideIsSetToNone {
+    [self initializePinpointWithConfiguration:[self getAWSPinpointConfigurationWithOptOut:NO] forceCreate:YES];
+    [self initializeMockApplicationWithRemoteNotifications:NO];
+    [self setDeviceTokenInUserDefaults];
+    self.pinpoint.targetingClient.currentEndpointProfile.optOut = @"NONE";
 
     AWSPinpointEndpointProfile *profile = [self.pinpoint.targetingClient currentEndpointProfile];
     XCTAssertTrue([profile.optOut isEqualToString:@"ALL"]);
@@ -270,6 +291,23 @@ static NSString *userId;
 
     AWSPinpointEndpointProfile *profile = [self.pinpoint.targetingClient currentEndpointProfile];
     XCTAssertTrue([profile.optOut isEqualToString:@"NONE"]);
+}
+
+- (void)testCurrentProfileReturnsOverrideDefaultOptOutWhenOptOutSetWithNotificationsAndDeviceTokenSet {
+    [self initializePinpointWithConfiguration:[self getAWSPinpointConfigurationWithOptOut:NO] forceCreate:YES];
+    [self initializeMockApplicationWithRemoteNotifications:YES];
+    [self setDeviceTokenInUserDefaults];
+
+    AWSPinpointEndpointProfile *profile = [self.pinpoint.targetingClient currentEndpointProfile];
+    XCTAssertTrue([profile.optOut isEqualToString:@"NONE"]);
+
+    self.pinpoint.targetingClient.currentEndpointProfile.optOut = @"ALL";
+    AWSPinpointEndpointProfile *profileWithOptOutAll = [self.pinpoint.targetingClient currentEndpointProfile];
+    XCTAssertTrue([profileWithOptOutAll.optOut isEqualToString:@"ALL"]);
+
+    self.pinpoint.targetingClient.currentEndpointProfile.optOut = @"NONE";
+    AWSPinpointEndpointProfile *profileWithOptOutNone = [self.pinpoint.targetingClient currentEndpointProfile];
+    XCTAssertTrue([profileWithOptOutNone.optOut isEqualToString:@"NONE"]);
 }
 
 - (void)testCurrentProfileReturnsOptOutAllForApplicationLevelOptOut {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Persist the optOut value set by the developer, ie.
```
self.pinpoint.targetingClient.currentEndpointProfile.optOut = @"ALL";
or
self.pinpoint.targetingClient.currentEndpointProfile.optOut = @"NONE";
```
in the user defaults to make sure it is used across app restarts.

By default, we maintain the current behavior for checking if the app has remote notifications enabled and allowed and address is set (pinpoint.intercept(deviceToken))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
