### PR TITLE
feat(pinpoint): deprecate handler argument in intercept notification methods

### DIFF
--- a/AWSPinpoint/AWSPinpointNotificationManager.h
+++ b/AWSPinpoint/AWSPinpointNotificationManager.h
@@ -44,77 +44,109 @@ typedef NS_ENUM(NSInteger, AWSPinpointPushEventSourceType) {
 #pragma mark - Notification Helpers
 /**
  Returns a Boolean indicating whether the app is currently registered for remote notifications.
- @return BOOL YES if the app is registered for remote notifications and received its device token or NO if registration has not occurred, has failed, or has been denied by the user.
+ @return BOOL YES if the app is registered for remote notifications and received its device token or NO if registration
+ has not occurred, has failed, or has been denied by the user.
  */
 + (BOOL)isNotificationEnabled;
 
 #pragma mark - Interceptors
 /**
- Intercepts the `- application:didFinishLaunchingWithOptions:` application delegate.
+ Invoke this method from the `- application:didFinishLaunchingWithOptions:` application delegate method.
  
- Targeting must intercept this callback in order to report campaign analytics correctly.
+ The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly.
  
- @param launchOptions A dictionary indicating the reason the app was launched (if any). The contents of this dictionary may be empty in situations where the user launched the app directly. For information about the possible keys in this dictionary and how to handle them.
+ @param launchOptions A dictionary indicating the reason the app was launched (if any). The contents of this dictionary
+ may be empty in situations where the user launched the app directly. For information about the possible keys in this
+ dictionary and how to handle them.
  */
 - (BOOL)interceptDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 
 /**
- Intercepts the `- application:didRegisterForRemoteNotificationsWithDeviceToken:` application delegate.
+ Invoke this method from the `- application:didRegisterForRemoteNotificationsWithDeviceToken:` application delegate
+ method.
  
- Targeting must intercept this callback in order to report campaign analytics correctly.
+ The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly.
  
  @param deviceToken A token that identifies the device to APNs.
  */
 - (void)interceptDidRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 
 /**
- Intercepts the `- application:didReceiveRemoteNotification:fetchCompletionHandler:` application delegate.
+ Invoke this method from the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` application delegate
+ method.
 
- Targeting must intercept this callback in order to report campaign analytics correctly.
+ The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly.
  
- @param userInfo    A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
- @param handler     The block to execute when the download operation is complete. When calling this block, pass in the fetch result value that best describes the results of your download operation. You must call this handler and should do so as soon as possible. For a list of possible values, see the UIBackgroundFetchResult type.
+ @param userInfo    A dictionary that contains information related to the remote notification, potentially including a
+ badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and
+ custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the
+ dictionary may contain only property-list objects plus `NSNull`.
+ @param handler     The block to execute when the download operation is complete. When calling this block, pass in the
+ fetch result value that best describes the results of your download operation. You must call this handler and should do
+ so as soon as possible. For a list of possible values, see the UIBackgroundFetchResult type.
  */
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
                        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler __attribute__((deprecated("Replaced by -interceptDidReceiveRemoteNotification:")));
 
 /**
- For iOS 9 and below, intercept the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` application delegate.
+ For iOS 9 and below, invoke this method from the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
+ application delegate method.
 
- For iOS 10 and above, intercept `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`. When intercepting the UserNotificationCenter on willPresent,
- pass in `notification.request.content.userInfo` as userInfo. When intercepting UserNotificationCenter on didReceive,
- pass in `response.notification.request.content.userInfo` as `userInfo`.
+ For iOS 10 and above, invoke this method from the `userNotificationCenter(_:willPresent:withCompletionHandler:)` and
+ `userNotificationCenter(_:didReceive:withCompletionHandler:)` UserNotificationCenter methods. When invoking this method
+ from `willPresent`, pass in `notification.request.content.userInfo` as userInfo. When invoking this method on
+ `didReceive`, pass in `response.notification.request.content.userInfo` as `userInfo`.
 
- Targeting must intercept this callback in order to report campaign analytics correctly.
+ The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly.
 
- @param userInfo    A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
+ @param userInfo    A dictionary that contains information related to the remote notification, potentially including a
+ badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and
+ custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the
+ dictionary may contain only property-list objects plus `NSNull`.
  */
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo;
 
 /**
- Intercepts the `- application:didReceiveRemoteNotification:fetchCompletionHandler:shouldHandleNotificationDeepLink:` application delegate.
+ Invoke this method from the `application:didReceiveRemoteNotification:fetchCompletionHandler:shouldHandleNotificationDeepLink:`
+ application delegate method.
 
- Targeting must intercept this callback in order to report campaign analytics correctly. Optionally specify 'shouldHandleNotificationDeepLink' to control whether or not the notification manager should attempt to open the remote notification deeplink, if present.
+ The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly. Optionally
+ specify 'shouldHandleNotificationDeepLink' to control whether or not the notification manager should attempt to open
+ the remote notification deeplink, if present.
 
- @param userInfo        A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
- @param handler         The block to execute when the download operation is complete. When calling this block, pass in the fetch result value that best describes the results of your download operation. You must call this handler and should do so as soon as possible. For a list of possible values, see the UIBackgroundFetchResult type.
- @param handleDeepLink  Whether or not notification manager should attempt to open the remote notification deeplink, if present
+ @param userInfo        A dictionary that contains information related to the remote notification, potentially including
+ a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier,
+ and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object;
+ the dictionary may contain only property-list objects plus `NSNull`.
+ @param handler         The block to execute when the download operation is complete. When calling this block, pass in
+ the fetch result value that best describes the results of your download operation. You must call this handler and
+ should do so as soon as possible. For a list of possible values, see the UIBackgroundFetchResult type.
+ @param handleDeepLink  Whether or not notification manager should attempt to open the remote notification deeplink, if
+ present
  */
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
                        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler
              shouldHandleNotificationDeepLink:(BOOL) handleDeepLink __attribute__((deprecated("Replaced by -interceptDidReceiveRemoteNotification:shouldHandleNotificationDeepLink:")));
 
 /**
- For iOS 9 and below, intercept the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` application delegate.
+ For iOS 9 and below, intercept the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` application
+ delegate.
 
- For iOS 10 and above, intercept `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`. When intercepting the UserNotificationCenter on willPresent,
- pass in `notification.request.content.userInfo` as `userInfo`. When intercepting UserNotificationCenter on didReceive,
- pass in `response.notification.request.content.userInfo` as `userInfo`.
+ For iOS 10 and above, invoke this method from the `userNotificationCenter(_:willPresent:withCompletionHandler:)` and
+ `userNotificationCenter(_:didReceive:withCompletionHandler:)` UserNotificationCenter methods. When invoking this method
+ from `willPresent`, pass in `notification.request.content.userInfo` as userInfo. When invoking this method on
+ `didReceive`, pass in `response.notification.request.content.userInfo` as `userInfo`.
 
- Targeting must intercept this callback in order to report campaign analytics correctly. Optionally specify 'shouldHandleNotificationDeepLink' to control whether or not the notification manager should attempt to open the remote notification deeplink, if present.
+ The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly. Optionally
+ specify 'shouldHandleNotificationDeepLink' to control whether or not the notification manager should attempt to open
+ the remote notification deeplink, if present.
 
- @param userInfo        A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
- @param handleDeepLink  Whether or not notification manager should attempt to open the remote notification deeplink, if present
+ @param userInfo        A dictionary that contains information related to the remote notification, potentially including
+ a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier,
+ and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object;
+ the dictionary may contain only property-list objects plus `NSNull`.
+ @param handleDeepLink  Whether or not notification manager should attempt to open the remote notification deeplink, if
+ present
  */
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
              shouldHandleNotificationDeepLink:(BOOL) handleDeepLink;

--- a/AWSPinpoint/AWSPinpointNotificationManager.h
+++ b/AWSPinpoint/AWSPinpointNotificationManager.h
@@ -56,8 +56,7 @@ typedef NS_ENUM(NSInteger, AWSPinpointPushEventSourceType) {
  The Pinpoint targeting client must intercept this callback in order to report campaign analytics correctly.
  
  @param launchOptions A dictionary indicating the reason the app was launched (if any). The contents of this dictionary
- may be empty in situations where the user launched the app directly. For information about the possible keys in this
- dictionary and how to handle them.
+ may be empty in situations where the user launched the app directly.
  */
 - (BOOL)interceptDidFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
 

--- a/AWSPinpoint/AWSPinpointNotificationManager.h
+++ b/AWSPinpoint/AWSPinpointNotificationManager.h
@@ -69,14 +69,27 @@ typedef NS_ENUM(NSInteger, AWSPinpointPushEventSourceType) {
 
 /**
  Intercepts the `- application:didReceiveRemoteNotification:fetchCompletionHandler:` application delegate.
- 
+
  Targeting must intercept this callback in order to report campaign analytics correctly.
  
  @param userInfo    A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
  @param handler     The block to execute when the download operation is complete. When calling this block, pass in the fetch result value that best describes the results of your download operation. You must call this handler and should do so as soon as possible. For a list of possible values, see the UIBackgroundFetchResult type.
  */
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
-                       fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler;
+                       fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler __attribute__((deprecated("Replaced by -interceptDidReceiveRemoteNotification:")));
+
+/**
+ For iOS 9 and below, intercept the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` application delegate.
+
+ For iOS 10 and above, intercept `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`. When intercepting the UserNotificationCenter on willPresent,
+ pass in `notification.request.content.userInfo` as userInfo. When intercepting UserNotificationCenter on didReceive,
+ pass in `response.notification.request.content.userInfo` as `userInfo`.
+
+ Targeting must intercept this callback in order to report campaign analytics correctly.
+
+ @param userInfo    A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
+ */
+- (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo;
 
 /**
  Intercepts the `- application:didReceiveRemoteNotification:fetchCompletionHandler:shouldHandleNotificationDeepLink:` application delegate.
@@ -89,6 +102,21 @@ typedef NS_ENUM(NSInteger, AWSPinpointPushEventSourceType) {
  */
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
                        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler
+             shouldHandleNotificationDeepLink:(BOOL) handleDeepLink __attribute__((deprecated("Replaced by -interceptDidReceiveRemoteNotification:shouldHandleNotificationDeepLink:")));
+
+/**
+ For iOS 9 and below, intercept the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` application delegate.
+
+ For iOS 10 and above, intercept `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`. When intercepting the UserNotificationCenter on willPresent,
+ pass in `notification.request.content.userInfo` as `userInfo`. When intercepting UserNotificationCenter on didReceive,
+ pass in `response.notification.request.content.userInfo` as `userInfo`.
+
+ Targeting must intercept this callback in order to report campaign analytics correctly. Optionally specify 'shouldHandleNotificationDeepLink' to control whether or not the notification manager should attempt to open the remote notification deeplink, if present.
+
+ @param userInfo        A dictionary that contains information related to the remote notification, potentially including a badge number for the app icon, an alert sound, an alert message to display to the user, a notification identifier, and custom data. The provider originates it as a JSON-defined dictionary that iOS converts to an `NSDictionary` object; the dictionary may contain only property-list objects plus `NSNull`.
+ @param handleDeepLink  Whether or not notification manager should attempt to open the remote notification deeplink, if present
+ */
+- (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
              shouldHandleNotificationDeepLink:(BOOL) handleDeepLink;
 
 @end

--- a/AWSPinpoint/AWSPinpointNotificationManager.m
+++ b/AWSPinpoint/AWSPinpointNotificationManager.m
@@ -124,9 +124,18 @@ NSString *const AWSPinpointJourneyKey = @"journey";
     }
 }
 
+- (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo {
+    [self interceptDidReceiveRemoteNotification:userInfo shouldHandleNotificationDeepLink:YES];
+}
+
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
                        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))handler {
     [self interceptDidReceiveRemoteNotification:userInfo fetchCompletionHandler:handler shouldHandleNotificationDeepLink:YES];
+}
+
+- (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo
+             shouldHandleNotificationDeepLink:(BOOL) handleDeepLink {
+    [self handleNotificationReceived:[UIApplication sharedApplication] withNotification:userInfo shouldHandleNotificationDeepLink:handleDeepLink];
 }
 
 - (void)interceptDidReceiveRemoteNotification:(NSDictionary *)userInfo


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR removes the `handler` parameter from the intercept methods. In the code, they're not used and can be deprecated. The new methods are the same without `handler`. 

See https://github.com/aws-amplify/docs/pull/2114/files#r456488463 for additional context

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
