### PR TITLE
feat: Update AWSGoogleSignInProvider to GoogleSignIn Version 5

### DIFF
--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDAuthentication.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDAuthentication.h
@@ -13,60 +13,53 @@
 @protocol GTMFetcherAuthorizationProtocol;
 @class GIDAuthentication;
 
-// @relates GIDAuthentication
-//
-// The callback block that takes a GIDAuthentication, or an error if attempt to refresh was
-// unsuccessful.
+/// The callback block that takes a `GIDAuthentication`, or an error if attempt
+/// to refresh was unsuccessful.
 typedef void (^GIDAuthenticationHandler)(GIDAuthentication *authentication, NSError *error);
 
-// @relates GIDAuthentication
-//
-// The callback block that takes an access token, or an error if attempt to refresh was
-// unsuccessful.
+/// The callback block that takes an access token, or an error if attempt to refresh was
+/// unsuccessful.
 typedef void (^GIDAccessTokenHandler)(NSString *accessToken, NSError *error);
 
-// This class represents the OAuth 2.0 entities needed for sign-in.
-@interface GIDAuthentication : NSObject <NSCoding>
+/// This class represents the OAuth 2.0 entities needed for sign-in.
+@interface GIDAuthentication : NSObject <NSSecureCoding>
 
-// The client ID associated with the authentication.
+/// The client ID associated with the authentication.
 @property(nonatomic, readonly) NSString *clientID;
 
-// The OAuth2 access token to access Google services.
+/// The OAuth2 access token to access Google services.
 @property(nonatomic, readonly) NSString *accessToken;
 
-// The estimated expiration date of the access token.
+/// The estimated expiration date of the access token.
 @property(nonatomic, readonly) NSDate *accessTokenExpirationDate;
 
-// The OAuth2 refresh token to exchange for new access tokens.
+/// The OAuth2 refresh token to exchange for new access tokens.
 @property(nonatomic, readonly) NSString *refreshToken;
 
-// An OpenID Connect ID token that identifies the user. Send this token to your server to
-// authenticate the user there. For more information on this topic, see
-// https://developers.google.com/identity/sign-in/ios/backend-auth
+/// An OpenID Connect ID token that identifies the user. Send this token to your server to
+/// authenticate the user there. For more information on this topic, see
+/// https://developers.google.com/identity/sign-in/ios/backend-auth
 @property(nonatomic, readonly) NSString *idToken;
 
-// The estimated expiration date of the ID token.
+/// The estimated expiration date of the ID token.
 @property(nonatomic, readonly) NSDate *idTokenExpirationDate;
 
-// Gets a new authorizer for GTLService, GTMSessionFetcher, or GTMHTTPFetcher.
+/// Gets a new authorizer for `GTLService`, `GTMSessionFetcher`, or `GTMHTTPFetcher`.
+///
+/// @return A new authorizer
 - (id<GTMFetcherAuthorizationProtocol>)fetcherAuthorizer;
 
-// Get a valid access token and a valid ID token, refreshing them first if they have expired or are
-// about to expire.
+/// Get a valid access token and a valid ID token, refreshing them first if they have expired or are
+/// about to expire.
+///
+/// @param handler A callback block that takes a `GIDAuthentication`, or an
+///                error if attempt to refresh was unsuccessful.
 - (void)getTokensWithHandler:(GIDAuthenticationHandler)handler;
 
-// Refreshes the access token and the ID token using the refresh token.
+/// Refreshes the access token and the ID token using the refresh token.
+///
+/// @param handler A callback block that takes a `GIDAuthentication`, or an
+///                error if attempt to refresh was unsuccessful.
 - (void)refreshTokensWithHandler:(GIDAuthenticationHandler)handler;
-
-// Gets the access token, which may be a new one from the refresh token if the original has already
-// expired or is about to expire. Deprecated: use |getTokensWithHandler:| to get access tokens
-// instead.
-- (void)getAccessTokenWithHandler:(GIDAccessTokenHandler)handler
-    DEPRECATED_MSG_ATTRIBUTE("Use |getTokensWithHandler:| instead.");
-
-// Refreshes the access token with the refresh token. Deprecated: Use |refreshTokensWithHandler:|
-// to refresh access tokens instead.
-- (void)refreshAccessTokenWithHandler:(GIDAccessTokenHandler)handler
-    DEPRECATED_MSG_ATTRIBUTE("Use |refreshTokensWithHandler:| instead.");
 
 @end

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDGoogleUser.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDGoogleUser.h
@@ -13,26 +13,27 @@
 @class GIDAuthentication;
 @class GIDProfileData;
 
