### PR TITLE
Replace block type alias borrowed from AVAudioSession with block sign…

### DIFF
--- a/AWSLex/AWSLexInteractionKit.h
+++ b/AWSLex/AWSLexInteractionKit.h
@@ -516,7 +516,7 @@ typedef NS_ENUM(NSInteger, AWSLexSpeechEncoding) {
 /**
  Request record permission to AVAudioSession.
  */
-- (void)requestRecordPermission:(PermissionBlock)response;
+- (void)requestRecordPermission:(void (^)(BOOL granted))response;
 
 /**
  Start observing for AVAudioSessionRouteChangeNotification if not already started.

--- a/AWSLex/AWSLexInteractionKit.m
+++ b/AWSLex/AWSLexInteractionKit.m
@@ -1000,7 +1000,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
     [session overrideOutputAudioPort:portOverride error:outError];
 }
 
-- (void)requestRecordPermission:(PermissionBlock)response {
+- (void)requestRecordPermission:(void (^)(BOOL granted))response {
     AVAudioSession *session = [AVAudioSession sharedInstance];
     [session requestRecordPermission:response];
 }


### PR DESCRIPTION
…ature. Removed in iOS 14.

*Issue #, if available:*
In iOS 14 the block type alias in `AVAudioSession.requestRecordPermission` was removed and replaced with the block signature (see: https://developer.apple.com/documentation/avfoundation/avaudiosession). This change causes the build to fail under iOS 14 beta 1 and beta 2. 

*Description of changes:*
I've replaced the removed block type alias with it's signature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
