### PR TITLE
chore: Update API doc for user attribute methods

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -825,6 +825,8 @@ extension AWSMobileClient {
 
     /// Verify a user attribute like phone_number.
     ///
+    /// This method is only valid for users signed in via UserPools (either directly or via HostedUI).
+    ///
     /// - Parameters:
     ///   - attributeName: name of the attribute.
     ///   - clientMetaData: A map of custom key-value pairs that you can provide as input for any
@@ -842,6 +844,8 @@ extension AWSMobileClient {
     }
     
     /// Update the attributes for a user.
+    ///
+    /// This method is only valid for users signed in via UserPools (either directly or via HostedUI).
     ///
     /// - Parameters:
     ///   - attributeMap: the attribute map of the user.
@@ -861,6 +865,8 @@ extension AWSMobileClient {
     
     /// Fetches the attributes for logged in user.
     ///
+    /// This method is only valid for users signed in via UserPools (either directly or via HostedUI).
+    ///
     /// - Parameter completionHandler: completion handler which will be invoked when result is available.
     public func getUserAttributes(completionHandler: @escaping (([String: String]?, Error?) -> Void)) {
         guard self.federationProvider == .userPools || self.federationProvider == .hostedUI else {
@@ -872,6 +878,8 @@ extension AWSMobileClient {
     }
     
     /// Confirm the updated attributes using a confirmation code.
+    ///
+    /// This method is only valid for users signed in via UserPools (either directly or via HostedUI).
     ///
     /// - Parameters:
     ///   - attributeName: the attribute to be confirmed.
@@ -886,6 +894,8 @@ extension AWSMobileClient {
     }
     
     /// Confirm the attribute using a confirmation code.
+    ///
+    /// This method is only valid for users signed in via UserPools (either directly or via HostedUI).
     ///
     /// - Parameters:
     ///   - attributeName: the attribute to be verified.


### PR DESCRIPTION
refs: #2894


@royjit Fixed a crash in accessing user attribute methods in https://github.com/aws-amplify/aws-sdk-ios/pull/2866. This PR extends the API doc to indicate that the method is only valid for User Pools (either directly or via HostedUI).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
