### PR TITLE
feat(AWSMobileClient): Pass clientMetadata for MFA confirmSignIn

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
@@ -28,6 +28,15 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B5FC69001FAFA1AA004790CB"
+            BuildableName = "AWSMobileClient.framework"
+            BlueprintName = "AWSMobileClient"
+            ReferencedContainer = "container:AWSAuthSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
@@ -28,15 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B5FC69001FAFA1AA004790CB"
-            BuildableName = "AWSMobileClient.framework"
-            BlueprintName = "AWSMobileClient"
-            ReferencedContainer = "container:AWSAuthSDK.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -623,7 +623,9 @@ extension AWSMobileClient {
                               completionHandler: @escaping ((SignInResult?, Error?) -> Void)) {
         if (self.userpoolOpsHelper.mfaCodeCompletionSource != nil) {
             self.userpoolOpsHelper.currentConfirmSignInHandlerCallback = completionHandler
-            self.userpoolOpsHelper.mfaCodeCompletionSource?.set(result: challengeResponse as NSString)
+            let mfaDetails = AWSCognitoIdentityMfaCodeDetails.init(mfaCode: challengeResponse);
+            mfaDetails.clientMetaData = clientMetaData;
+            self.userpoolOpsHelper.mfaCodeCompletionSource?.set(result: mfaDetails)
         } else if (self.userpoolOpsHelper.newPasswordRequiredTaskCompletionSource != nil) {
             self.userpoolOpsHelper.currentConfirmSignInHandlerCallback = completionHandler
             let passwordDetails = AWSCognitoIdentityNewPasswordRequiredDetails.init(proposedPassword: challengeResponse,
@@ -980,8 +982,9 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
             invokeSignInCallback(signResult: nil, error: AWSMobileClientError.makeMobileClientError(from: error))
         }
     }
-    
-    func getCode(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput, mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>) {
+
+    func getCode(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput,
+                 mfaCodeCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails>) {
         self.userpoolOpsHelper.mfaCodeCompletionSource = mfaCodeCompletionSource
         var codeDeliveryDetails: UserCodeDeliveryDetails? = nil
             switch(authenticationInput.deliveryMedium) {

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSUserPoolOperationsHandler.swift
@@ -32,11 +32,12 @@ protocol UserPoolAuthHelperlCallbacks {
     func getCustomAuthenticationDetails(_ customAuthenticationInput: AWSCognitoIdentityCustomAuthenticationInput, customAuthCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails>)
     
     func didCompleteCustomAuthenticationStepWithError(_ error: Error?)
-    
-    func getCode(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput, mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>)
+
+    func getCode(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput,
+                 mfaCodeCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails>)
     
     func didCompleteMultifactorAuthenticationStepWithError(_ error: Error?)
-    
+
 }
 
 internal class UserPoolOperationsHandler: NSObject,
@@ -55,7 +56,7 @@ AWSCognitoUserPoolInternalDelegate {
     internal var customAuthChallengeTaskCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails>?
     
     internal var mfaAuthenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput?
-    internal var mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>?
+    internal var mfaCodeCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails>?
     
     internal var currentSignInHandlerCallback: ((SignInResult?, Error?) -> Void)?
     internal var currentConfirmSignInHandlerCallback: ((SignInResult?, Error?) -> Void)?
@@ -151,7 +152,8 @@ extension UserPoolOperationsHandler: AWSCognitoIdentityNewPasswordRequired {
 
 extension UserPoolOperationsHandler: AWSCognitoIdentityMultiFactorAuthentication {
     
-    public func getCode(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput, mfaCodeCompletionSource: AWSTaskCompletionSource<NSString>) {
+    public func getCode_v2(_ authenticationInput: AWSCognitoIdentityMultifactorAuthenticationInput,
+                           mfaCodeCompletionSource: AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails>) {
         self.mfaAuthenticationInput = authenticationInput
         self.authHelperDelegate?.getCode(authenticationInput, mfaCodeCompletionSource: mfaCodeCompletionSource)
     }

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1095,51 +1095,92 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 /**
  * Invoke developer's ui to prompt user for mfa code and call enhanceAuth
  */
--(AWSTask<AWSCognitoIdentityUserSession *>*) mfaAuthInternal: (NSString *) deliveryMedium destination:(NSString *) destination  authState:(NSString *) authState challengeName: (AWSCognitoIdentityProviderChallengeNameType) challengeName authenticationDelegate:(id<AWSCognitoIdentityMultiFactorAuthentication>)authenticationDelegate{
-    AWSTaskCompletionSource<NSString *> *mfaCode = [[AWSTaskCompletionSource<NSString *> alloc] init];
-    AWSCognitoIdentityMultifactorAuthenticationInput* authenticationInput = [[AWSCognitoIdentityMultifactorAuthenticationInput alloc] initWithDeliveryMedium:deliveryMedium destination:destination];
-    [authenticationDelegate getMultiFactorAuthenticationCode:authenticationInput mfaCodeCompletionSource:mfaCode];
-    return [mfaCode.task
-            continueWithSuccessBlock:^id _Nullable(AWSTask<NSString *> * _Nonnull task) {
-                AWSCognitoIdentityProviderRespondToAuthChallengeRequest *mfaChallenge = [AWSCognitoIdentityProviderRespondToAuthChallengeRequest new];
-                mfaChallenge.session = authState;
-                mfaChallenge.challengeName = challengeName;
-                mfaChallenge.clientId = self.pool.userPoolConfiguration.clientId;
-                
-                NSString * responseKey = @"SMS_MFA_CODE";
-                if(AWSCognitoIdentityProviderChallengeNameTypeSoftwareTokenMfa == challengeName){
-                    responseKey = @"SOFTWARE_TOKEN_MFA_CODE";
-                }
-                NSMutableDictionary * challengeResponses = [[NSMutableDictionary alloc] initWithDictionary:@{responseKey: mfaCode.task.result}];
-                [self addSecretHashDeviceKeyAndUsername:challengeResponses];
-                mfaChallenge.challengeResponses = challengeResponses;
-                mfaChallenge.analyticsMetadata = [self.pool analyticsMetadata];
-                mfaChallenge.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
+-(AWSTask<AWSCognitoIdentityUserSession *>*) mfaAuthInternal: (NSString *) deliveryMedium
+                                                 destination: (NSString *) destination
+                                                   authState: (NSString *) authState
+                                               challengeName: (AWSCognitoIdentityProviderChallengeNameType) challengeName
+                                      authenticationDelegate: (id<AWSCognitoIdentityMultiFactorAuthentication>) authenticationDelegate {
 
-                return [[[self.pool.client respondToAuthChallenge:mfaChallenge] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderRespondToAuthChallengeResponse *> * _Nonnull task) {
-                    AWSCognitoIdentityProviderRespondToAuthChallengeResponse *response = task.result;
-                    AWSCognitoIdentityProviderAuthenticationResultType * authResult = response.authenticationResult;
-                    AWSCognitoIdentityUserSession * session = [[AWSCognitoIdentityUserSession alloc] initWithIdToken:authResult.idToken accessToken:authResult.accessToken refreshToken:authResult.refreshToken expiresIn:authResult.expiresIn];
-                    //last step is to perform device auth if device key is supplied or we are being challenged with device auth
-                    if(authResult.latestDeviceMetadata != nil || response.challengeName == AWSCognitoIdentityProviderChallengeNameTypeDeviceSrpAuth){
-                        return [self performDeviceAuth: task session:session];
-                    }else{
-                        [self updateUsernameAndPersistTokens:session];
-                        return [AWSTask taskWithResult:session];
-                    }
-                }] continueWithBlock:^id _Nullable(AWSTask * _Nonnull task) {
-                    [authenticationDelegate didCompleteMultifactorAuthenticationStepWithError:task.error];
-                    if([task isCancelled]){
-                        return task;
-                    }
-                    if(task.error){
-                        //retry on error
-                        return [self mfaAuthInternal:deliveryMedium destination:destination authState:authState challengeName: challengeName authenticationDelegate:authenticationDelegate];
-                    }else {
-                        return task;
-                    }
+    if ([authenticationDelegate respondsToSelector:@selector(getMultiFactorAuthenticationCode_v2:mfaCodeCompletionSource:)]) {
+        AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> *mfaCode = [[AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> alloc] init];
+        AWSCognitoIdentityMultifactorAuthenticationInput* authenticationInput = [[AWSCognitoIdentityMultifactorAuthenticationInput alloc]
+                                                                                 initWithDeliveryMedium:deliveryMedium
+                                                                                 destination:destination];
+        [authenticationDelegate getMultiFactorAuthenticationCode_v2:authenticationInput mfaCodeCompletionSource:mfaCode];
+        return [mfaCode.task continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityMfaCodeDetails *> * _Nonnull task) {
+            return [self mfaAuthInternal:deliveryMedium
+                             destination:destination
+                               authState:authState
+                           challengeName:challengeName
+                  authenticationDelegate:authenticationDelegate
+                                 mfaCode:task.result.mfaCode
+                          clientMetaData:task.result.clientMetaData];
+        }];
+    } else {
+        AWSTaskCompletionSource<NSString *> *mfaCode = [[AWSTaskCompletionSource<NSString *> alloc] init];
+        AWSCognitoIdentityMultifactorAuthenticationInput* authenticationInput = [[AWSCognitoIdentityMultifactorAuthenticationInput alloc] initWithDeliveryMedium:deliveryMedium destination:destination];
+        [authenticationDelegate getMultiFactorAuthenticationCode:authenticationInput mfaCodeCompletionSource:mfaCode];
+        return [mfaCode.task continueWithSuccessBlock:^id _Nullable(AWSTask<NSString *> * _Nonnull task) {
+            return [self mfaAuthInternal:deliveryMedium
+                             destination:destination
+                               authState:authState
+                           challengeName:challengeName
+                  authenticationDelegate:authenticationDelegate
+                                 mfaCode:task.result
+                          clientMetaData:nil];
                 }];
-            }];
+    }
+}
+
+-(AWSTask<AWSCognitoIdentityUserSession *>*) mfaAuthInternal: (NSString *) deliveryMedium
+                                                 destination: (NSString *) destination
+                                                   authState: (NSString *) authState
+                                               challengeName: (AWSCognitoIdentityProviderChallengeNameType) challengeName
+                                      authenticationDelegate: (id<AWSCognitoIdentityMultiFactorAuthentication>) authenticationDelegate
+                                                     mfaCode: (NSString *) mfaCode
+                                              clientMetaData: (nullable NSDictionary<NSString *,NSString *> *) clientMetaData {
+
+    AWSCognitoIdentityProviderRespondToAuthChallengeRequest *mfaChallenge = [AWSCognitoIdentityProviderRespondToAuthChallengeRequest new];
+    mfaChallenge.session = authState;
+    mfaChallenge.challengeName = challengeName;
+    mfaChallenge.clientId = self.pool.userPoolConfiguration.clientId;
+
+    NSString * responseKey = @"SMS_MFA_CODE";
+    if(AWSCognitoIdentityProviderChallengeNameTypeSoftwareTokenMfa == challengeName){
+        responseKey = @"SOFTWARE_TOKEN_MFA_CODE";
+    }
+
+    NSMutableDictionary * challengeResponses = [[NSMutableDictionary alloc] initWithDictionary:@{responseKey: mfaCode}];
+    [self addSecretHashDeviceKeyAndUsername:challengeResponses];
+
+    mfaChallenge.challengeResponses = challengeResponses;
+    mfaChallenge.analyticsMetadata = [self.pool analyticsMetadata];
+    mfaChallenge.userContextData = [self.pool userContextData:self.username deviceId: [self asfDeviceId]];
+    mfaChallenge.clientMetadata = clientMetaData;
+
+    return [[[self.pool.client respondToAuthChallenge:mfaChallenge] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderRespondToAuthChallengeResponse *> * _Nonnull task) {
+        AWSCognitoIdentityProviderRespondToAuthChallengeResponse *response = task.result;
+        AWSCognitoIdentityProviderAuthenticationResultType * authResult = response.authenticationResult;
+        AWSCognitoIdentityUserSession * session = [[AWSCognitoIdentityUserSession alloc] initWithIdToken:authResult.idToken accessToken:authResult.accessToken refreshToken:authResult.refreshToken expiresIn:authResult.expiresIn];
+        //last step is to perform device auth if device key is supplied or we are being challenged with device auth
+        if(authResult.latestDeviceMetadata != nil || response.challengeName == AWSCognitoIdentityProviderChallengeNameTypeDeviceSrpAuth){
+            return [self performDeviceAuth: task session:session];
+        } else {
+            [self updateUsernameAndPersistTokens:session];
+            return [AWSTask taskWithResult:session];
+        }
+    }] continueWithBlock:^id _Nullable(AWSTask * _Nonnull task) {
+        [authenticationDelegate didCompleteMultifactorAuthenticationStepWithError:task.error];
+        if([task isCancelled]){
+            return task;
+        }
+        if(task.error){
+            //retry on error
+            return [self mfaAuthInternal:deliveryMedium destination:destination authState:authState challengeName: challengeName authenticationDelegate:authenticationDelegate];
+        }else {
+            return task;
+        }
+    }];
 }
 
 /**

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1102,12 +1102,12 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                                       authenticationDelegate: (id<AWSCognitoIdentityMultiFactorAuthentication>) authenticationDelegate {
 
     if ([authenticationDelegate respondsToSelector:@selector(getMultiFactorAuthenticationCode_v2:mfaCodeCompletionSource:)]) {
-        AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> *mfaCode = [[AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> alloc] init];
+        AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> *mfaCompletionSource = [[AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> alloc] init];
         AWSCognitoIdentityMultifactorAuthenticationInput* authenticationInput = [[AWSCognitoIdentityMultifactorAuthenticationInput alloc]
                                                                                  initWithDeliveryMedium:deliveryMedium
                                                                                  destination:destination];
-        [authenticationDelegate getMultiFactorAuthenticationCode_v2:authenticationInput mfaCodeCompletionSource:mfaCode];
-        return [mfaCode.task continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityMfaCodeDetails *> * _Nonnull task) {
+        [authenticationDelegate getMultiFactorAuthenticationCode_v2:authenticationInput mfaCodeCompletionSource:mfaCompletionSource];
+        return [mfaCompletionSource.task continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityMfaCodeDetails *> * _Nonnull task) {
             return [self mfaAuthInternal:deliveryMedium
                              destination:destination
                                authState:authState
@@ -1117,10 +1117,10 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                           clientMetaData:task.result.clientMetaData];
         }];
     } else {
-        AWSTaskCompletionSource<NSString *> *mfaCode = [[AWSTaskCompletionSource<NSString *> alloc] init];
+        AWSTaskCompletionSource<NSString *> *mfaCompletionSource = [[AWSTaskCompletionSource<NSString *> alloc] init];
         AWSCognitoIdentityMultifactorAuthenticationInput* authenticationInput = [[AWSCognitoIdentityMultifactorAuthenticationInput alloc] initWithDeliveryMedium:deliveryMedium destination:destination];
-        [authenticationDelegate getMultiFactorAuthenticationCode:authenticationInput mfaCodeCompletionSource:mfaCode];
-        return [mfaCode.task continueWithSuccessBlock:^id _Nullable(AWSTask<NSString *> * _Nonnull task) {
+        [authenticationDelegate getMultiFactorAuthenticationCode:authenticationInput mfaCodeCompletionSource:mfaCompletionSource];
+        return [mfaCompletionSource.task continueWithSuccessBlock:^id _Nullable(AWSTask<NSString *> * _Nonnull task) {
             return [self mfaAuthInternal:deliveryMedium
                              destination:destination
                                authState:authState

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -17,6 +17,7 @@
 @class AWSCognitoIdentityUserPoolConfiguration;
 @class AWSCognitoIdentityUserPoolSignUpResponse;
 @class AWSCognitoIdentityNewPasswordRequiredDetails;
+@class AWSCognitoIdentityMfaCodeDetails;
 @class AWSCognitoIdentitySoftwareMfaSetupRequiredDetails;
 @class AWSCognitoIdentitySelectMfaDetails;
 
@@ -231,6 +232,27 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
 @end
 
 /**
+ When responding to a mfa code challenge this encapsulates the end users' mfa code and client metadata
+ */
+@interface AWSCognitoIdentityMfaCodeDetails : NSObject
+/**
+ The end user's new password
+ */
+@property(nonatomic, strong, nonnull) NSString *mfaCode;
+
+/**
+ A map of custom key-value pairs that you can provide as input for any custom workflows that this action triggers.
+ */
+@property(nonatomic, copy, nullable) NSDictionary<NSString*, NSString*> *clientMetaData;
+
+/**
+ Initializer given the mfa code
+ **/
+-(instancetype) initWithMfaCode: (NSString *) mfaCode;
+
+@end
+
+/**
  When responding to a custom sign in, this encapsulates the challenge parameters that define the challenge
  */
 @interface AWSCognitoIdentityCustomAuthenticationInput : NSObject
@@ -390,11 +412,25 @@ typedef NS_ENUM(NSInteger, AWSCognitoIdentityClientErrorType) {
 
 @protocol AWSCognitoIdentityMultiFactorAuthentication <NSObject>
 /**
- Obtain mfa code from the end user
+ Obtain mfa code from the end user. This is deprecated, thus made optional to account for new clients implementing only
+ `getMultiFactorAuthenticationCode_v2:mfaCodeCompletionSource:`
  @param authenticationInput details about the deliveryMedium and masked destination for where the code was sent
  @param mfaCodeCompletionSource set mfaCodeCompletionSource.result with the mfa code from end user
  */
--(void) getMultiFactorAuthenticationCode: (AWSCognitoIdentityMultifactorAuthenticationInput *) authenticationInput mfaCodeCompletionSource: (AWSTaskCompletionSource<NSString *> *) mfaCodeCompletionSource;
+@optional
+-(void) getMultiFactorAuthenticationCode: (AWSCognitoIdentityMultifactorAuthenticationInput *) authenticationInput
+                 mfaCodeCompletionSource: (AWSTaskCompletionSource<NSString *> *) mfaCodeCompletionSource __attribute__((deprecated("Use `getMultiFactorAuthenticationCode_v2:mfaCodeCompletionSource:` instead")));
+
+/**
+ Obtain mfa code and clientMetadata from the end user. This is optional for backwards compatibility with existing clients
+ that have already implemented the deprecated `getMultiFactorAuthenticationCode:mfaCodeCompletionSource` method.
+ New clients should implement this.
+ @param authenticationInput details about the deliveryMedium and masked destination for where the code was sent
+ @param mfaCodeCompletionSource set mfaCodeCompletionSource.result with the mfa code and client metadata from end user
+ */
+@optional
+-(void) getMultiFactorAuthenticationCode_v2: (AWSCognitoIdentityMultifactorAuthenticationInput *) authenticationInput
+                    mfaCodeCompletionSource: (AWSTaskCompletionSource<AWSCognitoIdentityMfaCodeDetails *> *) mfaCodeCompletionSource;
 /**
  This step completed, usually either display an error to the end user or dismiss ui
  @param error the error if any that occured

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.h
@@ -238,7 +238,7 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
 /**
  The end user's new password
  */
-@property(nonatomic, strong, nonnull) NSString *mfaCode;
+@property(nonatomic, copy, nonnull) NSString *mfaCode;
 
 /**
  A map of custom key-value pairs that you can provide as input for any custom workflows that this action triggers.

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -531,6 +531,16 @@ shouldProvideCognitoValidationData:(BOOL)shouldProvideCognitoValidationData
 
 @end
 
+@implementation AWSCognitoIdentityMfaCodeDetails
+-(instancetype) initWithMfaCode: (NSString *) mfaCode {
+    self = [super init];
+    if(nil != self){
+        _mfaCode = mfaCode;
+    }
+    return self;
+}
+@end
+
 @implementation AWSCognitoIdentityUserPoolSignUpResponse
 
 @end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AWSMobileClient.confirmSignIn is the second step of an MFA enabled signIn process, which calls Cognito  [RespondToAuthChallenge](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html) API. This PR adds support for passing clientMetadata to the RespondToAuthChallenge lambda triggers for MFA enabled sign in. Developers can already pass `clientMetadata` to the AWSMobilieClient.confirmSignIn. This propagates the data to the RespondToAuthChallenge API to trigger the PostAuth, PreToken, CreateAuth, DefineAuth, and VerifyAuth lambdas 

**Manual testing done**
1. Provisioning of Cognito User Pool, with MFA enabled ([instructions](https://docs.amplify.aws/lib/auth/signin/q/platform/ios#multi-factor-authentication)) and PostAuth lambda trigger
2. Local pod installation of PR branch
3. Sign Up a user: Call AWSMobileClient.signUp with email and phone_number, receive email with signUp code, confirmSignUp
3. MFA Sign In: Call AWSMobileClient.signIn, receive SMS code on phone,
4. Call AWSMobileClient.confirmSignIn() with code and clientMetadata

```
AWSMobileClient.default().confirmSignIn(challengeResponse: confirmSignInCode,
                                                clientMetaData: ["hello": "world"])
```
5. Check lambda trigger cloudwatch logs, `console.log(event)`
```
...
request:
   { userAttributes:
      { sub: '[SUB]',
        email_verified: 'true',
        'cognito:user_status': 'CONFIRMED',
        phone_number_verified: 'false',
        phone_number: '[PHONE_NUMBER]',
        email: '[EMAIL]' },
     newDeviceUsed: false,
     clientMetadata: { hello: 'world' } },
  response: {} }
```
6. Repeated for DropIn UI to ensure it execute successfully since it implements previous protocol method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
