### PR TITLE
Fix updated claims that contain special characters, such as chinese c…

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -36,25 +36,25 @@ public struct SessionToken {
                 return nil
             }
             let claims = tokenSplit[1]
+                .replacingOccurrences(of: "-", with: "+")
+                .replacingOccurrences(of: "_", with: "/")
             
             let paddedLength = claims.count + (4 - (claims.count % 4)) % 4
             //JWT is not padded with =, pad it if necessary
-            var updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
-            updatedClaims = updatedClaims.replacingOccurrences(of: "_", with: "/")
-            updatedClaims = updatedClaims.replacingOccurrences(of: "-", with: "+")
+            let updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
+            let encodedData = Data(base64Encoded: updatedClaims, options: .ignoreUnknownCharacters)
 
-            let claimsData = Data.init(base64Encoded: updatedClaims, options: .ignoreUnknownCharacters)
-            
-            guard claimsData != nil else {
+            guard let claimsData = encodedData else {
                 print("Cannot get claims in `Data` form. Token is not valid base64 encoded string.")
                 return nil
             }
-            let jsonObject = try? JSONSerialization.jsonObject(with: claimsData!, options: [])
-            guard jsonObject != nil else {
+            
+            let jsonObject = try? JSONSerialization.jsonObject(with: claimsData, options: [])
+            guard let convertedDictionary = jsonObject as? [String: AnyObject] else {
                 print("Cannot get claims in `Data` form. Token is not valid JSON string.")
                 return nil
             }
-            return jsonObject as? [String: AnyObject]
+            return convertedDictionary
         }
     }
     

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -39,7 +39,10 @@ public struct SessionToken {
             
             let paddedLength = claims.count + (4 - (claims.count % 4)) % 4
             //JWT is not padded with =, pad it if necessary
-            let updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
+            var updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)
+            updatedClaims = updatedClaims.replacingOccurrences(of: "_", with: "/")
+            updatedClaims = updatedClaims.replacingOccurrences(of: "-", with: "+")
+
             let claimsData = Data.init(base64Encoded: updatedClaims, options: .ignoreUnknownCharacters)
             
             guard claimsData != nil else {


### PR DESCRIPTION
…hars, by replacing _ and - with / and +

*Issue #, if available:*

*Description of changes:*

The current code to get claims from a JWT Token works well **_as long as there are no special characters_** in encoded in the base64.

By trying to decode claims that contain a name in Mandarin, the variable `claimsData` will be nil, and we are unable to obtain the JSON dictionary.

In order to fix the padded claims, the fix is to replace _ and - (which are invalid characters in a base64 string) with / and +, respectively. (See example [here](https://stackoverflow.com/questions/1228701/code-for-decoding-encoding-a-modified-base64-url))

The fix is the following lines in [aws-sdk-ios/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift](https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift)
```
var updatedClaims = claims.padding(toLength: paddedLength, withPad: "=", startingAt: 0)

// Replace _ with /
// Replace - with +
updatedClaims = updatedClaims.replacingOccurrences(of: "_", with: "/")
updatedClaims = updatedClaims.replacingOccurrences(of: "-", with: "+")
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
