### PR TITLE
chore: Update Cognito ASF version

### DIFF
--- a/AWSCognitoAuth.podspec
+++ b/AWSCognitoAuth.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'AWSCore', '2.15.2'
-  s.dependency 'AWSCognitoIdentityProviderASF', '1.0.1'
+  s.dependency 'AWSCognitoIdentityProviderASF', '1.0.2'
 
   s.source_files = 'AWSCognitoAuth/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoAuth/*.h'

--- a/AWSCognitoIdentityProvider.podspec
+++ b/AWSCognitoIdentityProvider.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks   = 'Security', 'UIKit'
   s.dependency 'AWSCore', '2.15.2'
-  s.dependency 'AWSCognitoIdentityProviderASF', '1.0.1'
+  s.dependency 'AWSCognitoIdentityProviderASF', '1.0.2'
 
   s.source_files = 'AWSCognitoIdentityProvider/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoIdentityProvider/*.h'

--- a/AWSCognitoIdentityProviderASF.podspec
+++ b/AWSCognitoIdentityProviderASF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSCognitoIdentityProviderASF'
-  s.version      = '1.0.1'
+  s.version      = '1.0.2'
   s.summary      = 'Amazon Cognito Identity Provider Advanced Security Features library (Beta)'
 
   s.description  = 'Amazon Cognito Identity Provider ASF provides the information necessary to support adaptive authentication'


### PR DESCRIPTION
When we updated the license in the AWSCognitoIdentityProviderASF package, we
neglected to bump the version, which means that there is an inconsistency
between the podspec and what external tools like CocoaPods report. This change
rectifies that by bumping the version to 1.0.2, which should have been done
originally, and updating dependencies to use the new version. It's now Apache
all the way down.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
