### PR TITLE
fix(AWSMobileClient): Fixes the crash due to over-leaving dispatch group

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -545,9 +545,15 @@ extension AWSMobileClient {
     
     internal func performUserPoolSignOut() {
         if let task = self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.task, !task.isCompleted {
-            self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
+            let error = AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in.")
+            self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: error)
         }
         self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
+
+        if let task = self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.task, !task.isCompleted {
+            let error = AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in.")
+            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(error: error)
+        }
         self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = nil
         invokeSignInCallback(signResult: nil, error: AWSMobileClientError.unableToSignIn(message: "Could not get end user to sign in."))
         self.userPoolClient?.clearAll()
@@ -705,6 +711,8 @@ extension AWSMobileClient {
         if self.federationProvider == .userPools {
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
+            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
+            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = nil
         } else if self.federationProvider == .hostedUI {
             self.pendingGetTokensCompletion?(nil, AWSMobileClientError.unableToSignIn(message: "Could not get valid token from the user."))
             self.pendingGetTokensCompletion = nil
@@ -910,9 +918,11 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
         self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = customAuthCompletionSource
         
         // getCustomAuthenticationDetails will be invoked in a signIn process or when the token expires.
-        // If this get invoked when the token expires, we first inform the listener that
-        // the user got signedOut.
-        if (self.currentUserState == .signedIn) {
+        // If this get invoked when the token expires, we first inform the listener that the user got signedOut. This
+        // delegate is called in token expiry if the user state is .signedIn or .signedOutUserPoolsTokenInvalid with
+        // customAuthenticationInput.challengeParameters empty
+        if ((self.currentUserState == .signedIn || self.currentUserState == .signedOutUserPoolsTokenInvalid) &&
+            customAuthenticationInput.challengeParameters.isEmpty) {
             let username = self.userPoolClient?.currentUser()?.username ?? ""
             self.mobileClientStatusChanged(userState: .signedOutUserPoolsTokenInvalid,
                                            additionalInfo: ["username": username])

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -705,7 +705,6 @@ extension AWSMobileClient {
         if self.federationProvider == .userPools {
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
-            self.tokenFetchLock.leave()
         } else if self.federationProvider == .hostedUI {
             self.pendingGetTokensCompletion?(nil, AWSMobileClientError.unableToSignIn(message: "Could not get valid token from the user."))
             self.pendingGetTokensCompletion = nil

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -352,6 +352,8 @@ extension AWSMobileClient {
                         codeDeliveryDetails = UserCodeDeliveryDetails(deliveryMedium: .sms, destination: deliveryDetails.destination, attributeName: deliveryDetails.attributeName)
                     case .unknown:
                         codeDeliveryDetails = UserCodeDeliveryDetails(deliveryMedium: .unknown, destination: deliveryDetails.destination, attributeName: deliveryDetails.attributeName)
+                    @unknown default:
+                        codeDeliveryDetails = UserCodeDeliveryDetails(deliveryMedium: .unknown, destination: deliveryDetails.destination, attributeName: deliveryDetails.attributeName)
                     }
                 }
                 completionHandler(SignUpResult(signUpState: confirmedStatus!, codeDeliveryDetails: codeDeliveryDetails), nil)
@@ -952,7 +954,9 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
                 codeDeliveryDetails = UserCodeDeliveryDetails(deliveryMedium: .sms, destination: authenticationInput.destination, attributeName: "phone")
             case .unknown:
                 codeDeliveryDetails = UserCodeDeliveryDetails(deliveryMedium: .unknown, destination: authenticationInput.destination, attributeName: "unknown")
-            }
+            @unknown default:
+                codeDeliveryDetails = UserCodeDeliveryDetails(deliveryMedium: .unknown, destination: authenticationInput.destination, attributeName: "unknown")
+        }
         
         let result = SignInResult(signInState: .smsMFA, codeDetails: codeDeliveryDetails)
         invokeSignInCallback(signResult: result, error: nil)

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomAuthTests/AWSMobileClientCustomAuthTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomAuthTests/AWSMobileClientCustomAuthTests.swift
@@ -9,6 +9,11 @@ import AWSCore
 @testable import AWSCognitoIdentityProvider
 import AWSTestResources
 
+/// Test different custom auth use cases in AWSMobileClient
+///
+/// Test signUp, signIn, confirmSignIn and credentials api for an userpool configured with custom auth.
+/// Please note that, the test doesnot cover any network related error workflows, like retryability for retryable errors,
+/// these were manually tested.
 class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
     
     override class func setUp() {
@@ -240,7 +245,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
             }
         }
 
-        // Now invalidte the session and then try to call getToken
+        // Now invalidate the session and then try to call getToken
         invalidateSession(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
@@ -292,7 +297,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
             }
         }
 
-        // Now invalidte the session and then try to call getToken
+        // Now invalidate the session and then try to call getToken
         invalidateSession(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
@@ -349,7 +354,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
             }
         }
 
-        // Now invalidte the session and then try to call getToken
+        // Now invalidate the session and then try to call getToken
         invalidateSession(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
@@ -365,6 +370,29 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
         }
         wait(for: [tokenFetchFailExpectation], timeout: 20)
         AWSMobileClient.default().removeUserStateListener(self)
+    }
+
+    /// Calling releaseSignInWait without signIn should not crash
+    ///
+    /// - Given: A signOut session
+    /// - When:
+    ///    - I call releaseSignInWait
+    /// - Then:
+    ///    - Should complete without crashing
+    ///
+    func testReleaseSignInWaitWithOutSignIn() {
+        AWSMobileClient.default().releaseSignInWait()
+        let tokenFetchExpectation = expectation(description: "Token fetch should be completed")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchExpectation.fulfill()
+            }
+            guard error != nil else  {
+                XCTFail("Should produce an error when getToken called withOut SignIn")
+                return
+            }
+        }
+        wait(for: [tokenFetchExpectation], timeout: 20)
     }
     
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
@@ -269,4 +269,165 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
         wait(for: [signOutExpectation, tokenFetchExpectation2], timeout: 35, enforceOrder: true)
         AWSMobileClient.default().removeUserStateListener(self)
     }
