### PR TITLE
bug(auth): Fix drop-in ui button background issue

### DIFF
--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -417,9 +417,7 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         UIButton *btn = buttons[[buttonViews indexOfObject:signInButtonViewClass]];
         UIView<AWSSignInButtonView> *buttonView = [[signInButtonViewClass alloc] initWithFrame:CGRectMake(0, 0, btn.frame.size.width, btn.frame.size.height)];
         buttonView.buttonStyle = AWSSignInButtonStyleLarge;
-        if (self.config.secondaryBackgroundColor) {
-            buttonView.backgroundColor = self.config.secondaryBackgroundColor;
-        }
+        buttonView.backgroundColor = [AWSAuthUIHelper getSecondaryBackgroundColor];
         buttonView.delegate = self;
         
         [btn addSubview:buttonView];

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -417,8 +417,8 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
         UIButton *btn = buttons[[buttonViews indexOfObject:signInButtonViewClass]];
         UIView<AWSSignInButtonView> *buttonView = [[signInButtonViewClass alloc] initWithFrame:CGRectMake(0, 0, btn.frame.size.width, btn.frame.size.height)];
         buttonView.buttonStyle = AWSSignInButtonStyleLarge;
-        if (self.config.primaryColor) {
-            buttonView.backgroundColor = self.config.primaryColor;
+        if (self.config.secondaryBackgroundColor) {
+            buttonView.backgroundColor = self.config.secondaryBackgroundColor;
         }
         buttonView.delegate = self;
         


### PR DESCRIPTION
Reported here:
https://github.com/aws-amplify/aws-sdk-ios/issues/2844

It seems that we were setting the primary color to the background color instead of the secondary color.

The following screenshot corresponds to using the following code:
```
        let signInUIOptions = SignInUIOptions(canCancel: false,
                                     logoImage: UIImage( named:"loginViewIcon") ,
                                     backgroundColor: UIColor.systemGreen,
                                     primaryColor: UIColor.systemRed)
```
![Screen Shot 2020-07-10 at 3 09 16 PM](https://user-images.githubusercontent.com/1911939/87206813-5fcc7b80-c2bf-11ea-84d7-50903f1443b1.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
