### PR TITLE
refactor(AWSMobileClient): Make the service configuration optional

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -641,8 +641,8 @@ extension AWSMobileClient {
 
 public extension AWSMobileClient {
     
-    static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration,
-                                     identityPoolConfiguration: AWSServiceConfiguration) {
+    static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration?,
+                                     identityPoolConfiguration: AWSServiceConfiguration?) {
         let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,
                                                         identityPoolServiceConfiguration: identityPoolConfiguration)
         self.serviceConfiguration = configuration
@@ -653,7 +653,7 @@ public extension AWSMobileClient {
 
 struct CognitoServiceConfiguration {
 
-    let userPoolServiceConfiguration: AWSServiceConfiguration
+    let userPoolServiceConfiguration: AWSServiceConfiguration?
 
-    let identityPoolServiceConfiguration: AWSServiceConfiguration
+    let identityPoolServiceConfiguration: AWSServiceConfiguration?
 }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -643,7 +643,7 @@ public extension AWSMobileClient {
 
     /// Updates the service configuration for the Cognito Services
     ///
-    /// - Warning: This method is intended for internal user only.
+    /// - Warning: This method is intended for internal use only.
     static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration?,
                                      identityPoolConfiguration: AWSServiceConfiguration?) {
         let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -641,6 +641,9 @@ extension AWSMobileClient {
 
 public extension AWSMobileClient {
 
+    /// Updates the service configuration for the Cognito Services
+    ///
+    /// - Warning: This method is intended for internal user only.
     static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration?,
                                      identityPoolConfiguration: AWSServiceConfiguration?) {
         let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,
@@ -651,7 +654,7 @@ public extension AWSMobileClient {
     }
 }
 
-internal struct CognitoServiceConfiguration {
+struct CognitoServiceConfiguration {
 
     let userPoolServiceConfiguration: AWSServiceConfiguration?
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -640,7 +640,7 @@ extension AWSMobileClient {
 // MARK:- AWSMobileClient Cognito configuration
 
 public extension AWSMobileClient {
-    
+
     static func updateCognitoService(userPoolConfiguration: AWSServiceConfiguration?,
                                      identityPoolConfiguration: AWSServiceConfiguration?) {
         let configuration = CognitoServiceConfiguration(userPoolServiceConfiguration: userPoolConfiguration,
@@ -651,7 +651,7 @@ public extension AWSMobileClient {
     }
 }
 
-struct CognitoServiceConfiguration {
+internal struct CognitoServiceConfiguration {
 
     let userPoolServiceConfiguration: AWSServiceConfiguration?
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -64,7 +64,7 @@ AWSCognitoUserPoolInternalDelegate {
     var customAuthHandler: AWSUserPoolCustomAuthHandler?
     internal static let sharedInstance: UserPoolOperationsHandler = UserPoolOperationsHandler()
 
-    internal static var serviceConfiguration: CognitoServiceConfiguration? = nil
+    static var serviceConfiguration: CognitoServiceConfiguration? = nil
 
     
     public override init() {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -64,7 +64,7 @@ AWSCognitoUserPoolInternalDelegate {
     var customAuthHandler: AWSUserPoolCustomAuthHandler?
     internal static let sharedInstance: UserPoolOperationsHandler = UserPoolOperationsHandler()
 
-    static var serviceConfiguration: CognitoServiceConfiguration? = nil
+    internal static var serviceConfiguration: CognitoServiceConfiguration? = nil
 
     
     public override init() {

--- a/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientInitializerTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientInitializerTests.swift
@@ -21,4 +21,71 @@ class AWSMobileClientInitializerTests: XCTestCase {
         XCTAssert(mobileClient.currentUserState != .unknown)
     }
 
+    func testInitWithBothCognitoServiceConfigPreLoaded() {
+        let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
+
+        let userPoolConfig = AWSServiceConfiguration(region: .USEast2, credentialsProvider: nil)
+        let anonymousCredentialProvider = AWSAnonymousCredentialsProvider()
+        let idpConfig = AWSServiceConfiguration(region: .USEast2, credentialsProvider: anonymousCredentialProvider)
+        AWSMobileClient.updateCognitoService(userPoolConfiguration: userPoolConfig,
+                                             identityPoolConfiguration: idpConfig)
+
+        let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
+        mobileClient.initialize { (userState, error) in
+            XCTAssertNil(error)
+            initializeExpectation.fulfill()
+        }
+        wait(for: [initializeExpectation], timeout: 5)
+        XCTAssert(mobileClient.currentUserState != .unknown)
+    }
+
+    func testInitWithUserPoolConfigPreLoaded() {
+        let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
+
+        let config = AWSServiceConfiguration(region: .USEast2, credentialsProvider: nil)
+
+        AWSMobileClient.updateCognitoService(userPoolConfiguration: config,
+                                             identityPoolConfiguration: nil)
+
+        let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
+        mobileClient.initialize { (userState, error) in
+            XCTAssertNil(error)
+            initializeExpectation.fulfill()
+        }
+        wait(for: [initializeExpectation], timeout: 5)
+        XCTAssert(mobileClient.currentUserState != .unknown)
+    }
+
+    func testInitWithIdentityPoolConfigPreLoaded() {
+        let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
+
+        let anonymousCredentialProvider = AWSAnonymousCredentialsProvider()
+        let idpConfig = AWSServiceConfiguration(region: .USEast2, credentialsProvider: anonymousCredentialProvider)
+
+        AWSMobileClient.updateCognitoService(userPoolConfiguration: nil,
+                                             identityPoolConfiguration: idpConfig)
+
+        let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
+        mobileClient.initialize { (userState, error) in
+            XCTAssertNil(error)
+            initializeExpectation.fulfill()
+        }
+        wait(for: [initializeExpectation], timeout: 5)
+        XCTAssert(mobileClient.currentUserState != .unknown)
+    }
+
+    func testInitWithBothCognitoServiceConfigNil() {
+        let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
+        AWSMobileClient.updateCognitoService(userPoolConfiguration: nil,
+                                             identityPoolConfiguration: nil)
+
+        let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
+        mobileClient.initialize { (userState, error) in
+            XCTAssertNil(error)
+            initializeExpectation.fulfill()
+        }
+        wait(for: [initializeExpectation], timeout: 5)
+        XCTAssert(mobileClient.currentUserState != .unknown)
+    }
+
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientInitializerTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientUnitTests/AWSMobileClientInitializerTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import AWSMobileClient
 
 class AWSMobileClientInitializerTests: XCTestCase {
-
+    
     func testInitWithConfiguration() {
         let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
         let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
@@ -20,16 +20,16 @@ class AWSMobileClientInitializerTests: XCTestCase {
         wait(for: [initializeExpectation], timeout: 5)
         XCTAssert(mobileClient.currentUserState != .unknown)
     }
-
+    
     func testInitWithBothCognitoServiceConfigPreLoaded() {
         let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
-
+        
         let userPoolConfig = AWSServiceConfiguration(region: .USEast2, credentialsProvider: nil)
         let anonymousCredentialProvider = AWSAnonymousCredentialsProvider()
         let idpConfig = AWSServiceConfiguration(region: .USEast2, credentialsProvider: anonymousCredentialProvider)
         AWSMobileClient.updateCognitoService(userPoolConfiguration: userPoolConfig,
                                              identityPoolConfiguration: idpConfig)
-
+        
         let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
         mobileClient.initialize { (userState, error) in
             XCTAssertNil(error)
@@ -38,15 +38,15 @@ class AWSMobileClientInitializerTests: XCTestCase {
         wait(for: [initializeExpectation], timeout: 5)
         XCTAssert(mobileClient.currentUserState != .unknown)
     }
-
+    
     func testInitWithUserPoolConfigPreLoaded() {
         let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
-
+        
         let config = AWSServiceConfiguration(region: .USEast2, credentialsProvider: nil)
-
+        
         AWSMobileClient.updateCognitoService(userPoolConfiguration: config,
                                              identityPoolConfiguration: nil)
-
+        
         let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
         mobileClient.initialize { (userState, error) in
             XCTAssertNil(error)
@@ -55,16 +55,16 @@ class AWSMobileClientInitializerTests: XCTestCase {
         wait(for: [initializeExpectation], timeout: 5)
         XCTAssert(mobileClient.currentUserState != .unknown)
     }
-
+    
     func testInitWithIdentityPoolConfigPreLoaded() {
         let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
-
+        
         let anonymousCredentialProvider = AWSAnonymousCredentialsProvider()
         let idpConfig = AWSServiceConfiguration(region: .USEast2, credentialsProvider: anonymousCredentialProvider)
-
+        
         AWSMobileClient.updateCognitoService(userPoolConfiguration: nil,
                                              identityPoolConfiguration: idpConfig)
-
+        
         let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
         mobileClient.initialize { (userState, error) in
             XCTAssertNil(error)
@@ -73,12 +73,12 @@ class AWSMobileClientInitializerTests: XCTestCase {
         wait(for: [initializeExpectation], timeout: 5)
         XCTAssert(mobileClient.currentUserState != .unknown)
     }
-
+    
     func testInitWithBothCognitoServiceConfigNil() {
         let initializeExpectation = expectation(description: "The AWSMobileClient initialization")
         AWSMobileClient.updateCognitoService(userPoolConfiguration: nil,
                                              identityPoolConfiguration: nil)
-
+        
         let mobileClient = AWSMobileClient(configuration: AWSMobileClientConfig)
         mobileClient.initialize { (userState, error) in
             XCTAssertNil(error)
@@ -87,5 +87,5 @@ class AWSMobileClientInitializerTests: XCTestCase {
         wait(for: [initializeExpectation], timeout: 5)
         XCTAssert(mobileClient.currentUserState != .unknown)
     }
-
+    
 }

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -46,8 +46,6 @@ NSString *const AWSCognitoAuthErrorDomain = @"com.amazon.cognito.AWSCognitoAuthE
 @property (nonatomic) BOOL isProcessingSignOut;
 @property (nonatomic) BOOL isProcessingSignIn;
 
-@property (nonatomic) AWSServiceConfiguration * userPoolConfig;
-
 @end
 
 API_AVAILABLE(ios(11.0))
@@ -66,6 +64,7 @@ API_AVAILABLE(ios(11.0))
 @property (nonatomic, readwrite) NSDictionary<NSString *, NSString *> * tokensUriQueryParameters;
 @property (nonatomic, readwrite) NSDictionary<NSString *, NSString *> * signOutUriQueryParameters;
 @property (nonatomic) BOOL isAuthProviderExternal;
+@property (nonatomic) AWSServiceConfiguration * userPoolConfig;
 
 @end
 
@@ -968,10 +967,10 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 }
 
 - (NSString *)fetchBaseUserAgent {
-    if (self.userPoolConfig == nil) {
+    if (self.authConfiguration.userPoolConfig == nil) {
         return [AWSCognitoAuth userAgent];
     }
-    return [self.userPoolConfig userAgent];
+    return [self.authConfiguration.userPoolConfig userAgent];
 }
 /**
  Generate the user agent string
@@ -1219,6 +1218,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         _signInUriQueryParameters = signInUriQueryParameters;
         _tokensUriQueryParameters = tokenUriQueryParameters;
         _isAuthProviderExternal = isProviderExternal;
+        _userPoolConfig = serviceConfig;
     }
     
     return self;

--- a/AWSCore/Service/AWSInfo.h
+++ b/AWSCore/Service/AWSInfo.h
@@ -49,7 +49,7 @@ FOUNDATION_EXPORT NSString *const AWSInfoDefault;
 /**
  * Service configuration to be used while creating the identity pool service.
  */
-+ (void)configureIdentityPoolService:(AWSServiceConfiguration *)config;
++ (void)configureIdentityPoolService:(nullable AWSServiceConfiguration *)config;
 
 - (nullable AWSServiceInfo *)serviceInfo:(NSString *)serviceName
                                   forKey:(NSString *)key;

--- a/AWSCore/Service/AWSInfo.h
+++ b/AWSCore/Service/AWSInfo.h
@@ -47,10 +47,9 @@ FOUNDATION_EXPORT NSString *const AWSInfoDefault;
 + (void)configureDefaultAWSInfo:(NSDictionary<NSString *, id> *)config;
 
 /**
- * @internal
  * Service configuration to be used while creating the identity pool service.
  *
- * - Attention: This method is intended for internal use only.
+ * - Warning: This method is intended for internal use only.
  */
 + (void)configureIdentityPoolService:(nullable AWSServiceConfiguration *)config;
 

--- a/AWSCore/Service/AWSInfo.h
+++ b/AWSCore/Service/AWSInfo.h
@@ -47,7 +47,10 @@ FOUNDATION_EXPORT NSString *const AWSInfoDefault;
 + (void)configureDefaultAWSInfo:(NSDictionary<NSString *, id> *)config;
 
 /**
+ * @internal
  * Service configuration to be used while creating the identity pool service.
+ *
+ * - Attention: This method is intended for internal use only.
  */
 + (void)configureIdentityPoolService:(nullable AWSServiceConfiguration *)config;
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/586
 
*Description of changes:*

- Made the service configurations for Cognito services optional.
- Fixed issue where the configuration was not correctly passed in when using HostedUI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
