### PR TITLE
Fix overcommit crash in AWSSRWebSocket

### DIFF
--- a/AWSIoT/Internal/SocketRocket/AWSSRWebSocket.m
+++ b/AWSIoT/Internal/SocketRocket/AWSSRWebSocket.m
@@ -1552,22 +1552,20 @@ static const size_t SRFrameHeaderOverhead = 32;
                 if (aStream.streamError) {
                     [self _failWithError:aStream.streamError];
                 } else {
-                    dispatch_async(self->_workQueue, ^{
-                        if (self.readyState != AWSSR_CLOSED) {
-                            self.readyState = AWSSR_CLOSED;
-                            self->_selfRetain = nil;
-                        }
+                    if (self.readyState != AWSSR_CLOSED) {
+                        self.readyState = AWSSR_CLOSED;
+                        self->_selfRetain = nil;
+                    }
 
-                        if (!self->_sentClose && !self->_failed) {
-                            self->_sentClose = YES;
-                            // If we get closed in this state it's probably not clean because we should be sending this when we send messages
-                            [self _performDelegateBlock:^{
-                                if ([self.delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)]) {
-                                    [self.delegate webSocket:self didCloseWithCode:AWSSRStatusCodeGoingAway reason:@"Stream end encountered" wasClean:NO];
-                                }
-                            }];
-                        }
-                    });
+                    if (!self->_sentClose && !self->_failed) {
+                        self->_sentClose = YES;
+                        // If we get closed in this state it's probably not clean because we should be sending this when we send messages
+                        [self _performDelegateBlock:^{
+                            if ([self.delegate respondsToSelector:@selector(webSocket:didCloseWithCode:reason:wasClean:)]) {
+                                [self.delegate webSocket:self didCloseWithCode:AWSSRStatusCodeGoingAway reason:@"Stream end encountered" wasClean:NO];
+                            }
+                        }];
+                    }
                 }
                 
                 break;


### PR DESCRIPTION
This should fix various crashes related to threading issues in `AWSSRWebSocket`.

The issue seems to be that it's calling `dispatch_async` to `_workQueue`, but we already are in `_workQueue` at that time.

We have released a build with this fix and are no longer seeing any crashes in `AWSSRWebSocket`, which were relatively frequent before.

Should fix the following issues:
https://github.com/aws-amplify/aws-sdk-ios/issues/1434
https://github.com/aws-amplify/aws-sdk-ios/issues/1490

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.