### PR TITLE
CHANGELOG for model updates published around: Mon Aug 31 18:31:17 UTC 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 ## Unreleased
 
 ### Note for Xcode 12 support
-- All SDKs have been updated to support minimum iOS version 9.0, dropping support for iOS 8.0 in this release. Xcode 12 has dropped support for iOS 8 and requires upgrading to this version to continue building on Xcode 12.
+- All SDKs have been updated to support minimum iOS version 9.0, dropping support for iOS 8.0 in this release. Xcode 12 has dropped support for iOS 8 and requires upgrading to this version to continue building on Xcode 12. ([PR #2981](https://github.com/aws-amplify/aws-sdk-ios/pull/2981))
 
 ### Misc. Updates
 - Model updates for the following services.
-  - **Breaking Change** Amazon EC2
-  - **Breaking Change** Amazon Elastic Load Balancing (ELB)
+  - **Breaking Change** Amazon EC2 ([PR #2986](https://github.com/aws-amplify/aws-sdk-ios/pull/2986))
+  - **Breaking Change** Amazon Elastic Load Balancing (ELB) ([PR #2951](https://github.com/aws-amplify/aws-sdk-ios/pull/2951))
 
 ## 2.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 ## Unreleased
 
 ### Note for Xcode 12 support
-- All SDKs have been updated to support minimum iOS version 9.0, dropping support for iOS 8.0 in this release. Xcode 12 has dropped support for iOS 8 and requires upgrading to this version to continue building on Xcode 12. ([PR #2981](https://github.com/aws-amplify/aws-sdk-ios/pull/2981))
+- All SDKs have been updated to support minimum iOS version 9.0, dropping support for iOS 8.0 in this release. Xcode 12 has dropped support for iOS 8 and requires setting your app's minimum supported version to 9.0 or greater to continue building on Xcode 12. ([PR #2981](https://github.com/aws-amplify/aws-sdk-ios/pull/2981))
 
 ### Misc. Updates
 - Model updates for the following services.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+---
+
+MOVE THIS SECTION TO THE CORRECT LOCATION
+
+### Misc. Updates
+
+- Model updates for the following services
+---AWSSQS
+---AWSEC2
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 
 ### Misc. Updates
 - Model updates for the following services.
-  - **Breaking Change** Amazon SQS
   - **Breaking Change** Amazon EC2
   - **Breaking Change** Amazon Elastic Load Balancing (ELB)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 
 ### Misc. Updates
 - Model updates for the following services.
-  - **Breaking Change** Amazon EC2 ([PR #2986](https://github.com/aws-amplify/aws-sdk-ios/pull/2986))
+  - **Breaking Change** Amazon EC2 - reverted a change that was mistakenly released in the previous model update ([PR #2986](https://github.com/aws-amplify/aws-sdk-ios/pull/2986))
   - **Breaking Change** Amazon Elastic Load Balancing (ELB) ([PR #2951](https://github.com/aws-amplify/aws-sdk-ios/pull/2951))
 
 ## 2.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 ### Misc. Updates
 - Model updates for the following services.
   - **Breaking Change** Amazon EC2 - reverted a change that was mistakenly released in the previous model update ([PR #2986](https://github.com/aws-amplify/aws-sdk-ios/pull/2986))
-  - **Breaking Change** Amazon Elastic Load Balancing (ELB) ([PR #2951](https://github.com/aws-amplify/aws-sdk-ios/pull/2951))
+  - **Breaking Change** Amazon Elastic Load Balancing - updated to API version `2015-12-01` ([PR #2951](https://github.com/aws-amplify/aws-sdk-ios/pull/2951))
 
 ## 2.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 MOVE THIS SECTION TO THE CORRECT LOCATION
 
-### Misc. Updates
 
-- Model updates for the following services
----AWSSQS
----AWSEC2
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
 
-- *Features for next release*
+### Note for Xcode 12 support
+- All SDKs have been updated to support minimum iOS version 9.0, dropping support for iOS 8.0 in this release. Xcode 12 has dropped support for iOS 8 and requires upgrading to this version to continue building on Xcode 12.
+
+### Misc. Updates
+- Model updates for the following services.
+  - **Breaking Change** Amazon SQS
+  - **Breaking Change** Amazon EC2
+  - **Breaking Change** Amazon Elastic Load Balancing (ELB)
 
 ## 2.15.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 ### Note for Xcode 12 support
 - All SDKs have been updated to support minimum iOS version 9.0, dropping support for iOS 8.0 in this release. Xcode 12 has dropped support for iOS 8 and requires setting your app's minimum supported version to 9.0 or greater to continue building on Xcode 12. ([PR #2981](https://github.com/aws-amplify/aws-sdk-ios/pull/2981))
 
+### Bug Fixes
+- **AWSiOT** 
+  - Backport crash fix into AWSSRWebSocket ([PR #2984](https://github.com/aws-amplify/aws-sdk-ios/pull/2984))
+
 ### Misc. Updates
 - Model updates for the following services.
   - **Breaking Change** Amazon EC2 - reverted a change that was mistakenly released in the previous model update ([PR #2986](https://github.com/aws-amplify/aws-sdk-ios/pull/2986))


### PR DESCRIPTION
CHANGELOG for model updates published around: Mon Aug 31 18:31:17 UTC 2020


**NOTE:** Remember to note a minor version bump b/c of SES, EC2 and ELB breaking service model changes

update(sept 3): revert SES - https://github.com/aws-amplify/aws-sdk-ios/pull/2997