### PR TITLE
fix(pinpoint): remove global event source attributes on session end

### DIFF
--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -289,11 +289,11 @@ NSObject *sessionLock;
         _session = nil;
     }
 
-    return [self.context.analyticsClient recordEvent:stopEvent];
-
     //Remove global event source attributes
     AWSDDLogVerbose(@"Removed global event source attributes");
     [self.context.analyticsClient removeAllGlobalEventSourceAttributes];
+
+    return [self.context.analyticsClient recordEvent:stopEvent];
 }
 
 - (void) endCurrentSessionWithBlock:(AWSPinpointTimeoutBlock) block {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-ios/issues/2650

bug was introduced in [2.6.34](https://github.com/aws-amplify/aws-sdk-ios/commit/aeb130753243778f373add44e2fa68ef42958064)

*Description of changes:*
The global source attributes were not being removed on session end. When handling notifications, `addGlobalEventSourceMetadata` is called on `open` and `background` push types. This means that a session event will be associated with the related campaign/journey data retrieved from the global event attributes. By not removing the global attributes, the new session will have the attributes additionally associated with the new session resulting in multiple  sessions associated with the same campaign/journey.

*Testing done:*
Manual test with the previous code: trigger a notification through pinpoint campaign, have the app in the background to receive it, tap on the notification to bring app to foreground, ensure that the global attributes are added. bring the app to the background. open the app to start a new session and check that the new session has the campaign associated with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
