### PR TITLE
fix(AWSMobileClient): Crash while accessing user attributes/password without signed in to Cognito User Pool

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -737,7 +737,7 @@ extension AWSMobileClient {
         case .userPools, .hostedUI:
             break
         default:
-            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in, please sign in to use this API."))
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         
@@ -812,7 +812,11 @@ extension AWSMobileClient {
 
 //MARK: Extension to hold user attribute operations
 extension AWSMobileClient {
-    
+
+    var notSignedInErrorMessage: String {
+        return "User is not signed in to Cognito User Pool, please sign in to use this API."
+    }
+
     /// Verify a user attribute like phone_number.
     ///
     /// - Parameters:
@@ -821,7 +825,7 @@ extension AWSMobileClient {
     public func verifyUserAttribute(attributeName: String,
                                     completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
-            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
@@ -836,7 +840,7 @@ extension AWSMobileClient {
     public func updateUserAttributes(attributeMap: [String: String],
                                      completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
-            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
@@ -848,7 +852,7 @@ extension AWSMobileClient {
     /// - Parameter completionHandler: completion handler which will be invoked when result is available.
     public func getUserAttributes(completionHandler: @escaping (([String: String]?, Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
-            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
@@ -863,7 +867,7 @@ extension AWSMobileClient {
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func confirmUpdateUserAttributes(attributeName: String, code: String, completionHandler: @escaping ((Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
-            completionHandler(AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            completionHandler(AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         self.confirmVerifyUserAttribute(attributeName: attributeName, code: code, completionHandler: completionHandler)
@@ -877,7 +881,7 @@ extension AWSMobileClient {
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func confirmVerifyUserAttribute(attributeName: String, code: String, completionHandler: @escaping ((Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
-            completionHandler(AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            completionHandler(AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
@@ -905,7 +909,7 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
             return
         }
         if (self.federationProvider != .userPools) {
-            passwordAuthenticationCompletionSource.set(error: AWSMobileClientError.notSignedIn(message: "User is not signed in, please sign in to use this API."))
+            passwordAuthenticationCompletionSource.set(error: AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
         }
         switch self.currentUserState {
         case .signedIn, .signedOutUserPoolsTokenInvalid:

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -820,6 +820,10 @@ extension AWSMobileClient {
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func verifyUserAttribute(attributeName: String,
                                     completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
+        guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            return
+        }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
         userDetails.verifyUserAttribute(attributeName: attributeName, completionHandler: completionHandler)
     }
@@ -831,6 +835,10 @@ extension AWSMobileClient {
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func updateUserAttributes(attributeMap: [String: String],
                                      completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
+        guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            return
+        }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
         userDetails.updateUserAttributes(attributeMap: attributeMap, completionHandler: completionHandler)
     }
@@ -839,6 +847,10 @@ extension AWSMobileClient {
     ///
     /// - Parameter completionHandler: completion handler which will be invoked when result is available.
     public func getUserAttributes(completionHandler: @escaping (([String: String]?, Error?) -> Void)) {
+        guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            return
+        }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
         userDetails.getUserAttributes(completionHandler: completionHandler)
     }
@@ -850,6 +862,10 @@ extension AWSMobileClient {
     ///   - code: the code sent to the user.
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func confirmUpdateUserAttributes(attributeName: String, code: String, completionHandler: @escaping ((Error?) -> Void)) {
+        guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
+            completionHandler(AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            return
+        }
         self.confirmVerifyUserAttribute(attributeName: attributeName, code: code, completionHandler: completionHandler)
     }
     
@@ -860,6 +876,10 @@ extension AWSMobileClient {
     ///   - code: the code sent to the user.
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func confirmVerifyUserAttribute(attributeName: String, code: String, completionHandler: @escaping ((Error?) -> Void)) {
+        guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
+            completionHandler(AWSMobileClientError.notSignedIn(message: "User is not signed in to Cognito User Pool, please sign in to use this API."))
+            return
+        }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
         userDetails.confirmVerifyUserAttribute(attributeName: attributeName,
                                                code: code,


### PR DESCRIPTION

*Issue: https://github.com/aws-amplify/amplify-ios/issues/627

*Description of changes:* 

User attributes and password can only be accessed or modified when the user is signed in to the Cognito User Pools. This change returns an error back in the callback if we try to access these apis while not signed in to user pools.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
