### PR TITLE
chore: Deprecate MD5 APIs; document remaining usage

### DIFF
--- a/AWSCore/Utility/AWSCategory.h
+++ b/AWSCore/Utility/AWSCategory.h
@@ -78,13 +78,26 @@ FOUNDATION_EXPORT NSString *const AWSDateShortDateFormat2;
 
 @interface NSString (AWS)
 
+/// A convenience method for calculating an MD5 hash of `data`.
+///
+/// MD5 is not suited for cryptographically-sensitive operations. Usages of this
+/// method in the AWS Mobile SDK are limited to calculating checksums for AWS S3
+/// operations that require a `Content-MD5` HTTP header, and do not repesent a
+/// security risk. We are exposing this method as a convenience API for
+/// applications that need to calculate that value manually.
 + (NSString *)aws_base64md5FromData:(NSData *)data;
+
 - (BOOL)aws_isBase64Data;
 - (NSString *)aws_stringWithURLEncoding;
 - (NSString *)aws_stringWithURLEncodingPath;
 - (NSString *)aws_stringWithURLEncodingPathWithoutPriorDecoding;
-- (NSString *)aws_md5String;
-- (NSString *)aws_md5StringLittleEndian;
+
+/// Deprecated. This method will be removed in an upcoming version of the SDK.
+- (NSString *)aws_md5String DEPRECATED_MSG_ATTRIBUTE("This method will be removed in an upcoming version of the SDK.");
+
+/// Deprecated. This method will be removed in an upcoming version of the SDK.
+- (NSString *)aws_md5StringLittleEndian DEPRECATED_MSG_ATTRIBUTE("This method will be removed in an upcoming version of the SDK.");
+
 - (BOOL)aws_isVirtualHostedStyleCompliant;
 
 - (AWSRegionType)aws_regionTypeValue;

--- a/AWSKinesis/AWSAbstractKinesisRecorder.m
+++ b/AWSKinesis/AWSAbstractKinesisRecorder.m
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 
+#import <CommonCrypto/CommonDigest.h>
 #import "AWSAbstractKinesisRecorder.h"
 #import "AWSKinesis.h"
 
@@ -366,6 +367,26 @@ NSString *const AWSKinesisAbstractClientRecorderDatabasePathPrefix = @"com/amazo
     } else {
         _batchRecordsByteLimit = batchRecordsByteLimit;
     }
+}
+
+/// Calculates a path-safe database database name for `key`.
+///
+/// Note that the internal implementation of this method uses MD5 to calculate a
+/// hash of the key. MD5 is not suited for cryptographically-sensitive operations,
+/// but this method is using it simply to get a database name that is associated
+/// with the specified `key`, and doesn't contain special characters, etc. The use
+/// of MD5 is carried over from previous implementations for
+/// backwards-compatibility, and does not represent a security risk.
++ (NSString *) databasePathForKey:(NSString *)key {
+    NSData *dataString = [key dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
+    unsigned char digestArray[CC_MD5_DIGEST_LENGTH];
+    CC_MD5([dataString bytes], (CC_LONG)[dataString length], digestArray);
+
+    NSMutableString *md5String = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
+        [md5String appendFormat:@"%02x", digestArray[i]];
+    }
+    return md5String;
 }
 
 @end

--- a/AWSKinesis/AWSFirehoseRecorder.m
+++ b/AWSKinesis/AWSFirehoseRecorder.m
@@ -46,6 +46,8 @@ NSString *const AWSFirehoseRecorderCacheName = @"com.amazonaws.AWSFirehoseRecord
                            identifier:(NSString *)identifier
                             cacheName:(NSString *)cacheName;
 
++ (NSString *) databasePathForKey:(NSString *)key;
+
 @end
 
 @implementation AWSFirehoseRecorder
@@ -87,8 +89,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         _serviceClients = [AWSSynchronizedMutableDictionary new];
     });
 
+    NSString *identifier = [AWSAbstractKinesisRecorder databasePathForKey:key];
     AWSFirehoseRecorder *FirehoseRecorder = [[AWSFirehoseRecorder alloc] initWithConfiguration:configuration
-                                                                                 identifier:[key aws_md5StringLittleEndian]
+                                                                                 identifier:identifier
                                                                                   cacheName:[NSString stringWithFormat:@"%@.%@", AWSFirehoseRecorderCacheName, key]];
     [_serviceClients setObject:FirehoseRecorder
                         forKey:key];

--- a/AWSKinesis/AWSKinesisRecorder.m
+++ b/AWSKinesis/AWSKinesisRecorder.m
@@ -46,6 +46,8 @@ NSString *const AWSKinesisRecorderCacheName = @"com.amazonaws.AWSKinesisRecorder
                            identifier:(NSString *)identifier
                             cacheName:(NSString *)cacheName;
 
++ (NSString *) databasePathForKey:(NSString *)key;
+
 @end
 
 @interface AWSKinesis()
@@ -93,8 +95,9 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         _serviceClients = [AWSSynchronizedMutableDictionary new];
     });
 
+    NSString *identifier = [AWSAbstractKinesisRecorder databasePathForKey:key];
     AWSKinesisRecorder *kinesisRecorder = [[AWSKinesisRecorder alloc] initWithConfiguration:configuration
-                                                                                 identifier:[key aws_md5StringLittleEndian]
+                                                                                 identifier:identifier
                                                                                   cacheName:[NSString stringWithFormat:@"%@.%@", AWSKinesisRecorderCacheName, key]];
     [_serviceClients setObject:kinesisRecorder
                         forKey:key];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
--Features for next release
+
+### Misc. Updates
+- Deprecated 2 MD5-related methods in AWSCore. These methods will be removed in an upcoming version of the SDK. (#2964)
 
 ## 2.15.1
 


### PR DESCRIPTION
*Description of changes:*

**`aws_md5String`**
* This PR: Deprecate the publicly exported method, to provide customers with time to migrate to some other mechanism for calculating hashes before we remove it on or about 1-Dec-2020.
* ECD 1-Dec-2020: Remove the publicly exported symbol and method implementation from the SDK altogether.

**`aws_md5StringLittleEndian`**
* This PR: Deprecate the publicly exported method, to provide customers with time to migrate to some other mechanism for calculating hashes before we remove it on or about 1-Dec-2020.
* Create a private implementation in Kinesis that mirrors the previous usage for naming local KinesisFirehose & Kinesis SQLite databases. Document the method implementation source code with an explanation that the usage does not represent a security issue.
* ECD 1-Dec-2020: Remove the publicly exported symbol and method implementation from the SDK altogether.

**`aws_base64md5FromData`**
* This PR: Document its usage in source code with an explanation that the usage does not represent a security issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