-// This class represents a user account.
-@interface GIDGoogleUser : NSObject <NSCoding>
+/// This class represents a user account.
+@interface GIDGoogleUser : NSObject <NSSecureCoding>
 
-// The Google user ID.
+/// The Google user ID.
 @property(nonatomic, readonly) NSString *userID;
 
-// Representation of the Basic profile data. It is only available if |shouldFetchBasicProfile|
-// is set and either |signInWithUser| or |SignIn| has been completed successfully.
+/// Representation of the Basic profile data. It is only available if
+/// `GIDSignIn.shouldFetchBasicProfile` is set and either `-[GIDSignIn signIn]` or
+/// `-[GIDSignIn restorePreviousSignIn]` has been completed successfully.
 @property(nonatomic, readonly) GIDProfileData *profile;
 
-// The authentication object for the user.
+/// The authentication object for the user.
 @property(nonatomic, readonly) GIDAuthentication *authentication;
 
-// The API scopes requested by the app in an array of |NSString|s.
-@property(nonatomic, readonly) NSArray *accessibleScopes;
+/// The API scopes granted to the app in an array of `NSString`.
+@property(nonatomic, readonly) NSArray *grantedScopes;
 
-// For Google Apps hosted accounts, the domain of the user.
+/// For Google Apps hosted accounts, the domain of the user.
 @property(nonatomic, readonly) NSString *hostedDomain;
 
-// An OAuth2 authorization code for the home server.
+/// An OAuth2 authorization code for the home server.
 @property(nonatomic, readonly) NSString *serverAuthCode;
 
 @end

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDProfileData.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDProfileData.h
@@ -10,25 +10,28 @@
 
 #import <Foundation/Foundation.h>
 
-// This class represents the basic profile information of a GIDGoogleUser.
-@interface GIDProfileData : NSObject <NSCoding>
+/// This class represents the basic profile information of a `GIDGoogleUser`.
+@interface GIDProfileData : NSObject <NSCopying, NSSecureCoding>
 
-// The Google user's email.
+/// The Google user's email.
 @property(nonatomic, readonly) NSString *email;
 
-// The Google user's full name.
+/// The Google user's full name.
 @property(nonatomic, readonly) NSString *name;
 
-// The Google user's given name.
+/// The Google user's given name.
 @property(nonatomic, readonly) NSString *givenName;
 
-// The Google user's family name.
+/// The Google user's family name.
 @property(nonatomic, readonly) NSString *familyName;
 
-// Whether or not the user has profile image.
+/// Whether or not the user has profile image.
 @property(nonatomic, readonly) BOOL hasImage;
 
-// Gets the user's profile image URL for the given dimension in pixels for each side of the square.
+/// Gets the user's profile image URL for the given dimension in pixels for each side of the square.
+///
+/// @param dimension The desired height (and width) of the profile image.
+/// @return The URL of the user's profile image.
 - (NSURL *)imageURLWithDimension:(NSUInteger)dimension;
 
 @end

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignIn.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignIn.h
@@ -14,172 +14,157 @@
 @class GIDGoogleUser;
 @class GIDSignIn;
 
-// The error domain for NSErrors returned by the Google Identity SDK.
+/// The error domain for `NSError`s returned by the Google Identity SDK.
 extern NSString *const kGIDSignInErrorDomain;
 
-// A list of potential error codes returned from the Google Identity SDK.
+/// A list of potential error codes returned from the Google Identity SDK.
 typedef NS_ENUM(NSInteger, GIDSignInErrorCode) {
-  // Indicates an unknown error has occured.
+  /// Indicates an unknown error has occurred.
   kGIDSignInErrorCodeUnknown = -1,
-  // Indicates a problem reading or writing to the application keychain.
+  /// Indicates a problem reading or writing to the application keychain.
   kGIDSignInErrorCodeKeychain = -2,
-  // Indicates no appropriate applications are installed on the user's device which can handle
-  // sign-in. This code will only ever be returned if using webview and switching to browser have
-  // both been disabled.
-  kGIDSignInErrorCodeNoSignInHandlersInstalled = -3,
-  // Indicates there are no auth tokens in the keychain. This error code will be returned by
-  // signInSilently if the user has never signed in before with the given scopes, or if they have
-  // since signed out.
+  /// Indicates there are no valid auth tokens in the keychain. This error code will be returned by
+  /// `restorePreviousSignIn` if the user has not signed in before or if they have since signed out.
   kGIDSignInErrorCodeHasNoAuthInKeychain = -4,
-  // Indicates the user canceled the sign in request.
+  /// Indicates the user canceled the sign in request.
   kGIDSignInErrorCodeCanceled = -5,
+  /// Indicates an Enterprise Mobility Management related error has occurred.
+  kGIDSignInErrorCodeEMM = -6,
 };
 
