### PR TITLE
feat(AWSMobileClient): Added api to fetch userSub for the loggedin user

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -148,7 +148,21 @@ final public class AWSMobileClient: _AWSMobileClient {
     public var username: String? {
         return self.userpoolOpsHelper.currentActiveUser?.username
     }
-    
+
+    public var userSub: String? {
+        guard  (isSignedIn && (federationProvider == .hostedUI || federationProvider == .userPools)) else {
+            return nil
+        }
+
+        guard let idToken = self.cachedLoginsMap.first?.value else {
+            return nil
+        }
+        let sessionToken = SessionToken(tokenString: idToken)
+        guard let sub = sessionToken.claims?["sub"] as? String else {
+            return nil
+        }
+        return sub
+    }
     
     /// The identity id associated with this provider. This value will be fetched from the keychain at startup. If you do not want to reuse the existing identity id, you must call the clearKeychain method. If the identityId is not fetched yet, it will return nil. Use `getIdentityId()` method to force a server fetch when identityId is not available.
     override public var identityId: String? {


### PR DESCRIPTION
*Description of changes:* 
Added a public api for getting the userSub of the logged in user. This is value can be used as a unique identifier for a user logged in to Cognito User Pool


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
