### PR TITLE
Fix example code syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ To initialize logging to your Xcode console, use the following code:
 **Swift**
 
 ```swift
-AWSDDLog.add(AWSDDTTYLogger.sharedInstance()) // TTY = Xcode console
+AWSDDLog.add(AWSDDTTYLogger.sharedInstance) // TTY = Xcode console
 ```
 
 **Objective-C**


### PR DESCRIPTION
As currently written, the README's example Swift logging code throws a compile error `Cannot call value of non-function type 'AWSDDTTYLogger?'`. 

*Description of changes:* Stopped it from trying to call a non-existent function by removing`()` from end of sharedInstance singleton on line 356 of README.md.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.