### PR TITLE
fix(AWSMobileClient): Federated SignIn completion handler is assigned before status change is issued

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -697,11 +697,10 @@ extension AWSMobileClient {
                     } else if error._domain == AWSCognitoIdentityErrorDomain
                         && error._code == AWSCognitoIdentityErrorType.notAuthorized.rawValue
                         && self.federationProvider == .oidcFederation {
-                        
-                        self.mobileClientStatusChanged(userState: .signedOutFederatedTokensInvalid, additionalInfo: [self.ProviderKey:self.cachedLoginsMap.first!.key])
                         // store a reference to the completion handler which we would be calling later on.
                         self.pendingAWSCredentialsCompletion = completionHandler
                         
+                        self.mobileClientStatusChanged(userState: .signedOutFederatedTokensInvalid, additionalInfo: [self.ProviderKey:self.cachedLoginsMap.first!.key])
                     } else {
                         self.credentialsFetchLock.leave()
                         completionHandler(nil, error)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bug Fixes
 - **AWSMobileClient**
-  - Fixed an issue where the completion handler is not set before a status change is returned to the api. (See [PR #<>](https://github.com/aws-amplify/aws-sdk-ios/pull/))
+  - Fixed an issue where the completion handler is not set before a status change is returned to the api. (See [PR #2948](https://github.com/aws-amplify/aws-sdk-ios/pull/2948))
 
 ## 2.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 -Features for next release
 
+### Bug Fixes
+- **AWSMobileClient**
+  - Fixed an issue where the completion handler is not set before a status change is returned to the api. (See [PR #<>](https://github.com/aws-amplify/aws-sdk-ios/pull/))
+
 ## 2.15.1
 
 ### New features


### PR DESCRIPTION

*Issue #:* https://github.com/aws-amplify/amplify-ios/issues/640

*Description of changes:*

Federated sign in to Cognito Identity pool returns a status `signedOutFederatedTokensInvalid` when the token expire. When this happens, a fetch to aws credential will wait till the user signin. But the user can break from this wait by calling `releaseSignInWait`. But `releaseSignInWait` will only work if the completionHandler is set. This change make sure that the completion handler is set before the `signedOutFederatedTokensInvalid` is published.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
