### PR TITLE
feat: Support virtual-host (V2) style addressing for S3 operations

### DIFF
--- a/AWSS3/AWSS3Serializer.h
+++ b/AWSS3/AWSS3Serializer.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.

--- a/AWSS3/AWSS3Serializer.m
+++ b/AWSS3/AWSS3Serializer.m
@@ -55,7 +55,7 @@
 }
 
 - (AWSTask *)serializeRequest:(NSMutableURLRequest *)request headers:(NSDictionary *)headers parameters:(NSDictionary *)parameters {
-    return [[_requestSerializer serializeRequest:request headers:headers parameters:parameters] continueWithBlock:^id _Nullable(AWSTask * _Nonnull t) {
+    return [[_requestSerializer serializeRequest:request headers:headers parameters:parameters] continueWithSuccessBlock:^id _Nullable(AWSTask * _Nonnull t) {
         [self updateRequestToUseVirtualHostURL:request];
         return nil;
     }];

--- a/AWSS3/AWSS3Serializer.m
+++ b/AWSS3/AWSS3Serializer.m
@@ -1,5 +1,5 @@
 //
-// Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
@@ -54,8 +54,69 @@
     return [_requestSerializer validateRequest:request];
 }
 
-- (AWSTask *)serializeRequest:(NSMutableURLRequest *)request headers:(NSDictionary *)headers parameters:(NSDictionary *)parameters{
-    return [_requestSerializer serializeRequest:request headers:headers parameters:parameters];
+- (AWSTask *)serializeRequest:(NSMutableURLRequest *)request headers:(NSDictionary *)headers parameters:(NSDictionary *)parameters {
+    return [[_requestSerializer serializeRequest:request headers:headers parameters:parameters] continueWithBlock:^id _Nullable(AWSTask * _Nonnull t) {
+        [self updateRequestToUseVirtualHostURL:request];
+        return nil;
+    }];
+}
+
+// Virtual host logic from Boto
+// https://github.com/boto/botocore/blob/08d0e5995284656895f5c8a0bddd8c386a8483c4/botocore/utils.py#L954
+- (void)updateRequestToUseVirtualHostURL:(NSMutableURLRequest *)request {
+    if ([self isGetBucketLocationRequest:request]) {
+        AWSDDLogDebug(@"Request is for bucket location request, continuing to use path-style URL");
+        return;
+    }
+
+    NSURLComponents *components = [NSURLComponents componentsWithURL:request.URL resolvingAgainstBaseURL:NO];
+    NSMutableArray<NSString *> *pathParts = [self normalizedPathPartsFromComponents:components];
+
+    NSString *bucketName = [pathParts firstObject];
+    if (![bucketName aws_isVirtualHostedStyleCompliant]) {
+        AWSDDLogDebug(@"Bucket name '%@' is not compatible with virtual-host URLs, continuing to use path-style URL", bucketName);
+        return;
+    }
+
+    AWSDDLogDebug(@"Updating request to use virtual-host style URL");
+    [self updatePathComponentForVirtualHostStyleURL:components pathParts:pathParts];
+    [self updateHostComponentForVirtualHostStyleURL:components bucketName:bucketName];
+
+    NSURL *newURL = [components URL];
+
+    AWSDDLogDebug(@"Rewrote request URL to: %@", newURL);
+    request.URL = newURL;
+
+    return;
+}
+
+- (NSMutableArray<NSString *> *)normalizedPathPartsFromComponents:(NSURLComponents *)components {
+    NSMutableArray<NSString *> *pathParts = [[components.percentEncodedPath componentsSeparatedByString:@"/"] mutableCopy];
+    // remove leading '/' if path exists
+    if (pathParts.count > 0) {
+        [pathParts removeObjectAtIndex:0];
+    }
+    return pathParts;
+}
+
+- (void)updatePathComponentForVirtualHostStyleURL:(NSURLComponents *)components
+                                        pathParts:(NSMutableArray<NSString *> *)pathParts {
+    [pathParts removeObjectAtIndex:0];
+    NSMutableString *path = [[pathParts componentsJoinedByString:@"/"] mutableCopy];
+    // ALl paths must have leading slash
+    [path insertString:@"/" atIndex:0];
+    components.percentEncodedPath = path;
+}
+
+- (void)updateHostComponentForVirtualHostStyleURL:(NSURLComponents *)components
+                                       bucketName:(NSString *) bucketName {
+    NSString *oldHostName = components.host;
+    NSString *newHostName = [NSString stringWithFormat:@"%@.%@", bucketName, oldHostName];
+    components.host = newHostName;
+}
+
+- (BOOL)isGetBucketLocationRequest:(NSMutableURLRequest *)request {
+    return [request.URL.query hasSuffix:@"?location"];
 }
 
 @end

--- a/AWSS3/AWSS3TransferManager.h
+++ b/AWSS3/AWSS3TransferManager.h
@@ -242,6 +242,7 @@ DEPRECATED_MSG_ATTRIBUTE("Use `AWSS3TransferUtility` for upload and download ope
 
 @end
 
+DEPRECATED_MSG_ATTRIBUTE("Use `AWSS3TransferUtility` for upload and download operations.")
 @interface AWSS3TransferManagerUploadRequest : AWSS3PutObjectRequest
 
 @property (nonatomic, assign, readonly) AWSS3TransferManagerRequestState state;
@@ -249,16 +250,19 @@ DEPRECATED_MSG_ATTRIBUTE("Use `AWSS3TransferUtility` for upload and download ope
 
 @end
 
+DEPRECATED_MSG_ATTRIBUTE("Use `AWSS3TransferUtility` for upload and download operations.")
 @interface AWSS3TransferManagerUploadOutput : AWSS3PutObjectOutput
 
 @end
 
+DEPRECATED_MSG_ATTRIBUTE("Use `AWSS3TransferUtility` for upload and download operations.")
 @interface AWSS3TransferManagerDownloadRequest : AWSS3GetObjectRequest
 
 @property (nonatomic, assign, readonly) AWSS3TransferManagerRequestState state;
 
 @end
 
+DEPRECATED_MSG_ATTRIBUTE("Use `AWSS3TransferUtility` for upload and download operations.")
 @interface AWSS3TransferManagerDownloadOutput : AWSS3GetObjectOutput
 
 @end

--- a/AWSS3Tests/AWSS3TestHelper.m
+++ b/AWSS3Tests/AWSS3TestHelper.m
@@ -46,6 +46,7 @@
     __block BOOL success = NO;
     [[[s3 createBucket:createBucketReq] continueWithBlock:^id(AWSTask *task) {
         if (task.error) {
+            NSLog(@"Could not create bucket '%@': %@", bucketName, task.error);
             success = NO;
         } else {
             success = YES;
@@ -121,6 +122,7 @@
     __block BOOL success = NO;
     [[[s3 deleteBucket:deleteBucketReq] continueWithBlock:^id(AWSTask *task) {
         if (task.error) {
+            NSLog(@"Could not delete bucket '%@': %@", bucketName, task.error);
             success = NO;
         } else {
             success = YES;
@@ -152,7 +154,7 @@
         deleteObjectsRequest.remove = s3Remove;
         [[s3 deleteObjects:deleteObjectsRequest] continueWithBlock:^id(AWSTask *task) {
             if (task.error) {
-                NSLog(@"Failed to delete: %@", task.error);
+                NSLog(@"Could not delete objects from bucket '%@': %@", bucketName, task.error);
             } else {
                 NSLog(@"Successfully deleted: %@", objects);
             }
@@ -170,6 +172,7 @@
     __block BOOL success = NO;
     [[[s3 headObject:headObjectRequest] continueWithBlock:^id(AWSTask *task) {
         if (task.error) {
+            NSLog(@"Failed to headObject '%@' in bucket '%@': %@", keyName, bucketName, task.error);
             success = NO;
         } else {
             success = YES;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
--Features for next release
+
+### New features
+
+- **Amazon S3**
+  - The AWSS3 SDK now uses [virtual-host style addressing](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#virtual-hosted-style-access) for DNS-compliant bucket names. (See [issue #1535](https://github.com/aws-amplify/aws-sdk-ios/issues/1535), and [PR #2996](https://github.com/aws-amplify/aws-sdk-ios/pull/2996)). This does not affect AWSS3TransferUtility, which already uses virtual-host style addressing in its operations.
 
 ## 2.16.0
 


### PR DESCRIPTION
As noted in [this forum announcement](https://forums.aws.amazon.com/ann.jspa?annID=6776):

> S3 buckets created after September 30, 2020 will support only virtual-hosted style requests.

This change updates `AWSS3Serializer.m` to change the URL and path of an S3 request just before it is signed. This mimics the logic in place in the [Python SDK and AWS CLI](https://github.com/boto/botocore/blob/08d0e5995284656895f5c8a0bddd8c386a8483c4/botocore/utils.py#L954).

This change does not affect AWSS3TransferUtility, which already uses virtual-host style addressing in its Presigned URL operations.

The serializer isn't easily amenable to unit testing since it requires quite a bit of infrastructure mocking to use. However, it is exercised by the existing integration tests, which verify proper operation of the new code.

Refs: #1535

**Additional changes**
- Also adds additional deprecation messages to TransferManager APIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
