### PR TITLE
[AWSMobileClient] Support ClientMetaData in verifyUserAttribute, resendSignUpCode, updateUserAttributes

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -407,18 +407,24 @@ extension AWSMobileClient {
     ///
     /// - Parameters:
     ///   - username: username of the user who wants a new registration code.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when a result is available.
-    public func resendSignUpCode(username: String, completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+    public func resendSignUpCode(username: String,
+                                 clientMetaData: [String:String] = [:],
+                                 completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
         if let uname = self.userpoolOpsHelper.signUpUser?.username, uname == username {
-            resendSignUpCode(user: self.userpoolOpsHelper.signUpUser!, completionHandler: completionHandler)
+            resendSignUpCode(user: self.userpoolOpsHelper.signUpUser!, clientMetaData: clientMetaData, completionHandler: completionHandler)
         } else {
             let user = self.userPoolClient?.getUser(username)
-            resendSignUpCode(user: user!, completionHandler: completionHandler)
+            resendSignUpCode(user: user!, clientMetaData: clientMetaData, completionHandler: completionHandler)
         }
     }
     
-    internal func resendSignUpCode(user: AWSCognitoIdentityUser, completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
-        user.resendConfirmationCode().continueWith(block: { (task) -> Any? in
+    internal func resendSignUpCode(user: AWSCognitoIdentityUser,
+                                   clientMetaData: [String:String] = [:],
+                                   completionHandler: @escaping ((SignUpResult?, Error?) -> Void)) {
+        user.resendConfirmationCode(clientMetaData).continueWith(block: { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let result = task.result {
@@ -821,30 +827,36 @@ extension AWSMobileClient {
     ///
     /// - Parameters:
     ///   - attributeName: name of the attribute.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func verifyUserAttribute(attributeName: String,
+                                    clientMetaData: [String:String] = [:],
                                     completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
             completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
-        userDetails.verifyUserAttribute(attributeName: attributeName, completionHandler: completionHandler)
+        userDetails.verifyUserAttribute(attributeName: attributeName, clientMetaData: clientMetaData, completionHandler: completionHandler)
     }
     
     /// Update the attributes for a user.
     ///
     /// - Parameters:
     ///   - attributeMap: the attribute map of the user.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
     public func updateUserAttributes(attributeMap: [String: String],
+                                     clientMetaData: [String:String] = [:],
                                      completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
             completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
         let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
-        userDetails.updateUserAttributes(attributeMap: attributeMap, completionHandler: completionHandler)
+        userDetails.updateUserAttributes(attributeMap: attributeMap, clientMetaData: clientMetaData, completionHandler: completionHandler)
     }
     
     /// Fetches the attributes for logged in user.

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSMobileClientUserDetails.swift
@@ -33,9 +33,14 @@ internal class AWSMobileClientUserDetails {
     ///
     /// - Parameters:
     ///   - attributeName: name of the attribute.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
-    public func verifyUserAttribute(attributeName: String, completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
-        self.cognitoIdentityUser.getAttributeVerificationCode(attributeName).continueWith { (task) -> Any? in
+    public func verifyUserAttribute(attributeName: String,
+                                    clientMetaData: [String:String] = [:],
+                                    completionHandler: @escaping ((UserCodeDeliveryDetails?, Error?) -> Void)) {
+        self.cognitoIdentityUser.getAttributeVerificationCode(attributeName,
+                                                              clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let result = task.result {
@@ -53,10 +58,12 @@ internal class AWSMobileClientUserDetails {
     ///
     /// - Parameters:
     ///   - attributeMap: the attribute map of the user.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when the result is avilable.
-    public func updateUserAttributes(attributeMap: [String: String], completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
+    public func updateUserAttributes(attributeMap: [String: String], clientMetaData: [String:String] = [:], completionHandler: @escaping (([UserCodeDeliveryDetails]?, Error?) -> Void)) {
         let attributes = attributeMap.map {AWSCognitoIdentityUserAttributeType.init(name: $0, value: $1) }
-        self.cognitoIdentityUser.update(attributes).continueWith { (task) -> Any? in
+        self.cognitoIdentityUser.update(attributes, clientMetaData: clientMetaData).continueWith { (task) -> Any? in
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let result = task.result {

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTests.swift
@@ -30,7 +30,8 @@ class AWSMobileClientTests: AWSMobileClientTestBase {
         signUpUser(username: username)
 
         let verificationCodeSent = expectation(description: "verification code should be sent via email.")
-        AWSMobileClient.default().resendSignUpCode(username: username) { (result, error) in
+        let clientMetaData = ["client": "metadata"]
+        AWSMobileClient.default().resendSignUpCode(username: username, clientMetaData: clientMetaData) { (result, error) in
             if let error = error {
                 XCTFail("Failed due to error: \(error.localizedDescription)")
                 return

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
@@ -16,8 +16,8 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
         signUpAndVerifyUser(username: username)
         signIn(username: username)
         let verifyAttrExpectation = expectation(description: "verify attribute expectation.")
-        
-        AWSMobileClient.default().verifyUserAttribute(attributeName: "email") { (codeDeliveryDetails, error) in
+        let clientMetaData = ["client": "metadata"]
+        AWSMobileClient.default().verifyUserAttribute(attributeName: "email", clientMetaData: clientMetaData) { (codeDeliveryDetails, error) in
             if let codeDeliveryDetails = codeDeliveryDetails {
                 print(codeDeliveryDetails.deliveryMedium)
             } else if let error = error {
@@ -63,8 +63,10 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
             "custom:mutableStringAttr1": "new value for previously set attribute",
             "custom:mutableStringAttr2": "value for never-before-set attribute"
         ]
-        
-        AWSMobileClient.default().updateUserAttributes(attributeMap: newUserAttributes) { result, error in
+        let clientMetaData = ["client": "metadata"]
+
+        AWSMobileClient.default().updateUserAttributes(attributeMap: newUserAttributes,
+                                                       clientMetaData: clientMetaData) { result, error in
             defer {
                 updateUserAttributesResultHandlerInvoked.fulfill()
             }
@@ -105,9 +107,6 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
         
         wait(for: [getUserAttributesResultHandlerInvoked], timeout: 5)
     }
-    
-    
-    
     
     /// Test to verify that tokens are valid after an update attritbue
     /// Note: This test relies on the configuration of the test UserPools to have two mutable custom attributes:

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -96,6 +96,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Resend the confirmation code sent during sign up
  */
+- (AWSTask<AWSCognitoIdentityUserResendConfirmationCodeResponse *> *)resendConfirmationCode: (nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
 - (AWSTask<AWSCognitoIdentityUserResendConfirmationCodeResponse *> *)resendConfirmationCode;
 
 /**
@@ -149,6 +151,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Update this user's attributes
  */
+- (AWSTask<AWSCognitoIdentityUserUpdateAttributesResponse *> *)updateAttributes:(NSArray<AWSCognitoIdentityUserAttributeType *> *)attributes
+                                                                 clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
 - (AWSTask<AWSCognitoIdentityUserUpdateAttributesResponse *> *)updateAttributes:(NSArray<AWSCognitoIdentityUserAttributeType *> *)attributes;
 
 /**
@@ -166,6 +171,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Request a verification code to verify an attribute.
  */
+- (AWSTask<AWSCognitoIdentityUserGetAttributeVerificationCodeResponse *> *)getAttributeVerificationCode:(NSString *)attributeName
+                                                                                         clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
 - (AWSTask<AWSCognitoIdentityUserGetAttributeVerificationCodeResponse *> *)getAttributeVerificationCode:(NSString *)attributeName;
 
 /**

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -137,20 +137,24 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                               clientMetaData:nil];
 }
 
-
--(AWSTask<AWSCognitoIdentityUserResendConfirmationCodeResponse *> *) resendConfirmationCode {
+-(AWSTask<AWSCognitoIdentityUserResendConfirmationCodeResponse *> *) resendConfirmationCode: (nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     AWSCognitoIdentityProviderResendConfirmationCodeRequest *request = [AWSCognitoIdentityProviderResendConfirmationCodeRequest new];
     request.clientId = self.pool.userPoolConfiguration.clientId;
     request.username = self.username;
     request.secretHash = [self.pool calculateSecretHash:self.username];
     request.analyticsMetadata = [self.pool analyticsMetadata];
     request.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
-    
+    request.clientMetadata = clientMetaData;
+
     return [[self.pool.client resendConfirmationCode:request] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderResendConfirmationCodeResponse *> * _Nonnull task) {
         AWSCognitoIdentityUserResendConfirmationCodeResponse * response = [AWSCognitoIdentityUserResendConfirmationCodeResponse new];
         [response aws_copyPropertiesFromObject:task.result];
         return [AWSTask taskWithResult:response];
     }];
+}
+
+-(AWSTask<AWSCognitoIdentityUserResendConfirmationCodeResponse *> *) resendConfirmationCode {
+    return [self resendConfirmationCode: nil];
 }
 
 -(AWSTask<AWSCognitoIdentityUserChangePasswordResponse *>*) changePassword: (NSString*)currentPassword proposedPassword: (NSString *)proposedPassword {
@@ -1141,12 +1145,14 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 /**
  * Update this user's attributes
  */
--(AWSTask<AWSCognitoIdentityUserUpdateAttributesResponse *>*) updateAttributes: (NSArray<AWSCognitoIdentityUserAttributeType *>*) attributes {
+-(AWSTask<AWSCognitoIdentityUserUpdateAttributesResponse *>*) updateAttributes: (NSArray<AWSCognitoIdentityUserAttributeType *>*) attributes
+                                                                clientMetaData: (nullable NSDictionary<NSString *,NSString *> *) clientMetaData {
     AWSCognitoIdentityProviderUpdateUserAttributesRequest *request = [AWSCognitoIdentityProviderUpdateUserAttributesRequest new];
     return [[self getSession] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityUserSession *> * _Nonnull task) {
         request.accessToken = task.result.accessToken.tokenString;
         NSMutableArray *userAttributes = [NSMutableArray new];
         request.userAttributes = userAttributes;
+        request.clientMetadata = clientMetaData;
         for (AWSCognitoIdentityUserAttributeType * attribute in attributes) {
             AWSCognitoIdentityProviderAttributeType *apiAttribute = [AWSCognitoIdentityProviderAttributeType new];
             apiAttribute.name = attribute.name;
@@ -1161,6 +1167,10 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
             return [AWSTask taskWithResult:response];
         }];
     }];
+}
+
+-(AWSTask<AWSCognitoIdentityUserUpdateAttributesResponse *>*) updateAttributes: (NSArray<AWSCognitoIdentityUserAttributeType *>*) attributes {
+    return [self updateAttributes:attributes clientMetaData:nil];
 }
 
 /**
@@ -1199,17 +1209,23 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 /**
  * Request a verification code to verify an attribute.
  */
--(AWSTask<AWSCognitoIdentityUserGetAttributeVerificationCodeResponse *>*) getAttributeVerificationCode: (NSString *) attributeName {
+-(AWSTask<AWSCognitoIdentityUserGetAttributeVerificationCodeResponse *>*) getAttributeVerificationCode: (NSString *) attributeName
+                                                                                        clientMetaData: (nullable NSDictionary<NSString *,NSString *> *) clientMetaData {
     AWSCognitoIdentityProviderGetUserAttributeVerificationCodeRequest *request = [AWSCognitoIdentityProviderGetUserAttributeVerificationCodeRequest new];
     return [[self getSession] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityUserSession *> * _Nonnull task) {
         request.accessToken = task.result.accessToken.tokenString;
         request.attributeName = attributeName;
+        request.clientMetadata = clientMetaData;
         return [[self.pool.client getUserAttributeVerificationCode:request] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderGetUserAttributeVerificationCodeResponse *> * _Nonnull task) {
             AWSCognitoIdentityUserGetAttributeVerificationCodeResponse * response = [AWSCognitoIdentityUserGetAttributeVerificationCodeResponse new];
             [response aws_copyPropertiesFromObject:task.result];
             return [AWSTask taskWithResult:response];
         }];
     }];
+}
+
+-(AWSTask<AWSCognitoIdentityUserGetAttributeVerificationCodeResponse *>*) getAttributeVerificationCode: (NSString *) attributeName {
+    return [self getAttributeVerificationCode:attributeName clientMetaData:nil];
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds support for clientMetaData in AWSMobileClient for 3 APIs
1. verifyUserAttribute -> AWSMobileClientUserDetails.verifyUserAttribute -> getUserAttributeVerificationCode
2. resendSignUpCode -> resendConfirmationCode
3. updateUserAttributes -> AWSMobileClientUserDetails.updateUserAttributes -> update(attributes)

reference
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetUserAttributeVerificationCode.html
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ResendConfirmationCode.html
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserAttributes.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
