### PR TITLE
chore: Add AWSAllTestsHost to AWSAllTests target

### DIFF
--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				FA0E11EE24F6D4560003A65F /* PBXTargetDependency */,
 				18D04CE41DD51416008A3E01 /* PBXTargetDependency */,
 				18D04CE61DD51416008A3E01 /* PBXTargetDependency */,
 				9A19D4E32107EBA600C2FBB9 /* PBXTargetDependency */,
@@ -2545,6 +2546,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
 			remoteInfo = AWSTestResources;
+		};
+		FA0E11ED24F6D4560003A65F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE0D41541C6A66A9006B91B5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 181154751E201403008F184C;
+			remoteInfo = AWSAllTestsHost;
 		};
 		FA0FEE8824645C8100D14F7F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -14635,6 +14643,11 @@
 			isa = PBXTargetDependency;
 			target = FAD9DD1E245CD135003F84D0 /* AWSTestResources */;
 			targetProxy = FA0909162463948600E174F8 /* PBXContainerItemProxy */;
+		};
+		FA0E11EE24F6D4560003A65F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 181154751E201403008F184C /* AWSAllTestsHost */;
+			targetProxy = FA0E11ED24F6D4560003A65F /* PBXContainerItemProxy */;
 		};
 		FA0FEE8924645C8100D14F7F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/CircleciScripts/bump_sdk_version.py
+++ b/CircleciScripts/bump_sdk_version.py
@@ -184,7 +184,7 @@ class VersionBumper:
     def bump_changelog(self):
         changelog_pattern = {
             "match": r"## Unreleased",
-            "replace": "## Unreleased\\\n-Features for next release\\\n\\\n## {version}".format(
+            "replace": "## Unreleased\\\n\\\n-Features for next release\\\n\\\n## {version}".format(
                 version=self._new_sdk_version
             ),
             "files": ["CHANGELOG.md"],


### PR DESCRIPTION
We see intermittent but frequent failures in the 'pre_integrationtest' step of
the CI/CD pipeline, with the error message indicating that xcodebuild cannot
find AWSAllTestsHost.app. This change adds AWSAllTestsHost.app as a dependency
in the AWSAllTests aggregate target.

This change also adds an extra newline when bumping the version in CHANGELOG.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