-// A protocol implemented by the delegate of |GIDSignIn| to receive a refresh token or an error.
+/// A protocol implemented by the delegate of `GIDSignIn` to receive a refresh token or an error.
 @protocol GIDSignInDelegate <NSObject>
 
-// The sign-in flow has finished and was successful if |error| is |nil|.
+/// The sign-in flow has finished and was successful if `error` is `nil`.
 - (void)signIn:(GIDSignIn *)signIn
     didSignInForUser:(GIDGoogleUser *)user
            withError:(NSError *)error;
 
 @optional
 
-// Finished disconnecting |user| from the app successfully if |error| is |nil|.
+/// Finished disconnecting `user` from the app successfully if `error` is `nil`.
 - (void)signIn:(GIDSignIn *)signIn
     didDisconnectWithUser:(GIDGoogleUser *)user
                 withError:(NSError *)error;
 
 @end
 
-// A protocol which may be implemented by consumers of |GIDSignIn| to be notified of when
-// GIDSignIn has finished dispatching the sign-in request.
-//
-// This protocol is useful for developers who implement their own "Sign In with Google" button.
-// Because there may be a brief delay between when the call to |signIn| is made, and when the
-// app switch occurs, it is best practice to have the UI react to the user's input by displaying
-// a spinner or other UI element. The |signInWillDispatch| method should be used to
-// stop or hide the spinner.
-@protocol GIDSignInUIDelegate <NSObject>
-
-@optional
-
-// The sign-in flow has finished selecting how to proceed, and the UI should no longer display
-// a spinner or other "please wait" element.
-- (void)signInWillDispatch:(GIDSignIn *)signIn error:(NSError *)error;
-
-// If implemented, this method will be invoked when sign in needs to display a view controller.
-// The view controller should be displayed modally (via UIViewController's |presentViewController|
-// method, and not pushed unto a navigation controller's stack.
-- (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController;
-
-// If implemented, this method will be invoked when sign in needs to dismiss a view controller.
-// Typically, this should be implemented by calling |dismissViewController| on the passed
-// view controller.
-- (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController;
-
-@end
-
-// This class signs the user in with Google. It also provides single sign-on via a capable Google
-// app if one is installed.
-//
-// For reference, please see "Google Sign-In for iOS" at
-// https://developers.google.com/identity/sign-in/ios
-// Here is sample code to use |GIDSignIn|:
-// 1. Get a reference to the |GIDSignIn| shared instance:
-//    GIDSignIn *signIn = [GIDSignIn sharedInstance];
-// 2. Set the OAuth 2.0 scopes you want to request:
-//    [signIn setScopes:[NSArray arrayWithObject:@"https://www.googleapis.com/auth/plus.login"]];
-// 3. Call [signIn setDelegate:self];
-// 4. Set up delegate method |signIn:didSignInForUser:withError:|.
-// 5. Call |handleURL| on the shared instance from |application:openUrl:...| in your app delegate.
-// 6. Call |signIn| on the shared instance;
+/// This class signs the user in with Google. It also provides single sign-on via a capable Google
+/// app if one is installed.
+///
+/// For reference, please see "Google Sign-In for iOS" at
+/// https://developers.google.com/identity/sign-in/ios
+///
+/// Here is sample code to use `GIDSignIn`:
+/// 1. Get a reference to the `GIDSignIn` shared instance:
+///    ```
+///    GIDSignIn *signIn = [GIDSignIn sharedInstance];
+///    ```
+/// 2. Call `[signIn setDelegate:self]`;
+/// 3. Set up delegate method `signIn:didSignInForUser:withError:`.
+/// 4. Call `handleURL` on the shared instance from `application:openUrl:...` in your app delegate.
+/// 5. Call `signIn` on the shared instance;
 @interface GIDSignIn : NSObject
 
-// The authentication object for the current user, or |nil| if there is currently no logged in user.
+/// The authentication object for the current user, or `nil` if there is currently no logged in
+/// user.
 @property(nonatomic, readonly) GIDGoogleUser *currentUser;
 
-// The object to be notified when authentication is finished.
+/// The object to be notified when authentication is finished.
 @property(nonatomic, weak) id<GIDSignInDelegate> delegate;
 
-// The object to be notified when sign in dispatch selection is finished.
-@property(nonatomic, weak) id<GIDSignInUIDelegate> uiDelegate;
+/// The view controller used to present `SFSafariViewContoller` on iOS 9 and 10.
+@property(nonatomic, weak) UIViewController *presentingViewController;
 
-// The client ID of the app from the Google APIs console.  Must set for sign-in to work.
+/// The client ID of the app from the Google APIs console.  Must set for sign-in to work.
 @property(nonatomic, copy) NSString *clientID;
 
-// The API scopes requested by the app in an array of |NSString|s.  The default value is |@[]|.
-//
-// This property is optional. If you set it, set it before calling |signIn|.
+/// The API scopes requested by the app in an array of `NSString`s.  The default value is `@[]`.
+///
+/// This property is optional. If you set it, set it before calling `signIn`.
 @property(nonatomic, copy) NSArray *scopes;
 
-// Whether or not to fetch basic profile data after signing in. The data is saved in the
-// |GIDGoogleUser.profileData| object.
-//
-// Setting the flag will add "email" and "profile" to scopes.
-// Defaults to |YES|.
+/// Whether or not to fetch basic profile data after signing in. The data is saved in the
+/// `GIDGoogleUser.profileData` object.
+///
+/// Setting the flag will add "email" and "profile" to scopes.
+/// Defaults to `YES`.
 @property(nonatomic, assign) BOOL shouldFetchBasicProfile;
 
-// The language for sign-in, in the form of ISO 639-1 language code optionally followed by a dash
-// and ISO 3166-1 alpha-2 region code, such as |@"it"| or |@"pt-PT"|. Only set if different from
-// system default.
-//
-// This property is optional. If you set it, set it before calling |signIn|.
+/// The language for sign-in, in the form of ISO 639-1 language code optionally followed by a dash
+/// and ISO 3166-1 alpha-2 region code, such as `@"it"` or `@"pt-PT"`. Only set if different from
+/// system default.
+///
+/// This property is optional. If you set it, set it before calling `signIn`.
 @property(nonatomic, copy) NSString *language;
 
-// The login hint to the authorization server, for example the user's ID, or email address,
-// to be prefilled if possible.
-//
-// This property is optional. If you set it, set it before calling |signIn|.
+/// The login hint to the authorization server, for example the user's ID, or email address,
+/// to be prefilled if possible.
+///
+/// This property is optional. If you set it, set it before calling `signIn`.
 @property(nonatomic, copy) NSString *loginHint;
 
-// The client ID of the home web server.  This will be returned as the |audience| property of the
-// OpenID Connect ID token.  For more info on the ID token:
-// https://developers.google.com/identity/sign-in/ios/backend-auth
-//
-// This property is optional. If you set it, set it before calling |signIn|.
+/// The client ID of the home web server.  This will be returned as the `audience` property of the
+/// OpenID Connect ID token.  For more info on the ID token:
+/// https://developers.google.com/identity/sign-in/ios/backend-auth
+///
+/// This property is optional. If you set it, set it before calling `signIn`.
 @property(nonatomic, copy) NSString *serverClientID;
 
-// The OpenID2 realm of the home web server. This allows Google to include the user's OpenID
-// Identifier in the OpenID Connect ID token.
-//
-// This property is optional. If you set it, set it before calling |signIn|.
+/// The OpenID2 realm of the home web server. This allows Google to include the user's OpenID
+/// Identifier in the OpenID Connect ID token.
+///
+/// This property is optional. If you set it, set it before calling `signIn`.
 @property(nonatomic, copy) NSString *openIDRealm;
 
-// The Google Apps domain to which users must belong to sign in.  To verify, check |GIDGoogleUser|'s
-// |hostedDomain| property.
-//
-// This property is optional. If you set it, set it before calling |signIn|.
+/// The Google Apps domain to which users must belong to sign in.  To verify, check
+/// `GIDGoogleUser`'s `hostedDomain` property.
+///
+/// This property is optional. If you set it, set it before calling `signIn`.
 @property(nonatomic, copy) NSString *hostedDomain;
 
-// Returns a shared |GIDSignIn| instance.
+/// Returns a shared `GIDSignIn` instance.
 + (GIDSignIn *)sharedInstance;
 
-// This method should be called from your |UIApplicationDelegate|'s
-// |application:openURL:sourceApplication:annotation|.  Returns |YES| if |GIDSignIn| handled this
-// URL.
-- (BOOL)handleURL:(NSURL *)url
-    sourceApplication:(NSString *)sourceApplication
-           annotation:(id)annotation;
+/// Unavailable. Use `sharedInstance` to instantiate `GIDSignIn`.
++ (instancetype)new NS_UNAVAILABLE;
 
-// Checks whether the user has either currently signed in or has previous authentication saved in
-// keychain.
-- (BOOL)hasAuthInKeychain;
+/// Unavailable. Use `sharedInstance` to instantiate `GIDSignIn`.
+- (instancetype)init NS_UNAVAILABLE;
 
-// Attempts to sign in a previously authenticated user without interaction.  The delegate will be
-// called at the end of this process indicating success or failure.
-- (void)signInSilently;
+/// This method should be called from your `UIApplicationDelegate`'s `application:openURL:options`
+/// and `application:openURL:sourceApplication:annotation` method(s).
+///
+/// @param url The URL that was passed to the app.
+/// @return `YES` if `GIDSignIn` handled this URL.
+- (BOOL)handleURL:(NSURL *)url;
 
-// Starts the sign-in process.  The delegate will be called at the end of this process.  Note that
-// this method should not be called when the app is starting up, (e.g in
-// application:didFinishLaunchingWithOptions:). Instead use the |signInSilently| method.
+/// Checks if there is a previously authenticated user saved in keychain.
+///
+/// @return `YES` if there is a previously authenticated user saved in keychain.
+- (BOOL)hasPreviousSignIn;
+
+/// Attempts to restore a previously authenticated user without interaction.
+
+/// The delegate will be
+/// called at the end of this process indicating success or failure.  The current values of
+/// `GIDSignIn`'s configuration properties will not impact the restored user.
+- (void)restorePreviousSignIn;
+
+/// Starts an interactive sign-in flow using `GIDSignIn`'s configuration properties.
+///
+/// The delegate
+/// will be called at the end of this process.  Any saved sign-in state will be replaced by the
+/// result of this flow.  Note that this method should not be called when the app is starting up,
+/// (e.g in `application:didFinishLaunchingWithOptions:`); instead use the `restorePreviousSignIn`
+/// method to restore a previous sign-in.
 - (void)signIn;
 
-// Marks current user as being in the signed out state.
+/// Marks current user as being in the signed out state.
 - (void)signOut;
 
-// Disconnects the current user from the app and revokes previous authentication. If the operation
-// succeeds, the OAuth 2.0 token is also removed from keychain.
+/// Disconnects the current user from the app and revokes previous authentication. If the operation
+/// succeeds, the OAuth 2.0 token is also removed from keychain.
 - (void)disconnect;
 
 @end

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignInButton.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignInButton.h
@@ -10,42 +10,44 @@
 
 #import <UIKit/UIKit.h>
 
-// The various layout styles supported by the GIDSignInButton.
-// The minimum size of the button depends on the language used for text.
-// The following dimensions (in points) fit for all languages:
-// kGIDSignInButtonStyleStandard: 230 x 48
-// kGIDSignInButtonStyleWide:     312 x 48
-// kGIDSignInButtonStyleIconOnly: 48 x 48 (no text, fixed size)
+/// The layout styles supported by the `GIDSignInButton`.
+///
+/// The minimum size of the button depends on the language used for text.
+/// The following dimensions (in points) fit for all languages:
+/// - kGIDSignInButtonStyleStandard: 230 x 48
+/// - kGIDSignInButtonStyleWide:     312 x 48
+/// - kGIDSignInButtonStyleIconOnly: 48 x 48 (no text, fixed size)
 typedef NS_ENUM(NSInteger, GIDSignInButtonStyle) {
   kGIDSignInButtonStyleStandard = 0,
   kGIDSignInButtonStyleWide = 1,
   kGIDSignInButtonStyleIconOnly = 2
 };
 
-// The various color schemes supported by the GIDSignInButton.
+/// The color schemes supported by the `GIDSignInButton`.
 typedef NS_ENUM(NSInteger, GIDSignInButtonColorScheme) {
   kGIDSignInButtonColorSchemeDark = 0,
   kGIDSignInButtonColorSchemeLight = 1
 };
 
-// This class provides the "Sign in with Google" button. You can instantiate this
-// class programmatically or from a NIB file.  You should set up the
-// |GIDSignIn| shared instance with your client ID and any additional scopes,
-// implement the delegate methods for |GIDSignIn|, and add this button to your
-// view hierarchy.
+/// This class provides the "Sign in with Google" button.
+///
+/// You can instantiate this class programmatically or from a NIB file. You
+/// should set up the `GIDSignIn` shared instance with your client ID and any
+/// additional scopes, implement the delegate methods for `GIDSignIn`, and add
+/// this button to your view hierarchy.
 @interface GIDSignInButton : UIControl
 
-// The layout style for the sign-in button.
-// Possible values:
-// - kGIDSignInButtonStyleStandard: 230 x 48 (default)
-// - kGIDSignInButtonStyleWide:     312 x 48
-// - kGIDSignInButtonStyleIconOnly: 48 x 48 (no text, fixed size)
+/// The layout style for the sign-in button.
+/// Possible values:
+/// - kGIDSignInButtonStyleStandard: 230 x 48 (default)
+/// - kGIDSignInButtonStyleWide:     312 x 48
+/// - kGIDSignInButtonStyleIconOnly: 48 x 48 (no text, fixed size)
 @property(nonatomic, assign) GIDSignInButtonStyle style;
 
-// The color scheme for the sign-in button.
-// Possible values:
-// - kGIDSignInButtonColorSchemeDark
-// - kGIDSignInButtonColorSchemeLight (default)
+/// The color scheme for the sign-in button.
+/// Possible values:
+/// - kGIDSignInButtonColorSchemeDark
+/// - kGIDSignInButtonColorSchemeLight (default)
 @property(nonatomic, assign) GIDSignInButtonColorScheme colorScheme;
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New features
 
 - **AWSAuthSDK**
-  - **Breaking Change** Updated AWSGoogleSignInProvider to GoogleSignIn Version 5.0.2. This change requires any app that uses GoogleSignIn to update the framework to version 5.0.2. (See [PR #2836](https://github.com/aws-amplify/aws-sdk-ios/pull/2836)) Thanks, [@cornr](https://github.com/cornr)!
+  - **Breaking Change** Updated AWSGoogleSignInProvider to GoogleSignIn Version 5.0.2. This change requires any app that uses GoogleSignIn to update the framework to version 5.0.2. (See [PR #2851](https://github.com/aws-amplify/aws-sdk-ios/pull/2851)) Thanks, [@cornr](https://github.com/cornr)!
 
 ## 2.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New features
 
 - **AWSAuthSDK**
-  - **Breaking Change** Updated AWSGoogleSignInProvider to GoogleSignIn Version 5.0.2. This change requires any app that uses GoogleSignIn to update the framework to version 5.0.2. (See [PR #2851](https://github.com/aws-amplify/aws-sdk-ios/pull/2851)) Thanks, [@cornr](https://github.com/cornr)!
+  - **Breaking Change** Updated AWSGoogleSignInProvider to GoogleSignIn Version 5.0.2. This change requires any app that uses GoogleSignIn to update the framework to version 5.0.2. (See [Issue #1993](https://github.com/aws-amplify/aws-sdk-ios/issues/1993) and [PR #2851](https://github.com/aws-amplify/aws-sdk-ios/pull/2851)) Thanks, [@cornr](https://github.com/cornr)!
 
 ## 2.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
--Features for next release
+
+### New features
+
+- **AWSAuthSDK**
+  - **Breaking Change** Updated AWSGoogleSignInProvider to GoogleSignIn Version 5.0.2. This change requires any app that uses GoogleSignIn to update the framework to version 5.0.2. (See [PR #2836](https://github.com/aws-amplify/aws-sdk-ios/pull/2836)) Thanks, [@cornr](https://github.com/cornr)!
 
 ## 2.14.2
 


### PR DESCRIPTION
* Update AWSGoogleSignInProvider to current GoogleSignIn API > 5.0
* Cleaner API Usage of GIDSignIn

BREAKING CHANGE: Any app using GoogleSignIn must update the framework to
version 5.0.2

*Issue #, if available:* #1993

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
