### PR TITLE
refactor(AWSMobileClient): Make the service configuration configurable for AWSMobileClient

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -44,7 +44,9 @@ enum FederationProvider: String {
 final public class AWSMobileClient: _AWSMobileClient {
     
     static var _sharedInstance: AWSMobileClient = AWSMobileClient(setDelegate: true)
-    
+
+    static var serviceConfiguration: CognitoServiceConfiguration? = nil
+
     // MARK: Feature availability variables
     
     /// Determines if there is any Cognito Identity Pool available to federate against it.
@@ -296,7 +298,8 @@ final public class AWSMobileClient: _AWSMobileClient {
                                                                                                       tokensUri: tokensURI,
                                                                                                       signInUriQueryParameters: self.signInURIQueryParameters,
                                                                                                       signOutUriQueryParameters: self.signOutURIQueryParameters,
-                                                                                                      tokenUriQueryParameters: self.tokenURIQueryParameters)
+                                                                                                      tokenUriQueryParameters: self.tokenURIQueryParameters,
+                                                                                                      userPoolServiceConfiguration: AWSMobileClient.serviceConfiguration?.userPoolServiceConfiguration)
                 
                 if (isCognitoAuthRegistered) {
                     AWSCognitoAuth.remove(forKey: CognitoAuthRegistrationKey)
@@ -474,7 +477,8 @@ final public class AWSMobileClient: _AWSMobileClient {
                                              tokensUri: tokensURI,
                                              signInUriQueryParameters: self.signInURIQueryParameters,
                                              signOutUriQueryParameters: self.signOutURIQueryParameters,
-                                             tokenUriQueryParameters: self.tokenURIQueryParameters)
+                                             tokenUriQueryParameters: self.tokenURIQueryParameters,
+                                             userPoolServiceConfiguration: AWSMobileClient.serviceConfiguration?.userPoolServiceConfiguration)
 
             if (isCognitoAuthRegistered) {
                 AWSCognitoAuth.remove(forKey: CognitoAuthRegistrationKey)
@@ -631,4 +635,24 @@ extension AWSMobileClient {
         self.internalCredentialsProvider?.clearKeychain()
     }
     
+}
+
+// MARK:- AWSMobileClient Cognito configuration
+
+extension AWSMobileClient {
+
+    static func configureCognitoService(userPoolConfiguration: AWSServiceConfiguration,
+                                        identityPoolConfiguration: AWSServiceConfiguration) {
+        let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,
+                                                        identityPoolServiceConfiguration: identityPoolConfiguration)
+        self.serviceConfiguration = configuration
+        UserPoolOperationsHandler.serviceConfiguration = configuration
+    }
+}
+
+struct CognitoServiceConfiguration {
+
+    let userPoolServiceConfiguration: AWSServiceConfiguration
+
+    let identityPoolServiceConfiguration: AWSServiceConfiguration
 }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -641,12 +641,13 @@ extension AWSMobileClient {
 
 public extension AWSMobileClient {
 
-    static func configureCognitoService(userPoolConfiguration: AWSServiceConfiguration,
+    static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration,
                                         identityPoolConfiguration: AWSServiceConfiguration) {
         let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,
                                                         identityPoolServiceConfiguration: identityPoolConfiguration)
         self.serviceConfiguration = configuration
         UserPoolOperationsHandler.serviceConfiguration = configuration
+        AWSInfo.configureIdentityPoolService(configuration.identityPoolServiceConfiguration)
     }
 }
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -639,7 +639,7 @@ extension AWSMobileClient {
 
 // MARK:- AWSMobileClient Cognito configuration
 
-extension AWSMobileClient {
+public extension AWSMobileClient {
 
     static func configureCognitoService(userPoolConfiguration: AWSServiceConfiguration,
                                         identityPoolConfiguration: AWSServiceConfiguration) {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -640,9 +640,9 @@ extension AWSMobileClient {
 // MARK:- AWSMobileClient Cognito configuration
 
 public extension AWSMobileClient {
-
+    
     static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration,
-                                        identityPoolConfiguration: AWSServiceConfiguration) {
+                                     identityPoolConfiguration: AWSServiceConfiguration) {
         let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,
                                                         identityPoolServiceConfiguration: identityPoolConfiguration)
         self.serviceConfiguration = configuration

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -63,13 +63,34 @@ AWSCognitoUserPoolInternalDelegate {
     var authHelperDelegate: UserPoolAuthHelperlCallbacks?
     var customAuthHandler: AWSUserPoolCustomAuthHandler?
     internal static let sharedInstance: UserPoolOperationsHandler = UserPoolOperationsHandler()
+
+    static var serviceConfiguration: CognitoServiceConfiguration? = nil
+
+    let identityPoolClientKey = "identityPoolClientKey"
     
     public override init() {
         super.init()
         if (AWSInfo.default().defaultServiceInfo("CognitoUserPool") != nil) {
-            self.userpoolClient = AWSCognitoIdentityUserPool.default()
+            self.userpoolClient = self.getUserPoolClient()
             self.userpoolClient?.delegate = self
         }
+    }
+
+    private func getUserPoolClient() -> AWSCognitoIdentityUserPool {
+        
+        guard let serviceConfig = UserPoolOperationsHandler.serviceConfiguration?.userPoolServiceConfiguration else {
+            return AWSCognitoIdentityUserPool.default()
+        }
+        let clientKey = "CognitoUserPoolKey"
+        guard let client = AWSCognitoIdentityUserPool.init(forKey: clientKey) else {
+            let serviceInfo = AWSInfo.default().defaultServiceInfo("CognitoUserPool")
+            let userPoolConfig = AWSCognitoIdentityUserPool.buildConfiguration(serviceInfo)
+            AWSCognitoIdentityUserPool.register(with: serviceConfig,
+                                                userPoolConfiguration: userPoolConfig,
+                                                forKey: clientKey)
+            return AWSCognitoIdentityUserPool.init(forKey: clientKey)!
+        }
+        return client
     }
     
     internal func startPasswordAuthentication() -> AWSCognitoIdentityPasswordAuthentication {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -66,7 +66,6 @@ AWSCognitoUserPoolInternalDelegate {
 
     static var serviceConfiguration: CognitoServiceConfiguration? = nil
 
-    let identityPoolClientKey = "identityPoolClientKey"
     
     public override init() {
         super.init()
@@ -82,13 +81,14 @@ AWSCognitoUserPoolInternalDelegate {
             return AWSCognitoIdentityUserPool.default()
         }
         let clientKey = "CognitoUserPoolKey"
-        guard let client = AWSCognitoIdentityUserPool.init(forKey: clientKey) else {
+        let client = AWSCognitoIdentityUserPool.init(forKey: clientKey)
+        if (client == nil) {
             let serviceInfo = AWSInfo.default().defaultServiceInfo("CognitoUserPool")
             let userPoolConfig = AWSCognitoIdentityUserPool.buildConfiguration(serviceInfo)
             AWSCognitoIdentityUserPool.register(with: serviceConfig,
                                                 userPoolConfiguration: userPoolConfig,
                                                 forKey: clientKey)
-            return AWSCognitoIdentityUserPool.init(forKey: clientKey)!
+            return AWSCognitoIdentityUserPool.init(forKey: clientKey)
         }
         return client
     }

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
@@ -32,7 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
                           tokensUri:(nullable NSString *) tokensUri
            signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
           signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters;
+            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
+       userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration;
 
 @end
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
@@ -43,20 +43,20 @@
 @implementation AWSCognitoAuthConfiguration(Extension)
 
 - (instancetype)initWithAppClientId:(NSString *) appClientId
-             appClientSecret:(nullable NSString *)appClientSecret
-                      scopes:(NSSet<NSString *> *) scopes
-           signInRedirectUri:(NSString *) signInRedirectUri
-          signOutRedirectUri:(NSString *) signOutRedirectUri
-                   webDomain:(NSString *) webDomain
-            identityProvider:(nullable NSString *)identityProvider
-               idpIdentifier:(nullable NSString *)idpIdentifier
-                   signInUri:(nullable NSString *) signInUri
-                  signOutUri:(nullable NSString *) signOutUri
-                   tokensUri:(nullable NSString *) tokensUri
-    signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
-   signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-     tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
-userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration {
+                    appClientSecret:(nullable NSString *)appClientSecret
+                             scopes:(NSSet<NSString *> *) scopes
+                  signInRedirectUri:(NSString *) signInRedirectUri
+                 signOutRedirectUri:(NSString *) signOutRedirectUri
+                          webDomain:(NSString *) webDomain
+                   identityProvider:(nullable NSString *)identityProvider
+                      idpIdentifier:(nullable NSString *)idpIdentifier
+                          signInUri:(nullable NSString *) signInUri
+                         signOutUri:(nullable NSString *) signOutUri
+                          tokensUri:(nullable NSString *) tokensUri
+           signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
+          signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
+            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
+       userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration {
     
     BOOL isProviderExternal = YES;
     if (signInUri == nil && signOutUri == nil && tokensUri == nil) {

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
@@ -15,6 +15,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AWSMobileClient/AWSCognitoAuth.h>
+#import <AWSCore/AWSCore.h>
 
 @interface AWSCognitoAuthConfiguration()
 
@@ -34,26 +35,28 @@
                    signInUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
                     tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
-                         isProviderExternal:(BOOL) isProviderExternal;
+                         isProviderExternal:(BOOL) isProviderExternal
+               cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig;
 
 @end
 
 @implementation AWSCognitoAuthConfiguration(Extension)
 
 - (instancetype)initWithAppClientId:(NSString *) appClientId
-                    appClientSecret:(nullable NSString *)appClientSecret
-                             scopes:(NSSet<NSString *> *) scopes
-                  signInRedirectUri:(NSString *) signInRedirectUri
-                 signOutRedirectUri:(NSString *) signOutRedirectUri
-                          webDomain:(NSString *) webDomain
-                   identityProvider:(nullable NSString *)identityProvider
-                      idpIdentifier:(nullable NSString *)idpIdentifier
-                          signInUri:(nullable NSString *) signInUri
-                         signOutUri:(nullable NSString *) signOutUri
-                          tokensUri:(nullable NSString *) tokensUri
-           signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
-          signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters {
+             appClientSecret:(nullable NSString *)appClientSecret
+                      scopes:(NSSet<NSString *> *) scopes
+           signInRedirectUri:(NSString *) signInRedirectUri
+          signOutRedirectUri:(NSString *) signOutRedirectUri
+                   webDomain:(NSString *) webDomain
+            identityProvider:(nullable NSString *)identityProvider
+               idpIdentifier:(nullable NSString *)idpIdentifier
+                   signInUri:(nullable NSString *) signInUri
+                  signOutUri:(nullable NSString *) signOutUri
+                   tokensUri:(nullable NSString *) tokensUri
+    signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
+   signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
+     tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
+userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration {
     
     BOOL isProviderExternal = YES;
     if (signInUri == nil && signOutUri == nil && tokensUri == nil) {
@@ -76,7 +79,8 @@
                     signInUriQueryParameters:signInUriQueryParameters
                    signOutUriQueryParameters:signOutUriQueryParameters
                      tokenUriQueryParameters:tokenUriQueryParameters
-                          isProviderExternal:isProviderExternal];
+                          isProviderExternal:isProviderExternal
+                cognitoUserPoolServiceConfig:serviceConfiguration];
 }
 
 @end

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -18,6 +18,7 @@
 #import <SafariServices/SafariServices.h>
 #import <CommonCrypto/CommonDigest.h>
 #import <CommonCrypto/CommonHMAC.h>
+#import <AWSCore/AWSCore.h>
 
 NSString *const AWSCognitoAuthErrorDomain = @"com.amazon.cognito.AWSCognitoAuthErrorDomain";
 
@@ -44,6 +45,8 @@ NSString *const AWSCognitoAuthErrorDomain = @"com.amazon.cognito.AWSCognitoAuthE
 @property (nonatomic) BOOL isAuthProviderExternal;
 @property (nonatomic) BOOL isProcessingSignOut;
 @property (nonatomic) BOOL isProcessingSignIn;
+
+@property (nonatomic) AWSServiceConfiguration * userPoolConfig;
 
 @end
 
@@ -741,7 +744,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         value = [NSString stringWithFormat: @"Basic %@", value];
         [request setValue:value forHTTPHeaderField:@"Authorization"];
     }
-    [request setValue: [AWSCognitoAuth userAgent] forHTTPHeaderField:@"User-Agent"];
+    [request setValue: [self fetchBaseUserAgent] forHTTPHeaderField:@"User-Agent"];
 }
 
 /**
@@ -964,7 +967,12 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
     });
 }
 
-
+- (NSString *)fetchBaseUserAgent {
+    if (self.userPoolConfig == nil) {
+        return [AWSCognitoAuth userAgent];
+    }
+    return [self.userPoolConfig userAgent];
+}
 /**
  Generate the user agent string
  */
@@ -1145,6 +1153,45 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
                     tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
                          isProviderExternal:(BOOL) isProviderExternal {
+
+    return [self initWithAppClientIdInternal:appClientId
+                             appClientSecret:appClientSecret
+                                      scopes:scopes
+                           signInRedirectUri:signInRedirectUri
+                          signOutRedirectUri:signOutRedirectUri
+                                   webDomain:webDomain
+                            identityProvider:identityProvider
+                               idpIdentifier:idpIdentifier
+                    userPoolIdForEnablingASF:userPoolIdForEnablingASF
+              enableSFAuthSessionIfAvailable:enableSFAuthSession
+                                   signInUri:signInUri
+                                  signOutUri:signOutUri
+                                   tokensUri:tokensUri
+                    signInUriQueryParameters:signInUriQueryParameters
+                   signOutUriQueryParameters:signOutUriQueryParameters
+                     tokenUriQueryParameters:tokenUriQueryParameters
+                          isProviderExternal:isProviderExternal
+                cognitoUserPoolServiceConfig: nil];
+}
+
+- (instancetype)initWithAppClientIdInternal:(NSString *) appClientId
+                            appClientSecret:(nullable NSString *)appClientSecret
+                                     scopes:(NSSet<NSString *> *) scopes
+                          signInRedirectUri:(NSString *) signInRedirectUri
+                         signOutRedirectUri:(NSString *) signOutRedirectUri
+                                  webDomain:(NSString *) webDomain
+                           identityProvider:(nullable NSString *) identityProvider
+                              idpIdentifier:(nullable NSString *) idpIdentifier
+                   userPoolIdForEnablingASF:(nullable NSString *) userPoolIdForEnablingASF
+             enableSFAuthSessionIfAvailable:(BOOL) enableSFAuthSession
+                                  signInUri:(NSString *) signInUri
+                                 signOutUri:(NSString *) signOutUri
+                                  tokensUri:(NSString *) tokensUri
+                   signInUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
+                  signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
+                    tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
+                         isProviderExternal:(BOOL) isProviderExternal
+               cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig {
     if (self = [super init]) {
         
         if (!isProviderExternal) {

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -56,9 +56,11 @@ NS_ASSUME_NONNULL_BEGIN
                                    userPoolConfiguration:(AWSCognitoIdentityUserPoolConfiguration *)userPoolConfiguration
                                                   forKey:(NSString *)key;
 
-+ (instancetype)CognitoIdentityUserPoolForKey:(NSString *)key;
++ (nullable instancetype)CognitoIdentityUserPoolForKey:(NSString *)key;
 
 + (void)removeCognitoIdentityUserPoolForKey:(NSString *)key;
+
++ (AWSCognitoIdentityUserPoolConfiguration *)buildUserPoolConfiguration:(nullable AWSServiceInfo *) serviceInfo;
 
 /**
  Sign up a new user

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                                    userPoolConfiguration:(AWSCognitoIdentityUserPoolConfiguration *)userPoolConfiguration
                                                   forKey:(NSString *)key;
 
-+ (nullable instancetype)CognitoIdentityUserPoolForKey:(NSString *)key;
++ (instancetype)CognitoIdentityUserPoolForKey:(NSString *)key;
 
 + (void)removeCognitoIdentityUserPoolForKey:(NSString *)key;
 

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -61,36 +61,14 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     dispatch_once(&onceToken, ^{
         AWSServiceConfiguration *serviceConfiguration = nil;
         AWSServiceInfo *serviceInfo = [[AWSInfo defaultAWSInfo] defaultServiceInfo:AWSInfoCognitoUserPool];
-        
+
         if (serviceInfo) {
             serviceConfiguration = [[AWSServiceConfiguration alloc] initWithRegion:serviceInfo.region
                                                                credentialsProvider:nil];
         }
-        
-        NSString *poolId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolId] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolIdLegacy];
-        NSString *clientId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientId] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientIdLegacy];
-        NSString *clientSecret = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecret] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecretLegacy];
-        NSString *pinpointAppId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolPinpointAppId];
-        NSNumber *migrationEnabled = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolMigrationEnabled];
-        BOOL migrationEnabledBoolean = NO;
-        if (migrationEnabled != nil) {
-            migrationEnabledBoolean = [migrationEnabled boolValue];
-        }
-
-        if (poolId && clientId) {
-            AWSCognitoIdentityUserPoolConfiguration *configuration = [[AWSCognitoIdentityUserPoolConfiguration alloc] initWithClientId:clientId
-                                                                                                                          clientSecret:clientSecret
-                                                                                                                                poolId:poolId
-                                                                                                    shouldProvideCognitoValidationData:YES
-                                                                                                                         pinpointAppId:pinpointAppId
-                                                                    migrationEnabled:migrationEnabledBoolean ];
-            _defaultUserPool = [[AWSCognitoIdentityUserPool alloc] initWithConfiguration:serviceConfiguration
-                                                                   userPoolConfiguration:configuration];
-        } else {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                           reason:@"The service configuration is `nil`. You need to configure `Info.plist` before using this method."
-                                         userInfo:nil];
-        }
+        AWSCognitoIdentityUserPoolConfiguration *configuration = [AWSCognitoIdentityUserPool buildUserPoolConfiguration: serviceInfo];
+        _defaultUserPool = [[AWSCognitoIdentityUserPool alloc] initWithConfiguration:serviceConfiguration
+                                                               userPoolConfiguration:configuration];
     });
     
     return _defaultUserPool;
@@ -135,6 +113,32 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
                                    reason:@"`- init` is not a valid initializer. Use `+ defaultCognitoIdentityProvider` or `+ CognitoIdentityProviderForKey:` instead."
                                  userInfo:nil];
     return nil;
+}
+
++ (AWSCognitoIdentityUserPoolConfiguration *)buildUserPoolConfiguration:(AWSServiceInfo *) serviceInfo {
+    NSString *poolId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolId] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolIdLegacy];
+    NSString *clientId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientId] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientIdLegacy];
+    NSString *clientSecret = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecret] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecretLegacy];
+    NSString *pinpointAppId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolPinpointAppId];
+    NSNumber *migrationEnabled = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolMigrationEnabled];
+    BOOL migrationEnabledBoolean = NO;
+    if (migrationEnabled != nil) {
+        migrationEnabledBoolean = [migrationEnabled boolValue];
+    }
+
+    if (poolId && clientId) {
+        return [[AWSCognitoIdentityUserPoolConfiguration alloc] initWithClientId:clientId
+                                                                    clientSecret:clientSecret
+                                                                          poolId:poolId
+                                              shouldProvideCognitoValidationData:YES
+                                                                   pinpointAppId:pinpointAppId
+                                                                migrationEnabled:migrationEnabledBoolean ];
+
+    } else {
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                       reason:@"The service configuration is `nil`. You need to configure `Info.plist` before using this method."
+                                     userInfo:nil];
+    }
 }
 
 // Internal init method

--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -200,7 +200,7 @@ Initializer for credentials provider with enhanced authentication flow. This is 
 @param configuration Configuration to be used while creating service client for Identity Pool
 */
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
-           identityPoolId:(NSString *)identityPoolId
+                    identityPoolId:(NSString *)identityPoolId
          identityPoolConfiguration:(AWSServiceConfiguration *)configuration;
 
 /**

--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -193,6 +193,17 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
                     identityPoolId:(NSString *)identityPoolId;
 
 /**
+Initializer for credentials provider with enhanced authentication flow. This is the recommended constructor for first time Amazon Cognito developers. Will create an instance of `AWSEnhancedCognitoIdentityProvider`.
+
+@param regionType The region in which your identity pool exists.
+@param identityPoolId The identity pool id for this provider. Value is used to communicate with Amazon Cognito as well as namespace values stored in the keychain.
+@param identityPoolConfiguration Configuration to be used while creating service client for Identity Pool
+*/
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+           identityPoolId:(NSString *)identityPoolId
+         identityPoolConfiguration:(AWSServiceConfiguration *)configuration;
+
+/**
  Initializer for credentials provider with enhanced authentication flow. This is the recommended method for first time Amazon Cognito developers. Will create an instance of `AWSEnhancedCognitoIdentityProvider`.
 
  @param regionType The region in which your identity pool exists.

--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -197,7 +197,7 @@ Initializer for credentials provider with enhanced authentication flow. This is 
 
 @param regionType The region in which your identity pool exists.
 @param identityPoolId The identity pool id for this provider. Value is used to communicate with Amazon Cognito as well as namespace values stored in the keychain.
-@param identityPoolConfiguration Configuration to be used while creating service client for Identity Pool
+@param configuration Configuration to be used while creating service client for Identity Pool
 */
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
            identityPoolId:(NSString *)identityPoolId

--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -293,19 +293,30 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 @synthesize internalCredentials = _internalCredentials;
 
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
-                    identityPoolId:(NSString *)identityPoolId {
+                    identityPoolId:(NSString *)identityPoolId
+         identityPoolConfiguration:(AWSServiceConfiguration *)configuration {
     if (self = [super init]) {
         AWSCognitoCredentialsProviderHelper *identityProvider = [[AWSCognitoCredentialsProviderHelper alloc] initWithRegionType:regionType
                                                                                                                  identityPoolId:identityPoolId
                                                                                                                 useEnhancedFlow:YES
-                                                                                                        identityProviderManager:nil];
+                                                                                                        identityProviderManager:nil
+                                                                                                      identityPoolConfiguration:configuration];
         [self setUpWithRegionType:regionType
                  identityProvider:identityProvider
                     unauthRoleArn:nil
-                      authRoleArn:nil];
+                      authRoleArn:nil
+        identityPoolConfiguration:configuration];
     }
 
     return self;
+}
+
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId {
+    AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
+                                                                         credentialsProvider:credentialsProvider];
+    return [self initWithRegionType:regionType identityPoolId:identityPoolId identityPoolConfiguration:configuration];
 }
 
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
@@ -373,7 +384,8 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
 - (void)setUpWithRegionType:(AWSRegionType)regionType
            identityProvider:(id<AWSCognitoCredentialsProviderHelper>)identityProvider
               unauthRoleArn:(NSString *)unauthRoleArn
-                authRoleArn:(NSString *)authRoleArn {
+                authRoleArn:(NSString *)authRoleArn
+  identityPoolConfiguration:(AWSServiceConfiguration *)configuration {
     _refreshExecutor = [AWSExecutor executorWithOperationQueue:[NSOperationQueue new]];
     _refreshingCredentials = NO;
     _semaphore = dispatch_semaphore_create(0);
@@ -394,13 +406,8 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     else {
         identityProvider.identityId = _keychain[AWSCredentialsProviderKeychainIdentityId];
     }
-
-    AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
-                                                                         credentialsProvider:credentialsProvider];
-
     _cognitoIdentity = [[AWSCognitoIdentity alloc] initWithConfiguration:configuration];
-    
+
     _customRoleArnOverride = nil;
 
     if (!_useEnhancedFlow) {
@@ -408,6 +415,20 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     }
 
     _internalCredentials = [[AWSCredentials alloc] initFromKeychain:self.keychain];
+}
+
+- (void)setUpWithRegionType:(AWSRegionType)regionType
+           identityProvider:(id<AWSCognitoCredentialsProviderHelper>)identityProvider
+              unauthRoleArn:(NSString *)unauthRoleArn
+                authRoleArn:(NSString *)authRoleArn {
+    AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
+                                                                         credentialsProvider:credentialsProvider];
+    [self setUpWithRegionType:regionType
+             identityProvider:identityProvider
+                unauthRoleArn:unauthRoleArn
+                  authRoleArn:authRoleArn
+    identityPoolConfiguration:configuration];
 }
 
 - (AWSTask<AWSCredentials *> *)getCredentialsWithSTS:(NSDictionary<NSString *,NSString *> *)logins

--- a/AWSCore/Authentication/AWSIdentityProvider.h
+++ b/AWSCore/Authentication/AWSIdentityProvider.h
@@ -131,6 +131,7 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderHelperErrorType) {
 
 @end
 
+@class AWSServiceConfiguration;
 /**
  An abstract implementation of the AWSCognitoCredentialsProviderHelper. Developers should extend this class when they want to implement developer authenticated identities and want to support the basic Amazon Cognito authflow in the same application.
  */
@@ -142,6 +143,12 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderHelperErrorType) {
                     identityPoolId:(NSString *)identityPoolId
                    useEnhancedFlow:(BOOL)useEnhancedFlow
            identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager;
+
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+                   useEnhancedFlow:(BOOL)useEnhancedFlow
+           identityProviderManager:(nullable id<AWSIdentityProviderManager>)identityProviderManager
+         identityPoolConfiguration:(AWSServiceConfiguration *)configuration;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSCore/Authentication/AWSIdentityProvider.m
+++ b/AWSCore/Authentication/AWSIdentityProvider.m
@@ -125,7 +125,8 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
 - (instancetype)initWithRegionType:(AWSRegionType)regionType
                     identityPoolId:(NSString *)identityPoolId
                    useEnhancedFlow:(BOOL)useEnhancedFlow
-           identityProviderManager:(id<AWSIdentityProviderManager>)identityProviderManager {
+           identityProviderManager:(id<AWSIdentityProviderManager>)identityProviderManager
+         identityPoolConfiguration:(AWSServiceConfiguration *)configuration {
     if (self = [super init]) {
         _executor = [AWSExecutor executorWithOperationQueue:[NSOperationQueue new]];
         _count = 0;
@@ -133,15 +134,26 @@ NSString *const AWSIdentityProviderAmazonCognitoIdentity = @"cognito-identity.am
         _useEnhancedFlow = useEnhancedFlow;
         self.identityPoolId = identityPoolId;
         self.identityProviderManager = identityProviderManager;
-        
-        AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
-        AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
-                                                                             credentialsProvider:credentialsProvider];
         _cognitoIdentity = [[AWSCognitoIdentity alloc] initWithConfiguration:configuration];
     }
-    
     return self;
 }
+
+- (instancetype)initWithRegionType:(AWSRegionType)regionType
+                    identityPoolId:(NSString *)identityPoolId
+                   useEnhancedFlow:(BOOL)useEnhancedFlow
+           identityProviderManager:(id<AWSIdentityProviderManager>)identityProviderManager {
+
+    AWSAnonymousCredentialsProvider *credentialsProvider = [AWSAnonymousCredentialsProvider new];
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:regionType
+                                                                         credentialsProvider:credentialsProvider];
+    return [self initWithRegionType:regionType
+                     identityPoolId:identityPoolId
+                    useEnhancedFlow:useEnhancedFlow
+            identityProviderManager:identityProviderManager
+          identityPoolConfiguration:configuration];
+}
+
 
 #pragma mark - AWSIdentityProvider
 

--- a/AWSCore/Service/AWSInfo.h
+++ b/AWSCore/Service/AWSInfo.h
@@ -22,7 +22,7 @@ FOUNDATION_EXPORT NSString *const AWSInfoDefault;
 
 @class AWSServiceInfo;
 @class AWSCognitoCredentialsProvider;
-
+@class AWSServiceConfiguration;
 /**
  * The AWSInfo holds the configuration values for the various supported services.
  */
@@ -45,6 +45,11 @@ FOUNDATION_EXPORT NSString *const AWSInfoDefault;
  * @param config The dictionary containing the configuration
  */
 + (void)configureDefaultAWSInfo:(NSDictionary<NSString *, id> *)config;
+
+/**
+ * Service configuration to be used while creating the identity pool service.
+ */
++ (void)configureIdentityPoolService:(AWSServiceConfiguration *)config;
 
 - (nullable AWSServiceInfo *)serviceInfo:(NSString *)serviceName
                                   forKey:(NSString *)key;

--- a/AWSCore/Service/AWSInfo.m
+++ b/AWSCore/Service/AWSInfo.m
@@ -51,6 +51,7 @@ static NSString *const AWSInfoIdentityManager = @"IdentityManager";
 
 static AWSInfo *_defaultAWSInfo = nil;
 static NSDictionary<NSString *, id> * _userConfig = nil;
+static AWSServiceConfiguration *_identityPoolConfiguration = nil;
 
 - (instancetype)initWithConfiguration:(NSDictionary<NSString *, id> *)config {
     if (self = [super init]) {
@@ -69,8 +70,15 @@ static NSDictionary<NSString *, id> * _userConfig = nil;
         NSString *cognitoIdentityPoolID = [defaultCredentialsProviderDictionary objectForKey:AWSInfoCognitoIdentityPoolId];
         AWSRegionType cognitoIdentityRegion =  [[defaultCredentialsProviderDictionary objectForKey:AWSInfoRegion] aws_regionTypeValue];
         if (cognitoIdentityPoolID && cognitoIdentityRegion != AWSRegionUnknown) {
-            _defaultCognitoCredentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:cognitoIdentityRegion
-                                                                                            identityPoolId:cognitoIdentityPoolID];
+            if (_identityPoolConfiguration == nil) {
+                _defaultCognitoCredentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:cognitoIdentityRegion
+                                                                                                           identityPoolId:cognitoIdentityPoolID];
+            } else {
+                _defaultCognitoCredentialsProvider = [[AWSCognitoCredentialsProvider alloc] initWithRegionType:cognitoIdentityRegion
+                                                                                                           identityPoolId:cognitoIdentityPoolID
+                                                                                     identityPoolConfiguration: _identityPoolConfiguration];
+            }
+
         }
 
         _defaultRegion = [[defaultInfoDictionary objectForKey:AWSInfoRegion] aws_regionTypeValue];
@@ -128,6 +136,10 @@ static NSDictionary<NSString *, id> * _userConfig = nil;
     } else {
         _userConfig = config;
     }
+}
+
++ (void)configureIdentityPoolService:(AWSServiceConfiguration *)config {
+    _identityPoolConfiguration = config;
 }
 
 + (void)overrideCredentialsProvider:(AWSCognitoCredentialsProvider *)cognitoCredentialsProvider {


### PR DESCRIPTION
*Description of changes:* `AWSMobileClient` internally uses Amazon Cognito User Pool and Amazon Cognito Identity Pool to make service calls. The service configuration used inside AWSMobileClient was not configurable. This PR makes the service configuration configurable. This change is backward compatible.

After this change to configure AWSMobileClient we should call the following before using any AWSMobileClient methods.
```
AWSMobileClient.configureCognitoService(userPoolConfiguration: userPoolConfiguration, 
                                    identityPoolConfiguration: identityPoolConfiguration)
```

---
*Revision 3*
- Reverted the nullable return type of `CognitoIdentityUserPoolForKey:(NSString *)key;`
- Added the missing `AWSInfo.configureIdentityPoolService(configuration.identityPoolServiceConfiguration)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
