### PR TITLE
feat(AWSMobileClient): Pass clientMetadata for SignIn SRP_A, migration, customAuth auth flows

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -171,7 +171,8 @@ extension AWSMobileClient {
     /// - Parameters:
     ///   - username: username of the user.
     ///   - password: password of the user.
-    ///   - validationData: validation data for this sign in. Takes precedent if there is the same key in `clientMetaData`. 
+    ///   - validationData: validation data for this sign in. Overrides any key-value pairs in `clientMetadata` when the
+    ///   same key exists in validation data.
     ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
     ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when result is available.

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -171,7 +171,7 @@ extension AWSMobileClient {
     /// - Parameters:
     ///   - username: username of the user.
     ///   - password: password of the user.
-    ///   - validationData: validation data for this sign in.
+    ///   - validationData: validation data for this sign in. Takes precedent if there is the same key in `clientMetaData`. 
     ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
     ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when result is available.

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -172,10 +172,13 @@ extension AWSMobileClient {
     ///   - username: username of the user.
     ///   - password: password of the user.
     ///   - validationData: validation data for this sign in.
+    ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
+    ///   custom workflows that this action triggers.
     ///   - completionHandler: completionHandler which will be called when result is available.
     public func signIn(username: String,
                        password: String,
                        validationData: [String: String]? = nil,
+                       clientMetaData: [String: String] = [:],
                        completionHandler: @escaping ((SignInResult?, Error?) -> Void)) {
         
         switch self.currentUserState {
@@ -211,6 +214,7 @@ extension AWSMobileClient {
             user!.getSession(username,
                              password: password,
                              validationData: validationAttributes,
+                             clientMetaData: clientMetaData,
                              isInitialCustomChallenge: isCustomAuth).continueWith { (task) -> Any? in
                 if let error = task.error {
                     self.invokeSignInCallback(signResult: nil, error: AWSMobileClientError.makeMobileClientError(from: error))

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -115,6 +115,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (AWSTask<AWSCognitoIdentityUserSession *> *)getSession:(NSString *)username
                                                 password:(NSString *)password
                                           validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData
+                                          clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData;
+
+- (AWSTask<AWSCognitoIdentityUserSession *> *)getSession:(NSString *)username
+                                                password:(NSString *)password
+                                          validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData
+                                isInitialCustomChallenge:(BOOL)isInitialCustomChallenge;
+
+- (AWSTask<AWSCognitoIdentityUserSession *> *)getSession:(NSString *)username
+                                                password:(NSString *)password
+                                          validationData:(nullable NSArray<AWSCognitoIdentityUserAttributeType *> *)validationData
+                                          clientMetaData:(nullable NSDictionary<NSString *, NSString*> *) clientMetaData
                                 isInitialCustomChallenge:(BOOL)isInitialCustomChallenge;
 
 /**

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -743,7 +743,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     else{
         AWSCognitoIdentityProviderInitiateAuthRequest *input = [AWSCognitoIdentityProviderInitiateAuthRequest new];
         input.clientId = self.pool.userPoolConfiguration.clientId;
-        input.clientMetadata = [self.pool getValidationData:validationData];
+        input.clientMetadata = [self.pool getValidationData:validationData clientMetaData: clientMetaData];
         input.analyticsMetadata = [self.pool analyticsMetadata];
         input.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
         input.authFlow = AWSCognitoIdentityProviderAuthFlowTypeUserPasswordAuth;
@@ -804,7 +804,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 - (AWSTask<AWSCognitoIdentityProviderInitiateAuthResponse*>*) performInitiateCustomAuthChallenge: (AWSCognitoIdentityCustomChallengeDetails *) challengeDetails {
     AWSCognitoIdentityProviderInitiateAuthRequest *input = [AWSCognitoIdentityProviderInitiateAuthRequest new];
     input.clientId = self.pool.userPoolConfiguration.clientId;
-    input.clientMetadata = [self.pool getValidationData:challengeDetails.validationData];
+    input.clientMetadata = [self.pool getValidationData:challengeDetails.validationData clientMetaData:challengeDetails.clientMetaData];
     input.analyticsMetadata = [self.pool analyticsMetadata];
     input.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
 
@@ -948,7 +948,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     }else{
         AWSCognitoIdentityProviderInitiateAuthRequest *input = [AWSCognitoIdentityProviderInitiateAuthRequest new];
         input.clientId = self.pool.userPoolConfiguration.clientId;
-        input.clientMetadata = [self.pool getValidationData:validationData];
+        input.clientMetadata = [self.pool getValidationData:validationData clientMetaData:clientMetaData];
         input.analyticsMetadata = [self.pool analyticsMetadata];
         input.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
 

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -352,10 +352,14 @@ AWSCognitoIdentityUserAttributeType* attribute(NSString *name, NSString *value) 
     return result;
 }
 
-- (NSDictionary<NSString*, NSString *>*) getValidationData:(NSArray<AWSCognitoIdentityUserAttributeType*>*)devProvidedValidationData {
+- (NSDictionary<NSString*, NSString *>*) getValidationData:(NSArray<AWSCognitoIdentityUserAttributeType*>*)devProvidedValidationData
+                                            clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData {
     NSMutableDictionary *result = [NSMutableDictionary new];
     if (self.userPoolConfiguration.shouldProvideCognitoValidationData) {
         [result addEntriesFromDictionary:[self cognitoValidationData]];
+    }
+    if (clientMetaData != nil) {
+        [result addEntriesFromDictionary:clientMetaData];
     }
     if (devProvidedValidationData != nil) {
         for (AWSCognitoIdentityUserAttributeType * att in devProvidedValidationData) {
@@ -366,7 +370,7 @@ AWSCognitoIdentityUserAttributeType* attribute(NSString *name, NSString *value) 
 }
 
 - (NSArray<AWSCognitoIdentityUserAttributeType*>*) getValidationDataAsArray:(NSArray<AWSCognitoIdentityUserAttributeType*>*)devProvidedValidationData {
-    NSDictionary * dictionary = [self getValidationData:devProvidedValidationData];
+    NSDictionary * dictionary = [self getValidationData:devProvidedValidationData clientMetaData:nil];
     NSMutableArray * result = [NSMutableArray new];
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL* stop) {
         [result addObject:attribute(key,value)];

--- a/AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h
+++ b/AWSCognitoIdentityProvider/Internal/AWSCognitoIdentityUserPool_Internal.h
@@ -16,7 +16,8 @@
 
 - (NSString * _Nullable) calculateSecretHash: (NSString* _Nonnull) userName;
 - (void) setCurrentUser:(NSString * _Nullable) username;
-- (NSDictionary<NSString *, NSString*>* _Nonnull)getValidationData:(NSArray<AWSCognitoIdentityUserAttributeType*>* _Nullable)devProvidedValidationData;
+- (NSDictionary<NSString *, NSString*>* _Nonnull)getValidationData:(NSArray<AWSCognitoIdentityUserAttributeType*>* _Nullable)devProvidedValidationData
+                                                    clientMetaData:(nullable NSDictionary<NSString *,NSString *> *)clientMetaData;
 - (AWSCognitoIdentityProviderUserContextDataType * _Nonnull) userContextData: (NSString * _Nonnull)  username deviceId:(NSString * _Nullable) deviceId;
 - (NSString* _Nullable) currentUsername;
 - (NSString* _Nonnull) strippedPoolId;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AWSMobileClient.signIn manages the auth flow by calling Cognito [InitialAuth](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html) and [RespondToAuthChallenge](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html) APIs, in either SRP_A, migration, customAuth scenarios.

Developers can pass `validationData` to the AWSMobilieClient.signIn call and have it passed to InitiateAuth API as clientMetadata. The clientMetadata is then passed to the PreSignUp and PreAuth lambdas if configured. 

This PR is to add support for passing `clientMetadata` into the signIn API call to pass to both InitialAuth and RespondToAuthChallenge. For InitialAuth, validationData will override clientMetadata for backwards compatability and continue to trigger the PreSignUp, PreAuth, UserMigration. For RespondToAuthChallenge, it will trigger lambdas such as PostAuth, PreToken, CreateAuth, DefineAuth, and VerifyAuth.

**Android code**
Like [Android](https://github.com/aws-amplify/aws-sdk-android/pull/1984/files#diff-4c45bdc12da735f85afbec1351910e2d), this introduces another parameter to pass client metadata. 
[Android InitialAuthRequest](https://github.com/aws-amplify/aws-sdk-android/blame/main/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java#L3389-L3410) always passes cliientMetadata to the InitiateAuthRequest. If validationData is set, this overrides clientMetadata, essentially deprecating validationData.

[Android responseToAuthChallenge](https://github.com/aws-amplify/aws-sdk-android/blame/main/aws-android-sdk-cognitoidentityprovider/src/main/java/com/amazonaws/mobileconnectors/cognitoidentityprovider/CognitoUser.java#L3547-L3612) passes clientMetadata to responseToAuthChallengeRequest.

**Manual testing done**
1. Provisioning of Cognito User Pool with PreAuth and PostAuth lambda trigger
2. Local pod installation of PR branch
3. Call AWSMobileClient.signIn
```
AWSMobileClient.default().signIn(username: "testUser4",
                                         password: "password",
                                         validationData: ["hello2":"world2", "replace":"you"],
                                         clientMetaData: ["hello":"world", "replace":"me"]
```
4. Check lambda trigger cloudwatch logs, `console.log(event)`
```
PreAuth
...
request:
   { userAttributes:
      { sub: '[SUB]',
        email_verified: 'true',
        'cognito:user_status': 'CONFIRMED',
        email: '[EMAIL]' },
     validationData:
      { 'cognito:iOSVersion': '14.0',
        'cognito:bundleShortV': '1.0',
        'cognito:bundleVersion': '1',
        'cognito:idForVendor': '[I],
        'cognito:systemName': 'iOS',
        'cognito:bundleId': '[BUNDLE]',
        replace: 'you',
        hello2: 'world2',
        hello: 'world',
        'cognito:deviceName': 'iPhone SE (2nd generation)',
        'cognito:model': 'iPhone' } },
  response: {} }
```
PostAuth
```
request:
   { userAttributes:
      { sub: '[SUB]',
        email_verified: 'true',
        'cognito:user_status': 'CONFIRMED',
        email: '[EMAIL]' },
     newDeviceUsed: false,
     clientMetadata: { replace: 'me', hello: 'world' } },
  response: {} }
```

**lambda payloads**
`This payload contains a validationData attribute, which provides the data that you assigned to the ClientMetadata parameter in your InitiateAuth request. In your function code in AWS Lambda, you can process the validationData value to enhance your workflow for your specific needs.` ([link](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html#API_InitiateAuth_RequestSyntax))

1. So AWSMobileClient.signIn takes in validationData and clientMetaData, both are passed to the request payload for InitialAuth as clientMetadata, which is then passed to the PreAuth lambda as validationData.
2. Only clientMetadata is passed to ResponseToAuthChallenge as clientMetadata, which is then passed to the PostAuth lambda as clientMetadata.

developers can use validationData as the backwards compability part of this API, which will show up in PreAuth lambda as validationData. new callers can use clientMetadata which will show up in PreAuth lamba as validationData and PostAuth as clientMetadata.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
