### PR TITLE
Add username and password to MQTT ioTMQTTConfiguration for enhanced custom authorizer

### DIFF
--- a/AWSIoT/AWSIoTDataManager.h
+++ b/AWSIoT/AWSIoTDataManager.h
@@ -105,6 +105,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign, readonly) NSUInteger publishRetryThrottle;
 
 /**
+ MQTT username used to construct the MQTT username field for enhanced custom authentication use case:
+ https://docs.aws.amazon.com/iot/latest/developerguide/enhanced-custom-auth-using.html#enhanced-custom-auth-using-mqtt
+ **/
+@property (nonatomic, copy) NSString *username;
+
+/**
+ MQTT password used for the MQTT password field for enhanced custom authentication use case:
+ https://docs.aws.amazon.com/iot/latest/developerguide/enhanced-custom-auth-using.html#enhanced-custom-auth-using-mqtt
+ **/
+@property (nonatomic, copy) NSString *password;
+
+
+/**
  Create an AWSIoTMQTTConfiguration object and initialize its parameters.
  The AWSIoTMQTTConfiguration object is then passed to AWSIoTDataManager to initialize it.
  Note, clients need to either specify all parameters explicitly or not customize any

--- a/AWSIoT/AWSIoTDataManager.m
+++ b/AWSIoT/AWSIoTDataManager.m
@@ -335,9 +335,8 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 }
 
 - (nonnull NSString*)baseUserMetaDataString:(nullable NSString*)username {
-    return username.length
-    ? [NSString stringWithFormat:@"%@%@%@", username, @"?SDK=iOS&Version=", AWSIoTSDKVersion]
-    : [NSString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
+    NSString *usernameComponent = username.length ? username : @"";
+    return [NSString stringWithFormat:@"%@?SDK=iOS&Version=%@", usernameComponent, AWSIoTSDKVersion];
 }
 
 - (void)enableMetricsCollection:(BOOL)enabled {

--- a/AWSIoT/AWSIoTDataManager.m
+++ b/AWSIoT/AWSIoTDataManager.m
@@ -323,13 +323,21 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         if(_mqttClient == nil){
             AWSDDLogError(@"**** mqttClient is nil. **** ");
         }
-        _mqttClient.userMetaData = [NSString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
+
+        _mqttClient.userMetaData = [self baseUserMetaDataString:mqttConfig.username];
+        _mqttClient.password = mqttConfig.password.length ? mqttConfig.password : @"";
         _userMetaDataDict = [[NSMutableDictionary alloc] init];
         _mqttClient.associatedObject = self;
         _userDidIssueDisconnect = NO;
         _userDidIssueConnect = NO;
     }
     return self;
+}
+
+- (nonnull NSString*)baseUserMetaDataString:(nullable NSString*)username {
+    return username.length
+    ? [NSString stringWithFormat:@"%@%@%@", username, @"?SDK=iOS&Version=", AWSIoTSDKVersion]
+    : [NSString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
 }
 
 - (void)enableMetricsCollection:(BOOL)enabled {
@@ -368,7 +376,8 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
     }
 
     // validate the length of username field
-    NSMutableString *userMetaDataString = [NSMutableString stringWithFormat:@"%@%@", @"?SDK=iOS&Version=", AWSIoTSDKVersion];
+    NSMutableString *userMetaDataString = [[self baseUserMetaDataString:self.mqttConfiguration.username] mutableCopy];
+    
     NSUInteger baseLength = [userMetaDataString length];
 
     // Append each of the user-specified key-value pair to the connection username

--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -90,7 +90,7 @@
 
 @property(atomic, assign) BOOL isMetricsEnabled;
 @property(atomic, assign) NSUInteger publishRetryThrottle;
-@property(atomic, strong) NSString *userMetaData;
+@property(atomic, copy) NSString *userMetaData;
 @property(atomic, copy) NSString *password;
 
 /**

--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -91,6 +91,7 @@
 @property(atomic, assign) BOOL isMetricsEnabled;
 @property(atomic, assign) NSUInteger publishRetryThrottle;
 @property(atomic, strong) NSString *userMetaData;
+@property(atomic, copy) NSString *password;
 
 /**
  The client ID for the current connection; can be nil if not connected.

--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -299,7 +299,7 @@
     if (self.session == nil ) {
         self.session= [[AWSMQTTSession alloc] initWithClientId:self.clientId
                                                userName:self.userMetaData
-                                               password:@""
+                                               password:self.password
                                               keepAlive:self.keepAliveInterval
                                            cleanSession:self.cleanSession
                                               willTopic:self.lastWillAndTestamentTopic
@@ -556,7 +556,7 @@
     if (self.session == nil ) {
         self.session = [[AWSMQTTSession alloc] initWithClientId:self.clientId
                                                        userName:self.userMetaData
-                                                       password:@""
+                                                       password:self.password
                                                       keepAlive:self.keepAliveInterval
                                                    cleanSession:self.cleanSession
                                                       willTopic:self.lastWillAndTestamentTopic

--- a/AWSIoTUnitTests/AWSIoTDataUnitTests.m
+++ b/AWSIoTUnitTests/AWSIoTDataUnitTests.m
@@ -164,6 +164,30 @@ static id mockNetworking = nil;
 
 }
 
+-(void)testRegisterIoTDataManagerWithConfigurationUserNamePasswordWithMQTTConfiguration {
+    NSString *key = @"testRegisterIoTDataManagerWithMQTTConfigurationUserNamePassword";
+    AWSCognitoCredentialsProvider *credentialsProvider =
+    [[AWSCognitoCredentialsProvider alloc] initWithRegionType:AWSRegionUSWest2
+                                               identityPoolId:@"TESTCognitoPoolID"];
+    AWSServiceConfiguration *configuration =
+    [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSWest2
+                                           endpoint:[[AWSEndpoint alloc] initWithURLString:@"TESTENDPOINT.iot.amazonaws.com"]
+                                credentialsProvider:credentialsProvider];
+    
+    AWSIoTMQTTConfiguration *mqttConfig = [[AWSIoTMQTTConfiguration alloc] init];
+    mqttConfig.username = @"testUserName";
+    mqttConfig.password = @"testPassword";
+    
+    [AWSIoTDataManager registerIoTDataManagerWithConfiguration:configuration
+                                         withMQTTConfiguration:mqttConfig
+                                                        forKey:key];
+    AWSIoTDataManager *dm = [AWSIoTDataManager IoTDataManagerForKey:@"testRegisterIoTDataManagerWithMQTTConfigurationUserNamePassword"];
+    XCTAssertNotNil(dm);
+    XCTAssertEqual(dm.configuration.regionType, AWSRegionUSWest2);
+    XCTAssertEqual(dm.mqttConfiguration.username, @"testUserName");
+    XCTAssertEqual(dm.mqttConfiguration.password, @"testPassword");
+}
+
 - (void)testDeleteThingShadow {
     NSString *key = @"testDeleteThingShadow";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];


### PR DESCRIPTION
To use this:
```
        let ioTMQTTConfiguration = AWSIoTMQTTConfiguration()
        ioTMQTTConfiguration.username = "<YOURUSERNAMEHERE>"
        ioTMQTTConfiguration.password = "<YOURPASSWORDHERE>"
        AWSIoTDataManager.register(with: iotDataConfiguration!, with: ioTMQTTConfiguration, forKey: AWS_IOT_DATA_MANAGER_KEY)
        iotDataManager = AWSIoTDataManager(forKey: AWS_IOT_DATA_MANAGER_KEY)
```

As a result, when connecting over a websocket & mqtt, the username and password will be sent with the MQTT hello message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
