### PR TITLE
chore(IoT): Stop multiple threads from entering CR while connecting

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -715,7 +715,8 @@
     //The unit of measure for the dispatch_time function is nano seconds.
 
     dispatch_semaphore_wait(_timerSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1800 * NSEC_PER_SEC));
-    if (! self.reconnectTimer && self.mqttStatus != AWSIoTMQTTStatusConnected ) {
+    BOOL isConnectingOrConnected = self.mqttStatus == AWSIoTMQTTStatusConnected || self.mqttStatus == AWSIoTMQTTStatusConnecting;
+    if (!self.reconnectTimer && !isConnectingOrConnected) {
         self.reconnectTimer = [NSTimer timerWithTimeInterval:self.currentReconnectTime
                                                       target:self
                                                     selector: @selector(reconnectToSession)


### PR DESCRIPTION
In attempts to address one of the issues reported here:
https://github.com/aws-amplify/aws-sdk-ios/issues/2939

It seems that there are competing threads attempting to connect to the websocket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
