### PR TITLE
fix: Added nullable modifier to the return instance form the method CognitoIdentityUserPoolForKey:

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -75,22 +75,22 @@ AWSCognitoUserPoolInternalDelegate {
         }
     }
 
-    private func getUserPoolClient() -> AWSCognitoIdentityUserPool {
+    private func getUserPoolClient() -> AWSCognitoIdentityUserPool? {
         
         guard let serviceConfig = UserPoolOperationsHandler.serviceConfiguration?.userPoolServiceConfiguration else {
             return AWSCognitoIdentityUserPool.default()
         }
         let clientKey = "CognitoUserPoolKey"
-        let client = AWSCognitoIdentityUserPool.init(forKey: clientKey)
-        if (client == nil) {
-            let serviceInfo = AWSInfo.default().defaultServiceInfo("CognitoUserPool")
-            let userPoolConfig = AWSCognitoIdentityUserPool.buildConfiguration(serviceInfo)
-            AWSCognitoIdentityUserPool.register(with: serviceConfig,
-                                                userPoolConfiguration: userPoolConfig,
-                                                forKey: clientKey)
-            return AWSCognitoIdentityUserPool.init(forKey: clientKey)
+        if let client = AWSCognitoIdentityUserPool.init(forKey: clientKey) {
+            return client
         }
-        return client
+
+        let serviceInfo = AWSInfo.default().defaultServiceInfo("CognitoUserPool")
+        let userPoolConfig = AWSCognitoIdentityUserPool.buildConfiguration(serviceInfo)
+        AWSCognitoIdentityUserPool.register(with: serviceConfig,
+                                            userPoolConfiguration: userPoolConfig,
+                                            forKey: clientKey)
+        return AWSCognitoIdentityUserPool.init(forKey: clientKey)
     }
     
     internal func startPasswordAuthentication() -> AWSCognitoIdentityPasswordAuthentication {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -75,22 +75,30 @@ AWSCognitoUserPoolInternalDelegate {
         }
     }
 
-    private func getUserPoolClient() -> AWSCognitoIdentityUserPool? {
+    private func getUserPoolClient() -> AWSCognitoIdentityUserPool {
         
         guard let serviceConfig = UserPoolOperationsHandler.serviceConfiguration?.userPoolServiceConfiguration else {
             return AWSCognitoIdentityUserPool.default()
         }
+
+        // Check if a AWSCognitoIdentityUserPool is already registered with the given key.
         let clientKey = "CognitoUserPoolKey"
         if let client = AWSCognitoIdentityUserPool.init(forKey: clientKey) {
             return client
         }
 
+        // If the AWSCognitoIdentityUserPool is not registered, register it and then return the same object.
         let serviceInfo = AWSInfo.default().defaultServiceInfo("CognitoUserPool")
         let userPoolConfig = AWSCognitoIdentityUserPool.buildConfiguration(serviceInfo)
         AWSCognitoIdentityUserPool.register(with: serviceConfig,
                                             userPoolConfiguration: userPoolConfig,
                                             forKey: clientKey)
-        return AWSCognitoIdentityUserPool.init(forKey: clientKey)
+        if let client =  AWSCognitoIdentityUserPool.init(forKey: clientKey) {
+            return client
+        }
+
+        /// Fall back to the default client if the client was not registered correctly.
+        return AWSCognitoIdentityUserPool.default()
     }
     
     internal func startPasswordAuthentication() -> AWSCognitoIdentityPasswordAuthentication {

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                                    userPoolConfiguration:(AWSCognitoIdentityUserPoolConfiguration *)userPoolConfiguration
                                                   forKey:(NSString *)key;
 
-+ (instancetype)CognitoIdentityUserPoolForKey:(NSString *)key;
++ (nullable instancetype)CognitoIdentityUserPoolForKey:(NSString *)key;
 
 + (void)removeCognitoIdentityUserPoolForKey:(NSString *)key;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Bug Fixes
 
 - **AWSCognitoIdentityProvider**
-  - Added `nullable` modifier to the return instance form the method `CognitoIdentityUserPoolForKey:`. 
+  - **Breaking Change** Added `nullable` modifier to the return instance form the method `CognitoIdentityUserPoolForKey:`. See [PR: #2815](https://github.com/aws-amplify/aws-sdk-ios/pull/2815)
 
 ## 2.13.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 -Features for next release
 
+## 2.14.0
+
+### Bug Fixes
+
+- **AWSCognitoIdentityProvider**
+  - Added `nullable` modifier to the return instance form the method `CognitoIdentityUserPoolForKey:`. 
+
 ## 2.13.6
 
 ### Misc. Updates


### PR DESCRIPTION
*Description of changes:* 

The implementation of the method `CognitoIdentityUserPoolForKey:` looks like this:
```
+ (instancetype)CognitoIdentityUserPoolForKey:(NSString *)key {
    return [_serviceClients objectForKey:key];
}
```
Internally it just returns an item from a dictionary. And this can return a null object back.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