+
+    /// Test if calling releaseSignInWait after a session expiry releases the waiting getToken call
+    ///
+    /// - Given: A signedIn valid session
+    /// - When:
+    ///    - I call releaseSignInWait after receiving signedOutUserPoolsTokenInvalid
+    /// - Then:
+    ///    - The waiting getTokens call should complete with an .unableToSignIn error.
+    ///
+    func testReleaseSignInWaitOnSessionExpiry() {
+        XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Should be in signOut state")
+
+        // SignIn the user and assert that the token is valid
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        let tokenFetchExpectation = expectation(description: "Token fetch after signIn should be successful")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchExpectation.fulfill()
+            }
+            if let error = error {
+                XCTFail("Get token failed: \(error.localizedDescription)")
+                return
+            }
+        }
+        wait(for: [tokenFetchExpectation], timeout: 20)
+
+        // Setup a listener to call releaseSignInWait whenever you get signedOutUserPoolsTokenInvalid
+        AWSMobileClient.default().addUserStateListener(self) { (userstate, info) in
+            if (userstate == .signedOutUserPoolsTokenInvalid) {
+                AWSMobileClient.default().releaseSignInWait()
+            }
+        }
+
+        // Now invalidte the session and then try to call getToken
+        invalidateSession(username: username)
+
+        let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchFailExpectation.fulfill()
+            }
+            guard let error = error as? AWSMobileClientError,
+                case .unableToSignIn = error else {
+                XCTFail("Should receive an unable to signIn error")
+                return
+            }
+        }
+        wait(for: [tokenFetchFailExpectation], timeout: 20)
+        AWSMobileClient.default().removeUserStateListener(self)
+    }
+
+    /// Test if calling releaseSignInWait after a session expiry releases all the waiting getToken call
+    ///
+    /// - Given: A signedIn valid session
+    /// - When:
+    ///    - I call releaseSignInWait after receiving signedOutUserPoolsTokenInvalid
+    /// - Then:
+    ///    - All the waiting getTokens call should complete with an .unableToSignIn error.
+    ///
+    func testReleaseSignInWaitOnMultipleSessionExpiry() {
+        XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Should be in signOut state")
+
+        // SignIn the user and assert that the token is valid
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        let tokenFetchExpectation = expectation(description: "Token fetch after signIn should be successful")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchExpectation.fulfill()
+            }
+            if let error = error {
+                XCTFail("Get token failed: \(error.localizedDescription)")
+                return
+            }
+        }
+        wait(for: [tokenFetchExpectation], timeout: 20)
+
+        // Setup a listener to call releaseSignInWait whenever you get signedOutUserPoolsTokenInvalid
+        AWSMobileClient.default().addUserStateListener(self) { (userstate, info) in
+            if (userstate == .signedOutUserPoolsTokenInvalid) {
+                AWSMobileClient.default().releaseSignInWait()
+            }
+        }
+
+        // Now invalidte the session and then try to call getToken
+        invalidateSession(username: username)
+
+        let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
+        tokenFetchFailExpectation.expectedFulfillmentCount = 50
+
+        for _ in 1...tokenFetchFailExpectation.expectedFulfillmentCount {
+            AWSMobileClient.default().getTokens { (token, error) in
+                defer {
+                    tokenFetchFailExpectation.fulfill()
+                }
+                guard let error = error as? AWSMobileClientError,
+                    case .unableToSignIn = error else {
+                    XCTFail("Should receive an unable to signIn error")
+                    return
+                }
+            }
+        }
+
+        wait(for: [tokenFetchFailExpectation], timeout: 20)
+        AWSMobileClient.default().removeUserStateListener(self)
+    }
+
+    /// Test if calling signOut after a session expiry releases the waiting getToken call
+    ///
+    /// - Given: A signedIn valid session
+    /// - When:
+    ///    - I call signOut after receiving signedOutUserPoolsTokenInvalid
+    /// - Then:
+    ///    - The waiting getTokens call should complete with an .unableToSignIn error.
+    ///
+    func testSignOutOnSessionExpiry() {
+        XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Should be in signOut state")
+
+        // SignIn the user and assert that the token is valid
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username)
+        signIn(username: username)
+        let tokenFetchExpectation = expectation(description: "Token fetch after signIn should be successful")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchExpectation.fulfill()
+            }
+            if let error = error {
+                XCTFail("Get token failed: \(error.localizedDescription)")
+                return
+            }
+        }
+        wait(for: [tokenFetchExpectation], timeout: 20)
+
+        // Setup a listener to call signOut whenever you get signedOutUserPoolsTokenInvalid
+        AWSMobileClient.default().addUserStateListener(self) { (userstate, info) in
+            if (userstate == .signedOutUserPoolsTokenInvalid) {
+                AWSMobileClient.default().signOut()
+            }
+        }
+
+        // Now invalidte the session and then try to call getToken
+        invalidateSession(username: username)
+
+        let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchFailExpectation.fulfill()
+            }
+            guard let error = error as? AWSMobileClientError,
+                case .unableToSignIn = error else {
+                XCTFail("Should receive an unable to signIn error")
+                return
+            }
+        }
+        wait(for: [tokenFetchFailExpectation], timeout: 20)
+        AWSMobileClient.default().removeUserStateListener(self)
+    }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
@@ -304,7 +304,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
             }
         }
 
