### PR TITLE
fix: HostedUI will now send  signedOutUserPoolsTokenInvalid when the token expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Fix issue where SDK is not respecting developer set OptOut value. Persist the developer set optOut in user defaults. See [PR: #2552](https://github.com/aws-amplify/aws-sdk-ios/pull/2552)
 
 - **AWSMobileClient**
-  - *Breaking Change* If the token expired while signed in using HostedUI, `AWSMobileClient` will now send the event `.signedOutUserPoolsTokenInvalid` and the request that invoked the token fetch will wait till the user is signed in. In the previous implementation the requested operation will complete with error and user event listener was not invoked.
+  - *Breaking Change* If the token expired while signed in using HostedUI, AWSMobileClient will now send the event signedOutUserPoolsTokenInvalid and the request that invoked the token fetch will wait till the user signin or signout or invoke release signin wait. In the previous implementation the requested operation will complete with error and user event listener was not invoked.
     See [PR: #2739](https://github.com/aws-amplify/aws-sdk-ios/pull/2739)
 
 ### Misc. Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 ## Unreleased
 -Features for next release
 ### Bug Fixes
+
 - **Amazon Pinpoint**
   - Fix issue where SDK is not respecting developer set OptOut value. Persist the developer set optOut in user defaults. See [PR: #2552](https://github.com/aws-amplify/aws-sdk-ios/pull/2552)
+
+- **AWSMobileClient**
+  - *Breaking Change* If the token expired while signed in using HostedUI, `AWSMobileClient` will now send the event `.signedOutUserPoolsTokenInvalid` and the request that invoked the token fetch will wait till the user is signed in. In the previous implementation the requested operation will complete with error and user event listener was not invoked.
+    See [PR: #2739](https://github.com/aws-amplify/aws-sdk-ios/pull/2739)
+
 ### Misc. Updates
 - Model updates for the following services:
   - AWS IoT
-  
+
 ## 2.13.4
 ### New features
 - **Integration tests**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Fix issue where SDK is not respecting developer set OptOut value. Persist the developer set optOut in user defaults. See [PR: #2552](https://github.com/aws-amplify/aws-sdk-ios/pull/2552)
 
 - **AWSMobileClient**
-  - *Breaking Change* If the token expired while signed in using HostedUI, AWSMobileClient will now send the event signedOutUserPoolsTokenInvalid and the request that invoked the token fetch will wait till the user signin or signout or invoke release signin wait. In the previous implementation the requested operation will complete with error and user event listener was not invoked.
+  - If the token expired while signed in using HostedUI, AWSMobileClient will now send the event signedOutUserPoolsTokenInvalid and the request that invoked the token fetch will wait till the user signin or signout or invoke release signin wait. In the previous implementation the requested operation will complete with error and user event listener was not invoked.
     See [PR: #2739](https://github.com/aws-amplify/aws-sdk-ios/pull/2739)
 
 ### Misc. Updates


### PR DESCRIPTION
*Issue : https://github.com/aws-amplify/aws-sdk-ios/issues/2598

*Description of changes:*
If the token expired while signed in using HostedUI, `AWSMobileClient` will now send the event `.signedOutUserPoolsTokenInvalid` and the request that invoked the token fetch will wait till the user is signed in. In the previous implementation the requested operation will complete with error and user event listener was not invoked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
