### PR TITLE
[DO NOT REVIEW] Prototype code of including username and password in mqtt message

### DIFF
--- a/AWSIoT/AWSIoTDataManager.h
+++ b/AWSIoT/AWSIoTDataManager.h
@@ -104,6 +104,11 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 @property(nonatomic, assign, readonly) NSUInteger publishRetryThrottle;
 
+@property (nonatomic, copy) NSString *username;
+
+@property (nonatomic, copy) NSString *password;
+
+
 /**
  Create an AWSIoTMQTTConfiguration object and initialize its parameters.
  The AWSIoTMQTTConfiguration object is then passed to AWSIoTDataManager to initialize it.

--- a/AWSIoT/AWSIoTDataManager.m
+++ b/AWSIoT/AWSIoTDataManager.m
@@ -323,13 +323,21 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         if(_mqttClient == nil){
             AWSDDLogError(@"**** mqttClient is nil. **** ");
         }
-        _mqttClient.userMetaData = [NSString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
+
+        _mqttClient.userMetaData = [self baseUserMetaDataString:mqttConfig.username];
+        _mqttClient.password = mqttConfig.password.length ? mqttConfig.password : @"";
         _userMetaDataDict = [[NSMutableDictionary alloc] init];
         _mqttClient.associatedObject = self;
         _userDidIssueDisconnect = NO;
         _userDidIssueConnect = NO;
     }
     return self;
+}
+
+- (nonnull NSString*)baseUserMetaDataString:(nullable NSString*)username {
+    return username.length
+    ? [NSString stringWithFormat:@"%@%@%@", username, @"?SDK=iOS&Version=", AWSIoTSDKVersion]
+    : [NSString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
 }
 
 - (void)enableMetricsCollection:(BOOL)enabled {
@@ -368,7 +376,8 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
     }
 
     // validate the length of username field
-    NSMutableString *userMetaDataString = [NSMutableString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
+    NSMutableString *userMetaDataString = [[self baseUserMetaDataString:self.mqttConfiguration.username] mutableCopy];
+    
     NSUInteger baseLength = [userMetaDataString length];
 
     // Append each of the user-specified key-value pair to the connection username

--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -91,6 +91,7 @@
 @property(atomic, assign) BOOL isMetricsEnabled;
 @property(atomic, assign) NSUInteger publishRetryThrottle;
 @property(atomic, strong) NSString *userMetaData;
+@property(atomic, copy) NSString *password;
 
 /**
  The client ID for the current connection; can be nil if not connected.

--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -299,7 +299,7 @@
     if (self.session == nil ) {
         self.session= [[AWSMQTTSession alloc] initWithClientId:self.clientId
                                                userName:self.userMetaData
-                                               password:@""
+                                               password:self.password
                                               keepAlive:self.keepAliveInterval
                                            cleanSession:self.cleanSession
                                               willTopic:self.lastWillAndTestamentTopic
@@ -556,7 +556,7 @@
     if (self.session == nil ) {
         self.session = [[AWSMQTTSession alloc] initWithClientId:self.clientId
                                                        userName:self.userMetaData
-                                                       password:@""
+                                                       password:self.password
                                                       keepAlive:self.keepAliveInterval
                                                    cleanSession:self.cleanSession
                                                       willTopic:self.lastWillAndTestamentTopic


### PR DESCRIPTION
To use this code, i'm basically instantiating the data plane code as-such:
```
    func initializeDataPlane(credentialsProvider: AWSCredentialsProvider) {
        //Initialize Dataplane:
        // IoT Dataplane must use your account specific IoT endpoint
        let iotEndPoint = AWSEndpoint(urlString: IOT_ENDPOINT)
        
        // Configuration for AWSIoT data plane APIs
        let iotDataConfiguration = AWSServiceConfiguration(region: AWS_REGION,
                                                           endpoint: iotEndPoint,
                                                           credentialsProvider: credentialsProvider)
        //IoTData manager operates on xxxxxxx-iot.<region>.amazonaws.com
        let ioTMQTTConfiguration = AWSIoTMQTTConfiguration()
        ioTMQTTConfiguration.username = "wooj2"
        ioTMQTTConfiguration.password = "<thisIsNotARealPassword>"
        AWSIoTDataManager.register(with: iotDataConfiguration!, with: ioTMQTTConfiguration, forKey: AWS_IOT_DATA_MANAGER_KEY)
        iotDataManager = AWSIoTDataManager(forKey: AWS_IOT_DATA_MANAGER_KEY)
    }

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
