### PR TITLE
bug(UICKeychainStore): serialize access to keychain on setData

### DIFF
--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -511,7 +511,13 @@ static NSString *_defaultService;
     return [self setData:data forKey:key genericAttribute:nil label:label comment:comment error:error];
 }
 
-- (BOOL)setData:(NSData *)data forKey:(NSString *)key genericAttribute:(id)genericAttribute label:(NSString *)label comment:(NSString *)comment error:(NSError *__autoreleasing *)error
+- (BOOL)setData:(NSData *)data forKey:(NSString *)key genericAttribute:(id)genericAttribute label:(NSString *)label comment:(NSString *)comment error:(NSError *__autoreleasing *)error {
+    @synchronized (self) {
+        return [self setDataNoLock: data forKey:key genericAttribute:genericAttribute label:label comment:comment error:error];
+    }
+}
+
+- (BOOL)setDataNoLock:(NSData *)data forKey:(NSString *)key genericAttribute:(id)genericAttribute label:(NSString *)label comment:(NSString *)comment error:(NSError *__autoreleasing *)error
 {
     if (!key) {
         NSError *e = [self.class argumentError:NSLocalizedString(@"the key must not to be nil", nil)];


### PR DESCRIPTION
OSStatus error bug reported here:
https://github.com/aws-amplify/amplify-ios/issues/649

We looked into the above issue and noticed that there were two processes attempting to store the same key into the keychain.  This PR attempts to serialize calls when calling `setData:` into the keychain.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