-        // Now invalidte the session and then try to call getToken
+        // Now invalidate the session and then try to call getToken
         invalidateSession(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
@@ -356,7 +356,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
             }
         }
 
-        // Now invalidte the session and then try to call getToken
+        // Now invalidate the session and then try to call getToken
         invalidateSession(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
@@ -413,7 +413,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
             }
         }
 
-        // Now invalidte the session and then try to call getToken
+        // Now invalidate the session and then try to call getToken
         invalidateSession(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
@@ -429,5 +429,28 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
         }
         wait(for: [tokenFetchFailExpectation], timeout: 20)
         AWSMobileClient.default().removeUserStateListener(self)
+    }
+
+    /// Calling releaseSignInWait without signIn should not crash
+    ///
+    /// - Given: A signOut session
+    /// - When:
+    ///    - I call releaseSignInWait
+    /// - Then:
+    ///    - Should complete without crashing
+    ///
+    func testReleaseSignInWaitWithOutSignIn() {
+        AWSMobileClient.default().releaseSignInWait()
+        let tokenFetchExpectation = expectation(description: "Token fetch should be completed")
+        AWSMobileClient.default().getTokens { (token, error) in
+            defer {
+                tokenFetchExpectation.fulfill()
+            }
+            guard error != nil else  {
+                XCTFail("Should produce an error when getToken called withOut SignIn")
+                return
+            }
+        }
+        wait(for: [tokenFetchExpectation], timeout: 20)
     }
 }

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -735,7 +735,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails *> *customAuthenticationDetails = [AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails *> new];
     AWSCognitoIdentityCustomAuthenticationInput *input = [[AWSCognitoIdentityCustomAuthenticationInput alloc] initWithChallengeParameters: [NSDictionary new]];
     [authenticationDelegate getCustomChallengeDetails:input customAuthCompletionSource:customAuthenticationDetails];
