### PR TITLE
chore: Deprecate AWSiOSSDKv2 aggregate pod in favor of Amplify

### DIFF
--- a/AWSCognitoSync.podspec
+++ b/AWSCognitoSync.podspec
@@ -4,7 +4,9 @@ Pod::Spec.new do |s|
   s.version      = '2.14.2'
   s.summary      = 'Amazon Cognito SDK for iOS'
 
-  s.description  = 'Amazon Cognito offers multi device data synchronization with offline access'
+  s.deprecated = true
+  s.deprecated_in_favor_of = 'Amplify'
+  s.description  = 'This framework is deprecated. Use Amplify DataStore for synchronizing app data, and Amplify Auth for authentication and authorization.'
 
   s.homepage     = 'http://aws.amazon.com/cognito'
   s.license      = 'Apache License, Version 2.0'
@@ -15,7 +17,4 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.library      = 'sqlite3'
   s.dependency 'AWSCognito', '2.14.2'
-
-  s.deprecated = true
-  s.deprecated_in_favor_of = 'AWSCognito'
 end

--- a/AWSMobileAnalytics.podspec
+++ b/AWSMobileAnalytics.podspec
@@ -3,7 +3,9 @@ Pod::Spec.new do |s|
   s.version      = '2.14.2'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
-  s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
+  s.deprecated = true
+  s.deprecated_in_favor_of = 'Amplify'
+  s.description  = 'This framework is deprecated. Use Amplify Analytics or AWSPinpoint.'
 
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
@@ -16,6 +18,4 @@ Pod::Spec.new do |s|
   s.source_files = 'AWSMobileAnalytics/*.{h,m}', 'AWSMobileAnalytics/**/*.{h,m}'
   s.private_header_files = 'AWSMobileAnalytics/Internal/*.h'
 
-  s.deprecated = true
-  s.deprecated_in_favor_of = 'AWSPinpoint'
 end

--- a/AWSiOSSDKv2.podspec
+++ b/AWSiOSSDKv2.podspec
@@ -4,7 +4,9 @@ Pod::Spec.new do |s|
   s.version      = '2.14.2'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
-  s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
+  s.deprecated = true
+  s.deprecated_in_favor_of = 'Amplify'
+  s.description  = 'This pod is deprecated. Use Amplify for iOS to build fullstack iOS apps, or use individual AWS Mobile SDK pods for individual services.'
 
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'


### PR DESCRIPTION
Deprecated the aggregate pod and updated AWSMobileAnalytics and AWSCognitoSync with deprecation messages referring customers to Amplify. We've discussed the deprecation messages internally and agreed that they are fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