-    return [[customAuthenticationDetails.task continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityCustomChallengeDetails *> * _Nonnull task) {
+    return [customAuthenticationDetails.task continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityCustomChallengeDetails *> * _Nonnull task) {
         
         //if first challenge is SRP auth
         if([self isFirstCustomStepSRP:task.result]){
@@ -757,13 +757,6 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                             return [self getSessionInternal:[AWSTask taskWithResult:response]];
                         }
                     }];
-        }
-    }] continueWithBlock:^id _Nullable(AWSTask<AWSCognitoIdentityUserSession *> * _Nonnull task) {
-        if(task.error){
-            //retry auth on error
-            return [self customAuthInternal:authenticationDelegate];
-        }else {
-            return task;
         }
     }];
 }

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -731,7 +731,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
  * Prompt developer to obtain custom challenge details
  */
 - (AWSTask<AWSCognitoIdentityUserSession*>*) customAuthInternal: (id<AWSCognitoIdentityCustomAuthentication>) authenticationDelegate {
-
+    
     AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails *> *customAuthenticationDetails = [AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails *> new];
     AWSCognitoIdentityCustomAuthenticationInput *input = [[AWSCognitoIdentityCustomAuthenticationInput alloc] initWithChallengeParameters: [NSDictionary new]];
     [authenticationDelegate getCustomChallengeDetails:input customAuthCompletionSource:customAuthenticationDetails];
@@ -743,20 +743,20 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
         }else {
             return [[self performInitiateCustomAuthChallenge:task.result]
                     continueWithBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderInitiateAuthResponse *> * _Nonnull task) {
-                        [authenticationDelegate didCompleteCustomAuthenticationStepWithError:task.error];
-                        if(task.isCancelled){
-                            return task;
-                        }
-                        if(task.error){
-                            //retry auth on error
-                            return [self customAuthInternal:authenticationDelegate];
-                        }else {
-                            //morph this initiate auth response into a respond to auth challenge response so it works as input to getSessionInternal
-                            AWSCognitoIdentityProviderRespondToAuthChallengeResponse * response = [AWSCognitoIdentityProviderRespondToAuthChallengeResponse new];
-                            [response aws_copyPropertiesFromObject:task.result];
-                            return [self getSessionInternal:[AWSTask taskWithResult:response]];
-                        }
-                    }];
+                [authenticationDelegate didCompleteCustomAuthenticationStepWithError:task.error];
+                if(task.isCancelled){
+                    return task;
+                }
+                if(task.error){
+                    //retry auth on error
+                    return [self customAuthInternal:authenticationDelegate];
+                }else {
+                    //morph this initiate auth response into a respond to auth challenge response so it works as input to getSessionInternal
+                    AWSCognitoIdentityProviderRespondToAuthChallengeResponse * response = [AWSCognitoIdentityProviderRespondToAuthChallengeResponse new];
+                    [response aws_copyPropertiesFromObject:task.result];
+                    return [self getSessionInternal:[AWSTask taskWithResult:response]];
+                }
+            }];
         }
     }];
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - **Integration tests**
     - AWS Mobile SDK for iOS integration tests are now provisioned from a CloudFormation stack created by [the new amplify-ci-support package](LINK TBD). See [the README](LINK TBD) for details on how to provision your account to run integration tests.
 
+### Bug Fixes
+- **AWSMobileClient**
+    - Crash in `releaseSignInWait` api due to over fulfilling a fetchlock. See [Issue #1278](https://github.com/aws-amplify/aws-sdk-ios/issues/1278) and [PR #2571](https://github.com/aws-amplify/aws-sdk-ios/pull/2571)
+    - Fix `releaseSignInWait` for custom Auth to clear the lock correctly. [PR #2571](https://github.com/aws-amplify/aws-sdk-ios/pull/2571)
+
+- **AWSCognitoIdentityProvider**
+    - Removed cyclic retry logic in custom auth delegate. [PR #2571](https://github.com/aws-amplify/aws-sdk-ios/pull/2571)
+
 ### Misc. Updates
 - Model updates for the following services:
   - AWS Lambda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     - Fix `releaseSignInWait` for custom Auth to clear the lock correctly. [PR #2571](https://github.com/aws-amplify/aws-sdk-ios/pull/2571)
 
 - **AWSCognitoIdentityProvider**
-    - Removed cyclic retry logic in custom auth delegate. [PR #2571](https://github.com/aws-amplify/aws-sdk-ios/pull/2571)
+    - Removed cyclic retry logic in custom auth delegate. See [Issue #2504](https://github.com/aws-amplify/aws-sdk-ios/issues/2504), [PR #2571](https://github.com/aws-amplify/aws-sdk-ios/pull/2571)
 
 ### Misc. Updates
 - Model updates for the following services:


### PR DESCRIPTION


## Changes

- Removed `tokenFetchLock` leave from releaseSignInWait - Issues #1278 
- Fixed releaseSignInWait for custom Auth
- Removed cyclic retry logic in custom AuthIssues - Issue #2504 
- Added integration test for the changes

## Explanation of tokenFetLock

leave `tokenFetchLock` dispatch group  for userPool federation is already handled in getTokens api. So there is no need to call this again.

`releaseSignInWait` is to release any waiting call that require signIn to happen. SignIn wait could be triggered from 3 scenarios, and this PR is for Scenario 1.

**Scenario 1 - Signed in to userPool through non-UI api**

In this case signIn wait is triggered from getToken api. Here is the flow:
1. getToken call is invoked and enters tokenFetchLock 
1. getToken internally calls getSession from the underlying Cognito SDK.
1. tokenFetchLock waits till we get a result back from getSession
1. getSession can behave in these three ways - Return a valid session, return an error, ask the user to signIn. Last behavior is the signIn wait, based on the signIn result getSession returns a session or error.
1. Point to note here is that in all the three behavior above, the result always returns to getSession call, which release the tokenFetchLock. So there is no need to release it outside from getToken.

**Scenario 2 - Signed in to userPool through Hosted UI** 

In this case signIn wait is again triggered from getToken api. Here is the flow:
1. getToken call is invoked and enters tokenFetchLock 
1. getToken internally calls getSession from AWSCognito Auth
1. tokenFetchLock waits till we get a result back from getSession
1. If getSession returns refreshToken Expired error, it leaves out from getToken with the tokenFetchLock active.
1. In this case it is okay to leave from the dispatch group outside of getToken api.

**Scenario 3 - Signed in to Identity Pool** 

In this case signIn wait is triggered from getAWSCredentials api. Here is the flow:
1. getAWSCredentials call is invoked and enters credentialsFetchLock 
1. getAWSCredentials internally calls `credentials` from underlying credentials Provider
1. credentialsFetchLock waits till we get a result back from `credentials`
1. If `credentials` returns notAuthorized error, it leaves out from getAWSCredentials with the credentialsFetchLock active.
1. In this case it is okay to leave from the dispatch group outside of getAWSCredentials api.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
