### PR TITLE
Revert "feat(AWSSESv2): update models to latest (#2955)"

### DIFF
--- a/AWSElasticLoadBalancingTests/AWSElasticLoadBalancingTests.m
+++ b/AWSElasticLoadBalancingTests/AWSElasticLoadBalancingTests.m
@@ -44,60 +44,19 @@
 
     XCTAssertFalse([NSDate aws_getRuntimeClockSkew], @"current RunTimeClockSkew is not zero!");
     [AWSTestUtility setMockDate:[NSDate dateWithTimeIntervalSince1970:3600]];
+
     AWSElasticLoadBalancing *elb = [AWSElasticLoadBalancing defaultElasticLoadBalancing];
     XCTAssertNotNil(elb);
 
-    AWSElasticLoadBalancingDescribeAccessPointsInput *describeAccessPointsInput = [AWSElasticLoadBalancingDescribeAccessPointsInput new];
-    [[[elb describeLoadBalancers:describeAccessPointsInput] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            XCTFail(@"Error: [%@]", task.error);
-        }
+    AWSElasticLoadBalancingDescribeAccountLimitsInput *input = [AWSElasticLoadBalancingDescribeAccountLimitsInput new];
 
-        if (task.result) {
-            XCTAssertTrue([task.result isKindOfClass:[AWSElasticLoadBalancingDescribeAccessPointsOutput class]]);
-            AWSElasticLoadBalancingDescribeAccessPointsOutput *describeAccessPointsOutput = task.result;
-            XCTAssertNotNil(describeAccessPointsOutput.loadBalancerDescriptions, @"loadBalancerDescriptions Array should not be nil");
-        }
-
+    [[[elb describeAccountLimits:input] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNil(task.error);
+        XCTAssertNotNil(task.result);
         return nil;
     }] waitUntilFinished];
 
     [AWSTestUtility revertSwizzling];
-}
-
-- (void)testDescribeLoadBalancers {
-    AWSElasticLoadBalancing *elb = [AWSElasticLoadBalancing defaultElasticLoadBalancing];
-
-    AWSElasticLoadBalancingDescribeAccessPointsInput *describeAccessPointsInput = [AWSElasticLoadBalancingDescribeAccessPointsInput new];
-    [[[elb describeLoadBalancers:describeAccessPointsInput] continueWithBlock:^id(AWSTask *task) {
-        if (task.error) {
-            XCTFail(@"Error: [%@]", task.error);
-        }
-
-        if (task.result) {
-            XCTAssertTrue([task.result isKindOfClass:[AWSElasticLoadBalancingDescribeAccessPointsOutput class]]);
-            AWSElasticLoadBalancingDescribeAccessPointsOutput *describeAccessPointsOutput = task.result;
-            XCTAssertNotNil(describeAccessPointsOutput.loadBalancerDescriptions, @"loadBalancerDescriptions Array should not be nil");
-        }
-
-        return nil;
-    }] waitUntilFinished];
-}
-
-- (void)testConfigureHealthCheckFailed {
-    AWSElasticLoadBalancing *elb = [AWSElasticLoadBalancing defaultElasticLoadBalancing];
-    
-    AWSElasticLoadBalancingConfigureHealthCheckInput *healthCheckInput = [AWSElasticLoadBalancingConfigureHealthCheckInput new];
-    healthCheckInput.loadBalancerName = @""; //loadBalancerName is empty
-    
-    [[[elb configureHealthCheck:healthCheckInput] continueWithBlock:^id(AWSTask *task) {
-        
-        XCTAssertNotNil(task.error, @"expected Validation Error, but got nil");
-        XCTAssertEqual(task.error.code, 0);
-        XCTAssertTrue([@"ValidationError" isEqualToString:task.error.userInfo[@"Code"]]);
-        XCTAssertTrue([@"1 validation error detected: Value null at 'healthCheck' failed to satisfy constraint: Member must not be null" isEqualToString:task.error.userInfo[@"Message"]]);
-        return nil;
-    }] waitUntilFinished];
 }
 
 @end

--- a/AWSSES/AWSSESModel.h
+++ b/AWSSES/AWSSESModel.h
@@ -23,24 +23,56 @@ FOUNDATION_EXPORT NSString *const AWSSESErrorDomain;
 
 typedef NS_ENUM(NSInteger, AWSSESErrorType) {
     AWSSESErrorUnknown,
-    AWSSESErrorAccountSuspended,
+    AWSSESErrorAccountSendingPaused,
     AWSSESErrorAlreadyExists,
-    AWSSESErrorBadRequest,
-    AWSSESErrorConcurrentModification,
-    AWSSESErrorConflict,
-    AWSSESErrorInvalidNextToken,
+    AWSSESErrorCannotDelete,
+    AWSSESErrorConfigurationSetAlreadyExists,
+    AWSSESErrorConfigurationSetDoesNotExist,
+    AWSSESErrorConfigurationSetSendingPaused,
+    AWSSESErrorCustomVerificationEmailInvalidContent,
+    AWSSESErrorCustomVerificationEmailTemplateAlreadyExists,
+    AWSSESErrorCustomVerificationEmailTemplateDoesNotExist,
+    AWSSESErrorEventDestinationAlreadyExists,
+    AWSSESErrorEventDestinationDoesNotExist,
+    AWSSESErrorFromEmailAddressNotVerified,
+    AWSSESErrorInvalidCloudWatchDestination,
+    AWSSESErrorInvalidConfigurationSet,
+    AWSSESErrorInvalidDeliveryOptions,
+    AWSSESErrorInvalidFirehoseDestination,
+    AWSSESErrorInvalidLambdaFunction,
+    AWSSESErrorInvalidPolicy,
+    AWSSESErrorInvalidRenderingParameter,
+    AWSSESErrorInvalidS3Configuration,
+    AWSSESErrorInvalidSNSDestination,
+    AWSSESErrorInvalidSnsTopic,
+    AWSSESErrorInvalidTemplate,
+    AWSSESErrorInvalidTrackingOptions,
     AWSSESErrorLimitExceeded,
     AWSSESErrorMailFromDomainNotVerified,
     AWSSESErrorMessageRejected,
-    AWSSESErrorNotFound,
-    AWSSESErrorSendingPaused,
-    AWSSESErrorTooManyRequests,
+    AWSSESErrorMissingRenderingAttribute,
+    AWSSESErrorProductionAccessNotGranted,
+    AWSSESErrorRuleDoesNotExist,
+    AWSSESErrorRuleSetDoesNotExist,
+    AWSSESErrorTemplateDoesNotExist,
+    AWSSESErrorTrackingOptionsAlreadyExists,
+    AWSSESErrorTrackingOptionsDoesNotExist,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESBehaviorOnMxFailure) {
-    AWSSESBehaviorOnMxFailureUnknown,
-    AWSSESBehaviorOnMxFailureUseDefaultValue,
-    AWSSESBehaviorOnMxFailureRejectMessage,
+typedef NS_ENUM(NSInteger, AWSSESBehaviorOnMXFailure) {
+    AWSSESBehaviorOnMXFailureUnknown,
+    AWSSESBehaviorOnMXFailureUseDefaultValue,
+    AWSSESBehaviorOnMXFailureRejectMessage,
+};
+
+typedef NS_ENUM(NSInteger, AWSSESBounceType) {
+    AWSSESBounceTypeUnknown,
+    AWSSESBounceTypeDoesNotExist,
+    AWSSESBounceTypeMessageTooLarge,
+    AWSSESBounceTypeExceededQuota,
+    AWSSESBounceTypeContentRejected,
+    AWSSESBounceTypeUndefined,
+    AWSSESBounceTypeTemporaryFailure,
 };
 
 typedef NS_ENUM(NSInteger, AWSSESBulkEmailStatus) {
@@ -48,42 +80,33 @@ typedef NS_ENUM(NSInteger, AWSSESBulkEmailStatus) {
     AWSSESBulkEmailStatusSuccess,
     AWSSESBulkEmailStatusMessageRejected,
     AWSSESBulkEmailStatusMailFromDomainNotVerified,
-    AWSSESBulkEmailStatusConfigurationSetNotFound,
-    AWSSESBulkEmailStatusTemplateNotFound,
+    AWSSESBulkEmailStatusConfigurationSetDoesNotExist,
+    AWSSESBulkEmailStatusTemplateDoesNotExist,
     AWSSESBulkEmailStatusAccountSuspended,
     AWSSESBulkEmailStatusAccountThrottled,
     AWSSESBulkEmailStatusAccountDailyQuotaExceeded,
     AWSSESBulkEmailStatusInvalidSendingPoolName,
     AWSSESBulkEmailStatusAccountSendingPaused,
     AWSSESBulkEmailStatusConfigurationSetSendingPaused,
-    AWSSESBulkEmailStatusInvalidParameter,
+    AWSSESBulkEmailStatusInvalidParameterValue,
     AWSSESBulkEmailStatusTransientFailure,
     AWSSESBulkEmailStatusFailed,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESContactLanguage) {
-    AWSSESContactLanguageUnknown,
-    AWSSESContactLanguageEn,
-    AWSSESContactLanguageJa,
+typedef NS_ENUM(NSInteger, AWSSESConfigurationSetAttribute) {
+    AWSSESConfigurationSetAttributeUnknown,
+    AWSSESConfigurationSetAttributeEventDestinations,
+    AWSSESConfigurationSetAttributeTrackingOptions,
+    AWSSESConfigurationSetAttributeDeliveryOptions,
+    AWSSESConfigurationSetAttributeReputationOptions,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESDataFormat) {
-    AWSSESDataFormatUnknown,
-    AWSSESDataFormatCsv,
-    AWSSESDataFormatJson,
-};
-
-typedef NS_ENUM(NSInteger, AWSSESDeliverabilityDashboardAccountStatus) {
-    AWSSESDeliverabilityDashboardAccountStatusUnknown,
-    AWSSESDeliverabilityDashboardAccountStatusActive,
-    AWSSESDeliverabilityDashboardAccountStatusPendingExpiration,
-    AWSSESDeliverabilityDashboardAccountStatusDisabled,
-};
-
-typedef NS_ENUM(NSInteger, AWSSESDeliverabilityTestStatus) {
-    AWSSESDeliverabilityTestStatusUnknown,
-    AWSSESDeliverabilityTestStatusInProgress,
-    AWSSESDeliverabilityTestStatusCompleted,
+typedef NS_ENUM(NSInteger, AWSSESCustomMailFromStatus) {
+    AWSSESCustomMailFromStatusUnknown,
+    AWSSESCustomMailFromStatusPending,
+    AWSSESCustomMailFromStatusSuccess,
+    AWSSESCustomMailFromStatusFailed,
+    AWSSESCustomMailFromStatusTemporaryFailure,
 };
 
 typedef NS_ENUM(NSInteger, AWSSESDimensionValueSource) {
@@ -93,19 +116,13 @@ typedef NS_ENUM(NSInteger, AWSSESDimensionValueSource) {
     AWSSESDimensionValueSourceLinkTag,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESDkimSigningAttributesOrigin) {
-    AWSSESDkimSigningAttributesOriginUnknown,
-    AWSSESDkimSigningAttributesOriginAwsSes,
-    AWSSESDkimSigningAttributesOriginExternal,
-};
-
-typedef NS_ENUM(NSInteger, AWSSESDkimStatus) {
-    AWSSESDkimStatusUnknown,
-    AWSSESDkimStatusPending,
-    AWSSESDkimStatusSuccess,
-    AWSSESDkimStatusFailed,
-    AWSSESDkimStatusTemporaryFailure,
-    AWSSESDkimStatusNotStarted,
+typedef NS_ENUM(NSInteger, AWSSESDsnAction) {
+    AWSSESDsnActionUnknown,
+    AWSSESDsnActionFailed,
+    AWSSESDsnActionDelayed,
+    AWSSESDsnActionDelivered,
+    AWSSESDsnActionRelayed,
+    AWSSESDsnActionExpanded,
 };
 
 typedef NS_ENUM(NSInteger, AWSSESEventType) {
@@ -118,61 +135,42 @@ typedef NS_ENUM(NSInteger, AWSSESEventType) {
     AWSSESEventTypeOpen,
     AWSSESEventTypeClick,
     AWSSESEventTypeRenderingFailure,
-    AWSSESEventTypeDeliveryDelay,
 };
 
 typedef NS_ENUM(NSInteger, AWSSESIdentityType) {
     AWSSESIdentityTypeUnknown,
     AWSSESIdentityTypeEmailAddress,
     AWSSESIdentityTypeDomain,
-    AWSSESIdentityTypeManagedDomain,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESImportDestinationType) {
-    AWSSESImportDestinationTypeUnknown,
-    AWSSESImportDestinationTypeSuppressionList,
+typedef NS_ENUM(NSInteger, AWSSESInvocationType) {
+    AWSSESInvocationTypeUnknown,
+    AWSSESInvocationTypeEvent,
+    AWSSESInvocationTypeRequestResponse,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESJobStatus) {
-    AWSSESJobStatusUnknown,
-    AWSSESJobStatusCreated,
-    AWSSESJobStatusProcessing,
-    AWSSESJobStatusCompleted,
-    AWSSESJobStatusFailed,
+typedef NS_ENUM(NSInteger, AWSSESNotificationType) {
+    AWSSESNotificationTypeUnknown,
+    AWSSESNotificationTypeBounce,
+    AWSSESNotificationTypeComplaint,
+    AWSSESNotificationTypeDelivery,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESMailFromDomainStatus) {
-    AWSSESMailFromDomainStatusUnknown,
-    AWSSESMailFromDomainStatusPending,
-    AWSSESMailFromDomainStatusSuccess,
-    AWSSESMailFromDomainStatusFailed,
-    AWSSESMailFromDomainStatusTemporaryFailure,
+typedef NS_ENUM(NSInteger, AWSSESReceiptFilterPolicy) {
+    AWSSESReceiptFilterPolicyUnknown,
+    AWSSESReceiptFilterPolicyBlock,
+    AWSSESReceiptFilterPolicyAllow,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESMailType) {
-    AWSSESMailTypeUnknown,
-    AWSSESMailTypeMarketing,
-    AWSSESMailTypeTransactional,
+typedef NS_ENUM(NSInteger, AWSSESSNSActionEncoding) {
+    AWSSESSNSActionEncodingUnknown,
+    AWSSESSNSActionEncodingUtf8,
+    AWSSESSNSActionEncodingBase64,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESReviewStatus) {
-    AWSSESReviewStatusUnknown,
-    AWSSESReviewStatusPending,
-    AWSSESReviewStatusFailed,
-    AWSSESReviewStatusGranted,
-    AWSSESReviewStatusDenied,
-};
-
-typedef NS_ENUM(NSInteger, AWSSESSuppressionListImportAction) {
-    AWSSESSuppressionListImportActionUnknown,
-    AWSSESSuppressionListImportActionDelete,
-    AWSSESSuppressionListImportActionPut,
-};
-
-typedef NS_ENUM(NSInteger, AWSSESSuppressionListReason) {
-    AWSSESSuppressionListReasonUnknown,
-    AWSSESSuppressionListReasonBounce,
-    AWSSESSuppressionListReasonComplaint,
+typedef NS_ENUM(NSInteger, AWSSESStopScope) {
+    AWSSESStopScopeUnknown,
+    AWSSESStopScopeRuleSet,
 };
 
 typedef NS_ENUM(NSInteger, AWSSESTlsPolicy) {
@@ -181,329 +179,315 @@ typedef NS_ENUM(NSInteger, AWSSESTlsPolicy) {
     AWSSESTlsPolicyOptional,
 };
 
-typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
-    AWSSESWarmupStatusUnknown,
-    AWSSESWarmupStatusInProgress,
-    AWSSESWarmupStatusDone,
+typedef NS_ENUM(NSInteger, AWSSESVerificationStatus) {
+    AWSSESVerificationStatusUnknown,
+    AWSSESVerificationStatusPending,
+    AWSSESVerificationStatusSuccess,
+    AWSSESVerificationStatusFailed,
+    AWSSESVerificationStatusTemporaryFailure,
+    AWSSESVerificationStatusNotStarted,
 };
 
-@class AWSSESAccountDetails;
-@class AWSSESBlacklistEntry;
+@class AWSSESAddHeaderAction;
 @class AWSSESBody;
-@class AWSSESBulkEmailContent;
-@class AWSSESBulkEmailEntry;
-@class AWSSESBulkEmailEntryResult;
+@class AWSSESBounceAction;
+@class AWSSESBouncedRecipientInfo;
+@class AWSSESBulkEmailDestination;
+@class AWSSESBulkEmailDestinationStatus;
+@class AWSSESCloneReceiptRuleSetRequest;
+@class AWSSESCloneReceiptRuleSetResponse;
 @class AWSSESCloudWatchDestination;
 @class AWSSESCloudWatchDimensionConfiguration;
+@class AWSSESConfigurationSet;
 @class AWSSESContent;
 @class AWSSESCreateConfigurationSetEventDestinationRequest;
 @class AWSSESCreateConfigurationSetEventDestinationResponse;
 @class AWSSESCreateConfigurationSetRequest;
 @class AWSSESCreateConfigurationSetResponse;
+@class AWSSESCreateConfigurationSetTrackingOptionsRequest;
+@class AWSSESCreateConfigurationSetTrackingOptionsResponse;
 @class AWSSESCreateCustomVerificationEmailTemplateRequest;
-@class AWSSESCreateCustomVerificationEmailTemplateResponse;
-@class AWSSESCreateDedicatedIpPoolRequest;
-@class AWSSESCreateDedicatedIpPoolResponse;
-@class AWSSESCreateDeliverabilityTestReportRequest;
-@class AWSSESCreateDeliverabilityTestReportResponse;
-@class AWSSESCreateEmailIdentityPolicyRequest;
-@class AWSSESCreateEmailIdentityPolicyResponse;
-@class AWSSESCreateEmailIdentityRequest;
-@class AWSSESCreateEmailIdentityResponse;
-@class AWSSESCreateEmailTemplateRequest;
-@class AWSSESCreateEmailTemplateResponse;
-@class AWSSESCreateImportJobRequest;
-@class AWSSESCreateImportJobResponse;
-@class AWSSESCustomVerificationEmailTemplateMetadata;
-@class AWSSESDailyVolume;
-@class AWSSESDedicatedIp;
+@class AWSSESCreateReceiptFilterRequest;
+@class AWSSESCreateReceiptFilterResponse;
+@class AWSSESCreateReceiptRuleRequest;
+@class AWSSESCreateReceiptRuleResponse;
+@class AWSSESCreateReceiptRuleSetRequest;
+@class AWSSESCreateReceiptRuleSetResponse;
+@class AWSSESCreateTemplateRequest;
+@class AWSSESCreateTemplateResponse;
+@class AWSSESCustomVerificationEmailTemplate;
 @class AWSSESDeleteConfigurationSetEventDestinationRequest;
 @class AWSSESDeleteConfigurationSetEventDestinationResponse;
 @class AWSSESDeleteConfigurationSetRequest;
 @class AWSSESDeleteConfigurationSetResponse;
+@class AWSSESDeleteConfigurationSetTrackingOptionsRequest;
+@class AWSSESDeleteConfigurationSetTrackingOptionsResponse;
 @class AWSSESDeleteCustomVerificationEmailTemplateRequest;
-@class AWSSESDeleteCustomVerificationEmailTemplateResponse;
-@class AWSSESDeleteDedicatedIpPoolRequest;
-@class AWSSESDeleteDedicatedIpPoolResponse;
-@class AWSSESDeleteEmailIdentityPolicyRequest;
-@class AWSSESDeleteEmailIdentityPolicyResponse;
-@class AWSSESDeleteEmailIdentityRequest;
-@class AWSSESDeleteEmailIdentityResponse;
-@class AWSSESDeleteEmailTemplateRequest;
-@class AWSSESDeleteEmailTemplateResponse;
-@class AWSSESDeleteSuppressedDestinationRequest;
-@class AWSSESDeleteSuppressedDestinationResponse;
-@class AWSSESDeliverabilityTestReport;
+@class AWSSESDeleteIdentityPolicyRequest;
+@class AWSSESDeleteIdentityPolicyResponse;
+@class AWSSESDeleteIdentityRequest;
+@class AWSSESDeleteIdentityResponse;
+@class AWSSESDeleteReceiptFilterRequest;
+@class AWSSESDeleteReceiptFilterResponse;
+@class AWSSESDeleteReceiptRuleRequest;
+@class AWSSESDeleteReceiptRuleResponse;
+@class AWSSESDeleteReceiptRuleSetRequest;
+@class AWSSESDeleteReceiptRuleSetResponse;
+@class AWSSESDeleteTemplateRequest;
+@class AWSSESDeleteTemplateResponse;
+@class AWSSESDeleteVerifiedEmailAddressRequest;
 @class AWSSESDeliveryOptions;
+@class AWSSESDescribeActiveReceiptRuleSetRequest;
+@class AWSSESDescribeActiveReceiptRuleSetResponse;
+@class AWSSESDescribeConfigurationSetRequest;
+@class AWSSESDescribeConfigurationSetResponse;
+@class AWSSESDescribeReceiptRuleRequest;
+@class AWSSESDescribeReceiptRuleResponse;
+@class AWSSESDescribeReceiptRuleSetRequest;
+@class AWSSESDescribeReceiptRuleSetResponse;
 @class AWSSESDestination;
-@class AWSSESDkimAttributes;
-@class AWSSESDkimSigningAttributes;
-@class AWSSESDomainDeliverabilityCampaign;
-@class AWSSESDomainDeliverabilityTrackingOption;
-@class AWSSESDomainIspPlacement;
-@class AWSSESEmailContent;
-@class AWSSESEmailTemplateContent;
-@class AWSSESEmailTemplateMetadata;
 @class AWSSESEventDestination;
-@class AWSSESEventDestinationDefinition;
-@class AWSSESFailureInfo;
-@class AWSSESGetAccountRequest;
-@class AWSSESGetAccountResponse;
-@class AWSSESGetBlacklistReportsRequest;
-@class AWSSESGetBlacklistReportsResponse;
-@class AWSSESGetConfigurationSetEventDestinationsRequest;
-@class AWSSESGetConfigurationSetEventDestinationsResponse;
-@class AWSSESGetConfigurationSetRequest;
-@class AWSSESGetConfigurationSetResponse;
+@class AWSSESExtensionField;
+@class AWSSESGetAccountSendingEnabledResponse;
 @class AWSSESGetCustomVerificationEmailTemplateRequest;
 @class AWSSESGetCustomVerificationEmailTemplateResponse;
-@class AWSSESGetDedicatedIpRequest;
-@class AWSSESGetDedicatedIpResponse;
-@class AWSSESGetDedicatedIpsRequest;
-@class AWSSESGetDedicatedIpsResponse;
-@class AWSSESGetDeliverabilityDashboardOptionsRequest;
-@class AWSSESGetDeliverabilityDashboardOptionsResponse;
-@class AWSSESGetDeliverabilityTestReportRequest;
-@class AWSSESGetDeliverabilityTestReportResponse;
-@class AWSSESGetDomainDeliverabilityCampaignRequest;
-@class AWSSESGetDomainDeliverabilityCampaignResponse;
-@class AWSSESGetDomainStatisticsReportRequest;
-@class AWSSESGetDomainStatisticsReportResponse;
-@class AWSSESGetEmailIdentityPoliciesRequest;
-@class AWSSESGetEmailIdentityPoliciesResponse;
-@class AWSSESGetEmailIdentityRequest;
-@class AWSSESGetEmailIdentityResponse;
-@class AWSSESGetEmailTemplateRequest;
-@class AWSSESGetEmailTemplateResponse;
-@class AWSSESGetImportJobRequest;
-@class AWSSESGetImportJobResponse;
-@class AWSSESGetSuppressedDestinationRequest;
-@class AWSSESGetSuppressedDestinationResponse;
-@class AWSSESIdentityInfo;
-@class AWSSESImportDataSource;
-@class AWSSESImportDestination;
-@class AWSSESImportJobSummary;
-@class AWSSESInboxPlacementTrackingOption;
-@class AWSSESIspPlacement;
+@class AWSSESGetIdentityDkimAttributesRequest;
+@class AWSSESGetIdentityDkimAttributesResponse;
+@class AWSSESGetIdentityMailFromDomainAttributesRequest;
+@class AWSSESGetIdentityMailFromDomainAttributesResponse;
+@class AWSSESGetIdentityNotificationAttributesRequest;
+@class AWSSESGetIdentityNotificationAttributesResponse;
+@class AWSSESGetIdentityPoliciesRequest;
+@class AWSSESGetIdentityPoliciesResponse;
+@class AWSSESGetIdentityVerificationAttributesRequest;
+@class AWSSESGetIdentityVerificationAttributesResponse;
+@class AWSSESGetSendQuotaResponse;
+@class AWSSESGetSendStatisticsResponse;
+@class AWSSESGetTemplateRequest;
+@class AWSSESGetTemplateResponse;
+@class AWSSESIdentityDkimAttributes;
+@class AWSSESIdentityMailFromDomainAttributes;
+@class AWSSESIdentityNotificationAttributes;
+@class AWSSESIdentityVerificationAttributes;
 @class AWSSESKinesisFirehoseDestination;
+@class AWSSESLambdaAction;
 @class AWSSESListConfigurationSetsRequest;
 @class AWSSESListConfigurationSetsResponse;
 @class AWSSESListCustomVerificationEmailTemplatesRequest;
 @class AWSSESListCustomVerificationEmailTemplatesResponse;
-@class AWSSESListDedicatedIpPoolsRequest;
-@class AWSSESListDedicatedIpPoolsResponse;
-@class AWSSESListDeliverabilityTestReportsRequest;
-@class AWSSESListDeliverabilityTestReportsResponse;
-@class AWSSESListDomainDeliverabilityCampaignsRequest;
-@class AWSSESListDomainDeliverabilityCampaignsResponse;
-@class AWSSESListEmailIdentitiesRequest;
-@class AWSSESListEmailIdentitiesResponse;
-@class AWSSESListEmailTemplatesRequest;
-@class AWSSESListEmailTemplatesResponse;
-@class AWSSESListImportJobsRequest;
-@class AWSSESListImportJobsResponse;
-@class AWSSESListSuppressedDestinationsRequest;
-@class AWSSESListSuppressedDestinationsResponse;
-@class AWSSESListTagsForResourceRequest;
-@class AWSSESListTagsForResourceResponse;
-@class AWSSESMailFromAttributes;
+@class AWSSESListIdentitiesRequest;
+@class AWSSESListIdentitiesResponse;
+@class AWSSESListIdentityPoliciesRequest;
+@class AWSSESListIdentityPoliciesResponse;
+@class AWSSESListReceiptFiltersRequest;
+@class AWSSESListReceiptFiltersResponse;
+@class AWSSESListReceiptRuleSetsRequest;
+@class AWSSESListReceiptRuleSetsResponse;
+@class AWSSESListTemplatesRequest;
+@class AWSSESListTemplatesResponse;
+@class AWSSESListVerifiedEmailAddressesResponse;
 @class AWSSESMessage;
+@class AWSSESMessageDsn;
 @class AWSSESMessageTag;
-@class AWSSESOverallVolume;
-@class AWSSESPinpointDestination;
-@class AWSSESPlacementStatistics;
-@class AWSSESPutAccountDedicatedIpWarmupAttributesRequest;
-@class AWSSESPutAccountDedicatedIpWarmupAttributesResponse;
-@class AWSSESPutAccountDetailsRequest;
-@class AWSSESPutAccountDetailsResponse;
-@class AWSSESPutAccountSendingAttributesRequest;
-@class AWSSESPutAccountSendingAttributesResponse;
-@class AWSSESPutAccountSuppressionAttributesRequest;
-@class AWSSESPutAccountSuppressionAttributesResponse;
 @class AWSSESPutConfigurationSetDeliveryOptionsRequest;
 @class AWSSESPutConfigurationSetDeliveryOptionsResponse;
-@class AWSSESPutConfigurationSetReputationOptionsRequest;
-@class AWSSESPutConfigurationSetReputationOptionsResponse;
-@class AWSSESPutConfigurationSetSendingOptionsRequest;
-@class AWSSESPutConfigurationSetSendingOptionsResponse;
-@class AWSSESPutConfigurationSetSuppressionOptionsRequest;
-@class AWSSESPutConfigurationSetSuppressionOptionsResponse;
-@class AWSSESPutConfigurationSetTrackingOptionsRequest;
-@class AWSSESPutConfigurationSetTrackingOptionsResponse;
-@class AWSSESPutDedicatedIpInPoolRequest;
-@class AWSSESPutDedicatedIpInPoolResponse;
-@class AWSSESPutDedicatedIpWarmupAttributesRequest;
-@class AWSSESPutDedicatedIpWarmupAttributesResponse;
-@class AWSSESPutDeliverabilityDashboardOptionRequest;
-@class AWSSESPutDeliverabilityDashboardOptionResponse;
-@class AWSSESPutEmailIdentityDkimAttributesRequest;
-@class AWSSESPutEmailIdentityDkimAttributesResponse;
-@class AWSSESPutEmailIdentityDkimSigningAttributesRequest;
-@class AWSSESPutEmailIdentityDkimSigningAttributesResponse;
-@class AWSSESPutEmailIdentityFeedbackAttributesRequest;
-@class AWSSESPutEmailIdentityFeedbackAttributesResponse;
-@class AWSSESPutEmailIdentityMailFromAttributesRequest;
-@class AWSSESPutEmailIdentityMailFromAttributesResponse;
-@class AWSSESPutSuppressedDestinationRequest;
-@class AWSSESPutSuppressedDestinationResponse;
+@class AWSSESPutIdentityPolicyRequest;
+@class AWSSESPutIdentityPolicyResponse;
 @class AWSSESRawMessage;
-@class AWSSESReplacementEmailContent;
-@class AWSSESReplacementTemplate;
+@class AWSSESReceiptAction;
+@class AWSSESReceiptFilter;
+@class AWSSESReceiptIpFilter;
+@class AWSSESReceiptRule;
+@class AWSSESReceiptRuleSetMetadata;
+@class AWSSESRecipientDsnFields;
+@class AWSSESReorderReceiptRuleSetRequest;
+@class AWSSESReorderReceiptRuleSetResponse;
 @class AWSSESReputationOptions;
-@class AWSSESReviewDetails;
-@class AWSSESSendBulkEmailRequest;
-@class AWSSESSendBulkEmailResponse;
+@class AWSSESS3Action;
+@class AWSSESSNSAction;
+@class AWSSESSNSDestination;
+@class AWSSESSendBounceRequest;
+@class AWSSESSendBounceResponse;
+@class AWSSESSendBulkTemplatedEmailRequest;
+@class AWSSESSendBulkTemplatedEmailResponse;
 @class AWSSESSendCustomVerificationEmailRequest;
 @class AWSSESSendCustomVerificationEmailResponse;
+@class AWSSESSendDataPoint;
 @class AWSSESSendEmailRequest;
 @class AWSSESSendEmailResponse;
-@class AWSSESSendQuota;
-@class AWSSESSendingOptions;
-@class AWSSESSnsDestination;
-@class AWSSESSuppressedDestination;
-@class AWSSESSuppressedDestinationAttributes;
-@class AWSSESSuppressedDestinationSummary;
-@class AWSSESSuppressionAttributes;
-@class AWSSESSuppressionListDestination;
-@class AWSSESSuppressionOptions;
-@class AWSSESTag;
-@class AWSSESTagResourceRequest;
-@class AWSSESTagResourceResponse;
+@class AWSSESSendRawEmailRequest;
+@class AWSSESSendRawEmailResponse;
+@class AWSSESSendTemplatedEmailRequest;
+@class AWSSESSendTemplatedEmailResponse;
+@class AWSSESSetActiveReceiptRuleSetRequest;
+@class AWSSESSetActiveReceiptRuleSetResponse;
+@class AWSSESSetIdentityDkimEnabledRequest;
+@class AWSSESSetIdentityDkimEnabledResponse;
+@class AWSSESSetIdentityFeedbackForwardingEnabledRequest;
+@class AWSSESSetIdentityFeedbackForwardingEnabledResponse;
+@class AWSSESSetIdentityHeadersInNotificationsEnabledRequest;
+@class AWSSESSetIdentityHeadersInNotificationsEnabledResponse;
+@class AWSSESSetIdentityMailFromDomainRequest;
+@class AWSSESSetIdentityMailFromDomainResponse;
+@class AWSSESSetIdentityNotificationTopicRequest;
+@class AWSSESSetIdentityNotificationTopicResponse;
+@class AWSSESSetReceiptRulePositionRequest;
+@class AWSSESSetReceiptRulePositionResponse;
+@class AWSSESStopAction;
 @class AWSSESTemplate;
-@class AWSSESTestRenderEmailTemplateRequest;
-@class AWSSESTestRenderEmailTemplateResponse;
+@class AWSSESTemplateMetadata;
+@class AWSSESTestRenderTemplateRequest;
+@class AWSSESTestRenderTemplateResponse;
 @class AWSSESTrackingOptions;
-@class AWSSESUntagResourceRequest;
-@class AWSSESUntagResourceResponse;
+@class AWSSESUpdateAccountSendingEnabledRequest;
 @class AWSSESUpdateConfigurationSetEventDestinationRequest;
 @class AWSSESUpdateConfigurationSetEventDestinationResponse;
+@class AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest;
+@class AWSSESUpdateConfigurationSetSendingEnabledRequest;
+@class AWSSESUpdateConfigurationSetTrackingOptionsRequest;
+@class AWSSESUpdateConfigurationSetTrackingOptionsResponse;
 @class AWSSESUpdateCustomVerificationEmailTemplateRequest;
-@class AWSSESUpdateCustomVerificationEmailTemplateResponse;
-@class AWSSESUpdateEmailIdentityPolicyRequest;
-@class AWSSESUpdateEmailIdentityPolicyResponse;
-@class AWSSESUpdateEmailTemplateRequest;
-@class AWSSESUpdateEmailTemplateResponse;
-@class AWSSESVolumeStatistics;
+@class AWSSESUpdateReceiptRuleRequest;
+@class AWSSESUpdateReceiptRuleResponse;
+@class AWSSESUpdateTemplateRequest;
+@class AWSSESUpdateTemplateResponse;
+@class AWSSESVerifyDomainDkimRequest;
+@class AWSSESVerifyDomainDkimResponse;
+@class AWSSESVerifyDomainIdentityRequest;
+@class AWSSESVerifyDomainIdentityResponse;
+@class AWSSESVerifyEmailAddressRequest;
+@class AWSSESVerifyEmailIdentityRequest;
+@class AWSSESVerifyEmailIdentityResponse;
+@class AWSSESWorkmailAction;
 
 /**
- <p>An object that contains information about your account details.</p>
+ <p>When included in a receipt rule, this action adds a header to the received email.</p><p>For information about adding a header using a receipt rule, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-add-header.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [HeaderName, HeaderValue]
  */
-@interface AWSSESAccountDetails : AWSModel
+@interface AWSSESAddHeaderAction : AWSModel
 
 
 /**
- <p>Additional email addresses where updates are sent about your account review process.</p>
+ <p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>
  */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable additionalContactEmailAddresses;
+@property (nonatomic, strong) NSString * _Nullable headerName;
 
 /**
- <p>The language you would prefer for the case. The contact language can be one of <code>ENGLISH</code> or <code>JAPANESE</code>.</p>
+ <p>Must be less than 2048 characters, and must not contain newline characters ("\r" or "\n").</p>
  */
-@property (nonatomic, assign) AWSSESContactLanguage contactLanguage;
-
-/**
- <p>The type of email your account is sending. The mail type can be one of the following:</p><ul><li><p><code>MARKETING</code> – Most of your sending traffic is to keep your customers informed of your latest offering.</p></li><li><p><code>TRANSACTIONAL</code> – Most of your sending traffic is to communicate during a transaction with a customer.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESMailType mailType;
-
-/**
- <p>Information about the review of the latest details you submitted.</p>
- */
-@property (nonatomic, strong) AWSSESReviewDetails * _Nullable reviewDetails;
-
-/**
- <p>A description of the types of email that you plan to send.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable useCaseDescription;
-
-/**
- <p>The URL of your website. This information helps us better understand the type of content that you plan to send.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable websiteURL;
+@property (nonatomic, strong) NSString * _Nullable headerValue;
 
 @end
 
 /**
- <p>An object that contains information about a blacklisting event that impacts one of the dedicated IP addresses that is associated with your account.</p>
- */
-@interface AWSSESBlacklistEntry : AWSModel
-
-
-/**
- <p>Additional information about the blacklisting event, as provided by the blacklist maintainer.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable detail;
-
-/**
- <p>The time when the blacklisting event occurred, shown in Unix time format.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable listingTime;
-
-/**
- <p>The name of the blacklist that the IP address appears on.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable rblName;
-
-@end
-
-/**
- <p>Represents the body of the email message.</p>
+ <p>Represents the body of the message. You can specify text, HTML, or both. If you use both, then the message should display correctly in the widest variety of email clients.</p>
  */
 @interface AWSSESBody : AWSModel
 
 
 /**
- <p>An object that represents the version of the message that is displayed in email clients that support HTML. HTML messages can include formatted text, hyperlinks, images, and more. </p>
+ <p>The content of the message, in HTML format. Use this for email clients that can process HTML. You can include clickable links, formatted text, and much more in an HTML message.</p>
  */
 @property (nonatomic, strong) AWSSESContent * _Nullable html;
 
 /**
- <p>An object that represents the version of the message that is displayed in email clients that don't support HTML, or clients where the recipient has disabled HTML rendering.</p>
+ <p>The content of the message, in text format. Use this for text-based email clients, or clients on high-latency networks (such as mobile devices).</p>
  */
 @property (nonatomic, strong) AWSSESContent * _Nullable text;
 
 @end
 
 /**
- <p>An object that contains the body of the message. You can specify a template message.</p>
+ <p>When included in a receipt rule, this action rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p><p>For information about sending a bounce message in response to a received email, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-bounce.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [SmtpReplyCode, Message, Sender]
  */
-@interface AWSSESBulkEmailContent : AWSModel
+@interface AWSSESBounceAction : AWSModel
 
 
 /**
- <p>The template to use for the bulk email message.</p>
+ <p>Human-readable text to include in the bounce message.</p>
  */
-@property (nonatomic, strong) AWSSESTemplate * _Nullable template;
+@property (nonatomic, strong) NSString * _Nullable message;
+
+/**
+ <p>The email address of the sender of the bounced email. This is the address from which the bounce message will be sent.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable sender;
+
+/**
+ <p>The SMTP reply code, as defined by <a href="https://tools.ietf.org/html/rfc5321">RFC 5321</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable smtpReplyCode;
+
+/**
+ <p>The SMTP enhanced status code, as defined by <a href="https://tools.ietf.org/html/rfc3463">RFC 3463</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable statusCode;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the bounce action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable topicArn;
 
 @end
 
 /**
- 
+ <p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p><p>For information about receiving email through Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Recipient]
  */
-@interface AWSSESBulkEmailEntry : AWSModel
+@interface AWSSESBouncedRecipientInfo : AWSModel
 
 
 /**
- <p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the local part of a destination email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the domain part of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>.</p></note>
+ <p>The reason for the bounce. You must provide either this parameter or <code>RecipientDsnFields</code>.</p>
+ */
+@property (nonatomic, assign) AWSSESBounceType bounceType;
+
+/**
+ <p>The email address of the recipient of the bounced email.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable recipient;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to receive email for the recipient of the bounced email. For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable recipientArn;
+
+/**
+ <p>Recipient-related DSN fields, most of which would normally be filled in automatically when provided with a <code>BounceType</code>. You must provide either this parameter or <code>BounceType</code>.</p>
+ */
+@property (nonatomic, strong) AWSSESRecipientDsnFields * _Nullable recipientDsnFields;
+
+@end
+
+/**
+ <p>An array that contains one or more Destinations, as well as the tags and replacement data associated with each of those Destinations.</p>
+ Required parameters: [Destination]
+ */
+@interface AWSSESBulkEmailDestination : AWSModel
+
+
+/**
+ <p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a destination email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>.</p></note>
  */
 @property (nonatomic, strong) AWSSESDestination * _Nullable destination;
 
 /**
- <p>The <code>ReplacementEmailContent</code> associated with a <code>BulkEmailEntry</code>.</p>
- */
-@property (nonatomic, strong) AWSSESReplacementEmailContent * _Nullable replacementEmailContent;
-
-/**
- <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using the <code>SendBulkTemplatedEmail</code> operation. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
+ <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendBulkTemplatedEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
  */
 @property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable replacementTags;
+
+/**
+ <p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable replacementTemplateData;
 
 @end
 
 /**
- <p>The result of the <code>SendBulkEmail</code> operation of each specified <code>BulkEmailEntry</code>.</p>
+ <p>An object that contains the response from the <code>SendBulkTemplatedEmail</code> operation.</p>
  */
-@interface AWSSESBulkEmailEntryResult : AWSModel
+@interface AWSSESBulkEmailDestinationStatus : AWSModel
 
 
 /**
@@ -517,95 +501,131 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @property (nonatomic, strong) NSString * _Nullable messageId;
 
 /**
- <p>The status of a message sent using the <code>SendBulkTemplatedEmail</code> operation.</p><p>Possible values for this parameter include:</p><ul><li><p>SUCCESS: Amazon SES accepted the message, and will attempt to deliver it to the recipients.</p></li><li><p>MESSAGE_REJECTED: The message was rejected because it contained a virus.</p></li><li><p>MAIL_FROM_DOMAIN_NOT_VERIFIED: The sender's email address or domain was not verified.</p></li><li><p>CONFIGURATION_SET_DOES_NOT_EXIST: The configuration set you specified does not exist.</p></li><li><p>TEMPLATE_DOES_NOT_EXIST: The template you specified does not exist.</p></li><li><p>ACCOUNT_SUSPENDED: Your account has been shut down because of issues related to your email sending practices.</p></li><li><p>ACCOUNT_THROTTLED: The number of emails you can send has been reduced because your account has exceeded its allocated sending limit.</p></li><li><p>ACCOUNT_DAILY_QUOTA_EXCEEDED: You have reached or exceeded the maximum number of emails you can send from your account in a 24-hour period.</p></li><li><p>INVALID_SENDING_POOL_NAME: The configuration set you specified refers to an IP pool that does not exist.</p></li><li><p>ACCOUNT_SENDING_PAUSED: Email sending for the Amazon SES account was disabled using the <a href="https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateAccountSendingEnabled.html">UpdateAccountSendingEnabled</a> operation.</p></li><li><p>CONFIGURATION_SET_SENDING_PAUSED: Email sending for this configuration set was disabled using the <a href="https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateConfigurationSetSendingEnabled.html">UpdateConfigurationSetSendingEnabled</a> operation.</p></li><li><p>INVALID_PARAMETER_VALUE: One or more of the parameters you specified when calling this operation was invalid. See the error message for additional information.</p></li><li><p>TRANSIENT_FAILURE: Amazon SES was unable to process your request because of a temporary issue.</p></li><li><p>FAILED: Amazon SES was unable to process your request. See the error message for additional information.</p></li></ul>
+ <p>The status of a message sent using the <code>SendBulkTemplatedEmail</code> operation.</p><p>Possible values for this parameter include:</p><ul><li><p><code>Success</code>: Amazon SES accepted the message, and will attempt to deliver it to the recipients.</p></li><li><p><code>MessageRejected</code>: The message was rejected because it contained a virus.</p></li><li><p><code>MailFromDomainNotVerified</code>: The sender's email address or domain was not verified.</p></li><li><p><code>ConfigurationSetDoesNotExist</code>: The configuration set you specified does not exist.</p></li><li><p><code>TemplateDoesNotExist</code>: The template you specified does not exist.</p></li><li><p><code>AccountSuspended</code>: Your account has been shut down because of issues related to your email sending practices.</p></li><li><p><code>AccountThrottled</code>: The number of emails you can send has been reduced because your account has exceeded its allocated sending limit.</p></li><li><p><code>AccountDailyQuotaExceeded</code>: You have reached or exceeded the maximum number of emails you can send from your account in a 24-hour period.</p></li><li><p><code>InvalidSendingPoolName</code>: The configuration set you specified refers to an IP pool that does not exist.</p></li><li><p><code>AccountSendingPaused</code>: Email sending for the Amazon SES account was disabled using the <a>UpdateAccountSendingEnabled</a> operation.</p></li><li><p><code>ConfigurationSetSendingPaused</code>: Email sending for this configuration set was disabled using the <a>UpdateConfigurationSetSendingEnabled</a> operation.</p></li><li><p><code>InvalidParameterValue</code>: One or more of the parameters you specified when calling this operation was invalid. See the error message for additional information.</p></li><li><p><code>TransientFailure</code>: Amazon SES was unable to process your request because of a temporary issue.</p></li><li><p><code>Failed</code>: Amazon SES was unable to process your request. See the error message for additional information.</p></li></ul>
  */
 @property (nonatomic, assign) AWSSESBulkEmailStatus status;
 
 @end
 
 /**
- <p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to monitor and gain insights on your email sending metrics.</p>
+ <p>Represents a request to create a receipt rule set by cloning an existing one. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, OriginalRuleSetName]
+ */
+@interface AWSSESCloneReceiptRuleSetRequest : AWSRequest
+
+
+/**
+ <p>The name of the rule set to clone.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable originalRuleSetName;
+
+/**
+ <p>The name of the rule set to create. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Start and end with a letter or number.</p></li><li><p>Contain less than 64 characters.</p></li></ul>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESCloneReceiptRuleSetResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Contains information associated with an Amazon CloudWatch event destination to which email sending events are published.</p><p>Event destinations, such as Amazon CloudWatch, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [DimensionConfigurations]
  */
 @interface AWSSESCloudWatchDestination : AWSModel
 
 
 /**
- <p>An array of objects that define the dimensions to use when you send email events to Amazon CloudWatch.</p>
+ <p>A list of dimensions upon which to categorize your emails when you publish email sending events to Amazon CloudWatch.</p>
  */
 @property (nonatomic, strong) NSArray<AWSSESCloudWatchDimensionConfiguration *> * _Nullable dimensionConfigurations;
 
 @end
 
 /**
- <p>An object that defines the dimension configuration to use when you send email events to Amazon CloudWatch.</p>
+ <p>Contains the dimension configuration to use when you publish email sending events to Amazon CloudWatch.</p><p>For information about publishing email sending events to Amazon CloudWatch, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [DimensionName, DimensionValueSource, DefaultDimensionValue]
  */
 @interface AWSSESCloudWatchDimensionConfiguration : AWSModel
 
 
 /**
- <p>The default value of the dimension that is published to Amazon CloudWatch if you don't provide the value of the dimension when you send an email. This value has to meet the following criteria:</p><ul><li><p>It can only contain ASCII letters (a–z, A–Z), numbers (0–9), underscores (_), or dashes (-).</p></li><li><p>It can contain no more than 256 characters.</p></li></ul>
+ <p>The default value of the dimension that is published to Amazon CloudWatch if you do not provide the value of the dimension when you send an email. The default value must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Contain less than 256 characters.</p></li></ul>
  */
 @property (nonatomic, strong) NSString * _Nullable defaultDimensionValue;
 
 /**
- <p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name has to meet the following criteria:</p><ul><li><p>It can only contain ASCII letters (a–z, A–Z), numbers (0–9), underscores (_), or dashes (-).</p></li><li><p>It can contain no more than 256 characters.</p></li></ul>
+ <p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Contain less than 256 characters.</p></li></ul>
  */
 @property (nonatomic, strong) NSString * _Nullable dimensionName;
 
 /**
- <p>The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. If you want to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code> or <code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want to use your own email headers, choose <code>emailHeader</code>. If you want to use link tags, choose <code>linkTags</code>.</p>
+ <p>The place where Amazon SES finds the value of a dimension to publish to Amazon CloudWatch. If you want Amazon SES to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code>/<code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want Amazon SES to use your own email headers, choose <code>emailHeader</code>.</p>
  */
 @property (nonatomic, assign) AWSSESDimensionValueSource dimensionValueSource;
 
 @end
 
 /**
- <p>An object that represents the content of the email, and optionally a character set specification.</p>
+ <p>The name of the configuration set.</p><p>Configuration sets let you create groups of rules that you can apply to the emails you send using Amazon SES. For more information about using configuration sets, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html">Using Amazon SES Configuration Sets</a> in the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Name]
+ */
+@interface AWSSESConfigurationSet : AWSModel
+
+
+/**
+ <p>The name of the configuration set. The name must meet the following requirements:</p><ul><li><p>Contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Contain 64 characters or fewer.</p></li></ul>
+ */
+@property (nonatomic, strong) NSString * _Nullable name;
+
+@end
+
+/**
+ <p>Represents textual data, plus an optional character set specification.</p><p>By default, the text must be 7-bit ASCII, due to the constraints of the SMTP protocol. If the text must contain any other characters, then you must also specify a character set. Examples include UTF-8, ISO-8859-1, and Shift_JIS.</p>
  Required parameters: [Data]
  */
 @interface AWSSESContent : AWSModel
 
 
 /**
- <p>The character set for the content. Because of the constraints of the SMTP protocol, Amazon SES uses 7-bit ASCII by default. If the text includes characters outside of the ASCII range, you have to specify a character set. For example, you could specify <code>UTF-8</code>, <code>ISO-8859-1</code>, or <code>Shift_JIS</code>.</p>
+ <p>The character set of the content.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable charset;
 
 /**
- <p>The content of the message itself.</p>
+ <p>The textual data of the content.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable data;
 
 @end
 
 /**
- <p>A request to add an event destination to a configuration set.</p>
- Required parameters: [ConfigurationSetName, EventDestinationName, EventDestination]
+ <p>Represents a request to create a configuration set event destination. A configuration set event destination, which can be either Amazon CloudWatch or Amazon Kinesis Firehose, describes an AWS service in which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [ConfigurationSetName, EventDestination]
  */
 @interface AWSSESCreateConfigurationSetEventDestinationRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that you want to add an event destination to.</p>
+ <p>The name of the configuration set that the event destination should be associated with.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>An object that defines the event destination.</p>
+ <p>An object that describes the AWS service that email sending event information will be published to.</p>
  */
-@property (nonatomic, strong) AWSSESEventDestinationDefinition * _Nullable eventDestination;
-
-/**
- <p>A name that identifies the event destination within the configuration set.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable eventDestinationName;
+@property (nonatomic, strong) AWSSESEventDestination * _Nullable eventDestination;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
 @interface AWSSESCreateConfigurationSetEventDestinationResponse : AWSModel
 
@@ -613,53 +633,50 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>A request to create a configuration set.</p>
- Required parameters: [ConfigurationSetName]
+ <p>Represents a request to create a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [ConfigurationSet]
  */
 @interface AWSSESCreateConfigurationSetRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set.</p>
+ <p>A data structure that contains the name of the configuration set.</p>
+ */
+@property (nonatomic, strong) AWSSESConfigurationSet * _Nullable configurationSet;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESCreateConfigurationSetResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to create an open and click tracking option object in a configuration set. </p>
+ Required parameters: [ConfigurationSetName, TrackingOptions]
+ */
+@interface AWSSESCreateConfigurationSetTrackingOptionsRequest : AWSRequest
+
+
+/**
+ <p>The name of the configuration set that the tracking options should be associated with.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESDeliveryOptions * _Nullable deliveryOptions;
-
-/**
- <p>An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESReputationOptions * _Nullable reputationOptions;
-
-/**
- <p>An object that defines whether or not Amazon SES can send email that you send using the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESSendingOptions * _Nullable sendingOptions;
-
-/**
- <p>An object that contains information about the suppression list preferences for your account.</p>
- */
-@property (nonatomic, strong) AWSSESSuppressionOptions * _Nullable suppressionOptions;
-
-/**
- <p>An array of objects that define the tags (keys and values) that you want to associate with the configuration set.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-/**
- <p>An object that defines the open and click tracking options for emails that you send using the configuration set.</p>
+ <p>A domain that is used to redirect email recipients to an Amazon SES-operated domain. This domain captures open and click events generated by Amazon SES emails.</p><p>For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Configuring Custom Domains to Handle Open and Click Tracking</a> in the <i>Amazon SES Developer Guide</i>.</p>
  */
 @property (nonatomic, strong) AWSSESTrackingOptions * _Nullable trackingOptions;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
-@interface AWSSESCreateConfigurationSetResponse : AWSModel
+@interface AWSSESCreateConfigurationSetTrackingOptionsResponse : AWSModel
 
 
 @end
@@ -687,7 +704,7 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @property (nonatomic, strong) NSString * _Nullable successRedirectionURL;
 
 /**
- <p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html#custom-verification-emails-faq">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>
+ <p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html#custom-verification-emails-faq">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable templateContent;
 
@@ -704,230 +721,107 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>
+ <p>Represents a request to create a new IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Filter]
  */
-@interface AWSSESCreateCustomVerificationEmailTemplateResponse : AWSModel
+@interface AWSSESCreateReceiptFilterRequest : AWSRequest
+
+
+/**
+ <p>A data structure that describes the IP address filter to create, which consists of a name, an IP address range, and whether to allow or block mail from it.</p>
+ */
+@property (nonatomic, strong) AWSSESReceiptFilter * _Nullable filter;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESCreateReceiptFilterResponse : AWSModel
 
 
 @end
 
 /**
- <p>A request to create a new dedicated IP pool.</p>
- Required parameters: [PoolName]
+ <p>Represents a request to create a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, Rule]
  */
-@interface AWSSESCreateDedicatedIpPoolRequest : AWSRequest
+@interface AWSSESCreateReceiptRuleRequest : AWSRequest
 
 
 /**
- <p>The name of the dedicated IP pool.</p>
+ <p>The name of an existing rule after which the new rule will be placed. If this parameter is null, the new rule will be inserted at the beginning of the rule list.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable poolName;
+@property (nonatomic, strong) NSString * _Nullable after;
 
 /**
- <p>An object that defines the tags (keys and values) that you want to associate with the pool.</p>
+ <p>A data structure that contains the specified rule's name, actions, recipients, domains, enabled status, scan status, and TLS policy.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
+@property (nonatomic, strong) AWSSESReceiptRule * _Nullable rule;
+
+/**
+ <p>The name of the rule set that the receipt rule will be added to.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
-@interface AWSSESCreateDedicatedIpPoolResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to perform a predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will be handled by various email providers around the world. When you perform a predictive inbox placement test, you provide a sample message that contains the content that you plan to send to your customers. We send that message to special email addresses spread across several major email providers around the world. The test takes about 24 hours to complete. When the test is complete, you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.</p>
- Required parameters: [FromEmailAddress, Content]
- */
-@interface AWSSESCreateDeliverabilityTestReportRequest : AWSRequest
-
-
-/**
- <p>The HTML body of the message that you sent when you performed the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) AWSSESEmailContent * _Nullable content;
-
-/**
- <p>The email address that the predictive inbox placement test email was sent from.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromEmailAddress;
-
-/**
- <p>A unique name that helps you to identify the predictive inbox placement test when you retrieve the results.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable reportName;
-
-/**
- <p>An array of objects that define the tags (keys and values) that you want to associate with the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-@end
-
-/**
- <p>Information about the predictive inbox placement test that you created.</p>
- Required parameters: [ReportId, DeliverabilityTestStatus]
- */
-@interface AWSSESCreateDeliverabilityTestReportResponse : AWSModel
-
-
-/**
- <p>The status of the predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> to view the results of the test.</p>
- */
-@property (nonatomic, assign) AWSSESDeliverabilityTestStatus deliverabilityTestStatus;
-
-/**
- <p>A unique string that identifies the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable reportId;
-
-@end
-
-/**
- <p>Represents a request to create a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [EmailIdentity, PolicyName, Policy]
- */
-@interface AWSSESCreateEmailIdentityPolicyRequest : AWSRequest
-
-
-/**
- <p>The email identity for which you want to create a policy.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p><p>For information about the syntax of sending authorization policies, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html">Amazon SES Developer Guide</a>.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable policy;
-
-/**
- <p>The name of the policy.</p><p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable policyName;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESCreateEmailIdentityPolicyResponse : AWSModel
+@interface AWSSESCreateReceiptRuleResponse : AWSModel
 
 
 @end
 
 /**
- <p>A request to begin the verification process for an email identity (an email address or domain).</p>
- Required parameters: [EmailIdentity]
+ <p>Represents a request to create an empty receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName]
  */
-@interface AWSSESCreateEmailIdentityRequest : AWSRequest
+@interface AWSSESCreateReceiptRuleSetRequest : AWSRequest
 
 
 /**
- <p>If your request includes this object, Amazon SES configures the identity to use Bring Your Own DKIM (BYODKIM) for DKIM authentication purposes, as opposed to the default method, <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a>.</p><p>You can only specify this object if the email identity is a domain, as opposed to an address.</p>
+ <p>The name of the rule set to create. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Start and end with a letter or number.</p></li><li><p>Contain less than 64 characters.</p></li></ul>
  */
-@property (nonatomic, strong) AWSSESDkimSigningAttributes * _Nullable dkimSigningAttributes;
-
-/**
- <p>The email address or domain that you want to verify.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p>An array of objects that define the tags (keys and values) that you want to associate with the email identity.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
 
 @end
 
 /**
- <p>If the email identity is a domain, this object contains information about the DKIM verification status for the domain.</p><p>If the email identity is an email address, this object is empty. </p>
+ <p>An empty element returned on a successful request.</p>
  */
-@interface AWSSESCreateEmailIdentityResponse : AWSModel
+@interface AWSSESCreateReceiptRuleSetResponse : AWSModel
 
-
-/**
- <p>An object that contains information about the DKIM attributes for the identity.</p>
- */
-@property (nonatomic, strong) AWSSESDkimAttributes * _Nullable dkimAttributes;
-
-/**
- <p>The email identity type.</p>
- */
-@property (nonatomic, assign) AWSSESIdentityType identityType;
-
-/**
- <p>Specifies whether or not the identity is verified. You can only send email from verified email addresses or domains. For more information about verifying identities, see the <a href="https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-email-manage-verify.html">Amazon Pinpoint User Guide</a>.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable verifiedForSendingStatus;
 
 @end
 
 /**
  <p>Represents a request to create an email template. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [TemplateName, TemplateContent]
+ Required parameters: [Template]
  */
-@interface AWSSESCreateEmailTemplateRequest : AWSRequest
+@interface AWSSESCreateTemplateRequest : AWSRequest
 
 
 /**
- <p>The content of the email template, composed of a subject line, an HTML part, and a text-only part.</p>
+ <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
  */
-@property (nonatomic, strong) AWSSESEmailTemplateContent * _Nullable templateContent;
-
-/**
- <p>The name of the template you want to create.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable templateName;
+@property (nonatomic, strong) AWSSESTemplate * _Nullable template;
 
 @end
 
 /**
- <p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>
+ 
  */
-@interface AWSSESCreateEmailTemplateResponse : AWSModel
+@interface AWSSESCreateTemplateResponse : AWSModel
 
-
-@end
-
-/**
- <p>Represents a request to create an import job from a data source for a data destination.</p>
- Required parameters: [ImportDestination, ImportDataSource]
- */
-@interface AWSSESCreateImportJobRequest : AWSRequest
-
-
-/**
- <p>The data source for the import job.</p>
- */
-@property (nonatomic, strong) AWSSESImportDataSource * _Nullable importDataSource;
-
-/**
- <p>The destination for the import job.</p>
- */
-@property (nonatomic, strong) AWSSESImportDestination * _Nullable importDestination;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESCreateImportJobResponse : AWSModel
-
-
-/**
- <p>A string that represents the import job ID.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable jobId;
 
 @end
 
 /**
  <p>Contains information about a custom verification email template.</p>
  */
-@interface AWSSESCustomVerificationEmailTemplateMetadata : AWSModel
+@interface AWSSESCustomVerificationEmailTemplate : AWSModel
 
 
 /**
@@ -958,78 +852,26 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>An object that contains information about the volume of email sent on each day of the analysis period.</p>
- */
-@interface AWSSESDailyVolume : AWSModel
-
-
-/**
- <p>An object that contains inbox placement metrics for a specified day in the analysis period, broken out by the recipient's email provider.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDomainIspPlacement *> * _Nullable domainIspPlacements;
-
-/**
- <p>The date that the DailyVolume metrics apply to, in Unix time.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable startDate;
-
-/**
- <p>An object that contains inbox placement metrics for a specific day in the analysis period.</p>
- */
-@property (nonatomic, strong) AWSSESVolumeStatistics * _Nullable volumeStatistics;
-
-@end
-
-/**
- <p>Contains information about a dedicated IP address that is associated with your Amazon SES account.</p><p>To learn more about requesting dedicated IP addresses, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/dedicated-ip-case.html">Requesting and Relinquishing Dedicated IP Addresses</a> in the <i>Amazon SES Developer Guide</i>.</p>
- Required parameters: [Ip, WarmupStatus, WarmupPercentage]
- */
-@interface AWSSESDedicatedIp : AWSModel
-
-
-/**
- <p>An IPv4 address.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable ip;
-
-/**
- <p>The name of the dedicated IP pool that the IP address is associated with.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable poolName;
-
-/**
- <p>Indicates how complete the dedicated IP warm-up process is. When this value equals 1, the address has completed the warm-up process and is ready for use.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable warmupPercentage;
-
-/**
- <p>The warm-up status of a dedicated IP address. The status can have one of the following values:</p><ul><li><p><code>IN_PROGRESS</code> – The IP address isn't ready to use because the dedicated IP warm-up process is ongoing.</p></li><li><p><code>DONE</code> – The dedicated IP warm-up process is complete, and the IP address is ready to use.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESWarmupStatus warmupStatus;
-
-@end
-
-/**
- <p>A request to delete an event destination from a configuration set.</p>
+ <p>Represents a request to delete a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [ConfigurationSetName, EventDestinationName]
  */
 @interface AWSSESDeleteConfigurationSetEventDestinationRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that contains the event destination that you want to delete.</p>
+ <p>The name of the configuration set from which to delete the event destination.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>The name of the event destination that you want to delete.</p>
+ <p>The name of the event destination to delete.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable eventDestinationName;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
 @interface AWSSESDeleteConfigurationSetEventDestinationResponse : AWSModel
 
@@ -1037,23 +879,45 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>A request to delete a configuration set.</p>
+ <p>Represents a request to delete a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [ConfigurationSetName]
  */
 @interface AWSSESDeleteConfigurationSetRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that you want to delete.</p>
+ <p>The name of the configuration set to delete.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
 @interface AWSSESDeleteConfigurationSetResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to delete open and click tracking options in a configuration set. </p>
+ Required parameters: [ConfigurationSetName]
+ */
+@interface AWSSESDeleteConfigurationSetTrackingOptionsRequest : AWSRequest
+
+
+/**
+ <p>The name of the configuration set from which you want to delete the tracking options.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESDeleteConfigurationSetTrackingOptionsResponse : AWSModel
 
 
 @end
@@ -1073,80 +937,121 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>
+ <p>Represents a request to delete a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, PolicyName]
  */
-@interface AWSSESDeleteCustomVerificationEmailTemplateResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to delete a dedicated IP pool.</p>
- Required parameters: [PoolName]
- */
-@interface AWSSESDeleteDedicatedIpPoolRequest : AWSRequest
+@interface AWSSESDeleteIdentityPolicyRequest : AWSRequest
 
 
 /**
- <p>The name of the dedicated IP pool that you want to delete.</p>
+ <p>The identity that is associated with the policy that you want to delete. You can specify the identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p><p>To successfully call this API, you must own the identity.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable poolName;
-
-@end
+@property (nonatomic, strong) NSString * _Nullable identity;
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESDeleteDedicatedIpPoolResponse : AWSModel
-
-
-@end
-
-/**
- <p>Represents a request to delete a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [EmailIdentity, PolicyName]
- */
-@interface AWSSESDeleteEmailIdentityPolicyRequest : AWSRequest
-
-
-/**
- <p>The email identity for which you want to delete a policy.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p>The name of the policy.</p><p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>
+ <p>The name of the policy to be deleted.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable policyName;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
-@interface AWSSESDeleteEmailIdentityPolicyResponse : AWSModel
+@interface AWSSESDeleteIdentityPolicyResponse : AWSModel
 
 
 @end
 
 /**
- <p>A request to delete an existing email identity. When you delete an identity, you lose the ability to send email from that identity. You can restore your ability to send email by completing the verification process for the identity again.</p>
- Required parameters: [EmailIdentity]
+ <p>Represents a request to delete one of your Amazon SES identities (an email address or domain).</p>
+ Required parameters: [Identity]
  */
-@interface AWSSESDeleteEmailIdentityRequest : AWSRequest
+@interface AWSSESDeleteIdentityRequest : AWSRequest
 
 
 /**
- <p>The identity (that is, the email address or domain) that you want to delete.</p>
+ <p>The identity to be removed from the list of identities for the AWS Account.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
+@property (nonatomic, strong) NSString * _Nullable identity;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
-@interface AWSSESDeleteEmailIdentityResponse : AWSModel
+@interface AWSSESDeleteIdentityResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to delete an IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [FilterName]
+ */
+@interface AWSSESDeleteReceiptFilterRequest : AWSRequest
+
+
+/**
+ <p>The name of the IP address filter to delete.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable filterName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESDeleteReceiptFilterResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to delete a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, RuleName]
+ */
+@interface AWSSESDeleteReceiptRuleRequest : AWSRequest
+
+
+/**
+ <p>The name of the receipt rule to delete.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleName;
+
+/**
+ <p>The name of the receipt rule set that contains the receipt rule to delete.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESDeleteReceiptRuleResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to delete a receipt rule set and all of the receipt rules it contains. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName]
+ */
+@interface AWSSESDeleteReceiptRuleSetRequest : AWSRequest
+
+
+/**
+ <p>The name of the receipt rule set to delete.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESDeleteReceiptRuleSetResponse : AWSModel
 
 
 @end
@@ -1155,7 +1060,7 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
  <p>Represents a request to delete an email template. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [TemplateName]
  */
-@interface AWSSESDeleteEmailTemplateRequest : AWSRequest
+@interface AWSSESDeleteTemplateRequest : AWSRequest
 
 
 /**
@@ -1166,83 +1071,32 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>
+ 
  */
-@interface AWSSESDeleteEmailTemplateResponse : AWSModel
+@interface AWSSESDeleteTemplateResponse : AWSModel
 
 
 @end
 
 /**
- <p>A request to remove an email address from the suppression list for your account.</p>
+ <p>Represents a request to delete an email address from the list of email addresses you have attempted to verify under your AWS account.</p>
  Required parameters: [EmailAddress]
  */
-@interface AWSSESDeleteSuppressedDestinationRequest : AWSRequest
+@interface AWSSESDeleteVerifiedEmailAddressRequest : AWSRequest
 
 
 /**
- <p>The suppressed email destination to remove from the account suppression list.</p>
+ <p>An email address to be removed from the list of verified addresses.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable emailAddress;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESDeleteSuppressedDestinationResponse : AWSModel
-
-
-@end
-
-/**
- <p>An object that contains metadata related to a predictive inbox placement test.</p>
- */
-@interface AWSSESDeliverabilityTestReport : AWSModel
-
-
-/**
- <p>The date and time when the predictive inbox placement test was created, in Unix time format.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable createDate;
-
-/**
- <p>The status of the predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> to view the results of the test.</p>
- */
-@property (nonatomic, assign) AWSSESDeliverabilityTestStatus deliverabilityTestStatus;
-
-/**
- <p>The sender address that you specified for the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromEmailAddress;
-
-/**
- <p>A unique string that identifies the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable reportId;
-
-/**
- <p>A name that helps you identify a predictive inbox placement test report.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable reportName;
-
-/**
- <p>The subject line for an email that you submitted in a predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable subject;
-
-@end
-
-/**
- <p>Used to associate a configuration set with a dedicated IP pool.</p>
+ <p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS).</p>
  */
 @interface AWSSESDeliveryOptions : AWSModel
 
-
-/**
- <p>The name of the dedicated IP pool that you want to associate with the configuration set.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable sendingPoolName;
 
 /**
  <p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.</p>
@@ -1252,533 +1106,238 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>An object that describes the recipients for an email.</p>
+ <p>Represents a request to return the metadata and receipt rules for the receipt rule set that is currently active. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ */
+@interface AWSSESDescribeActiveReceiptRuleSetRequest : AWSRequest
+
+
+@end
+
+/**
+ <p>Represents the metadata and receipt rules for the receipt rule set that is currently active.</p>
+ */
+@interface AWSSESDescribeActiveReceiptRuleSetResponse : AWSModel
+
+
+/**
+ <p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and a timestamp of when the rule set was created.</p>
+ */
+@property (nonatomic, strong) AWSSESReceiptRuleSetMetadata * _Nullable metadata;
+
+/**
+ <p>The receipt rules that belong to the active rule set.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESReceiptRule *> * _Nullable rules;
+
+@end
+
+/**
+ <p>Represents a request to return the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [ConfigurationSetName]
+ */
+@interface AWSSESDescribeConfigurationSetRequest : AWSRequest
+
+
+/**
+ <p>A list of configuration set attributes to return.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable configurationSetAttributeNames;
+
+/**
+ <p>The name of the configuration set to describe.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+
+@end
+
+/**
+ <p>Represents the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ */
+@interface AWSSESDescribeConfigurationSetResponse : AWSModel
+
+
+/**
+ <p>The configuration set object associated with the specified configuration set.</p>
+ */
+@property (nonatomic, strong) AWSSESConfigurationSet * _Nullable configurationSet;
+
+/**
+ <p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS).</p>
+ */
+@property (nonatomic, strong) AWSSESDeliveryOptions * _Nullable deliveryOptions;
+
+/**
+ <p>A list of event destinations associated with the configuration set. </p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESEventDestination *> * _Nullable eventDestinations;
+
+/**
+ <p>An object that represents the reputation settings for the configuration set. </p>
+ */
+@property (nonatomic, strong) AWSSESReputationOptions * _Nullable reputationOptions;
+
+/**
+ <p>The name of the custom open and click tracking domain associated with the configuration set.</p>
+ */
+@property (nonatomic, strong) AWSSESTrackingOptions * _Nullable trackingOptions;
+
+@end
+
+/**
+ <p>Represents a request to return the details of a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, RuleName]
+ */
+@interface AWSSESDescribeReceiptRuleRequest : AWSRequest
+
+
+/**
+ <p>The name of the receipt rule.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleName;
+
+/**
+ <p>The name of the receipt rule set that the receipt rule belongs to.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>Represents the details of a receipt rule.</p>
+ */
+@interface AWSSESDescribeReceiptRuleResponse : AWSModel
+
+
+/**
+ <p>A data structure that contains the specified receipt rule's name, actions, recipients, domains, enabled status, scan status, and Transport Layer Security (TLS) policy.</p>
+ */
+@property (nonatomic, strong) AWSSESReceiptRule * _Nullable rule;
+
+@end
+
+/**
+ <p>Represents a request to return the details of a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName]
+ */
+@interface AWSSESDescribeReceiptRuleSetRequest : AWSRequest
+
+
+/**
+ <p>The name of the receipt rule set to describe.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>Represents the details of the specified receipt rule set.</p>
+ */
+@interface AWSSESDescribeReceiptRuleSetResponse : AWSModel
+
+
+/**
+ <p>The metadata for the receipt rule set, which consists of the rule set name and the timestamp of when the rule set was created.</p>
+ */
+@property (nonatomic, strong) AWSSESReceiptRuleSetMetadata * _Nullable metadata;
+
+/**
+ <p>A list of the receipt rules that belong to the specified receipt rule set.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESReceiptRule *> * _Nullable rules;
+
+@end
+
+/**
+ <p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a destination email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>.</p></note>
  */
 @interface AWSSESDestination : AWSModel
 
 
 /**
- <p>An array that contains the email addresses of the "BCC" (blind carbon copy) recipients for the email.</p>
+ <p>The recipients to place on the BCC: line of the message.</p>
  */
 @property (nonatomic, strong) NSArray<NSString *> * _Nullable bccAddresses;
 
 /**
- <p>An array that contains the email addresses of the "CC" (carbon copy) recipients for the email.</p>
+ <p>The recipients to place on the CC: line of the message.</p>
  */
 @property (nonatomic, strong) NSArray<NSString *> * _Nullable ccAddresses;
 
 /**
- <p>An array that contains the email addresses of the "To" recipients for the email.</p>
+ <p>The recipients to place on the To: line of the message.</p>
  */
 @property (nonatomic, strong) NSArray<NSString *> * _Nullable toAddresses;
 
 @end
 
 /**
- <p>An object that contains information about the DKIM authentication status for an email identity.</p><p>Amazon SES determines the authentication status by searching for specific records in the DNS configuration for the domain. If you used <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a> to set up DKIM authentication, Amazon SES tries to find three unique CNAME records in the DNS configuration for your domain. If you provided a public key to perform DKIM authentication, Amazon SES tries to find a TXT record that uses the selector that you specified. The value of the TXT record must be a public key that's paired with the private key that you specified in the process of creating the identity</p>
- */
-@interface AWSSESDkimAttributes : AWSModel
-
-
-/**
- <p>A string that indicates how DKIM was configured for the identity. There are two possible values:</p><ul><li><p><code>AWS_SES</code> – Indicates that DKIM was configured for the identity by using <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a>.</p></li><li><p><code>EXTERNAL</code> – Indicates that DKIM was configured for the identity by using Bring Your Own DKIM (BYODKIM).</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESDkimSigningAttributesOrigin signingAttributesOrigin;
-
-/**
- <p>If the value is <code>true</code>, then the messages that you send from the identity are signed using DKIM. If the value is <code>false</code>, then the messages that you send from the identity aren't DKIM-signed.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable signingEnabled;
-
-/**
- <p>Describes whether or not Amazon SES has successfully located the DKIM records in the DNS records for the domain. The status can be one of the following:</p><ul><li><p><code>PENDING</code> – The verification process was initiated, but Amazon SES hasn't yet detected the DKIM records in the DNS configuration for the domain.</p></li><li><p><code>SUCCESS</code> – The verification process completed successfully.</p></li><li><p><code>FAILED</code> – The verification process failed. This typically occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the domain.</p></li><li><p><code>TEMPORARY_FAILURE</code> – A temporary issue is preventing Amazon SES from determining the DKIM authentication status of the domain.</p></li><li><p><code>NOT_STARTED</code> – The DKIM verification process hasn't been initiated for the domain.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESDkimStatus status;
-
-/**
- <p>If you used <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a> to configure DKIM authentication for the domain, then this object contains a set of unique strings that you use to create a set of CNAME records that you add to the DNS configuration for your domain. When Amazon SES detects these records in the DNS configuration for your domain, the DKIM authentication process is complete.</p><p>If you configured DKIM authentication for the domain by providing your own public-private key pair, then this object contains the selector for the public key.</p><p>Regardless of the DKIM authentication method you use, Amazon SES searches for the appropriate records in the DNS configuration of the domain for up to 72 hours.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable tokens;
-
-@end
-
-/**
- <p>An object that contains information about the tokens used for setting up Bring Your Own DKIM (BYODKIM).</p>
- Required parameters: [DomainSigningSelector, DomainSigningPrivateKey]
- */
-@interface AWSSESDkimSigningAttributes : AWSModel
-
-
-/**
- <p>A private key that's used to generate a DKIM signature.</p><p>The private key must use 1024-bit RSA encryption, and must be encoded using base64 encoding.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable domainSigningPrivateKey;
-
-/**
- <p>A string that's used to identify a public key in the DNS configuration for a domain.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable domainSigningSelector;
-
-@end
-
-/**
- <p>An object that contains the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for (<code>PutDeliverabilityDashboardOption</code> operation).</p>
- */
-@interface AWSSESDomainDeliverabilityCampaign : AWSModel
-
-
-/**
- <p>The unique identifier for the campaign. The Deliverability dashboard automatically generates and assigns this identifier to a campaign.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable campaignId;
-
-/**
- <p>The percentage of email messages that were deleted by recipients, without being opened first. Due to technical limitations, this value only includes recipients who opened the message by using an email client that supports images.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable deleteRate;
-
-/**
- <p>The major email providers who handled the email message.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable esps;
-
-/**
- <p>The first time, in Unix time format, when the email message was delivered to any recipient's inbox. This value can help you determine how long it took for a campaign to deliver an email message.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable firstSeenDateTime;
-
-/**
- <p>The verified email address that the email message was sent from.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromAddress;
-
-/**
- <p>The URL of an image that contains a snapshot of the email message that was sent.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable imageUrl;
-
-/**
- <p>The number of email messages that were delivered to recipients’ inboxes.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable inboxCount;
-
-/**
- <p>The last time, in Unix time format, when the email message was delivered to any recipient's inbox. This value can help you determine how long it took for a campaign to deliver an email message.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable lastSeenDateTime;
-
-/**
- <p>The projected number of recipients that the email message was sent to.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable projectedVolume;
-
-/**
- <p>The percentage of email messages that were opened and then deleted by recipients. Due to technical limitations, this value only includes recipients who opened the message by using an email client that supports images.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable readDeleteRate;
-
-/**
- <p>The percentage of email messages that were opened by recipients. Due to technical limitations, this value only includes recipients who opened the message by using an email client that supports images.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable readRate;
-
-/**
- <p>The IP addresses that were used to send the email message.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable sendingIps;
-
-/**
- <p>The number of email messages that were delivered to recipients' spam or junk mail folders.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable spamCount;
-
-/**
- <p>The subject line, or title, of the email message.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable subject;
-
-@end
-
-/**
- <p>An object that contains information about the Deliverability dashboard subscription for a verified domain that you use to send email and currently has an active Deliverability dashboard subscription. If a Deliverability dashboard subscription is active for a domain, you gain access to reputation, inbox placement, and other metrics for the domain.</p>
- */
-@interface AWSSESDomainDeliverabilityTrackingOption : AWSModel
-
-
-/**
- <p>A verified domain that’s associated with your AWS account and currently has an active Deliverability dashboard subscription.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable domain;
-
-/**
- <p>An object that contains information about the inbox placement data settings for the domain.</p>
- */
-@property (nonatomic, strong) AWSSESInboxPlacementTrackingOption * _Nullable inboxPlacementTrackingOption;
-
-/**
- <p>The date, in Unix time format, when you enabled the Deliverability dashboard for the domain.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable subscriptionStartDate;
-
-@end
-
-/**
- <p>An object that contains inbox placement data for email sent from one of your email domains to a specific email provider.</p>
- */
-@interface AWSSESDomainIspPlacement : AWSModel
-
-
-/**
- <p>The percentage of messages that were sent from the selected domain to the specified email provider that arrived in recipients' inboxes.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable inboxPercentage;
-
-/**
- <p>The total number of messages that were sent from the selected domain to the specified email provider that arrived in recipients' inboxes.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable inboxRawCount;
-
-/**
- <p>The name of the email provider that the inbox placement data applies to.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable ispName;
-
-/**
- <p>The percentage of messages that were sent from the selected domain to the specified email provider that arrived in recipients' spam or junk mail folders.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable spamPercentage;
-
-/**
- <p>The total number of messages that were sent from the selected domain to the specified email provider that arrived in recipients' spam or junk mail folders.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable spamRawCount;
-
-@end
-
-/**
- <p>An object that defines the entire content of the email, including the message headers and the body content. You can create a simple email message, in which you specify the subject and the text and HTML versions of the message body. You can also create raw messages, in which you specify a complete MIME-formatted message. Raw messages can include attachments and custom headers.</p>
- */
-@interface AWSSESEmailContent : AWSModel
-
-
-/**
- <p>The raw email message. The message has to meet the following criteria:</p><ul><li><p>The message has to contain a header and a body, separated by one blank line.</p></li><li><p>All of the required header fields must be present in the message.</p></li><li><p>Each part of a multipart MIME message must be formatted properly.</p></li><li><p>If you include attachments, they must be in a file format that the Amazon SES API v2 supports. </p></li><li><p>The entire message must be Base64 encoded.</p></li><li><p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, you should encode that content to ensure that recipients' email clients render the message properly.</p></li><li><p>The length of any single line of text in the message can't exceed 1,000 characters. This restriction is defined in <a href="https://tools.ietf.org/html/rfc5321">RFC 5321</a>.</p></li></ul>
- */
-@property (nonatomic, strong) AWSSESRawMessage * _Nullable raw;
-
-/**
- <p>The simple email message. The message consists of a subject and a message body.</p>
- */
-@property (nonatomic, strong) AWSSESMessage * _Nullable simple;
-
-/**
- <p>The template to use for the email message.</p>
- */
-@property (nonatomic, strong) AWSSESTemplate * _Nullable template;
-
-@end
-
-/**
- <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
- */
-@interface AWSSESEmailTemplateContent : AWSModel
-
-
-/**
- <p>The HTML body of the email.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable html;
-
-/**
- <p>The subject line of the email.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable subject;
-
-/**
- <p>The email body that will be visible to recipients whose email clients do not display HTML.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable text;
-
-@end
-
-/**
- <p>Contains information about an email template.</p>
- */
-@interface AWSSESEmailTemplateMetadata : AWSModel
-
-
-/**
- <p>The time and date the template was created.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable createdTimestamp;
-
-/**
- <p>The name of the template.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable templateName;
-
-@end
-
-/**
- <p>In the Amazon SES API v2, <i>events</i> include message sends, deliveries, opens, clicks, bounces, complaints and delivery delays. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Contains information about the event destination that the specified email sending events will be published to.</p><note><p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose or Amazon Simple Notification Service (Amazon SNS).</p></note><p>Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [Name, MatchingEventTypes]
  */
 @interface AWSSESEventDestination : AWSModel
 
 
 /**
- <p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to monitor and gain insights on your email sending metrics.</p>
+ <p>An object that contains the names, default values, and sources of the dimensions associated with an Amazon CloudWatch event destination.</p>
  */
 @property (nonatomic, strong) AWSSESCloudWatchDestination * _Nullable cloudWatchDestination;
 
 /**
- <p>If <code>true</code>, the event destination is enabled. When the event destination is enabled, the specified event types are sent to the destinations in this <code>EventDestinationDefinition</code>.</p><p>If <code>false</code>, the event destination is disabled. When the event destination is disabled, events aren't sent to the specified destinations.</p>
+ <p>Sets whether Amazon SES publishes events to this destination when you send an email with the associated configuration set. Set to <code>true</code> to enable publishing to this destination; set to <code>false</code> to prevent publishing to this destination. The default value is <code>false</code>.</p>
  */
 @property (nonatomic, strong) NSNumber * _Nullable enabled;
 
 /**
- <p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to stream data to other services, such as Amazon S3 and Amazon Redshift.</p>
+ <p>An object that contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p>
  */
 @property (nonatomic, strong) AWSSESKinesisFirehoseDestination * _Nullable kinesisFirehoseDestination;
 
 /**
- <p>The types of events that Amazon SES sends to the specified event destinations.</p>
+ <p>The type of email sending events to publish to the event destination.</p>
  */
 @property (nonatomic, strong) NSArray<NSString *> * _Nullable matchingEventTypes;
 
 /**
- <p>A name that identifies the event destination.</p>
+ <p>The name of the event destination. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Contain less than 64 characters.</p></li></ul>
  */
 @property (nonatomic, strong) NSString * _Nullable name;
 
 /**
- <p>An object that defines an Amazon Pinpoint project destination for email events. You can send email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging dashboards that are built in to Amazon Pinpoint. For more information, see <a href="https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html">Transactional Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>
+ <p>An object that contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p>
  */
-@property (nonatomic, strong) AWSSESPinpointDestination * _Nullable pinpointDestination;
-
-/**
- <p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to send notification when certain email events occur.</p>
- */
-@property (nonatomic, strong) AWSSESSnsDestination * _Nullable snsDestination;
+@property (nonatomic, strong) AWSSESSNSDestination * _Nullable SNSDestination;
 
 @end
 
 /**
- <p>An object that defines the event destination. Specifically, it defines which services receive events from emails sent using the configuration set that the event destination is associated with. Also defines the types of events that are sent to the event destination.</p>
+ <p>Additional X-headers to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p><p>For information about receiving email through Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Name, Value]
  */
-@interface AWSSESEventDestinationDefinition : AWSModel
+@interface AWSSESExtensionField : AWSModel
 
 
 /**
- <p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to monitor and gain insights on your email sending metrics.</p>
+ <p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>
  */
-@property (nonatomic, strong) AWSSESCloudWatchDestination * _Nullable cloudWatchDestination;
+@property (nonatomic, strong) NSString * _Nullable name;
 
 /**
- <p>If <code>true</code>, the event destination is enabled. When the event destination is enabled, the specified event types are sent to the destinations in this <code>EventDestinationDefinition</code>.</p><p>If <code>false</code>, the event destination is disabled. When the event destination is disabled, events aren't sent to the specified destinations.</p>
+ <p>The value of the header to add. Must be less than 2048 characters, and must not contain newline characters ("\r" or "\n").</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable value;
+
+@end
+
+/**
+ <p>Represents a request to return the email sending status for your Amazon SES account in the current AWS Region.</p>
+ */
+@interface AWSSESGetAccountSendingEnabledResponse : AWSModel
+
+
+/**
+ <p>Describes whether email sending is enabled or disabled for your Amazon SES account in the current AWS Region.</p>
  */
 @property (nonatomic, strong) NSNumber * _Nullable enabled;
-
-/**
- <p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to stream data to other services, such as Amazon S3 and Amazon Redshift.</p>
- */
-@property (nonatomic, strong) AWSSESKinesisFirehoseDestination * _Nullable kinesisFirehoseDestination;
-
-/**
- <p>An array that specifies which events the Amazon SES API v2 should send to the destinations in this <code>EventDestinationDefinition</code>.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable matchingEventTypes;
-
-/**
- <p>An object that defines an Amazon Pinpoint project destination for email events. You can send email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging dashboards that are built in to Amazon Pinpoint. For more information, see <a href="https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html">Transactional Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>
- */
-@property (nonatomic, strong) AWSSESPinpointDestination * _Nullable pinpointDestination;
-
-/**
- <p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to send notification when certain email events occur.</p>
- */
-@property (nonatomic, strong) AWSSESSnsDestination * _Nullable snsDestination;
-
-@end
-
-/**
- <p>An object that contains the failure details about an import job.</p>
- */
-@interface AWSSESFailureInfo : AWSModel
-
-
-/**
- <p>A message about why the import job failed.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable errorMessage;
-
-/**
- <p>An Amazon S3 presigned URL that contains all the failed records and related information.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable failedRecordsS3Url;
-
-@end
-
-/**
- <p>A request to obtain information about the email-sending capabilities of your Amazon SES account.</p>
- */
-@interface AWSSESGetAccountRequest : AWSRequest
-
-
-@end
-
-/**
- <p>A list of details about the email-sending capabilities of your Amazon SES account in the current AWS Region.</p>
- */
-@interface AWSSESGetAccountResponse : AWSModel
-
-
-/**
- <p>Indicates whether or not the automatic warm-up feature is enabled for dedicated IP addresses that are associated with your account.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable dedicatedIpAutoWarmupEnabled;
-
-/**
- <p>An object that defines your account details.</p>
- */
-@property (nonatomic, strong) AWSSESAccountDetails * _Nullable details;
-
-/**
- <p>The reputation status of your Amazon SES account. The status can be one of the following:</p><ul><li><p><code>HEALTHY</code> – There are no reputation-related issues that currently impact your account.</p></li><li><p><code>PROBATION</code> – We've identified potential issues with your Amazon SES account. We're placing your account under review while you work on correcting these issues.</p></li><li><p><code>SHUTDOWN</code> – Your account's ability to send email is currently paused because of an issue with the email sent from your account. When you correct the issue, you can contact us and request that your account's ability to send email is resumed.</p></li></ul>
- */
-@property (nonatomic, strong) NSString * _Nullable enforcementStatus;
-
-/**
- <p>Indicates whether or not your account has production access in the current AWS Region.</p><p>If the value is <code>false</code>, then your account is in the <i>sandbox</i>. When your account is in the sandbox, you can only send email to verified identities. Additionally, the maximum number of emails you can send in a 24-hour period (your sending quota) is 200, and the maximum number of emails you can send per second (your maximum sending rate) is 1.</p><p>If the value is <code>true</code>, then your account has production access. When your account has production access, you can send email to any address. The sending quota and maximum sending rate for your account vary based on your specific use case.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable productionAccessEnabled;
-
-/**
- <p>An object that contains information about the per-day and per-second sending limits for your Amazon SES account in the current AWS Region.</p>
- */
-@property (nonatomic, strong) AWSSESSendQuota * _Nullable sendQuota;
-
-/**
- <p>Indicates whether or not email sending is enabled for your Amazon SES account in the current AWS Region.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable sendingEnabled;
-
-/**
- <p>An object that contains information about the email address suppression preferences for your account in the current AWS Region.</p>
- */
-@property (nonatomic, strong) AWSSESSuppressionAttributes * _Nullable suppressionAttributes;
-
-@end
-
-/**
- <p>A request to retrieve a list of the blacklists that your dedicated IP addresses appear on.</p>
- Required parameters: [BlacklistItemNames]
- */
-@interface AWSSESGetBlacklistReportsRequest : AWSRequest
-
-
-/**
- <p>A list of IP addresses that you want to retrieve blacklist information about. You can only specify the dedicated IP addresses that you use to send email using Amazon SES or Amazon Pinpoint.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable blacklistItemNames;
-
-@end
-
-/**
- <p>An object that contains information about blacklist events.</p>
- Required parameters: [BlacklistReport]
- */
-@interface AWSSESGetBlacklistReportsResponse : AWSModel
-
-
-/**
- <p>An object that contains information about a blacklist that one of your dedicated IP addresses appears on.</p>
- */
-@property (nonatomic, strong) NSDictionary<NSString *, NSArray<AWSSESBlacklistEntry *> *> * _Nullable blacklistReport;
-
-@end
-
-/**
- <p>A request to obtain information about the event destinations for a configuration set.</p>
- Required parameters: [ConfigurationSetName]
- */
-@interface AWSSESGetConfigurationSetEventDestinationsRequest : AWSRequest
-
-
-/**
- <p>The name of the configuration set that contains the event destination.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
-
-@end
-
-/**
- <p>Information about an event destination for a configuration set.</p>
- */
-@interface AWSSESGetConfigurationSetEventDestinationsResponse : AWSModel
-
-
-/**
- <p>An array that includes all of the events destinations that have been configured for the configuration set.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESEventDestination *> * _Nullable eventDestinations;
-
-@end
-
-/**
- <p>A request to obtain information about a configuration set.</p>
- Required parameters: [ConfigurationSetName]
- */
-@interface AWSSESGetConfigurationSetRequest : AWSRequest
-
-
-/**
- <p>The name of the configuration set that you want to obtain more information about.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
-
-@end
-
-/**
- <p>Information about a configuration set.</p>
- */
-@interface AWSSESGetConfigurationSetResponse : AWSModel
-
-
-/**
- <p>The name of the configuration set.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
-
-/**
- <p>An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESDeliveryOptions * _Nullable deliveryOptions;
-
-/**
- <p>An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESReputationOptions * _Nullable reputationOptions;
-
-/**
- <p>An object that defines whether or not Amazon SES can send email that you send using the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESSendingOptions * _Nullable sendingOptions;
-
-/**
- <p>An object that contains information about the suppression list preferences for your account.</p>
- */
-@property (nonatomic, strong) AWSSESSuppressionOptions * _Nullable suppressionOptions;
-
-/**
- <p>An array of objects that define the tags (keys and values) that are associated with the configuration set.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-/**
- <p>An object that defines the open and click tracking options for emails that you send using the configuration set.</p>
- */
-@property (nonatomic, strong) AWSSESTrackingOptions * _Nullable trackingOptions;
 
 @end
 
@@ -1797,7 +1356,7 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>The following elements are returned by the service.</p>
+ <p>The content of the custom verification email template.</p>
  */
 @interface AWSSESGetCustomVerificationEmailTemplateResponse : AWSModel
 
@@ -1835,252 +1394,113 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>A request to obtain more information about a dedicated IP address.</p>
- Required parameters: [Ip]
+ <p>Represents a request for the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this request also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published. For more information about Easy DKIM, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identities]
  */
-@interface AWSSESGetDedicatedIpRequest : AWSRequest
+@interface AWSSESGetIdentityDkimAttributesRequest : AWSRequest
 
 
 /**
- <p>The IP address that you want to obtain more information about. The value you specify has to be a dedicated IP address that's assocaited with your AWS account.</p>
+ <p>A list of one or more verified identities - email addresses, domains, or both.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable ip;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable identities;
 
 @end
 
 /**
- <p>Information about a dedicated IP address.</p>
+ <p>Represents the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this response also contains the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published.</p>
+ Required parameters: [DkimAttributes]
  */
-@interface AWSSESGetDedicatedIpResponse : AWSModel
+@interface AWSSESGetIdentityDkimAttributesResponse : AWSModel
 
 
 /**
- <p>An object that contains information about a dedicated IP address.</p>
+ <p>The DKIM attributes for an email address or a domain.</p>
  */
-@property (nonatomic, strong) AWSSESDedicatedIp * _Nullable dedicatedIp;
+@property (nonatomic, strong) NSDictionary<NSString *, AWSSESIdentityDkimAttributes *> * _Nullable dkimAttributes;
 
 @end
 
 /**
- <p>A request to obtain more information about dedicated IP pools.</p>
+ <p>Represents a request to return the Amazon SES custom MAIL FROM attributes for a list of identities. For information about using a custom MAIL FROM domain, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identities]
  */
-@interface AWSSESGetDedicatedIpsRequest : AWSRequest
+@interface AWSSESGetIdentityMailFromDomainAttributesRequest : AWSRequest
 
 
 /**
- <p>A token returned from a previous call to <code>GetDedicatedIps</code> to indicate the position of the dedicated IP pool in the list of IP pools.</p>
+ <p>A list of one or more identities.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-/**
- <p>The number of results to show in a single call to <code>GetDedicatedIpsRequest</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
-
-/**
- <p>The name of the IP pool that the dedicated IP address is associated with.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable poolName;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable identities;
 
 @end
 
 /**
- <p>Information about the dedicated IP addresses that are associated with your AWS account.</p>
+ <p>Represents the custom MAIL FROM attributes for a list of identities.</p>
+ Required parameters: [MailFromDomainAttributes]
  */
-@interface AWSSESGetDedicatedIpsResponse : AWSModel
+@interface AWSSESGetIdentityMailFromDomainAttributesResponse : AWSModel
 
 
 /**
- <p>A list of dedicated IP addresses that are associated with your AWS account.</p>
+ <p>A map of identities to custom MAIL FROM attributes.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESDedicatedIp *> * _Nullable dedicatedIps;
-
-/**
- <p>A token that indicates that there are additional dedicated IP addresses to list. To view additional addresses, issue another request to <code>GetDedicatedIps</code>, passing this token in the <code>NextToken</code> parameter.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
+@property (nonatomic, strong) NSDictionary<NSString *, AWSSESIdentityMailFromDomainAttributes *> * _Nullable mailFromDomainAttributes;
 
 @end
 
 /**
- <p>Retrieve information about the status of the Deliverability dashboard for your AWS account. When the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and other metrics for your domains. You also gain the ability to perform predictive inbox placement tests.</p><p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href="http://aws.amazon.com/pinpoint/pricing/">Amazon Pinpoint Pricing</a>.</p>
+ <p>Represents a request to return the notification attributes for a list of identities you verified with Amazon SES. For information about Amazon SES notifications, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identities]
  */
-@interface AWSSESGetDeliverabilityDashboardOptionsRequest : AWSRequest
+@interface AWSSESGetIdentityNotificationAttributesRequest : AWSRequest
 
+
+/**
+ <p>A list of one or more identities. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable identities;
 
 @end
 
 /**
- <p>An object that shows the status of the Deliverability dashboard.</p>
- Required parameters: [DashboardEnabled]
+ <p>Represents the notification attributes for a list of identities.</p>
+ Required parameters: [NotificationAttributes]
  */
-@interface AWSSESGetDeliverabilityDashboardOptionsResponse : AWSModel
+@interface AWSSESGetIdentityNotificationAttributesResponse : AWSModel
 
 
 /**
- <p>The current status of your Deliverability dashboard subscription. If this value is <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end of the current calendar month.</p>
+ <p>A map of Identity to IdentityNotificationAttributes.</p>
  */
-@property (nonatomic, assign) AWSSESDeliverabilityDashboardAccountStatus accountStatus;
-
-/**
- <p>An array of objects, one for each verified domain that you use to send email and currently has an active Deliverability dashboard subscription that isn’t scheduled to expire at the end of the current calendar month.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDomainDeliverabilityTrackingOption *> * _Nullable activeSubscribedDomains;
-
-/**
- <p>Specifies whether the Deliverability dashboard is enabled. If this value is <code>true</code>, the dashboard is enabled.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable dashboardEnabled;
-
-/**
- <p>An array of objects, one for each verified domain that you use to send email and currently has an active Deliverability dashboard subscription that's scheduled to expire at the end of the current calendar month.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDomainDeliverabilityTrackingOption *> * _Nullable pendingExpirationSubscribedDomains;
-
-/**
- <p>The date, in Unix time format, when your current subscription to the Deliverability dashboard is scheduled to expire, if your subscription is scheduled to expire at the end of the current calendar month. This value is null if you have an active subscription that isn’t due to expire at the end of the month.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable subscriptionExpiryDate;
+@property (nonatomic, strong) NSDictionary<NSString *, AWSSESIdentityNotificationAttributes *> * _Nullable notificationAttributes;
 
 @end
 
 /**
- <p>A request to retrieve the results of a predictive inbox placement test.</p>
- Required parameters: [ReportId]
+ <p>Represents a request to return the requested sending authorization policies for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, PolicyNames]
  */
-@interface AWSSESGetDeliverabilityTestReportRequest : AWSRequest
+@interface AWSSESGetIdentityPoliciesRequest : AWSRequest
 
 
 /**
- <p>A unique string that identifies the predictive inbox placement test.</p>
+ <p>The identity for which the policies will be retrieved. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p><p>To successfully call this API, you must own the identity.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable reportId;
+@property (nonatomic, strong) NSString * _Nullable identity;
+
+/**
+ <p>A list of the names of policies to be retrieved. You can retrieve a maximum of 20 policies at a time. If you do not know the names of the policies that are attached to the identity, you can use <code>ListIdentityPolicies</code>.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable policyNames;
 
 @end
 
 /**
- <p>The results of the predictive inbox placement test.</p>
- Required parameters: [DeliverabilityTestReport, OverallPlacement, IspPlacements]
+ <p>Represents the requested sending authorization policies.</p>
+ Required parameters: [Policies]
  */
-@interface AWSSESGetDeliverabilityTestReportResponse : AWSModel
-
-
-/**
- <p>An object that contains the results of the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) AWSSESDeliverabilityTestReport * _Nullable deliverabilityTestReport;
-
-/**
- <p>An object that describes how the test email was handled by several email providers, including Gmail, Hotmail, Yahoo, AOL, and others.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESIspPlacement *> * _Nullable ispPlacements;
-
-/**
- <p>An object that contains the message that you sent when you performed this predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable message;
-
-/**
- <p>An object that specifies how many test messages that were sent during the predictive inbox placement test were delivered to recipients' inboxes, how many were sent to recipients' spam folders, and how many weren't delivered.</p>
- */
-@property (nonatomic, strong) AWSSESPlacementStatistics * _Nullable overallPlacement;
-
-/**
- <p>An array of objects that define the tags (keys and values) that are associated with the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-@end
-
-/**
- <p>Retrieve all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for (<code>PutDeliverabilityDashboardOption</code> operation).</p>
- Required parameters: [CampaignId]
- */
-@interface AWSSESGetDomainDeliverabilityCampaignRequest : AWSRequest
-
-
-/**
- <p>The unique identifier for the campaign. The Deliverability dashboard automatically generates and assigns this identifier to a campaign.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable campaignId;
-
-@end
-
-/**
- <p>An object that contains all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for.</p>
- Required parameters: [DomainDeliverabilityCampaign]
- */
-@interface AWSSESGetDomainDeliverabilityCampaignResponse : AWSModel
-
-
-/**
- <p>An object that contains the deliverability data for the campaign.</p>
- */
-@property (nonatomic, strong) AWSSESDomainDeliverabilityCampaign * _Nullable domainDeliverabilityCampaign;
-
-@end
-
-/**
- <p>A request to obtain deliverability metrics for a domain.</p>
- Required parameters: [Domain, StartDate, EndDate]
- */
-@interface AWSSESGetDomainStatisticsReportRequest : AWSRequest
-
-
-/**
- <p>The domain that you want to obtain deliverability metrics for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable domain;
-
-/**
- <p>The last day (in Unix time) that you want to obtain domain deliverability metrics for. The <code>EndDate</code> that you specify has to be less than or equal to 30 days after the <code>StartDate</code>.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable endDate;
-
-/**
- <p>The first day (in Unix time) that you want to obtain domain deliverability metrics for.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable startDate;
-
-@end
-
-/**
- <p>An object that includes statistics that are related to the domain that you specified.</p>
- Required parameters: [OverallVolume, DailyVolumes]
- */
-@interface AWSSESGetDomainStatisticsReportResponse : AWSModel
-
-
-/**
- <p>An object that contains deliverability metrics for the domain that you specified. This object contains data for each day, starting on the <code>StartDate</code> and ending on the <code>EndDate</code>.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDailyVolume *> * _Nullable dailyVolumes;
-
-/**
- <p>An object that contains deliverability metrics for the domain that you specified. The data in this object is a summary of all of the data that was collected from the <code>StartDate</code> to the <code>EndDate</code>.</p>
- */
-@property (nonatomic, strong) AWSSESOverallVolume * _Nullable overallVolume;
-
-@end
-
-/**
- <p>A request to return the policies of an email identity.</p>
- Required parameters: [EmailIdentity]
- */
-@interface AWSSESGetEmailIdentityPoliciesRequest : AWSRequest
-
-
-/**
- <p>The email identity that you want to retrieve policies for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-@end
-
-/**
- <p>Identity policies associated with email identity.</p>
- */
-@interface AWSSESGetEmailIdentityPoliciesResponse : AWSModel
+@interface AWSSESGetIdentityPoliciesResponse : AWSModel
 
 
 /**
@@ -2091,385 +1511,305 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>A request to return details about an email identity.</p>
- Required parameters: [EmailIdentity]
+ <p>Represents a request to return the Amazon SES verification status of a list of identities. For domain identities, this request also returns the verification token. For information about verifying identities with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identities]
  */
-@interface AWSSESGetEmailIdentityRequest : AWSRequest
+@interface AWSSESGetIdentityVerificationAttributesRequest : AWSRequest
 
 
 /**
- <p>The email identity that you want to retrieve details for.</p>
+ <p>A list of identities.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable identities;
 
 @end
 
 /**
- <p>Details about an email identity.</p>
+ <p>The Amazon SES verification status of a list of identities. For domain identities, this response also contains the verification token.</p>
+ Required parameters: [VerificationAttributes]
  */
-@interface AWSSESGetEmailIdentityResponse : AWSModel
+@interface AWSSESGetIdentityVerificationAttributesResponse : AWSModel
 
 
 /**
- <p>An object that contains information about the DKIM attributes for the identity.</p>
+ <p>A map of Identities to IdentityVerificationAttributes objects.</p>
  */
-@property (nonatomic, strong) AWSSESDkimAttributes * _Nullable dkimAttributes;
-
-/**
- <p>The feedback forwarding configuration for the identity.</p><p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p><p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable feedbackForwardingStatus;
-
-/**
- <p>The email identity type.</p>
- */
-@property (nonatomic, assign) AWSSESIdentityType identityType;
-
-/**
- <p>An object that contains information about the Mail-From attributes for the email identity.</p>
- */
-@property (nonatomic, strong) AWSSESMailFromAttributes * _Nullable mailFromAttributes;
-
-/**
- <p>A map of policy names to policies.</p>
- */
-@property (nonatomic, strong) NSDictionary<NSString *, NSString *> * _Nullable policies;
-
-/**
- <p>An array of objects that define the tags (keys and values) that are associated with the email identity.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-/**
- <p>Specifies whether or not the identity is verified. You can only send email from verified email addresses or domains. For more information about verifying identities, see the <a href="https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-email-manage-verify.html">Amazon Pinpoint User Guide</a>.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable verifiedForSendingStatus;
+@property (nonatomic, strong) NSDictionary<NSString *, AWSSESIdentityVerificationAttributes *> * _Nullable verificationAttributes;
 
 @end
 
 /**
- <p>Represents a request to display the template object (which includes the subject line, HTML part and text part) for the template you specify.</p>
- Required parameters: [TemplateName]
+ <p>Represents your Amazon SES daily sending quota, maximum send rate, and the number of emails you have sent in the last 24 hours.</p>
  */
-@interface AWSSESGetEmailTemplateRequest : AWSRequest
+@interface AWSSESGetSendQuotaResponse : AWSModel
 
 
 /**
- <p>The name of the template you want to retrieve.</p>
+ <p>The maximum number of emails the user is allowed to send in a 24-hour interval. A value of -1 signifies an unlimited quota.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable templateName;
+@property (nonatomic, strong) NSNumber * _Nullable max24HourSend;
+
+/**
+ <p>The maximum number of emails that Amazon SES can accept from the user's account per second.</p><note><p>The rate at which Amazon SES accepts the user's messages might be less than the maximum send rate.</p></note>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable maxSendRate;
+
+/**
+ <p>The number of emails sent during the previous 24 hours.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable sentLast24Hours;
 
 @end
 
 /**
- <p>The following element is returned by the service.</p>
- Required parameters: [TemplateName, TemplateContent]
+ <p>Represents a list of data points. This list contains aggregated data from the previous two weeks of your sending activity with Amazon SES.</p>
  */
-@interface AWSSESGetEmailTemplateResponse : AWSModel
+@interface AWSSESGetSendStatisticsResponse : AWSModel
 
 
 /**
- <p>The content of the email template, composed of a subject line, an HTML part, and a text-only part.</p>
+ <p>A list of data points, each of which represents 15 minutes of activity.</p>
  */
-@property (nonatomic, strong) AWSSESEmailTemplateContent * _Nullable templateContent;
-
-/**
- <p>The name of the template you want to retrieve.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable templateName;
+@property (nonatomic, strong) NSArray<AWSSESSendDataPoint *> * _Nullable sendDataPoints;
 
 @end
-
-/**
- <p>Represents a request for information about an import job using the import job ID.</p>
- Required parameters: [JobId]
- */
-@interface AWSSESGetImportJobRequest : AWSRequest
-
-
-/**
- <p>The ID of the import job.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable jobId;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESGetImportJobResponse : AWSModel
-
-
-/**
- <p>The time stamp of when the import job was completed.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable completedTimestamp;
-
-/**
- <p>The time stamp of when the import job was created.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable createdTimestamp;
-
-/**
- <p>The number of records that failed processing because of invalid input or other reasons.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable failedRecordsCount;
-
-/**
- <p>The failure details about an import job.</p>
- */
-@property (nonatomic, strong) AWSSESFailureInfo * _Nullable failureInfo;
-
-/**
- <p>The data source of the import job.</p>
- */
-@property (nonatomic, strong) AWSSESImportDataSource * _Nullable importDataSource;
-
-/**
- <p>The destination of the import job.</p>
- */
-@property (nonatomic, strong) AWSSESImportDestination * _Nullable importDestination;
-
-/**
- <p>A string that represents the import job ID.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable jobId;
-
-/**
- <p>The status of the import job.</p>
- */
-@property (nonatomic, assign) AWSSESJobStatus jobStatus;
-
-/**
- <p>The current number of records processed.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable processedRecordsCount;
-
-@end
-
-/**
- <p>A request to retrieve information about an email address that's on the suppression list for your account.</p>
- Required parameters: [EmailAddress]
- */
-@interface AWSSESGetSuppressedDestinationRequest : AWSRequest
-
-
-/**
- <p>The email address that's on the account suppression list.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailAddress;
-
-@end
-
-/**
- <p>Information about the suppressed email address.</p>
- Required parameters: [SuppressedDestination]
- */
-@interface AWSSESGetSuppressedDestinationResponse : AWSModel
-
-
-/**
- <p>An object containing information about the suppressed email address.</p>
- */
-@property (nonatomic, strong) AWSSESSuppressedDestination * _Nullable suppressedDestination;
-
-@end
-
-/**
- <p>Information about an email identity.</p>
- */
-@interface AWSSESIdentityInfo : AWSModel
-
-
-/**
- <p>The address or domain of the identity.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable identityName;
-
-/**
- <p>The email identity type. The identity type can be one of the following:</p><ul><li><p><code>EMAIL_ADDRESS</code> – The identity is an email address.</p></li><li><p><code>DOMAIN</code> – The identity is a domain.</p></li><li><p><code>MANAGED_DOMAIN</code> – The identity is a domain that is managed by AWS.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESIdentityType identityType;
-
-/**
- <p>Indicates whether or not you can send email from the identity.</p><p>An <i>identity</i> is an email address or domain that you send email from. Before you can send email from an identity, you have to demostrate that you own the identity, and that you authorize Amazon SES to send email from that identity.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable sendingEnabled;
-
-@end
-
-/**
- <p>An object that contains details about the data source of the import job.</p>
- Required parameters: [S3Url, DataFormat]
- */
-@interface AWSSESImportDataSource : AWSModel
-
-
-/**
- <p>The data format of the import job's data source.</p>
- */
-@property (nonatomic, assign) AWSSESDataFormat dataFormat;
-
-/**
- <p>An Amazon S3 URL in the format s3://<i>&lt;bucket_name&gt;</i>/<i>&lt;object&gt;</i>.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable s3Url;
-
-@end
-
-/**
- <p>An object that contains details about the resource destination the import job is going to target.</p>
- Required parameters: [SuppressionListDestination]
- */
-@interface AWSSESImportDestination : AWSModel
-
-
-/**
- <p>An object that contains the action of the import job towards suppression list.</p>
- */
-@property (nonatomic, strong) AWSSESSuppressionListDestination * _Nullable suppressionListDestination;
-
-@end
-
-/**
- <p>A summary of the import job.</p>
- */
-@interface AWSSESImportJobSummary : AWSModel
-
 
 /**
  
  */
-@property (nonatomic, strong) NSDate * _Nullable createdTimestamp;
+@interface AWSSESGetTemplateRequest : AWSRequest
+
 
 /**
- <p>An object that contains details about the resource destination the import job is going to target.</p>
+ <p>The name of the template you want to retrieve.</p>
  */
-@property (nonatomic, strong) AWSSESImportDestination * _Nullable importDestination;
-
-/**
- <p>A string that represents the import job ID.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable jobId;
-
-/**
- <p>The status of the import job.</p>
- */
-@property (nonatomic, assign) AWSSESJobStatus jobStatus;
+@property (nonatomic, strong) NSString * _Nullable templateName;
 
 @end
 
 /**
- <p>An object that contains information about the inbox placement data settings for a verified domain that’s associated with your AWS account. This data is available only if you enabled the Deliverability dashboard for the domain.</p>
+ 
  */
-@interface AWSSESInboxPlacementTrackingOption : AWSModel
+@interface AWSSESGetTemplateResponse : AWSModel
 
 
 /**
- <p>Specifies whether inbox placement data is being tracked for the domain.</p>
+ <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable global;
-
-/**
- <p>An array of strings, one for each major email provider that the inbox placement data applies to.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable trackedIsps;
+@property (nonatomic, strong) AWSSESTemplate * _Nullable template;
 
 @end
 
 /**
- <p>An object that describes how email sent during the predictive inbox placement test was handled by a certain email provider.</p>
+ <p>Represents the DKIM attributes of a verified email address or a domain.</p>
+ Required parameters: [DkimEnabled, DkimVerificationStatus]
  */
-@interface AWSSESIspPlacement : AWSModel
+@interface AWSSESIdentityDkimAttributes : AWSModel
 
 
 /**
- <p>The name of the email provider that the inbox placement data applies to.</p>
+ <p>Is true if DKIM signing is enabled for email sent from the identity. It's false otherwise. The default value is true.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable ispName;
+@property (nonatomic, strong) NSNumber * _Nullable dkimEnabled;
 
 /**
- <p>An object that contains inbox placement metrics for a specific email provider.</p>
+ <p>A set of character strings that represent the domain's identity. Using these tokens, you need to create DNS CNAME records that point to DKIM public keys that are hosted by Amazon SES. Amazon Web Services eventually detects that you've updated your DNS records. This detection process might take up to 72 hours. After successful detection, Amazon SES is able to DKIM-sign email originating from that domain. (This only applies to domain identities, not email address identities.)</p><p>For more information about creating DNS records using DKIM tokens, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
  */
-@property (nonatomic, strong) AWSSESPlacementStatistics * _Nullable placementStatistics;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable dkimTokens;
+
+/**
+ <p>Describes whether Amazon SES has successfully verified the DKIM DNS records (tokens) published in the domain name's DNS. (This only applies to domain identities, not email address identities.)</p>
+ */
+@property (nonatomic, assign) AWSSESVerificationStatus dkimVerificationStatus;
 
 @end
 
 /**
- <p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to stream data to other services, such as Amazon S3 and Amazon Redshift.</p>
- Required parameters: [IamRoleArn, DeliveryStreamArn]
+ <p>Represents the custom MAIL FROM domain attributes of a verified identity (email address or domain).</p>
+ Required parameters: [MailFromDomain, MailFromDomainStatus, BehaviorOnMXFailure]
+ */
+@interface AWSSESIdentityMailFromDomainAttributes : AWSModel
+
+
+/**
+ <p>The action that Amazon SES takes if it cannot successfully read the required MX record when you send an email. A value of <code>UseDefaultValue</code> indicates that if Amazon SES cannot read the required MX record, it uses amazonses.com (or a subdomain of that) as the MAIL FROM domain. A value of <code>RejectMessage</code> indicates that if Amazon SES cannot read the required MX record, Amazon SES returns a <code>MailFromDomainNotVerified</code> error and does not send the email.</p><p>The custom MAIL FROM setup states that result in this behavior are <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>.</p>
+ */
+@property (nonatomic, assign) AWSSESBehaviorOnMXFailure behaviorOnMXFailure;
+
+/**
+ <p>The custom MAIL FROM domain that the identity is configured to use.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable mailFromDomain;
+
+/**
+ <p>The state that indicates whether Amazon SES has successfully read the MX record required for custom MAIL FROM domain setup. If the state is <code>Success</code>, Amazon SES uses the specified custom MAIL FROM domain when the verified identity sends an email. All other states indicate that Amazon SES takes the action described by <code>BehaviorOnMXFailure</code>.</p>
+ */
+@property (nonatomic, assign) AWSSESCustomMailFromStatus mailFromDomainStatus;
+
+@end
+
+/**
+ <p>Represents the notification attributes of an identity, including whether an identity has Amazon Simple Notification Service (Amazon SNS) topics set for bounce, complaint, and/or delivery notifications, and whether feedback forwarding is enabled for bounce and complaint notifications.</p>
+ Required parameters: [BounceTopic, ComplaintTopic, DeliveryTopic, ForwardingEnabled]
+ */
+@interface AWSSESIdentityNotificationAttributes : AWSModel
+
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish bounce notifications.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable bounceTopic;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish complaint notifications.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable complaintTopic;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish delivery notifications.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable deliveryTopic;
+
+/**
+ <p>Describes whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> indicates that Amazon SES will forward bounce and complaint notifications as email, while <code>false</code> indicates that bounce and complaint notifications will be published only to the specified bounce and complaint Amazon SNS topics.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable forwardingEnabled;
+
+/**
+ <p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Bounce</code>. A value of <code>true</code> specifies that Amazon SES will include headers in bounce notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in bounce notifications.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable headersInBounceNotificationsEnabled;
+
+/**
+ <p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Complaint</code>. A value of <code>true</code> specifies that Amazon SES will include headers in complaint notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in complaint notifications.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable headersInComplaintNotificationsEnabled;
+
+/**
+ <p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Delivery</code>. A value of <code>true</code> specifies that Amazon SES will include headers in delivery notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in delivery notifications.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable headersInDeliveryNotificationsEnabled;
+
+@end
+
+/**
+ <p>Represents the verification attributes of a single identity.</p>
+ Required parameters: [VerificationStatus]
+ */
+@interface AWSSESIdentityVerificationAttributes : AWSModel
+
+
+/**
+ <p>The verification status of the identity: "Pending", "Success", "Failed", or "TemporaryFailure".</p>
+ */
+@property (nonatomic, assign) AWSSESVerificationStatus verificationStatus;
+
+/**
+ <p>The verification token for a domain identity. Null for email address identities.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable verificationToken;
+
+@end
+
+/**
+ <p>Contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p><p>Event destinations, such as Amazon Kinesis Firehose, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [IAMRoleARN, DeliveryStreamARN]
  */
 @interface AWSSESKinesisFirehoseDestination : AWSModel
 
 
 /**
- <p>The Amazon Resource Name (ARN) of the Amazon Kinesis Data Firehose stream that the Amazon SES API v2 sends email events to.</p>
+ <p>The ARN of the Amazon Kinesis Firehose stream that email sending events should be published to.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable deliveryStreamArn;
+@property (nonatomic, strong) NSString * _Nullable deliveryStreamARN;
 
 /**
- <p>The Amazon Resource Name (ARN) of the IAM role that the Amazon SES API v2 uses to send email events to the Amazon Kinesis Data Firehose stream.</p>
+ <p>The ARN of the IAM role under which Amazon SES publishes email sending events to the Amazon Kinesis Firehose stream.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable iamRoleArn;
+@property (nonatomic, strong) NSString * _Nullable IAMRoleARN;
 
 @end
 
 /**
- <p>A request to obtain a list of configuration sets for your Amazon SES account in the current AWS Region.</p>
+ <p>When included in a receipt rule, this action calls an AWS Lambda function and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p><p>To enable Amazon SES to call your AWS Lambda function or to publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p><p>For information about using AWS Lambda actions in receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [FunctionArn]
+ */
+@interface AWSSESLambdaAction : AWSModel
+
+
+/**
+ <p>The Amazon Resource Name (ARN) of the AWS Lambda function. An example of an AWS Lambda function ARN is <code>arn:aws:lambda:us-west-2:account-id:function:MyFunction</code>. For more information about AWS Lambda, see the <a href="https://docs.aws.amazon.com/lambda/latest/dg/welcome.html">AWS Lambda Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable functionArn;
+
+/**
+ <p>The invocation type of the AWS Lambda function. An invocation type of <code>RequestResponse</code> means that the execution of the function will immediately result in a response, and a value of <code>Event</code> means that the function will be invoked asynchronously. The default value is <code>Event</code>. For information about AWS Lambda invocation types, see the <a href="https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html">AWS Lambda Developer Guide</a>.</p><important><p>There is a 30-second timeout on <code>RequestResponse</code> invocations. You should use <code>Event</code> invocation in most cases. Use <code>RequestResponse</code> only when you want to make a mail flow decision, such as whether to stop the receipt rule or the receipt rule set.</p></important>
+ */
+@property (nonatomic, assign) AWSSESInvocationType invocationType;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the Lambda action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable topicArn;
+
+@end
+
+/**
+ <p>Represents a request to list the configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  */
 @interface AWSSESListConfigurationSetsRequest : AWSRequest
 
 
 /**
- <p>A token returned from a previous call to <code>ListConfigurationSets</code> to indicate the position in the list of configuration sets.</p>
+ <p>The number of configuration sets to return.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
+@property (nonatomic, strong) NSNumber * _Nullable maxItems;
 
 /**
- <p>The number of results to show in a single call to <code>ListConfigurationSets</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>
+ <p>A token returned from a previous call to <code>ListConfigurationSets</code> to indicate the position of the configuration set in the configuration set list.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
+@property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>A list of configuration sets in your Amazon SES account in the current AWS Region.</p>
+ <p>A list of configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  */
 @interface AWSSESListConfigurationSetsResponse : AWSModel
 
 
 /**
- <p>An array that contains all of the configuration sets in your Amazon SES account in the current AWS Region.</p>
+ <p>A list of configuration sets.</p>
  */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable configurationSets;
+@property (nonatomic, strong) NSArray<AWSSESConfigurationSet *> * _Nullable configurationSets;
 
 /**
- <p>A token that indicates that there are additional configuration sets to list. To view additional configuration sets, issue another request to <code>ListConfigurationSets</code>, and pass this token in the <code>NextToken</code> parameter.</p>
+ <p>A token indicating that there are additional configuration sets available to be listed. Pass this token to successive calls of <code>ListConfigurationSets</code>. </p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>Represents a request to list the existing custom verification email templates for your account.</p>
+ <p>Represents a request to list the existing custom verification email templates for your account.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p>
  */
 @interface AWSSESListCustomVerificationEmailTemplatesRequest : AWSRequest
 
 
 /**
- <p>A token returned from a previous call to <code>ListCustomVerificationEmailTemplates</code> to indicate the position in the list of custom verification email templates.</p>
+ <p>The maximum number of custom verification email templates to return. This value must be at least 1 and less than or equal to 50. If you do not specify a value, or if you specify a value less than 1 or greater than 50, the operation will return up to 50 results.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
+@property (nonatomic, strong) NSNumber * _Nullable maxResults;
 
 /**
- <p>The number of results to show in a single call to <code>ListCustomVerificationEmailTemplates</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p><p>The value you specify has to be at least 1, and can be no more than 50.</p>
+ <p>An array the contains the name and creation time stamp for each template in your Amazon SES account.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
+@property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>The following elements are returned by the service.</p>
+ <p>A paginated list of custom verification email templates.</p>
  */
 @interface AWSSESListCustomVerificationEmailTemplatesResponse : AWSModel
 
@@ -2477,593 +1817,264 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 /**
  <p>A list of the custom verification email templates that exist in your account.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESCustomVerificationEmailTemplateMetadata *> * _Nullable customVerificationEmailTemplates;
+@property (nonatomic, strong) NSArray<AWSSESCustomVerificationEmailTemplate *> * _Nullable customVerificationEmailTemplates;
 
 /**
- <p>A token indicating that there are additional custom verification email templates available to be listed. Pass this token to a subsequent call to <code>ListCustomVerificationEmailTemplates</code> to retrieve the next 50 custom verification email templates.</p>
+ <p>A token indicating that there are additional custom verification email templates available to be listed. Pass this token to a subsequent call to <code>ListTemplates</code> to retrieve the next 50 custom verification email templates.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>A request to obtain a list of dedicated IP pools.</p>
+ <p>Represents a request to return a list of all identities (email addresses and domains) that you have attempted to verify under your AWS account, regardless of verification status.</p>
  */
-@interface AWSSESListDedicatedIpPoolsRequest : AWSRequest
+@interface AWSSESListIdentitiesRequest : AWSRequest
 
 
 /**
- <p>A token returned from a previous call to <code>ListDedicatedIpPools</code> to indicate the position in the list of dedicated IP pools.</p>
+ <p>The type of the identities to list. Possible values are "EmailAddress" and "Domain". If this parameter is omitted, then all identities will be listed.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
+@property (nonatomic, assign) AWSSESIdentityType identityType;
 
 /**
- <p>The number of results to show in a single call to <code>ListDedicatedIpPools</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>
+ <p>The maximum number of identities per page. Possible values are 1-1000 inclusive.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
-
-@end
+@property (nonatomic, strong) NSNumber * _Nullable maxItems;
 
 /**
- <p>A list of dedicated IP pools.</p>
- */
-@interface AWSSESListDedicatedIpPoolsResponse : AWSModel
-
-
-/**
- <p>A list of all of the dedicated IP pools that are associated with your AWS account in the current Region.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable dedicatedIpPools;
-
-/**
- <p>A token that indicates that there are additional IP pools to list. To view additional IP pools, issue another request to <code>ListDedicatedIpPools</code>, passing this token in the <code>NextToken</code> parameter.</p>
+ <p>The token to use for pagination.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>A request to list all of the predictive inbox placement tests that you've performed.</p>
+ <p>A list of all identities that you have attempted to verify under your AWS account, regardless of verification status.</p>
+ Required parameters: [Identities]
  */
-@interface AWSSESListDeliverabilityTestReportsRequest : AWSRequest
+@interface AWSSESListIdentitiesResponse : AWSModel
 
 
 /**
- <p>A token returned from a previous call to <code>ListDeliverabilityTestReports</code> to indicate the position in the list of predictive inbox placement tests.</p>
+ <p>A list of identities.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable identities;
 
 /**
- <p>The number of results to show in a single call to <code>ListDeliverabilityTestReports</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p><p>The value you specify has to be at least 0, and can be no more than 1000.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
-
-@end
-
-/**
- <p>A list of the predictive inbox placement test reports that are available for your account, regardless of whether or not those tests are complete.</p>
- Required parameters: [DeliverabilityTestReports]
- */
-@interface AWSSESListDeliverabilityTestReportsResponse : AWSModel
-
-
-/**
- <p>An object that contains a lists of predictive inbox placement tests that you've performed.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDeliverabilityTestReport *> * _Nullable deliverabilityTestReports;
-
-/**
- <p>A token that indicates that there are additional predictive inbox placement tests to list. To view additional predictive inbox placement tests, issue another request to <code>ListDeliverabilityTestReports</code>, and pass this token in the <code>NextToken</code> parameter.</p>
+ <p>The token used for pagination.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>Retrieve deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard.</p>
- Required parameters: [StartDate, EndDate, SubscribedDomain]
+ <p>Represents a request to return a list of sending authorization policies that are attached to an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity]
  */
-@interface AWSSESListDomainDeliverabilityCampaignsRequest : AWSRequest
+@interface AWSSESListIdentityPoliciesRequest : AWSRequest
 
 
 /**
- <p>The last day, in Unix time format, that you want to obtain deliverability data for. This value has to be less than or equal to 30 days after the value of the <code>StartDate</code> parameter.</p>
+ <p>The identity that is associated with the policy for which the policies will be listed. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p><p>To successfully call this API, you must own the identity.</p>
  */
-@property (nonatomic, strong) NSDate * _Nullable endDate;
-
-/**
- <p>A token that’s returned from a previous call to the <code>ListDomainDeliverabilityCampaigns</code> operation. This token indicates the position of a campaign in the list of campaigns.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-/**
- <p>The maximum number of results to include in response to a single call to the <code>ListDomainDeliverabilityCampaigns</code> operation. If the number of results is larger than the number that you specify in this parameter, the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
-
-/**
- <p>The first day, in Unix time format, that you want to obtain deliverability data for.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable startDate;
-
-/**
- <p>The domain to obtain deliverability data for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable subscribedDomain;
+@property (nonatomic, strong) NSString * _Nullable identity;
 
 @end
 
 /**
- <p>An array of objects that provide deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard for the domain.</p>
- Required parameters: [DomainDeliverabilityCampaigns]
+ <p>A list of names of sending authorization policies that apply to an identity.</p>
+ Required parameters: [PolicyNames]
  */
-@interface AWSSESListDomainDeliverabilityCampaignsResponse : AWSModel
+@interface AWSSESListIdentityPoliciesResponse : AWSModel
 
 
 /**
- <p>An array of responses, one for each campaign that used the domain to send email during the specified time range.</p>
+ <p>A list of names of policies that apply to the specified identity.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESDomainDeliverabilityCampaign *> * _Nullable domainDeliverabilityCampaigns;
-
-/**
- <p>A token that’s returned from a previous call to the <code>ListDomainDeliverabilityCampaigns</code> operation. This token indicates the position of the campaign in the list of campaigns.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable policyNames;
 
 @end
 
 /**
- <p>A request to list all of the email identities associated with your AWS account. This list includes identities that you've already verified, identities that are unverified, and identities that were verified in the past, but are no longer verified.</p>
+ <p>Represents a request to list the IP address filters that exist under your AWS account. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
  */
-@interface AWSSESListEmailIdentitiesRequest : AWSRequest
+@interface AWSSESListReceiptFiltersRequest : AWSRequest
 
-
-/**
- <p>A token returned from a previous call to <code>ListEmailIdentities</code> to indicate the position in the list of identities.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-/**
- <p>The number of results to show in a single call to <code>ListEmailIdentities</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p><p>The value you specify has to be at least 0, and can be no more than 1000.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
 
 @end
 
 /**
- <p>A list of all of the identities that you've attempted to verify, regardless of whether or not those identities were successfully verified.</p>
+ <p>A list of IP address filters that exist under your AWS account.</p>
  */
-@interface AWSSESListEmailIdentitiesResponse : AWSModel
+@interface AWSSESListReceiptFiltersResponse : AWSModel
 
 
 /**
- <p>An array that includes all of the email identities associated with your AWS account.</p>
+ <p>A list of IP address filter data structures, which each consist of a name, an IP address range, and whether to allow or block mail from it.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESIdentityInfo *> * _Nullable emailIdentities;
+@property (nonatomic, strong) NSArray<AWSSESReceiptFilter *> * _Nullable filters;
+
+@end
 
 /**
- <p>A token that indicates that there are additional configuration sets to list. To view additional configuration sets, issue another request to <code>ListEmailIdentities</code>, and pass this token in the <code>NextToken</code> parameter.</p>
+ <p>Represents a request to list the receipt rule sets that exist under your AWS account. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ */
+@interface AWSSESListReceiptRuleSetsRequest : AWSRequest
+
+
+/**
+ <p>A token returned from a previous call to <code>ListReceiptRuleSets</code> to indicate the position in the receipt rule set list.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 @end
 
 /**
- <p>Represents a request to list the email templates present in your Amazon SES account in the current AWS Region. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
+ <p>A list of receipt rule sets that exist under your AWS account.</p>
  */
-@interface AWSSESListEmailTemplatesRequest : AWSRequest
+@interface AWSSESListReceiptRuleSetsResponse : AWSModel
 
 
 /**
- <p>A token returned from a previous call to <code>ListEmailTemplates</code> to indicate the position in the list of email templates.</p>
+ <p>A token indicating that there are additional receipt rule sets available to be listed. Pass this token to successive calls of <code>ListReceiptRuleSets</code> to retrieve up to 100 receipt rule sets at a time.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 /**
- <p>The number of results to show in a single call to <code>ListEmailTemplates</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p><p>The value you specify has to be at least 1, and can be no more than 10.</p>
+ <p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and the timestamp of when the rule set was created.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
+@property (nonatomic, strong) NSArray<AWSSESReceiptRuleSetMetadata *> * _Nullable ruleSets;
 
 @end
 
 /**
- <p>The following elements are returned by the service.</p>
+ 
  */
-@interface AWSSESListEmailTemplatesResponse : AWSModel
+@interface AWSSESListTemplatesRequest : AWSRequest
 
 
 /**
- <p>A token indicating that there are additional email templates available to be listed. Pass this token to a subsequent <code>ListEmailTemplates</code> call to retrieve the next 10 email templates.</p>
+ <p>The maximum number of templates to return. This value must be at least 1 and less than or equal to 10. If you do not specify a value, or if you specify a value less than 1 or greater than 10, the operation will return up to 10 results.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable maxItems;
+
+/**
+ <p>A token returned from a previous call to <code>ListTemplates</code> to indicate the position in the list of email templates.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable nextToken;
+
+@end
+
+/**
+ 
+ */
+@interface AWSSESListTemplatesResponse : AWSModel
+
+
+/**
+ <p>A token indicating that there are additional email templates available to be listed. Pass this token to a subsequent call to <code>ListTemplates</code> to retrieve the next 50 email templates.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable nextToken;
 
 /**
  <p>An array the contains the name and creation time stamp for each template in your Amazon SES account.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESEmailTemplateMetadata *> * _Nullable templatesMetadata;
+@property (nonatomic, strong) NSArray<AWSSESTemplateMetadata *> * _Nullable templatesMetadata;
 
 @end
 
 /**
- <p>Represents a request to list all of the import jobs for a data destination within the specified maximum number of import jobs.</p>
+ <p>A list of email addresses that you have verified with Amazon SES under your AWS account.</p>
  */
-@interface AWSSESListImportJobsRequest : AWSRequest
+@interface AWSSESListVerifiedEmailAddressesResponse : AWSModel
 
 
 /**
- <p>The destination of the import job, which can be used to list import jobs that have a certain <code>ImportDestinationType</code>.</p>
+ <p>A list of email addresses that have been verified.</p>
  */
-@property (nonatomic, assign) AWSSESImportDestinationType importDestinationType;
-
-/**
- <p>A string token indicating that there might be additional import jobs available to be listed. Copy this token to a subsequent call to <code>ListImportJobs</code> with the same parameters to retrieve the next page of import jobs.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-/**
- <p>Maximum number of import jobs to return at once. Use this parameter to paginate results. If additional import jobs exist beyond the specified limit, the <code>NextToken</code> element is sent in the response. Use the <code>NextToken</code> value in subsequent requests to retrieve additional addresses.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable verifiedEmailAddresses;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESListImportJobsResponse : AWSModel
-
-
-/**
- <p>A list of the import job summaries.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESImportJobSummary *> * _Nullable importJobs;
-
-/**
- <p>A string token indicating that there might be additional import jobs available to be listed. Copy this token to a subsequent call to <code>ListImportJobs</code> with the same parameters to retrieve the next page of import jobs.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-@end
-
-/**
- <p>A request to obtain a list of email destinations that are on the suppression list for your account.</p>
- */
-@interface AWSSESListSuppressedDestinationsRequest : AWSRequest
-
-
-/**
- <p>Used to filter the list of suppressed email destinations so that it only includes addresses that were added to the list before a specific date. The date that you specify should be in Unix time format.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable endDate;
-
-/**
- <p>A token returned from a previous call to <code>ListSuppressedDestinations</code> to indicate the position in the list of suppressed email addresses.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-/**
- <p>The number of results to show in a single call to <code>ListSuppressedDestinations</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable pageSize;
-
-/**
- <p>The factors that caused the email address to be added to .</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable reasons;
-
-/**
- <p>Used to filter the list of suppressed email destinations so that it only includes addresses that were added to the list after a specific date. The date that you specify should be in Unix time format.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable startDate;
-
-@end
-
-/**
- <p>A list of suppressed email addresses.</p>
- */
-@interface AWSSESListSuppressedDestinationsResponse : AWSModel
-
-
-/**
- <p>A token that indicates that there are additional email addresses on the suppression list for your account. To view additional suppressed addresses, issue another request to <code>ListSuppressedDestinations</code>, and pass this token in the <code>NextToken</code> parameter.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable nextToken;
-
-/**
- <p>A list of summaries, each containing a summary for a suppressed email destination.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESSuppressedDestinationSummary *> * _Nullable suppressedDestinationSummaries;
-
-@end
-
-/**
- 
- */
-@interface AWSSESListTagsForResourceRequest : AWSRequest
-
-
-/**
- <p>The Amazon Resource Name (ARN) of the resource that you want to retrieve tag information for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable resourceArn;
-
-@end
-
-/**
- 
- */
-@interface AWSSESListTagsForResourceResponse : AWSModel
-
-
-/**
- <p>An array that lists all the tags that are associated with the resource. Each tag consists of a required tag key (<code>Key</code>) and an associated tag value (<code>Value</code>)</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-@end
-
-/**
- <p>A list of attributes that are associated with a MAIL FROM domain.</p>
- Required parameters: [MailFromDomain, MailFromDomainStatus, BehaviorOnMxFailure]
- */
-@interface AWSSESMailFromAttributes : AWSModel
-
-
-/**
- <p>The action that you want to take if the required MX record can't be found when you send an email. When you set this value to <code>UseDefaultValue</code>, the mail is sent using <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, the Amazon SES API v2 returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.</p><p>These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>
- */
-@property (nonatomic, assign) AWSSESBehaviorOnMxFailure behaviorOnMxFailure;
-
-/**
- <p>The name of a domain that an email identity uses as a custom MAIL FROM domain.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable mailFromDomain;
-
-/**
- <p>The status of the MAIL FROM domain. This status can have the following values:</p><ul><li><p><code>PENDING</code> – Amazon SES hasn't started searching for the MX record yet.</p></li><li><p><code>SUCCESS</code> – Amazon SES detected the required MX record for the MAIL FROM domain.</p></li><li><p><code>FAILED</code> – Amazon SES can't find the required MX record, or the record no longer exists.</p></li><li><p><code>TEMPORARY_FAILURE</code> – A temporary issue occurred, which prevented Amazon SES from determining the status of the MAIL FROM domain.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESMailFromDomainStatus mailFromDomainStatus;
-
-@end
-
-/**
- <p>Represents the email message that you're sending. The <code>Message</code> object consists of a subject line and a message body.</p>
+ <p>Represents the message to be sent, composed of a subject and a body.</p>
  Required parameters: [Subject, Body]
  */
 @interface AWSSESMessage : AWSModel
 
 
 /**
- <p>The body of the message. You can specify an HTML version of the message, a text-only version of the message, or both.</p>
+ <p>The message body.</p>
  */
 @property (nonatomic, strong) AWSSESBody * _Nullable body;
 
 /**
- <p>The subject line of the email. The subject line can only contain 7-bit ASCII characters. However, you can specify non-ASCII characters in the subject line by using encoded-word syntax, as described in <a href="https://tools.ietf.org/html/rfc2047">RFC 2047</a>.</p>
+ <p>The subject of the message: A short summary of the content, which will appear in the recipient's inbox.</p>
  */
 @property (nonatomic, strong) AWSSESContent * _Nullable subject;
 
 @end
 
 /**
- <p>Contains the name and value of a tag that you apply to an email. You can use message tags when you publish email sending events. </p>
+ <p>Message-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p><p>For information about receiving email through Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [ReportingMta]
+ */
+@interface AWSSESMessageDsn : AWSModel
+
+
+/**
+ <p>When the message was received by the reporting mail transfer agent (MTA), in <a href="https://www.ietf.org/rfc/rfc0822.txt">RFC 822</a> date-time format.</p>
+ */
+@property (nonatomic, strong) NSDate * _Nullable arrivalDate;
+
+/**
+ <p>Additional X-headers to include in the DSN.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESExtensionField *> * _Nullable extensionFields;
+
+/**
+ <p>The reporting MTA that attempted to deliver the message, formatted as specified in <a href="https://tools.ietf.org/html/rfc3464">RFC 3464</a> (<code>mta-name-type; mta-name</code>). The default value is <code>dns; inbound-smtp.[region].amazonaws.com</code>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable reportingMta;
+
+@end
+
+/**
+ <p>Contains the name and value of a tag that you can provide to <code>SendEmail</code> or <code>SendRawEmail</code> to apply to an email.</p><p>Message tags, which you use with configuration sets, enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
  Required parameters: [Name, Value]
  */
 @interface AWSSESMessageTag : AWSModel
 
 
 /**
- <p>The name of the message tag. The message tag name has to meet the following criteria:</p><ul><li><p>It can only contain ASCII letters (a–z, A–Z), numbers (0–9), underscores (_), or dashes (-).</p></li><li><p>It can contain no more than 256 characters.</p></li></ul>
+ <p>The name of the tag. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Contain less than 256 characters.</p></li></ul>
  */
 @property (nonatomic, strong) NSString * _Nullable name;
 
 /**
- <p>The value of the message tag. The message tag value has to meet the following criteria:</p><ul><li><p>It can only contain ASCII letters (a–z, A–Z), numbers (0–9), underscores (_), or dashes (-).</p></li><li><p>It can contain no more than 256 characters.</p></li></ul>
+ <p>The value of the tag. The value must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Contain less than 256 characters.</p></li></ul>
  */
 @property (nonatomic, strong) NSString * _Nullable value;
 
 @end
 
 /**
- <p>An object that contains information about email that was sent from the selected domain.</p>
- */
-@interface AWSSESOverallVolume : AWSModel
-
-
-/**
- <p>An object that contains inbox and junk mail placement metrics for individual email providers.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDomainIspPlacement *> * _Nullable domainIspPlacements;
-
-/**
- <p>The percentage of emails that were sent from the domain that were read by their recipients.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable readRatePercent;
-
-/**
- <p>An object that contains information about the numbers of messages that arrived in recipients' inboxes and junk mail folders.</p>
- */
-@property (nonatomic, strong) AWSSESVolumeStatistics * _Nullable volumeStatistics;
-
-@end
-
-/**
- <p>An object that defines an Amazon Pinpoint project destination for email events. You can send email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging dashboards that are built in to Amazon Pinpoint. For more information, see <a href="https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html">Transactional Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>
- */
-@interface AWSSESPinpointDestination : AWSModel
-
-
-/**
- <p>The Amazon Resource Name (ARN) of the Amazon Pinpoint project that you want to send email events to.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable applicationArn;
-
-@end
-
-/**
- <p>An object that contains inbox placement data for an email provider.</p>
- */
-@interface AWSSESPlacementStatistics : AWSModel
-
-
-/**
- <p>The percentage of emails that were authenticated by using DomainKeys Identified Mail (DKIM) during the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable dkimPercentage;
-
-/**
- <p>The percentage of emails that arrived in recipients' inboxes during the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable inboxPercentage;
-
-/**
- <p>The percentage of emails that didn't arrive in recipients' inboxes at all during the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable missingPercentage;
-
-/**
- <p>The percentage of emails that arrived in recipients' spam or junk mail folders during the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable spamPercentage;
-
-/**
- <p>The percentage of emails that were authenticated by using Sender Policy Framework (SPF) during the predictive inbox placement test.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable spfPercentage;
-
-@end
-
-/**
- <p>A request to enable or disable the automatic IP address warm-up feature.</p>
- */
-@interface AWSSESPutAccountDedicatedIpWarmupAttributesRequest : AWSRequest
-
-
-/**
- <p>Enables or disables the automatic warm-up feature for dedicated IP addresses that are associated with your Amazon SES account in the current AWS Region. Set to <code>true</code> to enable the automatic warm-up feature, or set to <code>false</code> to disable it.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable autoWarmupEnabled;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutAccountDedicatedIpWarmupAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to submit new account details.</p>
- Required parameters: [MailType, WebsiteURL, UseCaseDescription]
- */
-@interface AWSSESPutAccountDetailsRequest : AWSRequest
-
-
-/**
- <p>Additional email addresses that you would like to be notified regarding Amazon SES matters.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable additionalContactEmailAddresses;
-
-/**
- <p>The language you would prefer to be contacted with.</p>
- */
-@property (nonatomic, assign) AWSSESContactLanguage contactLanguage;
-
-/**
- <p>The type of email your account will send.</p>
- */
-@property (nonatomic, assign) AWSSESMailType mailType;
-
-/**
- <p>Indicates whether or not your account should have production access in the current AWS Region.</p><p>If the value is <code>false</code>, then your account is in the <i>sandbox</i>. When your account is in the sandbox, you can only send email to verified identities. Additionally, the maximum number of emails you can send in a 24-hour period (your sending quota) is 200, and the maximum number of emails you can send per second (your maximum sending rate) is 1.</p><p>If the value is <code>true</code>, then your account has production access. When your account has production access, you can send email to any address. The sending quota and maximum sending rate for your account vary based on your specific use case.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable productionAccessEnabled;
-
-/**
- <p>A description of the types of email that you plan to send.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable useCaseDescription;
-
-/**
- <p>The URL of your website. This information helps us better understand the type of content that you plan to send.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable websiteURL;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutAccountDetailsResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to change the ability of your account to send email.</p>
- */
-@interface AWSSESPutAccountSendingAttributesRequest : AWSRequest
-
-
-/**
- <p>Enables or disables your account's ability to send email. Set to <code>true</code> to enable email sending, or set to <code>false</code> to disable email sending.</p><note><p>If AWS paused your account's ability to send email, you can't use this operation to resume your account's ability to send email.</p></note>
- */
-@property (nonatomic, strong) NSNumber * _Nullable sendingEnabled;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutAccountSendingAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to change your account's suppression preferences.</p>
- */
-@interface AWSSESPutAccountSuppressionAttributesRequest : AWSRequest
-
-
-/**
- <p>A list that contains the reasons that email addresses will be automatically added to the suppression list for your account. This list can contain any or all of the following:</p><ul><li><p><code>COMPLAINT</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p></li><li><p><code>BOUNCE</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p></li></ul>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable suppressedReasons;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutAccountSuppressionAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to associate a configuration set with a dedicated IP pool.</p>
+ <p>A request to modify the delivery options for a configuration set.</p>
  Required parameters: [ConfigurationSetName]
  */
 @interface AWSSESPutConfigurationSetDeliveryOptionsRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that you want to associate with a dedicated IP pool.</p>
+ <p>The name of the configuration set that you want to specify the delivery options for.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>The name of the dedicated IP pool that you want to associate with the configuration set.</p>
+ <p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS).</p>
  */
-@property (nonatomic, strong) NSString * _Nullable sendingPoolName;
-
-/**
- <p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.</p>
- */
-@property (nonatomic, assign) AWSSESTlsPolicy tlsPolicy;
+@property (nonatomic, strong) AWSSESDeliveryOptions * _Nullable deliveryOptions;
 
 @end
 
@@ -3076,490 +2087,471 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>A request to enable or disable tracking of reputation metrics for a configuration set.</p>
- Required parameters: [ConfigurationSetName]
+ <p>Represents a request to add or update a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, PolicyName, Policy]
  */
-@interface AWSSESPutConfigurationSetReputationOptionsRequest : AWSRequest
+@interface AWSSESPutIdentityPolicyRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that you want to enable or disable reputation metric tracking for.</p>
+ <p>The identity that the policy will apply to. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p><p>To successfully call this API, you must own the identity.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+@property (nonatomic, strong) NSString * _Nullable identity;
 
 /**
- <p>If <code>true</code>, tracking of reputation metrics is enabled for the configuration set. If <code>false</code>, tracking of reputation metrics is disabled for the configuration set.</p>
+ <p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p><p>For information about the syntax of sending authorization policies, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html">Amazon SES Developer Guide</a>. </p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable reputationMetricsEnabled;
+@property (nonatomic, strong) NSString * _Nullable policy;
+
+/**
+ <p>The name of the policy.</p><p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable policyName;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
-@interface AWSSESPutConfigurationSetReputationOptionsResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to enable or disable the ability of Amazon SES to send emails that use a specific configuration set.</p>
- Required parameters: [ConfigurationSetName]
- */
-@interface AWSSESPutConfigurationSetSendingOptionsRequest : AWSRequest
-
-
-/**
- <p>The name of the configuration set that you want to enable or disable email sending for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
-
-/**
- <p>If <code>true</code>, email sending is enabled for the configuration set. If <code>false</code>, email sending is disabled for the configuration set.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable sendingEnabled;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutConfigurationSetSendingOptionsResponse : AWSModel
+@interface AWSSESPutIdentityPolicyResponse : AWSModel
 
 
 @end
 
 /**
- <p>A request to change the account suppression list preferences for a specific configuration set.</p>
- Required parameters: [ConfigurationSetName]
- */
-@interface AWSSESPutConfigurationSetSuppressionOptionsRequest : AWSRequest
-
-
-/**
- <p>The name of the configuration set that you want to change the suppression list preferences for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
-
-/**
- <p>A list that contains the reasons that email addresses are automatically added to the suppression list for your account. This list can contain any or all of the following:</p><ul><li><p><code>COMPLAINT</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p></li><li><p><code>BOUNCE</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p></li></ul>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable suppressedReasons;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutConfigurationSetSuppressionOptionsResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to add a custom domain for tracking open and click events to a configuration set.</p>
- Required parameters: [ConfigurationSetName]
- */
-@interface AWSSESPutConfigurationSetTrackingOptionsRequest : AWSRequest
-
-
-/**
- <p>The name of the configuration set that you want to add a custom tracking domain to.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable configurationSetName;
-
-/**
- <p>The domain that you want to use to track open and click events.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable customRedirectDomain;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutConfigurationSetTrackingOptionsResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to move a dedicated IP address to a dedicated IP pool.</p>
- Required parameters: [Ip, DestinationPoolName]
- */
-@interface AWSSESPutDedicatedIpInPoolRequest : AWSRequest
-
-
-/**
- <p>The name of the IP pool that you want to add the dedicated IP address to. You have to specify an IP pool that already exists.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable destinationPoolName;
-
-/**
- <p>The IP address that you want to move to the dedicated IP pool. The value you specify has to be a dedicated IP address that's associated with your AWS account.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable ip;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutDedicatedIpInPoolResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to change the warm-up attributes for a dedicated IP address. This operation is useful when you want to resume the warm-up process for an existing IP address.</p>
- Required parameters: [Ip, WarmupPercentage]
- */
-@interface AWSSESPutDedicatedIpWarmupAttributesRequest : AWSRequest
-
-
-/**
- <p>The dedicated IP address that you want to update the warm-up attributes for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable ip;
-
-/**
- <p>The warm-up percentage that you want to associate with the dedicated IP address.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable warmupPercentage;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutDedicatedIpWarmupAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email using Amazon SES API v2. You also gain the ability to perform predictive inbox placement tests.</p><p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href="http://aws.amazon.com/pinpoint/pricing/">Amazon Pinpoint Pricing</a>.</p>
- Required parameters: [DashboardEnabled]
- */
-@interface AWSSESPutDeliverabilityDashboardOptionRequest : AWSRequest
-
-
-/**
- <p>Specifies whether to enable the Deliverability dashboard. To enable the dashboard, set this value to <code>true</code>.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable dashboardEnabled;
-
-/**
- <p>An array of objects, one for each verified domain that you use to send email and enabled the Deliverability dashboard for.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESDomainDeliverabilityTrackingOption *> * _Nullable subscribedDomains;
-
-@end
-
-/**
- <p>A response that indicates whether the Deliverability dashboard is enabled.</p>
- */
-@interface AWSSESPutDeliverabilityDashboardOptionResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to enable or disable DKIM signing of email that you send from an email identity.</p>
- Required parameters: [EmailIdentity]
- */
-@interface AWSSESPutEmailIdentityDkimAttributesRequest : AWSRequest
-
-
-/**
- <p>The email identity that you want to change the DKIM settings for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p>Sets the DKIM signing configuration for the identity.</p><p>When you set this value <code>true</code>, then the messages that are sent from the identity are signed using DKIM. If you set this value to <code>false</code>, your messages are sent without DKIM signing.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable signingEnabled;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutEmailIdentityDkimAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to change the DKIM attributes for an email identity.</p>
- Required parameters: [EmailIdentity, SigningAttributesOrigin]
- */
-@interface AWSSESPutEmailIdentityDkimSigningAttributesRequest : AWSRequest
-
-
-/**
- <p>The email identity that you want to configure DKIM for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p>An object that contains information about the private key and selector that you want to use to configure DKIM for the identity. This object is only required if you want to configure Bring Your Own DKIM (BYODKIM) for the identity.</p>
- */
-@property (nonatomic, strong) AWSSESDkimSigningAttributes * _Nullable signingAttributes;
-
-/**
- <p>The method that you want to use to configure DKIM for the identity. There are two possible values:</p><ul><li><p><code>AWS_SES</code> – Configure DKIM for the identity by using <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a>.</p></li><li><p><code>EXTERNAL</code> – Configure DKIM for the identity by using Bring Your Own DKIM (BYODKIM).</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESDkimSigningAttributesOrigin signingAttributesOrigin;
-
-@end
-
-/**
- <p>If the action is successful, the service sends back an HTTP 200 response.</p><p>The following data is returned in JSON format by the service.</p>
- */
-@interface AWSSESPutEmailIdentityDkimSigningAttributesResponse : AWSModel
-
-
-/**
- <p>The DKIM authentication status of the identity. Amazon SES determines the authentication status by searching for specific records in the DNS configuration for your domain. If you used <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a> to set up DKIM authentication, Amazon SES tries to find three unique CNAME records in the DNS configuration for your domain.</p><p>If you provided a public key to perform DKIM authentication, Amazon SES tries to find a TXT record that uses the selector that you specified. The value of the TXT record must be a public key that's paired with the private key that you specified in the process of creating the identity.</p><p>The status can be one of the following:</p><ul><li><p><code>PENDING</code> – The verification process was initiated, but Amazon SES hasn't yet detected the DKIM records in the DNS configuration for the domain.</p></li><li><p><code>SUCCESS</code> – The verification process completed successfully.</p></li><li><p><code>FAILED</code> – The verification process failed. This typically occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the domain.</p></li><li><p><code>TEMPORARY_FAILURE</code> – A temporary issue is preventing Amazon SES from determining the DKIM authentication status of the domain.</p></li><li><p><code>NOT_STARTED</code> – The DKIM verification process hasn't been initiated for the domain.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESDkimStatus dkimStatus;
-
-/**
- <p>If you used <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a> to configure DKIM authentication for the domain, then this object contains a set of unique strings that you use to create a set of CNAME records that you add to the DNS configuration for your domain. When Amazon SES detects these records in the DNS configuration for your domain, the DKIM authentication process is complete.</p><p>If you configured DKIM authentication for the domain by providing your own public-private key pair, then this object contains the selector that's associated with your public key.</p><p>Regardless of the DKIM authentication method you use, Amazon SES searches for the appropriate records in the DNS configuration of the domain for up to 72 hours.</p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable dkimTokens;
-
-@end
-
-/**
- <p>A request to set the attributes that control how bounce and complaint events are processed.</p>
- Required parameters: [EmailIdentity]
- */
-@interface AWSSESPutEmailIdentityFeedbackAttributesRequest : AWSRequest
-
-
-/**
- <p>Sets the feedback forwarding configuration for the identity.</p><p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p><p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable emailForwardingEnabled;
-
-/**
- <p>The email identity that you want to configure bounce and complaint feedback forwarding for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutEmailIdentityFeedbackAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to configure the custom MAIL FROM domain for a verified identity.</p>
- Required parameters: [EmailIdentity]
- */
-@interface AWSSESPutEmailIdentityMailFromAttributesRequest : AWSRequest
-
-
-/**
- <p>The action that you want to take if the required MX record isn't found when you send an email. When you set this value to <code>UseDefaultValue</code>, the mail is sent using <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, the Amazon SES API v2 returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.</p><p>These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>
- */
-@property (nonatomic, assign) AWSSESBehaviorOnMxFailure behaviorOnMxFailure;
-
-/**
- <p>The verified email identity that you want to set up the custom MAIL FROM domain for.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p> The custom MAIL FROM domain that you want the verified identity to use. The MAIL FROM domain must meet the following criteria:</p><ul><li><p>It has to be a subdomain of the verified identity.</p></li><li><p>It can't be used to receive email.</p></li><li><p>It can't be used in a "From" address if the MAIL FROM domain is a destination for feedback forwarding emails.</p></li></ul>
- */
-@property (nonatomic, strong) NSString * _Nullable mailFromDomain;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutEmailIdentityMailFromAttributesResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to add an email destination to the suppression list for your account.</p>
- Required parameters: [EmailAddress, Reason]
- */
-@interface AWSSESPutSuppressedDestinationRequest : AWSRequest
-
-
-/**
- <p>The email address that should be added to the suppression list for your account.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailAddress;
-
-/**
- <p>The factors that should cause the email address to be added to the suppression list for your account.</p>
- */
-@property (nonatomic, assign) AWSSESSuppressionListReason reason;
-
-@end
-
-/**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
- */
-@interface AWSSESPutSuppressedDestinationResponse : AWSModel
-
-
-@end
-
-/**
- <p>Represents the raw content of an email message.</p>
+ <p>Represents the raw data of the message.</p>
  Required parameters: [Data]
  */
 @interface AWSSESRawMessage : AWSModel
 
 
 /**
- <p>The raw email message. The message has to meet the following criteria:</p><ul><li><p>The message has to contain a header and a body, separated by one blank line.</p></li><li><p>All of the required header fields must be present in the message.</p></li><li><p>Each part of a multipart MIME message must be formatted properly.</p></li><li><p>Attachments must be in a file format that the Amazon SES supports.</p></li><li><p>The entire message must be Base64 encoded.</p></li><li><p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, you should encode that content to ensure that recipients' email clients render the message properly.</p></li><li><p>The length of any single line of text in the message can't exceed 1,000 characters. This restriction is defined in <a href="https://tools.ietf.org/html/rfc5321">RFC 5321</a>.</p></li></ul>
+ <p>The raw data of the message. This data needs to base64-encoded if you are accessing Amazon SES directly through the HTTPS interface. If you are accessing Amazon SES using an AWS SDK, the SDK takes care of the base 64-encoding for you. In all cases, the client must ensure that the message format complies with Internet email standards regarding email header fields, MIME types, and MIME encoding.</p><p>The To:, CC:, and BCC: headers in the raw message can contain a group list.</p><p>If you are using <code>SendRawEmail</code> with sending authorization, you can include X-headers in the raw message to specify the "Source," "From," and "Return-Path" addresses. For more information, see the documentation for <code>SendRawEmail</code>. </p><important><p>Do not include these X-headers in the DKIM signature, because they are removed by Amazon SES before sending the email.</p></important><p>For more information, go to the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html">Amazon SES Developer Guide</a>.</p>
  */
 @property (nonatomic, strong) NSData * _Nullable data;
 
 @end
 
 /**
- <p>The <code>ReplaceEmailContent</code> object to be used for a specific <code>BulkEmailEntry</code>. The <code>ReplacementTemplate</code> can be specified within this object.</p>
+ <p>An action that Amazon SES can take when it receives an email on behalf of one or more email addresses or domains that you own. An instance of this data type can represent only one action.</p><p>For information about setting up receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p>
  */
-@interface AWSSESReplacementEmailContent : AWSModel
+@interface AWSSESReceiptAction : AWSModel
 
 
 /**
- <p>The <code>ReplacementTemplate</code> associated with <code>ReplacementEmailContent</code>.</p>
+ <p>Adds a header to the received email.</p>
  */
-@property (nonatomic, strong) AWSSESReplacementTemplate * _Nullable replacementTemplate;
+@property (nonatomic, strong) AWSSESAddHeaderAction * _Nullable addHeaderAction;
+
+/**
+ <p>Rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p>
+ */
+@property (nonatomic, strong) AWSSESBounceAction * _Nullable bounceAction;
+
+/**
+ <p>Calls an AWS Lambda function, and optionally, publishes a notification to Amazon SNS.</p>
+ */
+@property (nonatomic, strong) AWSSESLambdaAction * _Nullable lambdaAction;
+
+/**
+ <p>Saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon SNS.</p>
+ */
+@property (nonatomic, strong) AWSSESS3Action * _Nullable s3Action;
+
+/**
+ <p>Publishes the email content within a notification to Amazon SNS.</p>
+ */
+@property (nonatomic, strong) AWSSESSNSAction * _Nullable SNSAction;
+
+/**
+ <p>Terminates the evaluation of the receipt rule set and optionally publishes a notification to Amazon SNS.</p>
+ */
+@property (nonatomic, strong) AWSSESStopAction * _Nullable stopAction;
+
+/**
+ <p>Calls Amazon WorkMail and, optionally, publishes a notification to Amazon Amazon SNS.</p>
+ */
+@property (nonatomic, strong) AWSSESWorkmailAction * _Nullable workmailAction;
 
 @end
 
 /**
- <p>An object which contains <code>ReplacementTemplateData</code> to be used for a specific <code>BulkEmailEntry</code>.</p>
+ <p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p><p>For information about setting up IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Name, IpFilter]
  */
-@interface AWSSESReplacementTemplate : AWSModel
+@interface AWSSESReceiptFilter : AWSModel
 
 
 /**
- <p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>
+ <p>A structure that provides the IP addresses to block or allow, and whether to block or allow incoming mail from them.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable replacementTemplateData;
+@property (nonatomic, strong) AWSSESReceiptIpFilter * _Nullable ipFilter;
+
+/**
+ <p>The name of the IP address filter. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Start and end with a letter or number.</p></li><li><p>Contain less than 64 characters.</p></li></ul>
+ */
+@property (nonatomic, strong) NSString * _Nullable name;
 
 @end
 
 /**
- <p>Enable or disable collection of reputation metrics for emails that you send using this configuration set in the current AWS Region. </p>
+ <p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p><p>For information about setting up IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Policy, Cidr]
+ */
+@interface AWSSESReceiptIpFilter : AWSModel
+
+
+/**
+ <p>A single IP address or a range of IP addresses that you want to block or allow, specified in Classless Inter-Domain Routing (CIDR) notation. An example of a single email address is 10.0.0.1. An example of a range of IP addresses is 10.0.0.1/24. For more information about CIDR notation, see <a href="https://tools.ietf.org/html/rfc2317">RFC 2317</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable cidr;
+
+/**
+ <p>Indicates whether to block or allow incoming mail from the specified IP addresses.</p>
+ */
+@property (nonatomic, assign) AWSSESReceiptFilterPolicy policy;
+
+@end
+
+/**
+ <p>Receipt rules enable you to specify which actions Amazon SES should take when it receives mail on behalf of one or more email addresses or domains that you own.</p><p>Each receipt rule defines a set of email addresses or domains that it applies to. If the email addresses or domains match at least one recipient address of the message, Amazon SES executes all of the receipt rule's actions on the message.</p><p>For information about setting up receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Name]
+ */
+@interface AWSSESReceiptRule : AWSModel
+
+
+/**
+ <p>An ordered list of actions to perform on messages that match at least one of the recipient email addresses or domains specified in the receipt rule.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESReceiptAction *> * _Nullable actions;
+
+/**
+ <p>If <code>true</code>, the receipt rule is active. The default value is <code>false</code>.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable enabled;
+
+/**
+ <p>The name of the receipt rule. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Start and end with a letter or number.</p></li><li><p>Contain less than 64 characters.</p></li></ul>
+ */
+@property (nonatomic, strong) NSString * _Nullable name;
+
+/**
+ <p>The recipient domains and email addresses that the receipt rule applies to. If this field is not specified, this rule will match all recipients under all verified domains.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable recipients;
+
+/**
+ <p>If <code>true</code>, then messages that this receipt rule applies to are scanned for spam and viruses. The default value is <code>false</code>.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable scanEnabled;
+
+/**
+ <p>Specifies whether Amazon SES should require that incoming email is delivered over a connection encrypted with Transport Layer Security (TLS). If this parameter is set to <code>Require</code>, Amazon SES will bounce emails that are not received over TLS. The default is <code>Optional</code>.</p>
+ */
+@property (nonatomic, assign) AWSSESTlsPolicy tlsPolicy;
+
+@end
+
+/**
+ <p>Information about a receipt rule set.</p><p>A receipt rule set is a collection of rules that specify what Amazon SES should do with mail it receives on behalf of your account's verified domains.</p><p>For information about setting up receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p>
+ */
+@interface AWSSESReceiptRuleSetMetadata : AWSModel
+
+
+/**
+ <p>The date and time the receipt rule set was created.</p>
+ */
+@property (nonatomic, strong) NSDate * _Nullable createdTimestamp;
+
+/**
+ <p>The name of the receipt rule set. The name must:</p><ul><li><p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p></li><li><p>Start and end with a letter or number.</p></li><li><p>Contain less than 64 characters.</p></li></ul>
+ */
+@property (nonatomic, strong) NSString * _Nullable name;
+
+@end
+
+/**
+ <p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p><p>For information about receiving email through Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Action, Status]
+ */
+@interface AWSSESRecipientDsnFields : AWSModel
+
+
+/**
+ <p>The action performed by the reporting mail transfer agent (MTA) as a result of its attempt to deliver the message to the recipient address. This is required by <a href="https://tools.ietf.org/html/rfc3464">RFC 3464</a>.</p>
+ */
+@property (nonatomic, assign) AWSSESDsnAction action;
+
+/**
+ <p>An extended explanation of what went wrong; this is usually an SMTP response. See <a href="https://tools.ietf.org/html/rfc3463">RFC 3463</a> for the correct formatting of this parameter.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable diagnosticCode;
+
+/**
+ <p>Additional X-headers to include in the DSN.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESExtensionField *> * _Nullable extensionFields;
+
+/**
+ <p>The email address that the message was ultimately delivered to. This corresponds to the <code>Final-Recipient</code> in the DSN. If not specified, <code>FinalRecipient</code> will be set to the <code>Recipient</code> specified in the <code>BouncedRecipientInfo</code> structure. Either <code>FinalRecipient</code> or the recipient in <code>BouncedRecipientInfo</code> must be a recipient of the original bounced message.</p><note><p>Do not prepend the <code>FinalRecipient</code> email address with <code>rfc 822;</code>, as described in <a href="https://tools.ietf.org/html/rfc3798">RFC 3798</a>.</p></note>
+ */
+@property (nonatomic, strong) NSString * _Nullable finalRecipient;
+
+/**
+ <p>The time the final delivery attempt was made, in <a href="https://www.ietf.org/rfc/rfc0822.txt">RFC 822</a> date-time format.</p>
+ */
+@property (nonatomic, strong) NSDate * _Nullable lastAttemptDate;
+
+/**
+ <p>The MTA to which the remote MTA attempted to deliver the message, formatted as specified in <a href="https://tools.ietf.org/html/rfc3464">RFC 3464</a> (<code>mta-name-type; mta-name</code>). This parameter typically applies only to propagating synchronous bounces.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable remoteMta;
+
+/**
+ <p>The status code that indicates what went wrong. This is required by <a href="https://tools.ietf.org/html/rfc3464">RFC 3464</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable status;
+
+@end
+
+/**
+ <p>Represents a request to reorder the receipt rules within a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, RuleNames]
+ */
+@interface AWSSESReorderReceiptRuleSetRequest : AWSRequest
+
+
+/**
+ <p>A list of the specified receipt rule set's receipt rules in the order that you want to put them.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable ruleNames;
+
+/**
+ <p>The name of the receipt rule set to reorder.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESReorderReceiptRuleSetResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Contains information about the reputation settings for a configuration set.</p>
  */
 @interface AWSSESReputationOptions : AWSModel
 
 
 /**
- <p>The date and time (in Unix time) when the reputation metrics were last given a fresh start. When your account is given a fresh start, your reputation metrics are calculated starting from the date of the fresh start.</p>
+ <p>The date and time at which the reputation metrics for the configuration set were last reset. Resetting these metrics is known as a <i>fresh start</i>.</p><p>When you disable email sending for a configuration set using <a>UpdateConfigurationSetSendingEnabled</a> and later re-enable it, the reputation metrics for the configuration set (but not for the entire Amazon SES account) are reset.</p><p>If email sending for the configuration set has never been disabled and later re-enabled, the value of this attribute is <code>null</code>.</p>
  */
 @property (nonatomic, strong) NSDate * _Nullable lastFreshStart;
 
 /**
- <p>If <code>true</code>, tracking of reputation metrics is enabled for the configuration set. If <code>false</code>, tracking of reputation metrics is disabled for the configuration set.</p>
+ <p>Describes whether or not Amazon SES publishes reputation metrics for the configuration set, such as bounce and complaint rates, to Amazon CloudWatch.</p><p>If the value is <code>true</code>, reputation metrics are published. If the value is <code>false</code>, reputation metrics are not published. The default value is <code>false</code>.</p>
  */
 @property (nonatomic, strong) NSNumber * _Nullable reputationMetricsEnabled;
 
-@end
-
 /**
- <p>An object that contains information about your account details review.</p>
+ <p>Describes whether email sending is enabled or disabled for the configuration set. If the value is <code>true</code>, then Amazon SES will send emails that use the configuration set. If the value is <code>false</code>, Amazon SES will not send emails that use the configuration set. The default value is <code>true</code>. You can change this setting using <a>UpdateConfigurationSetSendingEnabled</a>.</p>
  */
-@interface AWSSESReviewDetails : AWSModel
-
-
-/**
- <p>The associated support center case ID (if any).</p>
- */
-@property (nonatomic, strong) NSString * _Nullable caseId;
-
-/**
- <p>The status of the latest review of your account. The status can be one of the following:</p><ul><li><p><code>PENDING</code> – We have received your appeal and are in the process of reviewing it.</p></li><li><p><code>GRANTED</code> – Your appeal has been reviewed and your production access has been granted.</p></li><li><p><code>DENIED</code> – Your appeal has been reviewed and your production access has been denied.</p></li><li><p><code>FAILED</code> – An internal error occurred and we didn't receive your appeal. You can submit your appeal again.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESReviewStatus status;
+@property (nonatomic, strong) NSNumber * _Nullable sendingEnabled;
 
 @end
 
 /**
- <p>Represents a request to send email messages to multiple destinations using Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [DefaultContent, BulkEmailEntries]
+ <p>When included in a receipt rule, this action saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p><p>To enable Amazon SES to write emails to your Amazon S3 bucket, use an AWS KMS key to encrypt your emails, or publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p><note><p>When you save your emails to an Amazon S3 bucket, the maximum email size (including headers) is 30 MB. Emails larger than that will bounce.</p></note><p>For information about specifying Amazon S3 actions in receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-s3.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [BucketName]
  */
-@interface AWSSESSendBulkEmailRequest : AWSRequest
+@interface AWSSESS3Action : AWSModel
 
 
 /**
- <p>The list of bulk email entry objects.</p>
+ <p>The name of the Amazon S3 bucket that incoming email will be saved to.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESBulkEmailEntry *> * _Nullable bulkEmailEntries;
+@property (nonatomic, strong) NSString * _Nullable bucketName;
 
 /**
- <p>The name of the configuration set that you want to use when sending the email.</p>
+ <p>The customer master key that Amazon SES should use to encrypt your emails before saving them to the Amazon S3 bucket. You can use the default master key or a custom master key you created in AWS KMS as follows:</p><ul><li><p>To use the default master key, provide an ARN in the form of <code>arn:aws:kms:REGION:ACCOUNT-ID-WITHOUT-HYPHENS:alias/aws/ses</code>. For example, if your AWS account ID is 123456789012 and you want to use the default master key in the US West (Oregon) region, the ARN of the default master key would be <code>arn:aws:kms:us-west-2:123456789012:alias/aws/ses</code>. If you use the default master key, you don't need to perform any extra steps to give Amazon SES permission to use the key.</p></li><li><p>To use a custom master key you created in AWS KMS, provide the ARN of the master key and ensure that you add a statement to your key's policy to give Amazon SES permission to use it. For more information about giving permissions, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p></li></ul><p>For more information about key policies, see the <a href="https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html">AWS KMS Developer Guide</a>. If you do not specify a master key, Amazon SES will not encrypt your emails.</p><important><p>Your mail is encrypted by Amazon SES using the Amazon S3 encryption client before the mail is submitted to Amazon S3 for storage. It is not encrypted using Amazon S3 server-side encryption. This means that you must use the Amazon S3 encryption client to decrypt the email after retrieving it from Amazon S3, as the service has no access to use your AWS KMS keys for decryption. This encryption client is currently available with the <a href="http://aws.amazon.com/sdk-for-java/">AWS SDK for Java</a> and <a href="http://aws.amazon.com/sdk-for-ruby/">AWS SDK for Ruby</a> only. For more information about client-side encryption using AWS KMS master keys, see the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html">Amazon S3 Developer Guide</a>.</p></important>
+ */
+@property (nonatomic, strong) NSString * _Nullable kmsKeyArn;
+
+/**
+ <p>The key prefix of the Amazon S3 bucket. The key prefix is similar to a directory name that enables you to store similar data under the same directory in a bucket.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable objectKeyPrefix;
+
+/**
+ <p>The ARN of the Amazon SNS topic to notify when the message is saved to the Amazon S3 bucket. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable topicArn;
+
+@end
+
+/**
+ <p>When included in a receipt rule, this action publishes a notification to Amazon Simple Notification Service (Amazon SNS). This action includes a complete copy of the email content in the Amazon SNS notifications. Amazon SNS notifications for all other actions simply provide information about the email. They do not include the email content itself.</p><p>If you own the Amazon SNS topic, you don't need to do anything to give Amazon SES permission to publish emails to it. However, if you don't own the Amazon SNS topic, you need to attach a policy to the topic to give Amazon SES permissions to access it. For information about giving permissions, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html">Amazon SES Developer Guide</a>.</p><important><p>You can only publish emails that are 150 KB or less (including the header) to Amazon SNS. Larger emails will bounce. If you anticipate emails larger than 150 KB, use the S3 action instead.</p></important><p>For information about using a receipt rule to publish an Amazon SNS notification, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-sns.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [TopicArn]
+ */
+@interface AWSSESSNSAction : AWSModel
+
+
+/**
+ <p>The encoding to use for the email within the Amazon SNS notification. UTF-8 is easier to use, but may not preserve all special characters when a message was encoded with a different encoding format. Base64 preserves all special characters. The default value is UTF-8.</p>
+ */
+@property (nonatomic, assign) AWSSESSNSActionEncoding encoding;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable topicArn;
+
+@end
+
+/**
+ <p>Contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p><p>Event destinations, such as Amazon SNS, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [TopicARN]
+ */
+@interface AWSSESSNSDestination : AWSModel
+
+
+/**
+ <p>The ARN of the Amazon SNS topic that email sending events will be published to. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable topicARN;
+
+@end
+
+/**
+ <p>Represents a request to send a bounce message to the sender of an email you received through Amazon SES.</p>
+ Required parameters: [OriginalMessageId, BounceSender, BouncedRecipientInfoList]
+ */
+@interface AWSSESSendBounceRequest : AWSRequest
+
+
+/**
+ <p>The address to use in the "From" header of the bounce message. This must be an identity that you have verified with Amazon SES.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable bounceSender;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the address in the "From" header of the bounce. For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable bounceSenderArn;
+
+/**
+ <p>A list of recipients of the bounced message, including the information required to create the Delivery Status Notifications (DSNs) for the recipients. You must specify at least one <code>BouncedRecipientInfo</code> in the list.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESBouncedRecipientInfo *> * _Nullable bouncedRecipientInfoList;
+
+/**
+ <p>Human-readable text for the bounce message to explain the failure. If not specified, the text will be auto-generated based on the bounced recipient information.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable explanation;
+
+/**
+ <p>Message-related DSN fields. If not specified, Amazon SES will choose the values.</p>
+ */
+@property (nonatomic, strong) AWSSESMessageDsn * _Nullable messageDsn;
+
+/**
+ <p>The message ID of the message to be bounced.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable originalMessageId;
+
+@end
+
+/**
+ <p>Represents a unique message ID.</p>
+ */
+@interface AWSSESSendBounceResponse : AWSModel
+
+
+/**
+ <p>The message ID of the bounce message.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable messageId;
+
+@end
+
+/**
+ <p>Represents a request to send a templated email to multiple destinations using Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Source, Template, Destinations]
+ */
+@interface AWSSESSendBulkTemplatedEmailRequest : AWSRequest
+
+
+/**
+ <p>The name of the configuration set to use when you send an email using <code>SendBulkTemplatedEmail</code>.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>An object that contains the body of the message. You can specify a template message.</p>
+ <p>A list of tags, in the form of name/value pairs, to apply to an email that you send to a destination using <code>SendBulkTemplatedEmail</code>.</p>
  */
-@property (nonatomic, strong) AWSSESBulkEmailContent * _Nullable defaultContent;
+@property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable defaultTags;
 
 /**
- <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using the <code>SendEmail</code> operation. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
+ <p>A list of replacement values to apply to the template when replacement data is not specified in a Destination object. These values act as a default or fallback option when no other data is available.</p><p>The template data is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable defaultEmailTags;
+@property (nonatomic, strong) NSString * _Nullable defaultTemplateData;
 
 /**
- <p>The address that you want bounce and complaint notifications to be sent to.</p>
+ <p>One or more <code>Destination</code> objects. All of the recipients in a <code>Destination</code> will receive the same version of the email. You can specify up to 50 <code>Destination</code> objects within a <code>Destinations</code> array.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable feedbackForwardingEmailAddress;
+@property (nonatomic, strong) NSArray<AWSSESBulkEmailDestination *> * _Nullable destinations;
 
 /**
- <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FeedbackForwardingEmailAddress</code> parameter.</p><p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use feedback@example.com, then you would specify the <code>FeedbackForwardingEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FeedbackForwardingEmailAddress</code> to be feedback@example.com.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable feedbackForwardingEmailAddressIdentityArn;
-
-/**
- <p>The email address that you want to use as the "From" address for the email. The address that you specify has to be verified.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromEmailAddress;
-
-/**
- <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FromEmailAddress</code> parameter.</p><p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use sender@example.com, then you would specify the <code>FromEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FromEmailAddress</code> to be sender@example.com.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromEmailAddressIdentityArn;
-
-/**
- <p>The "Reply-to" email addresses for the message. When the recipient replies to the message, each Reply-to address receives the reply.</p>
+ <p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>
  */
 @property (nonatomic, strong) NSArray<NSString *> * _Nullable replyToAddresses;
+
+/**
+ <p>The email address that bounces and complaints will be forwarded to when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPath;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPathArn;
+
+/**
+ <p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Amazon SES Developer Guide</a>.</p><p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in <a href="https://tools.ietf.org/html/rfc2047">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p></note>
+ */
+@property (nonatomic, strong) NSString * _Nullable source;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable sourceArn;
+
+/**
+ <p>The template to use when sending this email.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable template;
+
+/**
+ <p>The ARN of the template to use when sending this email.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable templateArn;
 
 @end
 
 /**
- <p>The following data is returned in JSON format by the service.</p>
- Required parameters: [BulkEmailEntryResults]
+ 
  */
-@interface AWSSESSendBulkEmailResponse : AWSModel
+@interface AWSSESSendBulkTemplatedEmailResponse : AWSModel
 
 
 /**
- <p>A list of <code>BulkMailEntry</code> objects.</p>
+ <p>The unique message identifier returned from the <code>SendBulkTemplatedEmail</code> action.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESBulkEmailEntryResult *> * _Nullable bulkEmailEntryResults;
+@property (nonatomic, strong) NSArray<AWSSESBulkEmailDestinationStatus *> * _Nullable status;
 
 @end
 
@@ -3588,7 +2580,7 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>The following element is returned by the service.</p>
+ <p>The response received when attempting to send the custom verification email.</p>
  */
 @interface AWSSESSendCustomVerificationEmailResponse : AWSModel
 
@@ -3601,306 +2593,519 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
+ <p>Represents sending statistics data. Each <code>SendDataPoint</code> contains statistics for a 15-minute period of sending activity. </p>
+ */
+@interface AWSSESSendDataPoint : AWSModel
+
+
+/**
+ <p>Number of emails that have bounced.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable bounces;
+
+/**
+ <p>Number of unwanted emails that were rejected by recipients.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable complaints;
+
+/**
+ <p>Number of emails that have been sent.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable deliveryAttempts;
+
+/**
+ <p>Number of emails rejected by Amazon SES.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable rejects;
+
+/**
+ <p>Time of the data point.</p>
+ */
+@property (nonatomic, strong) NSDate * _Nullable timestamp;
+
+@end
+
+/**
  <p>Represents a request to send a single formatted email using Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-formatted.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [Content]
+ Required parameters: [Source, Destination, Message]
  */
 @interface AWSSESSendEmailRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that you want to use when sending the email.</p>
+ <p>The name of the configuration set to use when you send an email using <code>SendEmail</code>.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>An object that contains the body of the message. You can send either a Simple message Raw message or a template Message.</p>
- */
-@property (nonatomic, strong) AWSSESEmailContent * _Nullable content;
-
-/**
- <p>An object that contains the recipients of the email message.</p>
+ <p>The destination for this email, composed of To:, CC:, and BCC: fields.</p>
  */
 @property (nonatomic, strong) AWSSESDestination * _Nullable destination;
 
 /**
- <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using the <code>SendEmail</code> operation. Tags correspond to characteristics of the email that you define, so that you can publish email sending events. </p>
+ <p>The message to be sent.</p>
  */
-@property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable emailTags;
+@property (nonatomic, strong) AWSSESMessage * _Nullable message;
 
 /**
- <p>The address that you want bounce and complaint notifications to be sent to.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable feedbackForwardingEmailAddress;
-
-/**
- <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FeedbackForwardingEmailAddress</code> parameter.</p><p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use feedback@example.com, then you would specify the <code>FeedbackForwardingEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FeedbackForwardingEmailAddress</code> to be feedback@example.com.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable feedbackForwardingEmailAddressIdentityArn;
-
-/**
- <p>The email address that you want to use as the "From" address for the email. The address that you specify has to be verified. </p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromEmailAddress;
-
-/**
- <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FromEmailAddress</code> parameter.</p><p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use sender@example.com, then you would specify the <code>FromEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FromEmailAddress</code> to be sender@example.com.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>For Raw emails, the <code>FromEmailAddressIdentityArn</code> value overrides the X-SES-SOURCE-ARN and X-SES-FROM-ARN headers specified in raw email message content.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable fromEmailAddressIdentityArn;
-
-/**
- <p>The "Reply-to" email addresses for the message. When the recipient replies to the message, each Reply-to address receives the reply.</p>
+ <p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>
  */
 @property (nonatomic, strong) NSArray<NSString *> * _Nullable replyToAddresses;
+
+/**
+ <p>The email address that bounces and complaints will be forwarded to when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPath;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPathArn;
+
+/**
+ <p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Amazon SES Developer Guide</a>.</p><p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in <a href="https://tools.ietf.org/html/rfc2047">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p></note>
+ */
+@property (nonatomic, strong) NSString * _Nullable source;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable sourceArn;
+
+/**
+ <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable tags;
 
 @end
 
 /**
- <p>A unique message ID that you receive when an email is accepted for sending.</p>
+ <p>Represents a unique message ID.</p>
+ Required parameters: [MessageId]
  */
 @interface AWSSESSendEmailResponse : AWSModel
 
 
 /**
- <p>A unique identifier for the message that is generated when the message is accepted.</p><note><p>It's possible for Amazon SES to accept a message without sending it. This can happen when the message that you're trying to send has an attachment contains a virus, or when you send a templated email that contains invalid personalization content, for example.</p></note>
+ <p>The unique message identifier returned from the <code>SendEmail</code> action. </p>
  */
 @property (nonatomic, strong) NSString * _Nullable messageId;
 
 @end
 
 /**
- <p>An object that contains information about the per-day and per-second sending limits for your Amazon SES account in the current AWS Region.</p>
+ <p>Represents a request to send a single raw email using Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RawMessage]
  */
-@interface AWSSESSendQuota : AWSModel
+@interface AWSSESSendRawEmailRequest : AWSRequest
 
 
 /**
- <p>The maximum number of emails that you can send in the current AWS Region over a 24-hour period. This value is also called your <i>sending quota</i>.</p>
+ <p>The name of the configuration set to use when you send an email using <code>SendRawEmail</code>.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable max24HourSend;
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>The maximum number of emails that you can send per second in the current AWS Region. This value is also called your <i>maximum sending rate</i> or your <i>maximum TPS (transactions per second) rate</i>.</p>
+ <p>A list of destinations for the message, consisting of To:, CC:, and BCC: addresses.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable maxSendRate;
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable destinations;
 
 /**
- <p>The number of emails sent from your Amazon SES account in the current AWS Region over the past 24 hours.</p>
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular "From" address in the header of the raw email.</p><p>Instead of using this parameter, you can use the X-header <code>X-SES-FROM-ARN</code> in the raw message of the email. If you use both the <code>FromArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>FromArn</code> parameter.</p><note><p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html">Amazon SES Developer Guide</a>.</p></note>
  */
-@property (nonatomic, strong) NSNumber * _Nullable sentLast24Hours;
+@property (nonatomic, strong) NSString * _Nullable fromArn;
+
+/**
+ <p>The raw email message itself. The message has to meet the following criteria:</p><ul><li><p>The message has to contain a header and a body, separated by a blank line.</p></li><li><p>All of the required header fields must be present in the message.</p></li><li><p>Each part of a multipart MIME message must be formatted properly.</p></li><li><p>Attachments must be of a content type that Amazon SES supports. For a list on unsupported content types, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mime-types.html">Unsupported Attachment Types</a> in the <i>Amazon SES Developer Guide</i>.</p></li><li><p>The entire message must be base64-encoded.</p></li><li><p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, we highly recommend that you encode that content. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html">Sending Raw Email</a> in the <i>Amazon SES Developer Guide</i>.</p></li><li><p>Per <a href="https://tools.ietf.org/html/rfc5321#section-4.5.3.1.6">RFC 5321</a>, the maximum length of each line of text, including the &lt;CRLF&gt;, must not exceed 1,000 characters.</p></li></ul>
+ */
+@property (nonatomic, strong) AWSSESRawMessage * _Nullable rawMessage;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p><p>Instead of using this parameter, you can use the X-header <code>X-SES-RETURN-PATH-ARN</code> in the raw message of the email. If you use both the <code>ReturnPathArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>ReturnPathArn</code> parameter.</p><note><p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html">Amazon SES Developer Guide</a>.</p></note>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPathArn;
+
+/**
+ <p>The identity's email address. If you do not provide a value for this parameter, you must specify a "From" address in the raw text of the message. (You can also specify both.)</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in<a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in <a href="https://tools.ietf.org/html/rfc2047">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p></note><p>If you specify the <code>Source</code> parameter and have feedback forwarding enabled, then bounces and complaints will be sent to this email address. This takes precedence over any Return-Path header that you might include in the raw text of the message.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable source;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p><p>Instead of using this parameter, you can use the X-header <code>X-SES-SOURCE-ARN</code> in the raw message of the email. If you use both the <code>SourceArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>SourceArn</code> parameter.</p><note><p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html">Amazon SES Developer Guide</a>.</p></note>
+ */
+@property (nonatomic, strong) NSString * _Nullable sourceArn;
+
+/**
+ <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendRawEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable tags;
 
 @end
 
 /**
- <p>Used to enable or disable email sending for messages that use this configuration set in the current AWS Region.</p>
+ <p>Represents a unique message ID.</p>
+ Required parameters: [MessageId]
  */
-@interface AWSSESSendingOptions : AWSModel
+@interface AWSSESSendRawEmailResponse : AWSModel
 
 
 /**
- <p>If <code>true</code>, email sending is enabled for the configuration set. If <code>false</code>, email sending is disabled for the configuration set.</p>
+ <p>The unique message identifier returned from the <code>SendRawEmail</code> action. </p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable sendingEnabled;
+@property (nonatomic, strong) NSString * _Nullable messageId;
 
 @end
 
 /**
- <p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to send notification when certain email events occur.</p>
- Required parameters: [TopicArn]
+ <p>Represents a request to send a templated email using Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Source, Destination, Template, TemplateData]
  */
-@interface AWSSESSnsDestination : AWSModel
+@interface AWSSESSendTemplatedEmailRequest : AWSRequest
 
 
 /**
- <p>The Amazon Resource Name (ARN) of the Amazon SNS topic that you want to publish email events to. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
+ <p>The name of the configuration set to use when you send an email using <code>SendTemplatedEmail</code>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+
+/**
+ <p>The destination for this email, composed of To:, CC:, and BCC: fields. A Destination can include up to 50 recipients across these three fields.</p>
+ */
+@property (nonatomic, strong) AWSSESDestination * _Nullable destination;
+
+/**
+ <p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable replyToAddresses;
+
+/**
+ <p>The email address that bounces and complaints will be forwarded to when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPath;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable returnPathArn;
+
+/**
+ <p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Amazon SES Developer Guide</a>.</p><p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><note><p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href="https://tools.ietf.org/html/rfc6531">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href="https://en.wikipedia.org/wiki/Email_address#Local-part">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href="https://tools.ietf.org/html/rfc3492.html">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in<a href="https://tools.ietf.org/html/rfc2047">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p></note>
+ */
+@property (nonatomic, strong) NSString * _Nullable source;
+
+/**
+ <p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p><p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable sourceArn;
+
+/**
+ <p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendTemplatedEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>
+ */
+@property (nonatomic, strong) NSArray<AWSSESMessageTag *> * _Nullable tags;
+
+/**
+ <p>The template to use when sending this email.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable template;
+
+/**
+ <p>The ARN of the template to use when sending this email.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable templateArn;
+
+/**
+ <p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable templateData;
+
+@end
+
+/**
+ 
+ */
+@interface AWSSESSendTemplatedEmailResponse : AWSModel
+
+
+/**
+ <p>The unique message identifier returned from the <code>SendTemplatedEmail</code> action. </p>
+ */
+@property (nonatomic, strong) NSString * _Nullable messageId;
+
+@end
+
+/**
+ <p>Represents a request to set a receipt rule set as the active receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ */
+@interface AWSSESSetActiveReceiptRuleSetRequest : AWSRequest
+
+
+/**
+ <p>The name of the receipt rule set to make active. Setting this value to null disables all email receiving.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetActiveReceiptRuleSetResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to enable or disable Amazon SES Easy DKIM signing for an identity. For more information about setting up Easy DKIM, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, DkimEnabled]
+ */
+@interface AWSSESSetIdentityDkimEnabledRequest : AWSRequest
+
+
+/**
+ <p>Sets whether DKIM signing is enabled for an identity. Set to <code>true</code> to enable DKIM signing for this identity; <code>false</code> to disable it. </p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable dkimEnabled;
+
+/**
+ <p>The identity for which DKIM signing should be enabled or disabled.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable identity;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetIdentityDkimEnabledResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to enable or disable whether Amazon SES forwards you bounce and complaint notifications through email. For information about email feedback forwarding, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-email.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, ForwardingEnabled]
+ */
+@interface AWSSESSetIdentityFeedbackForwardingEnabledRequest : AWSRequest
+
+
+/**
+ <p>Sets whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> specifies that Amazon SES will forward bounce and complaint notifications as email, in addition to any Amazon SNS topic publishing otherwise specified. <code>false</code> specifies that Amazon SES will publish bounce and complaint notifications only through Amazon SNS. This value can only be set to <code>false</code> when Amazon SNS topics are set for both <code>Bounce</code> and <code>Complaint</code> notification types.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable forwardingEnabled;
+
+/**
+ <p>The identity for which to set bounce and complaint notification forwarding. Examples: <code>user@example.com</code>, <code>example.com</code>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable identity;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetIdentityFeedbackForwardingEnabledResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to set whether Amazon SES includes the original email headers in the Amazon SNS notifications of a specified type. For information about notifications, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, NotificationType, Enabled]
+ */
+@interface AWSSESSetIdentityHeadersInNotificationsEnabledRequest : AWSRequest
+
+
+/**
+ <p>Sets whether Amazon SES includes the original email headers in Amazon SNS notifications of the specified notification type. A value of <code>true</code> specifies that Amazon SES will include headers in notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in notifications.</p><p>This value can only be set when <code>NotificationType</code> is already set to use a particular Amazon SNS topic.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable enabled;
+
+/**
+ <p>The identity for which to enable or disable headers in notifications. Examples: <code>user@example.com</code>, <code>example.com</code>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable identity;
+
+/**
+ <p>The notification type for which to enable or disable headers in notifications. </p>
+ */
+@property (nonatomic, assign) AWSSESNotificationType notificationType;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetIdentityHeadersInNotificationsEnabledResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to enable or disable the Amazon SES custom MAIL FROM domain setup for a verified identity. For information about using a custom MAIL FROM domain, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity]
+ */
+@interface AWSSESSetIdentityMailFromDomainRequest : AWSRequest
+
+
+/**
+ <p>The action that you want Amazon SES to take if it cannot successfully read the required MX record when you send an email. If you choose <code>UseDefaultValue</code>, Amazon SES will use amazonses.com (or a subdomain of that) as the MAIL FROM domain. If you choose <code>RejectMessage</code>, Amazon SES will return a <code>MailFromDomainNotVerified</code> error and not send the email.</p><p>The action specified in <code>BehaviorOnMXFailure</code> is taken when the custom MAIL FROM domain setup is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>
+ */
+@property (nonatomic, assign) AWSSESBehaviorOnMXFailure behaviorOnMXFailure;
+
+/**
+ <p>The verified identity for which you want to enable or disable the specified custom MAIL FROM domain.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable identity;
+
+/**
+ <p>The custom MAIL FROM domain that you want the verified identity to use. The MAIL FROM domain must 1) be a subdomain of the verified identity, 2) not be used in a "From" address if the MAIL FROM domain is the destination of email feedback forwarding (for more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html">Amazon SES Developer Guide</a>), and 3) not be used to receive emails. A value of <code>null</code> disables the custom MAIL FROM setting for the identity.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable mailFromDomain;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetIdentityMailFromDomainResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to specify the Amazon SNS topic to which Amazon SES will publish bounce, complaint, or delivery notifications for emails sent with that identity as the Source. For information about Amazon SES notifications, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Identity, NotificationType]
+ */
+@interface AWSSESSetIdentityNotificationTopicRequest : AWSRequest
+
+
+/**
+ <p>The identity (email address or domain) that you want to set the Amazon SNS topic for.</p><important><p>You can only specify a verified identity for this parameter.</p></important><p>You can specify an identity by using its name or by using its Amazon Resource Name (ARN). The following examples are all valid identities: <code>sender@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable identity;
+
+/**
+ <p>The type of notifications that will be published to the specified Amazon SNS topic.</p>
+ */
+@property (nonatomic, assign) AWSSESNotificationType notificationType;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic. If the parameter is omitted from the request or a null value is passed, <code>SnsTopic</code> is cleared and publishing is disabled.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable snsTopic;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetIdentityNotificationTopicResponse : AWSModel
+
+
+@end
+
+/**
+ <p>Represents a request to set the position of a receipt rule in a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, RuleName]
+ */
+@interface AWSSESSetReceiptRulePositionRequest : AWSRequest
+
+
+/**
+ <p>The name of the receipt rule after which to place the specified receipt rule.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable after;
+
+/**
+ <p>The name of the receipt rule to reposition.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleName;
+
+/**
+ <p>The name of the receipt rule set that contains the receipt rule to reposition.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESSetReceiptRulePositionResponse : AWSModel
+
+
+@end
+
+/**
+ <p>When included in a receipt rule, this action terminates the evaluation of the receipt rule set and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p><p>For information about setting a stop action in a receipt rule, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-stop.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Scope]
+ */
+@interface AWSSESStopAction : AWSModel
+
+
+/**
+ <p>The scope of the StopAction. The only acceptable value is <code>RuleSet</code>.</p>
+ */
+@property (nonatomic, assign) AWSSESStopScope scope;
+
+/**
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the stop action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable topicArn;
 
 @end
 
 /**
- <p>An object that contains information about an email address that is on the suppression list for your account.</p>
- Required parameters: [EmailAddress, Reason, LastUpdateTime]
- */
-@interface AWSSESSuppressedDestination : AWSModel
-
-
-/**
- <p>An optional value that can contain additional information about the reasons that the address was added to the suppression list for your account.</p>
- */
-@property (nonatomic, strong) AWSSESSuppressedDestinationAttributes * _Nullable attributes;
-
-/**
- <p>The email address that is on the suppression list for your account.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailAddress;
-
-/**
- <p>The date and time when the suppressed destination was last updated, shown in Unix time format.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable lastUpdateTime;
-
-/**
- <p>The reason that the address was added to the suppression list for your account.</p>
- */
-@property (nonatomic, assign) AWSSESSuppressionListReason reason;
-
-@end
-
-/**
- <p>An object that contains additional attributes that are related an email address that is on the suppression list for your account.</p>
- */
-@interface AWSSESSuppressedDestinationAttributes : AWSModel
-
-
-/**
- <p>A unique identifier that's generated when an email address is added to the suppression list for your account.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable feedbackId;
-
-/**
- <p>The unique identifier of the email message that caused the email address to be added to the suppression list for your account.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable messageId;
-
-@end
-
-/**
- <p>A summary that describes the suppressed email address.</p>
- Required parameters: [EmailAddress, Reason, LastUpdateTime]
- */
-@interface AWSSESSuppressedDestinationSummary : AWSModel
-
-
-/**
- <p>The email address that's on the suppression list for your account.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable emailAddress;
-
-/**
- <p>The date and time when the suppressed destination was last updated, shown in Unix time format.</p>
- */
-@property (nonatomic, strong) NSDate * _Nullable lastUpdateTime;
-
-/**
- <p>The reason that the address was added to the suppression list for your account.</p>
- */
-@property (nonatomic, assign) AWSSESSuppressionListReason reason;
-
-@end
-
-/**
- <p>An object that contains information about the email address suppression preferences for your account in the current AWS Region.</p>
- */
-@interface AWSSESSuppressionAttributes : AWSModel
-
-
-/**
- <p>A list that contains the reasons that email addresses will be automatically added to the suppression list for your account. This list can contain any or all of the following:</p><ul><li><p><code>COMPLAINT</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p></li><li><p><code>BOUNCE</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p></li></ul>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable suppressedReasons;
-
-@end
-
-/**
- <p>An object that contains details about the action of suppression list.</p>
- Required parameters: [SuppressionListImportAction]
- */
-@interface AWSSESSuppressionListDestination : AWSModel
-
-
-/**
- <p>The type of action that you want to perform on the address. Acceptable values:</p><ul><li><p>PUT: add the addresses to the suppression list. If the record already exists, it will override it with the new value.</p></li><li><p>DELETE: remove the addresses from the suppression list.</p></li></ul>
- */
-@property (nonatomic, assign) AWSSESSuppressionListImportAction suppressionListImportAction;
-
-@end
-
-/**
- <p>An object that contains information about the suppression list preferences for your account.</p>
- */
-@interface AWSSESSuppressionOptions : AWSModel
-
-
-/**
- <p>A list that contains the reasons that email addresses are automatically added to the suppression list for your account. This list can contain any or all of the following:</p><ul><li><p><code>COMPLAINT</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p></li><li><p><code>BOUNCE</code> – Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p></li></ul>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable suppressedReasons;
-
-@end
-
-/**
- <p>An object that defines the tags that are associated with a resource. A <i>tag</i> is a label that you optionally define and associate with a resource. Tags can help you categorize and manage resources in different ways, such as by purpose, owner, environment, or other criteria. A resource can have as many as 50 tags.</p><p>Each tag consists of a required <i>tag key</i> and an associated <i>tag value</i>, both of which you define. A tag key is a general label that acts as a category for a more specific tag value. A tag value acts as a descriptor within a tag key. A tag key can contain as many as 128 characters. A tag value can contain as many as 256 characters. The characters can be Unicode letters, digits, white space, or one of the following symbols: _ . : / = + -. The following additional restrictions apply to tags:</p><ul><li><p>Tag keys and values are case sensitive.</p></li><li><p>For each associated resource, each tag key must be unique and it can have only one value.</p></li><li><p>The <code>aws:</code> prefix is reserved for use by AWS; you can’t use it in any tag keys or values that you define. In addition, you can't edit or remove tag keys or values that use this prefix. Tags that use this prefix don’t count against the limit of 50 tags per resource.</p></li><li><p>You can associate tags with public or shared resources, but the tags are available only for your AWS account, not any other accounts that share the resource. In addition, the tags are available only for resources that are located in the specified AWS Region for your AWS account.</p></li></ul>
- Required parameters: [Key, Value]
- */
-@interface AWSSESTag : AWSModel
-
-
-/**
- <p>One part of a key-value pair that defines a tag. The maximum length of a tag key is 128 characters. The minimum length is 1 character.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable key;
-
-/**
- <p>The optional part of a key-value pair that defines a tag. The maximum length of a tag value is 256 characters. The minimum length is 0 characters. If you don't want a resource to have a specific tag value, don't specify a value for this parameter. If you don't specify a value, Amazon SES sets the value to an empty string.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable value;
-
-@end
-
-/**
- 
- */
-@interface AWSSESTagResourceRequest : AWSRequest
-
-
-/**
- <p>The Amazon Resource Name (ARN) of the resource that you want to add one or more tags to.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable resourceArn;
-
-/**
- <p>A list of the tags that you want to add to the resource. A tag consists of a required tag key (<code>Key</code>) and an associated tag value (<code>Value</code>). The maximum length of a tag key is 128 characters. The maximum length of a tag value is 256 characters.</p>
- */
-@property (nonatomic, strong) NSArray<AWSSESTag *> * _Nullable tags;
-
-@end
-
-/**
- 
- */
-@interface AWSSESTagResourceResponse : AWSModel
-
-
-@end
-
-/**
- <p>An object that defines the email template to use for an email message, and the values to use for any message variables in that template. An <i>email template</i> is a type of message template that contains content that you want to define, save, and reuse in email messages that you send.</p>
+ <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
+ Required parameters: [TemplateName]
  */
 @interface AWSSESTemplate : AWSModel
 
 
 /**
- <p>The Amazon Resource Name (ARN) of the template.</p>
+ <p>The HTML body of the email.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable templateArn;
+@property (nonatomic, strong) NSString * _Nullable htmlPart;
 
 /**
- <p>An object that defines the values to use for message variables in the template. This object is a set of key-value pairs. Each key defines a message variable in the template. The corresponding value defines the value to use for that variable.</p>
+ <p>The subject line of the email.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable templateData;
+@property (nonatomic, strong) NSString * _Nullable subjectPart;
 
 /**
- <p>The name of the template. You will refer to this name when you send email using the <code>SendTemplatedEmail</code> or <code>SendBulkTemplatedEmail</code> operations. </p>
+ <p>The name of the template. You will refer to this name when you send email using the <code>SendTemplatedEmail</code> or <code>SendBulkTemplatedEmail</code> operations.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable templateName;
+
+/**
+ <p>The email body that will be visible to recipients whose email clients do not display HTML.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable textPart;
 
 @end
 
 /**
- <p>&gt;Represents a request to create a preview of the MIME content of an email when provided with a template and a set of replacement data.</p>
- Required parameters: [TemplateName, TemplateData]
+ <p>Contains information about an email template.</p>
  */
-@interface AWSSESTestRenderEmailTemplateRequest : AWSRequest
+@interface AWSSESTemplateMetadata : AWSModel
+
+
+/**
+ <p>The time and date the template was created.</p>
+ */
+@property (nonatomic, strong) NSDate * _Nullable createdTimestamp;
+
+/**
+ <p>The name of the template.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable name;
+
+@end
+
+/**
+ 
+ */
+@interface AWSSESTestRenderTemplateRequest : AWSRequest
 
 
 /**
@@ -3916,85 +3121,65 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>The following element is returned by the service.</p>
- Required parameters: [RenderedTemplate]
+ 
  */
-@interface AWSSESTestRenderEmailTemplateResponse : AWSModel
+@interface AWSSESTestRenderTemplateResponse : AWSModel
 
 
 /**
- <p>The complete MIME message rendered by applying the data in the <code>TemplateData</code> parameter to the template specified in the TemplateName parameter.</p>
+ <p>The complete MIME message rendered by applying the data in the TemplateData parameter to the template specified in the TemplateName parameter.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable renderedTemplate;
 
 @end
 
 /**
- <p>An object that defines the tracking options for a configuration set. When you use the Amazon SES API v2 to send an email, it contains an invisible image that's used to track when recipients open your email. If your email contains links, those links are changed slightly in order to track when recipients click them.</p><p>These images and links include references to a domain operated by AWS. You can optionally configure the Amazon SES to use a domain that you operate for these images and links.</p>
- Required parameters: [CustomRedirectDomain]
+ <p>A domain that is used to redirect email recipients to an Amazon SES-operated domain. This domain captures open and click events generated by Amazon SES emails.</p><p>For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Configuring Custom Domains to Handle Open and Click Tracking</a> in the <i>Amazon SES Developer Guide</i>.</p>
  */
 @interface AWSSESTrackingOptions : AWSModel
 
 
 /**
- <p>The domain that you want to use for tracking open and click events.</p>
+ <p>The custom subdomain that will be used to redirect email recipients to the Amazon SES event tracking domain.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable customRedirectDomain;
 
 @end
 
 /**
- 
+ <p>Represents a request to enable or disable the email sending capabilities for your entire Amazon SES account.</p>
  */
-@interface AWSSESUntagResourceRequest : AWSRequest
+@interface AWSSESUpdateAccountSendingEnabledRequest : AWSRequest
 
 
 /**
- <p>The Amazon Resource Name (ARN) of the resource that you want to remove one or more tags from.</p>
+ <p>Describes whether email sending is enabled or disabled for your Amazon SES account in the current AWS Region.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable resourceArn;
-
-/**
- <p>The tags (tag keys) that you want to remove from the resource. When you specify a tag key, the action removes both that key and its associated tag value.</p><p>To remove more than one tag from the resource, append the <code>TagKeys</code> parameter and argument for each additional tag to remove, separated by an ampersand. For example: <code>/v2/email/tags?ResourceArn=ResourceArn&amp;TagKeys=Key1&amp;TagKeys=Key2</code></p>
- */
-@property (nonatomic, strong) NSArray<NSString *> * _Nullable tagKeys;
+@property (nonatomic, strong) NSNumber * _Nullable enabled;
 
 @end
 
 /**
- 
- */
-@interface AWSSESUntagResourceResponse : AWSModel
-
-
-@end
-
-/**
- <p>A request to change the settings for an event destination for a configuration set.</p>
- Required parameters: [ConfigurationSetName, EventDestinationName, EventDestination]
+ <p>Represents a request to update the event destination of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [ConfigurationSetName, EventDestination]
  */
 @interface AWSSESUpdateConfigurationSetEventDestinationRequest : AWSRequest
 
 
 /**
- <p>The name of the configuration set that contains the event destination that you want to modify.</p>
+ <p>The name of the configuration set that contains the event destination that you want to update.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable configurationSetName;
 
 /**
- <p>An object that defines the event destination.</p>
+ <p>The event destination object that you want to apply to the specified configuration set.</p>
  */
-@property (nonatomic, strong) AWSSESEventDestinationDefinition * _Nullable eventDestination;
-
-/**
- <p>The name of the event destination that you want to modify.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable eventDestinationName;
+@property (nonatomic, strong) AWSSESEventDestination * _Nullable eventDestination;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ <p>An empty element returned on a successful request.</p>
  */
 @interface AWSSESUpdateConfigurationSetEventDestinationResponse : AWSModel
 
@@ -4002,8 +3187,73 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
+ <p>Represents a request to modify the reputation metric publishing settings for a configuration set.</p>
+ Required parameters: [ConfigurationSetName, Enabled]
+ */
+@interface AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest : AWSRequest
+
+
+/**
+ <p>The name of the configuration set that you want to update.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+
+/**
+ <p>Describes whether or not Amazon SES will publish reputation metrics for the configuration set, such as bounce and complaint rates, to Amazon CloudWatch.</p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable enabled;
+
+@end
+
+/**
+ <p>Represents a request to enable or disable the email sending capabilities for a specific configuration set.</p>
+ Required parameters: [ConfigurationSetName, Enabled]
+ */
+@interface AWSSESUpdateConfigurationSetSendingEnabledRequest : AWSRequest
+
+
+/**
+ <p>The name of the configuration set that you want to update.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+
+/**
+ <p>Describes whether email sending is enabled or disabled for the configuration set. </p>
+ */
+@property (nonatomic, strong) NSNumber * _Nullable enabled;
+
+@end
+
+/**
+ <p>Represents a request to update the tracking options for a configuration set. </p>
+ Required parameters: [ConfigurationSetName, TrackingOptions]
+ */
+@interface AWSSESUpdateConfigurationSetTrackingOptionsRequest : AWSRequest
+
+
+/**
+ <p>The name of the configuration set for which you want to update the custom tracking domain.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable configurationSetName;
+
+/**
+ <p>A domain that is used to redirect email recipients to an Amazon SES-operated domain. This domain captures open and click events generated by Amazon SES emails.</p><p>For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Configuring Custom Domains to Handle Open and Click Tracking</a> in the <i>Amazon SES Developer Guide</i>.</p>
+ */
+@property (nonatomic, strong) AWSSESTrackingOptions * _Nullable trackingOptions;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESUpdateConfigurationSetTrackingOptionsResponse : AWSModel
+
+
+@end
+
+/**
  <p>Represents a request to update an existing custom verification email template.</p>
- Required parameters: [TemplateName, FromEmailAddress, TemplateSubject, TemplateContent, SuccessRedirectionURL, FailureRedirectionURL]
+ Required parameters: [TemplateName]
  */
 @interface AWSSESUpdateCustomVerificationEmailTemplateRequest : AWSRequest
 
@@ -4024,7 +3274,7 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @property (nonatomic, strong) NSString * _Nullable successRedirectionURL;
 
 /**
- <p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html#custom-verification-emails-faq">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>
+ <p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html#custom-verification-emails-faq">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>
  */
 @property (nonatomic, strong) NSString * _Nullable templateContent;
 
@@ -4041,97 +3291,161 @@ typedef NS_ENUM(NSInteger, AWSSESWarmupStatus) {
 @end
 
 /**
- <p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>
+ <p>Represents a request to update a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [RuleSetName, Rule]
  */
-@interface AWSSESUpdateCustomVerificationEmailTemplateResponse : AWSModel
+@interface AWSSESUpdateReceiptRuleRequest : AWSRequest
+
+
+/**
+ <p>A data structure that contains the updated receipt rule information.</p>
+ */
+@property (nonatomic, strong) AWSSESReceiptRule * _Nullable rule;
+
+/**
+ <p>The name of the receipt rule set that the receipt rule belongs to.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable ruleSetName;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESUpdateReceiptRuleResponse : AWSModel
 
 
 @end
 
 /**
- <p>Represents a request to update a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [EmailIdentity, PolicyName, Policy]
+ 
  */
-@interface AWSSESUpdateEmailIdentityPolicyRequest : AWSRequest
+@interface AWSSESUpdateTemplateRequest : AWSRequest
 
 
 /**
- <p>The email identity for which you want to update policy.</p>
+ <p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>
  */
-@property (nonatomic, strong) NSString * _Nullable emailIdentity;
-
-/**
- <p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p><p> For information about the syntax of sending authorization policies, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html">Amazon SES Developer Guide</a>.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable policy;
-
-/**
- <p>The name of the policy.</p><p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable policyName;
+@property (nonatomic, strong) AWSSESTemplate * _Nullable template;
 
 @end
 
 /**
- <p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>
+ 
  */
-@interface AWSSESUpdateEmailIdentityPolicyResponse : AWSModel
+@interface AWSSESUpdateTemplateResponse : AWSModel
 
 
 @end
 
 /**
- <p>Represents a request to update an email template. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p>
- Required parameters: [TemplateName, TemplateContent]
+ <p>Represents a request to generate the CNAME records needed to set up Easy DKIM with Amazon SES. For more information about setting up Easy DKIM, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Domain]
  */
-@interface AWSSESUpdateEmailTemplateRequest : AWSRequest
+@interface AWSSESVerifyDomainDkimRequest : AWSRequest
 
 
 /**
- <p>The content of the email template, composed of a subject line, an HTML part, and a text-only part.</p>
+ <p>The name of the domain to be verified for Easy DKIM signing.</p>
  */
-@property (nonatomic, strong) AWSSESEmailTemplateContent * _Nullable templateContent;
-
-/**
- <p>The name of the template you want to update.</p>
- */
-@property (nonatomic, strong) NSString * _Nullable templateName;
+@property (nonatomic, strong) NSString * _Nullable domain;
 
 @end
 
 /**
- <p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>
+ <p>Returns CNAME records that you must publish to the DNS server of your domain to set up Easy DKIM with Amazon SES.</p>
+ Required parameters: [DkimTokens]
  */
-@interface AWSSESUpdateEmailTemplateResponse : AWSModel
+@interface AWSSESVerifyDomainDkimResponse : AWSModel
+
+
+/**
+ <p>A set of character strings that represent the domain's identity. If the identity is an email address, the tokens represent the domain of that address.</p><p>Using these tokens, you need to create DNS CNAME records that point to DKIM public keys that are hosted by Amazon SES. Amazon Web Services eventually detects that you've updated your DNS records. This detection process might take up to 72 hours. After successful detection, Amazon SES is able to DKIM-sign email originating from that domain. (This only applies to domain identities, not email address identities.)</p><p>For more information about creating DNS records using DKIM tokens, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
+ */
+@property (nonatomic, strong) NSArray<NSString *> * _Nullable dkimTokens;
+
+@end
+
+/**
+ <p>Represents a request to begin Amazon SES domain verification and to generate the TXT records that you must publish to the DNS server of your domain to complete the verification. For information about domain verification, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [Domain]
+ */
+@interface AWSSESVerifyDomainIdentityRequest : AWSRequest
+
+
+/**
+ <p>The domain to be verified.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable domain;
+
+@end
+
+/**
+ <p>Returns a TXT record that you must publish to the DNS server of your domain to complete domain verification with Amazon SES.</p>
+ Required parameters: [VerificationToken]
+ */
+@interface AWSSESVerifyDomainIdentityResponse : AWSModel
+
+
+/**
+ <p>A TXT record that you must place in the DNS settings of the domain to complete domain verification with Amazon SES.</p><p>As Amazon SES searches for the TXT record, the domain's verification status is "Pending". When Amazon SES detects the record, the domain's verification status changes to "Success". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to "Failed." In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable verificationToken;
+
+@end
+
+/**
+ <p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [EmailAddress]
+ */
+@interface AWSSESVerifyEmailAddressRequest : AWSRequest
+
+
+/**
+ <p>The email address to be verified.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable emailAddress;
+
+@end
+
+/**
+ <p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [EmailAddress]
+ */
+@interface AWSSESVerifyEmailIdentityRequest : AWSRequest
+
+
+/**
+ <p>The email address to be verified.</p>
+ */
+@property (nonatomic, strong) NSString * _Nullable emailAddress;
+
+@end
+
+/**
+ <p>An empty element returned on a successful request.</p>
+ */
+@interface AWSSESVerifyEmailIdentityResponse : AWSModel
 
 
 @end
 
 /**
- <p>An object that contains information about the amount of email that was delivered to recipients.</p>
+ <p>When included in a receipt rule, this action calls Amazon WorkMail and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS). You will typically not use this action directly because Amazon WorkMail adds the rule automatically during its setup procedure.</p><p>For information using a receipt rule to call Amazon WorkMail, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-workmail.html">Amazon SES Developer Guide</a>.</p>
+ Required parameters: [OrganizationArn]
  */
-@interface AWSSESVolumeStatistics : AWSModel
+@interface AWSSESWorkmailAction : AWSModel
 
 
 /**
- <p>The total number of emails that arrived in recipients' inboxes.</p>
+ <p>The ARN of the Amazon WorkMail organization. An example of an Amazon WorkMail organization ARN is <code>arn:aws:workmail:us-west-2:123456789012:organization/m-68755160c4cb4e29a2b2f8fb58f359d7</code>. For information about Amazon WorkMail organizations, see the <a href="https://docs.aws.amazon.com/workmail/latest/adminguide/organizations_overview.html">Amazon WorkMail Administrator Guide</a>.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable inboxRawCount;
+@property (nonatomic, strong) NSString * _Nullable organizationArn;
 
 /**
- <p>An estimate of the percentage of emails sent from the current domain that will arrive in recipients' inboxes.</p>
+ <p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the WorkMail action is called. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href="https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html">Amazon SNS Developer Guide</a>.</p>
  */
-@property (nonatomic, strong) NSNumber * _Nullable projectedInbox;
-
-/**
- <p>An estimate of the percentage of emails sent from the current domain that will arrive in recipients' spam or junk mail folders.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable projectedSpam;
-
-/**
- <p>The total number of emails that arrived in recipients' spam or junk mail folders.</p>
- */
-@property (nonatomic, strong) NSNumber * _Nullable spamRawCount;
+@property (nonatomic, strong) NSString * _Nullable topicArn;
 
 @end
 

--- a/AWSSES/AWSSESModel.m
+++ b/AWSSES/AWSSESModel.m
@@ -18,83 +18,13 @@
 
 NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
-@implementation AWSSESAccountDetails
+@implementation AWSSESAddHeaderAction
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"additionalContactEmailAddresses" : @"AdditionalContactEmailAddresses",
-             @"contactLanguage" : @"ContactLanguage",
-             @"mailType" : @"MailType",
-             @"reviewDetails" : @"ReviewDetails",
-             @"useCaseDescription" : @"UseCaseDescription",
-             @"websiteURL" : @"WebsiteURL",
+             @"headerName" : @"HeaderName",
+             @"headerValue" : @"HeaderValue",
              };
-}
-
-+ (NSValueTransformer *)contactLanguageJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"EN"] == NSOrderedSame) {
-            return @(AWSSESContactLanguageEn);
-        }
-        if ([value caseInsensitiveCompare:@"JA"] == NSOrderedSame) {
-            return @(AWSSESContactLanguageJa);
-        }
-        return @(AWSSESContactLanguageUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESContactLanguageEn:
-                return @"EN";
-            case AWSSESContactLanguageJa:
-                return @"JA";
-            default:
-                return nil;
-        }
-    }];
-}
-
-+ (NSValueTransformer *)mailTypeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"MARKETING"] == NSOrderedSame) {
-            return @(AWSSESMailTypeMarketing);
-        }
-        if ([value caseInsensitiveCompare:@"TRANSACTIONAL"] == NSOrderedSame) {
-            return @(AWSSESMailTypeTransactional);
-        }
-        return @(AWSSESMailTypeUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESMailTypeMarketing:
-                return @"MARKETING";
-            case AWSSESMailTypeTransactional:
-                return @"TRANSACTIONAL";
-            default:
-                return nil;
-        }
-    }];
-}
-
-+ (NSValueTransformer *)reviewDetailsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReviewDetails class]];
-}
-
-@end
-
-@implementation AWSSESBlacklistEntry
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"detail" : @"Description",
-             @"listingTime" : @"ListingTime",
-             @"rblName" : @"RblName",
-             };
-}
-
-+ (NSValueTransformer *)listingTimeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
 }
 
 @end
@@ -118,36 +48,90 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESBulkEmailContent
+@implementation AWSSESBounceAction
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"template" : @"Template",
+             @"message" : @"Message",
+             @"sender" : @"Sender",
+             @"smtpReplyCode" : @"SmtpReplyCode",
+             @"statusCode" : @"StatusCode",
+             @"topicArn" : @"TopicArn",
              };
-}
-
-+ (NSValueTransformer *)templateJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTemplate class]];
 }
 
 @end
 
-@implementation AWSSESBulkEmailEntry
+@implementation AWSSESBouncedRecipientInfo
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"bounceType" : @"BounceType",
+             @"recipient" : @"Recipient",
+             @"recipientArn" : @"RecipientArn",
+             @"recipientDsnFields" : @"RecipientDsnFields",
+             };
+}
+
++ (NSValueTransformer *)bounceTypeJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"DoesNotExist"] == NSOrderedSame) {
+            return @(AWSSESBounceTypeDoesNotExist);
+        }
+        if ([value caseInsensitiveCompare:@"MessageTooLarge"] == NSOrderedSame) {
+            return @(AWSSESBounceTypeMessageTooLarge);
+        }
+        if ([value caseInsensitiveCompare:@"ExceededQuota"] == NSOrderedSame) {
+            return @(AWSSESBounceTypeExceededQuota);
+        }
+        if ([value caseInsensitiveCompare:@"ContentRejected"] == NSOrderedSame) {
+            return @(AWSSESBounceTypeContentRejected);
+        }
+        if ([value caseInsensitiveCompare:@"Undefined"] == NSOrderedSame) {
+            return @(AWSSESBounceTypeUndefined);
+        }
+        if ([value caseInsensitiveCompare:@"TemporaryFailure"] == NSOrderedSame) {
+            return @(AWSSESBounceTypeTemporaryFailure);
+        }
+        return @(AWSSESBounceTypeUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESBounceTypeDoesNotExist:
+                return @"DoesNotExist";
+            case AWSSESBounceTypeMessageTooLarge:
+                return @"MessageTooLarge";
+            case AWSSESBounceTypeExceededQuota:
+                return @"ExceededQuota";
+            case AWSSESBounceTypeContentRejected:
+                return @"ContentRejected";
+            case AWSSESBounceTypeUndefined:
+                return @"Undefined";
+            case AWSSESBounceTypeTemporaryFailure:
+                return @"TemporaryFailure";
+            default:
+                return nil;
+        }
+    }];
+}
+
++ (NSValueTransformer *)recipientDsnFieldsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESRecipientDsnFields class]];
+}
+
+@end
+
+@implementation AWSSESBulkEmailDestination
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"destination" : @"Destination",
-             @"replacementEmailContent" : @"ReplacementEmailContent",
              @"replacementTags" : @"ReplacementTags",
+             @"replacementTemplateData" : @"ReplacementTemplateData",
              };
 }
 
 + (NSValueTransformer *)destinationJSONTransformer {
     return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDestination class]];
-}
-
-+ (NSValueTransformer *)replacementEmailContentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReplacementEmailContent class]];
 }
 
 + (NSValueTransformer *)replacementTagsJSONTransformer {
@@ -156,7 +140,7 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESBulkEmailEntryResult
+@implementation AWSSESBulkEmailDestinationStatus
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -168,84 +152,99 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 + (NSValueTransformer *)statusJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"SUCCESS"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"Success"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusSuccess);
         }
-        if ([value caseInsensitiveCompare:@"MESSAGE_REJECTED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"MessageRejected"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusMessageRejected);
         }
-        if ([value caseInsensitiveCompare:@"MAIL_FROM_DOMAIN_NOT_VERIFIED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"MailFromDomainNotVerified"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusMailFromDomainNotVerified);
         }
-        if ([value caseInsensitiveCompare:@"CONFIGURATION_SET_NOT_FOUND"] == NSOrderedSame) {
-            return @(AWSSESBulkEmailStatusConfigurationSetNotFound);
+        if ([value caseInsensitiveCompare:@"ConfigurationSetDoesNotExist"] == NSOrderedSame) {
+            return @(AWSSESBulkEmailStatusConfigurationSetDoesNotExist);
         }
-        if ([value caseInsensitiveCompare:@"TEMPLATE_NOT_FOUND"] == NSOrderedSame) {
-            return @(AWSSESBulkEmailStatusTemplateNotFound);
+        if ([value caseInsensitiveCompare:@"TemplateDoesNotExist"] == NSOrderedSame) {
+            return @(AWSSESBulkEmailStatusTemplateDoesNotExist);
         }
-        if ([value caseInsensitiveCompare:@"ACCOUNT_SUSPENDED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"AccountSuspended"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusAccountSuspended);
         }
-        if ([value caseInsensitiveCompare:@"ACCOUNT_THROTTLED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"AccountThrottled"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusAccountThrottled);
         }
-        if ([value caseInsensitiveCompare:@"ACCOUNT_DAILY_QUOTA_EXCEEDED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"AccountDailyQuotaExceeded"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusAccountDailyQuotaExceeded);
         }
-        if ([value caseInsensitiveCompare:@"INVALID_SENDING_POOL_NAME"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"InvalidSendingPoolName"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusInvalidSendingPoolName);
         }
-        if ([value caseInsensitiveCompare:@"ACCOUNT_SENDING_PAUSED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"AccountSendingPaused"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusAccountSendingPaused);
         }
-        if ([value caseInsensitiveCompare:@"CONFIGURATION_SET_SENDING_PAUSED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"ConfigurationSetSendingPaused"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusConfigurationSetSendingPaused);
         }
-        if ([value caseInsensitiveCompare:@"INVALID_PARAMETER"] == NSOrderedSame) {
-            return @(AWSSESBulkEmailStatusInvalidParameter);
+        if ([value caseInsensitiveCompare:@"InvalidParameterValue"] == NSOrderedSame) {
+            return @(AWSSESBulkEmailStatusInvalidParameterValue);
         }
-        if ([value caseInsensitiveCompare:@"TRANSIENT_FAILURE"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"TransientFailure"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusTransientFailure);
         }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"Failed"] == NSOrderedSame) {
             return @(AWSSESBulkEmailStatusFailed);
         }
         return @(AWSSESBulkEmailStatusUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
             case AWSSESBulkEmailStatusSuccess:
-                return @"SUCCESS";
+                return @"Success";
             case AWSSESBulkEmailStatusMessageRejected:
-                return @"MESSAGE_REJECTED";
+                return @"MessageRejected";
             case AWSSESBulkEmailStatusMailFromDomainNotVerified:
-                return @"MAIL_FROM_DOMAIN_NOT_VERIFIED";
-            case AWSSESBulkEmailStatusConfigurationSetNotFound:
-                return @"CONFIGURATION_SET_NOT_FOUND";
-            case AWSSESBulkEmailStatusTemplateNotFound:
-                return @"TEMPLATE_NOT_FOUND";
+                return @"MailFromDomainNotVerified";
+            case AWSSESBulkEmailStatusConfigurationSetDoesNotExist:
+                return @"ConfigurationSetDoesNotExist";
+            case AWSSESBulkEmailStatusTemplateDoesNotExist:
+                return @"TemplateDoesNotExist";
             case AWSSESBulkEmailStatusAccountSuspended:
-                return @"ACCOUNT_SUSPENDED";
+                return @"AccountSuspended";
             case AWSSESBulkEmailStatusAccountThrottled:
-                return @"ACCOUNT_THROTTLED";
+                return @"AccountThrottled";
             case AWSSESBulkEmailStatusAccountDailyQuotaExceeded:
-                return @"ACCOUNT_DAILY_QUOTA_EXCEEDED";
+                return @"AccountDailyQuotaExceeded";
             case AWSSESBulkEmailStatusInvalidSendingPoolName:
-                return @"INVALID_SENDING_POOL_NAME";
+                return @"InvalidSendingPoolName";
             case AWSSESBulkEmailStatusAccountSendingPaused:
-                return @"ACCOUNT_SENDING_PAUSED";
+                return @"AccountSendingPaused";
             case AWSSESBulkEmailStatusConfigurationSetSendingPaused:
-                return @"CONFIGURATION_SET_SENDING_PAUSED";
-            case AWSSESBulkEmailStatusInvalidParameter:
-                return @"INVALID_PARAMETER";
+                return @"ConfigurationSetSendingPaused";
+            case AWSSESBulkEmailStatusInvalidParameterValue:
+                return @"InvalidParameterValue";
             case AWSSESBulkEmailStatusTransientFailure:
-                return @"TRANSIENT_FAILURE";
+                return @"TransientFailure";
             case AWSSESBulkEmailStatusFailed:
-                return @"FAILED";
+                return @"Failed";
             default:
                 return nil;
         }
     }];
 }
+
+@end
+
+@implementation AWSSESCloneReceiptRuleSetRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"originalRuleSetName" : @"OriginalRuleSetName",
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESCloneReceiptRuleSetResponse
 
 @end
 
@@ -275,28 +274,38 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 + (NSValueTransformer *)dimensionValueSourceJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"MESSAGE_TAG"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"messageTag"] == NSOrderedSame) {
             return @(AWSSESDimensionValueSourceMessageTag);
         }
-        if ([value caseInsensitiveCompare:@"EMAIL_HEADER"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"emailHeader"] == NSOrderedSame) {
             return @(AWSSESDimensionValueSourceEmailHeader);
         }
-        if ([value caseInsensitiveCompare:@"LINK_TAG"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"linkTag"] == NSOrderedSame) {
             return @(AWSSESDimensionValueSourceLinkTag);
         }
         return @(AWSSESDimensionValueSourceUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
             case AWSSESDimensionValueSourceMessageTag:
-                return @"MESSAGE_TAG";
+                return @"messageTag";
             case AWSSESDimensionValueSourceEmailHeader:
-                return @"EMAIL_HEADER";
+                return @"emailHeader";
             case AWSSESDimensionValueSourceLinkTag:
-                return @"LINK_TAG";
+                return @"linkTag";
             default:
                 return nil;
         }
     }];
+}
+
+@end
+
+@implementation AWSSESConfigurationSet
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"name" : @"Name",
+             };
 }
 
 @end
@@ -318,12 +327,11 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 	return @{
              @"configurationSetName" : @"ConfigurationSetName",
              @"eventDestination" : @"EventDestination",
-             @"eventDestinationName" : @"EventDestinationName",
              };
 }
 
 + (NSValueTransformer *)eventDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEventDestinationDefinition class]];
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEventDestination class]];
 }
 
 @end
@@ -336,34 +344,27 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"deliveryOptions" : @"DeliveryOptions",
-             @"reputationOptions" : @"ReputationOptions",
-             @"sendingOptions" : @"SendingOptions",
-             @"suppressionOptions" : @"SuppressionOptions",
-             @"tags" : @"Tags",
-             @"trackingOptions" : @"TrackingOptions",
+             @"configurationSet" : @"ConfigurationSet",
              };
 }
 
-+ (NSValueTransformer *)deliveryOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDeliveryOptions class]];
++ (NSValueTransformer *)configurationSetJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESConfigurationSet class]];
 }
 
-+ (NSValueTransformer *)reputationOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReputationOptions class]];
-}
+@end
 
-+ (NSValueTransformer *)sendingOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSendingOptions class]];
-}
+@implementation AWSSESCreateConfigurationSetResponse
 
-+ (NSValueTransformer *)suppressionOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSuppressionOptions class]];
-}
+@end
 
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
+@implementation AWSSESCreateConfigurationSetTrackingOptionsRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"trackingOptions" : @"TrackingOptions",
+             };
 }
 
 + (NSValueTransformer *)trackingOptionsJSONTransformer {
@@ -372,7 +373,7 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESCreateConfigurationSetResponse
+@implementation AWSSESCreateConfigurationSetTrackingOptionsResponse
 
 @end
 
@@ -391,209 +392,77 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESCreateCustomVerificationEmailTemplateResponse
-
-@end
-
-@implementation AWSSESCreateDedicatedIpPoolRequest
+@implementation AWSSESCreateReceiptFilterRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"poolName" : @"PoolName",
-             @"tags" : @"Tags",
+             @"filter" : @"Filter",
              };
 }
 
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
++ (NSValueTransformer *)filterJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptFilter class]];
 }
 
 @end
 
-@implementation AWSSESCreateDedicatedIpPoolResponse
+@implementation AWSSESCreateReceiptFilterResponse
 
 @end
 
-@implementation AWSSESCreateDeliverabilityTestReportRequest
+@implementation AWSSESCreateReceiptRuleRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"content" : @"Content",
-             @"fromEmailAddress" : @"FromEmailAddress",
-             @"reportName" : @"ReportName",
-             @"tags" : @"Tags",
+             @"after" : @"After",
+             @"rule" : @"Rule",
+             @"ruleSetName" : @"RuleSetName",
              };
 }
 
-+ (NSValueTransformer *)contentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEmailContent class]];
-}
-
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
++ (NSValueTransformer *)ruleJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptRule class]];
 }
 
 @end
 
-@implementation AWSSESCreateDeliverabilityTestReportResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"deliverabilityTestStatus" : @"DeliverabilityTestStatus",
-             @"reportId" : @"ReportId",
-             };
-}
-
-+ (NSValueTransformer *)deliverabilityTestStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"IN_PROGRESS"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityTestStatusInProgress);
-        }
-        if ([value caseInsensitiveCompare:@"COMPLETED"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityTestStatusCompleted);
-        }
-        return @(AWSSESDeliverabilityTestStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDeliverabilityTestStatusInProgress:
-                return @"IN_PROGRESS";
-            case AWSSESDeliverabilityTestStatusCompleted:
-                return @"COMPLETED";
-            default:
-                return nil;
-        }
-    }];
-}
+@implementation AWSSESCreateReceiptRuleResponse
 
 @end
 
-@implementation AWSSESCreateEmailIdentityPolicyRequest
+@implementation AWSSESCreateReceiptRuleSetRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"emailIdentity" : @"EmailIdentity",
-             @"policy" : @"Policy",
-             @"policyName" : @"PolicyName",
+             @"ruleSetName" : @"RuleSetName",
              };
 }
 
 @end
 
-@implementation AWSSESCreateEmailIdentityPolicyResponse
+@implementation AWSSESCreateReceiptRuleSetResponse
 
 @end
 
-@implementation AWSSESCreateEmailIdentityRequest
+@implementation AWSSESCreateTemplateRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"dkimSigningAttributes" : @"DkimSigningAttributes",
-             @"emailIdentity" : @"EmailIdentity",
-             @"tags" : @"Tags",
+             @"template" : @"Template",
              };
 }
 
-+ (NSValueTransformer *)dkimSigningAttributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDkimSigningAttributes class]];
-}
-
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
++ (NSValueTransformer *)templateJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTemplate class]];
 }
 
 @end
 
-@implementation AWSSESCreateEmailIdentityResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dkimAttributes" : @"DkimAttributes",
-             @"identityType" : @"IdentityType",
-             @"verifiedForSendingStatus" : @"VerifiedForSendingStatus",
-             };
-}
-
-+ (NSValueTransformer *)dkimAttributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDkimAttributes class]];
-}
-
-+ (NSValueTransformer *)identityTypeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"EMAIL_ADDRESS"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeEmailAddress);
-        }
-        if ([value caseInsensitiveCompare:@"DOMAIN"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeDomain);
-        }
-        if ([value caseInsensitiveCompare:@"MANAGED_DOMAIN"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeManagedDomain);
-        }
-        return @(AWSSESIdentityTypeUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESIdentityTypeEmailAddress:
-                return @"EMAIL_ADDRESS";
-            case AWSSESIdentityTypeDomain:
-                return @"DOMAIN";
-            case AWSSESIdentityTypeManagedDomain:
-                return @"MANAGED_DOMAIN";
-            default:
-                return nil;
-        }
-    }];
-}
+@implementation AWSSESCreateTemplateResponse
 
 @end
 
-@implementation AWSSESCreateEmailTemplateRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"templateContent" : @"TemplateContent",
-             @"templateName" : @"TemplateName",
-             };
-}
-
-+ (NSValueTransformer *)templateContentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEmailTemplateContent class]];
-}
-
-@end
-
-@implementation AWSSESCreateEmailTemplateResponse
-
-@end
-
-@implementation AWSSESCreateImportJobRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"importDataSource" : @"ImportDataSource",
-             @"importDestination" : @"ImportDestination",
-             };
-}
-
-+ (NSValueTransformer *)importDataSourceJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESImportDataSource class]];
-}
-
-+ (NSValueTransformer *)importDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESImportDestination class]];
-}
-
-@end
-
-@implementation AWSSESCreateImportJobResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"jobId" : @"JobId",
-             };
-}
-
-@end
-
-@implementation AWSSESCustomVerificationEmailTemplateMetadata
+@implementation AWSSESCustomVerificationEmailTemplate
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -603,68 +472,6 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
              @"templateName" : @"TemplateName",
              @"templateSubject" : @"TemplateSubject",
              };
-}
-
-@end
-
-@implementation AWSSESDailyVolume
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"domainIspPlacements" : @"DomainIspPlacements",
-             @"startDate" : @"StartDate",
-             @"volumeStatistics" : @"VolumeStatistics",
-             };
-}
-
-+ (NSValueTransformer *)domainIspPlacementsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDomainIspPlacement class]];
-}
-
-+ (NSValueTransformer *)startDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)volumeStatisticsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESVolumeStatistics class]];
-}
-
-@end
-
-@implementation AWSSESDedicatedIp
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"ip" : @"Ip",
-             @"poolName" : @"PoolName",
-             @"warmupPercentage" : @"WarmupPercentage",
-             @"warmupStatus" : @"WarmupStatus",
-             };
-}
-
-+ (NSValueTransformer *)warmupStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"IN_PROGRESS"] == NSOrderedSame) {
-            return @(AWSSESWarmupStatusInProgress);
-        }
-        if ([value caseInsensitiveCompare:@"DONE"] == NSOrderedSame) {
-            return @(AWSSESWarmupStatusDone);
-        }
-        return @(AWSSESWarmupStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESWarmupStatusInProgress:
-                return @"IN_PROGRESS";
-            case AWSSESWarmupStatusDone:
-                return @"DONE";
-            default:
-                return nil;
-        }
-    }];
 }
 
 @end
@@ -698,6 +505,20 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
+@implementation AWSSESDeleteConfigurationSetTrackingOptionsRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetName" : @"ConfigurationSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESDeleteConfigurationSetTrackingOptionsResponse
+
+@end
+
 @implementation AWSSESDeleteCustomVerificationEmailTemplateRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
@@ -708,54 +529,79 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESDeleteCustomVerificationEmailTemplateResponse
-
-@end
-
-@implementation AWSSESDeleteDedicatedIpPoolRequest
+@implementation AWSSESDeleteIdentityPolicyRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"poolName" : @"PoolName",
-             };
-}
-
-@end
-
-@implementation AWSSESDeleteDedicatedIpPoolResponse
-
-@end
-
-@implementation AWSSESDeleteEmailIdentityPolicyRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailIdentity" : @"EmailIdentity",
+             @"identity" : @"Identity",
              @"policyName" : @"PolicyName",
              };
 }
 
 @end
 
-@implementation AWSSESDeleteEmailIdentityPolicyResponse
+@implementation AWSSESDeleteIdentityPolicyResponse
 
 @end
 
-@implementation AWSSESDeleteEmailIdentityRequest
+@implementation AWSSESDeleteIdentityRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"emailIdentity" : @"EmailIdentity",
+             @"identity" : @"Identity",
              };
 }
 
 @end
 
-@implementation AWSSESDeleteEmailIdentityResponse
+@implementation AWSSESDeleteIdentityResponse
 
 @end
 
-@implementation AWSSESDeleteEmailTemplateRequest
+@implementation AWSSESDeleteReceiptFilterRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"filterName" : @"FilterName",
+             };
+}
+
+@end
+
+@implementation AWSSESDeleteReceiptFilterResponse
+
+@end
+
+@implementation AWSSESDeleteReceiptRuleRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"ruleName" : @"RuleName",
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESDeleteReceiptRuleResponse
+
+@end
+
+@implementation AWSSESDeleteReceiptRuleSetRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESDeleteReceiptRuleSetResponse
+
+@end
+
+@implementation AWSSESDeleteTemplateRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -765,11 +611,11 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESDeleteEmailTemplateResponse
+@implementation AWSSESDeleteTemplateResponse
 
 @end
 
-@implementation AWSSESDeleteSuppressedDestinationRequest
+@implementation AWSSESDeleteVerifiedEmailAddressRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -779,82 +625,155 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESDeleteSuppressedDestinationResponse
-
-@end
-
-@implementation AWSSESDeliverabilityTestReport
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"createDate" : @"CreateDate",
-             @"deliverabilityTestStatus" : @"DeliverabilityTestStatus",
-             @"fromEmailAddress" : @"FromEmailAddress",
-             @"reportId" : @"ReportId",
-             @"reportName" : @"ReportName",
-             @"subject" : @"Subject",
-             };
-}
-
-+ (NSValueTransformer *)createDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)deliverabilityTestStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"IN_PROGRESS"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityTestStatusInProgress);
-        }
-        if ([value caseInsensitiveCompare:@"COMPLETED"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityTestStatusCompleted);
-        }
-        return @(AWSSESDeliverabilityTestStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDeliverabilityTestStatusInProgress:
-                return @"IN_PROGRESS";
-            case AWSSESDeliverabilityTestStatusCompleted:
-                return @"COMPLETED";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
 @implementation AWSSESDeliveryOptions
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"sendingPoolName" : @"SendingPoolName",
              @"tlsPolicy" : @"TlsPolicy",
              };
 }
 
 + (NSValueTransformer *)tlsPolicyJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"REQUIRE"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"Require"] == NSOrderedSame) {
             return @(AWSSESTlsPolicyRequire);
         }
-        if ([value caseInsensitiveCompare:@"OPTIONAL"] == NSOrderedSame) {
+        if ([value caseInsensitiveCompare:@"Optional"] == NSOrderedSame) {
             return @(AWSSESTlsPolicyOptional);
         }
         return @(AWSSESTlsPolicyUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
             case AWSSESTlsPolicyRequire:
-                return @"REQUIRE";
+                return @"Require";
             case AWSSESTlsPolicyOptional:
-                return @"OPTIONAL";
+                return @"Optional";
             default:
                 return nil;
         }
     }];
+}
+
+@end
+
+@implementation AWSSESDescribeActiveReceiptRuleSetRequest
+
+@end
+
+@implementation AWSSESDescribeActiveReceiptRuleSetResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"metadata" : @"Metadata",
+             @"rules" : @"Rules",
+             };
+}
+
++ (NSValueTransformer *)metadataJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptRuleSetMetadata class]];
+}
+
++ (NSValueTransformer *)rulesJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESReceiptRule class]];
+}
+
+@end
+
+@implementation AWSSESDescribeConfigurationSetRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetAttributeNames" : @"ConfigurationSetAttributeNames",
+             @"configurationSetName" : @"ConfigurationSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESDescribeConfigurationSetResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSet" : @"ConfigurationSet",
+             @"deliveryOptions" : @"DeliveryOptions",
+             @"eventDestinations" : @"EventDestinations",
+             @"reputationOptions" : @"ReputationOptions",
+             @"trackingOptions" : @"TrackingOptions",
+             };
+}
+
++ (NSValueTransformer *)configurationSetJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESConfigurationSet class]];
+}
+
++ (NSValueTransformer *)deliveryOptionsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDeliveryOptions class]];
+}
+
++ (NSValueTransformer *)eventDestinationsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESEventDestination class]];
+}
+
++ (NSValueTransformer *)reputationOptionsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReputationOptions class]];
+}
+
++ (NSValueTransformer *)trackingOptionsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTrackingOptions class]];
+}
+
+@end
+
+@implementation AWSSESDescribeReceiptRuleRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"ruleName" : @"RuleName",
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESDescribeReceiptRuleResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"rule" : @"Rule",
+             };
+}
+
++ (NSValueTransformer *)ruleJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptRule class]];
+}
+
+@end
+
+@implementation AWSSESDescribeReceiptRuleSetRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESDescribeReceiptRuleSetResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"metadata" : @"Metadata",
+             @"rules" : @"Rules",
+             };
+}
+
++ (NSValueTransformer *)metadataJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptRuleSetMetadata class]];
+}
+
++ (NSValueTransformer *)rulesJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESReceiptRule class]];
 }
 
 @end
@@ -871,219 +790,6 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESDkimAttributes
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"signingAttributesOrigin" : @"SigningAttributesOrigin",
-             @"signingEnabled" : @"SigningEnabled",
-             @"status" : @"Status",
-             @"tokens" : @"Tokens",
-             };
-}
-
-+ (NSValueTransformer *)signingAttributesOriginJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"AWS_SES"] == NSOrderedSame) {
-            return @(AWSSESDkimSigningAttributesOriginAwsSes);
-        }
-        if ([value caseInsensitiveCompare:@"EXTERNAL"] == NSOrderedSame) {
-            return @(AWSSESDkimSigningAttributesOriginExternal);
-        }
-        return @(AWSSESDkimSigningAttributesOriginUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDkimSigningAttributesOriginAwsSes:
-                return @"AWS_SES";
-            case AWSSESDkimSigningAttributesOriginExternal:
-                return @"EXTERNAL";
-            default:
-                return nil;
-        }
-    }];
-}
-
-+ (NSValueTransformer *)statusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"PENDING"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusPending);
-        }
-        if ([value caseInsensitiveCompare:@"SUCCESS"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusSuccess);
-        }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusFailed);
-        }
-        if ([value caseInsensitiveCompare:@"TEMPORARY_FAILURE"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusTemporaryFailure);
-        }
-        if ([value caseInsensitiveCompare:@"NOT_STARTED"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusNotStarted);
-        }
-        return @(AWSSESDkimStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDkimStatusPending:
-                return @"PENDING";
-            case AWSSESDkimStatusSuccess:
-                return @"SUCCESS";
-            case AWSSESDkimStatusFailed:
-                return @"FAILED";
-            case AWSSESDkimStatusTemporaryFailure:
-                return @"TEMPORARY_FAILURE";
-            case AWSSESDkimStatusNotStarted:
-                return @"NOT_STARTED";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESDkimSigningAttributes
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"domainSigningPrivateKey" : @"DomainSigningPrivateKey",
-             @"domainSigningSelector" : @"DomainSigningSelector",
-             };
-}
-
-@end
-
-@implementation AWSSESDomainDeliverabilityCampaign
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"campaignId" : @"CampaignId",
-             @"deleteRate" : @"DeleteRate",
-             @"esps" : @"Esps",
-             @"firstSeenDateTime" : @"FirstSeenDateTime",
-             @"fromAddress" : @"FromAddress",
-             @"imageUrl" : @"ImageUrl",
-             @"inboxCount" : @"InboxCount",
-             @"lastSeenDateTime" : @"LastSeenDateTime",
-             @"projectedVolume" : @"ProjectedVolume",
-             @"readDeleteRate" : @"ReadDeleteRate",
-             @"readRate" : @"ReadRate",
-             @"sendingIps" : @"SendingIps",
-             @"spamCount" : @"SpamCount",
-             @"subject" : @"Subject",
-             };
-}
-
-+ (NSValueTransformer *)firstSeenDateTimeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)lastSeenDateTimeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-@end
-
-@implementation AWSSESDomainDeliverabilityTrackingOption
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"domain" : @"Domain",
-             @"inboxPlacementTrackingOption" : @"InboxPlacementTrackingOption",
-             @"subscriptionStartDate" : @"SubscriptionStartDate",
-             };
-}
-
-+ (NSValueTransformer *)inboxPlacementTrackingOptionJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESInboxPlacementTrackingOption class]];
-}
-
-+ (NSValueTransformer *)subscriptionStartDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-@end
-
-@implementation AWSSESDomainIspPlacement
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"inboxPercentage" : @"InboxPercentage",
-             @"inboxRawCount" : @"InboxRawCount",
-             @"ispName" : @"IspName",
-             @"spamPercentage" : @"SpamPercentage",
-             @"spamRawCount" : @"SpamRawCount",
-             };
-}
-
-@end
-
-@implementation AWSSESEmailContent
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"raw" : @"Raw",
-             @"simple" : @"Simple",
-             @"template" : @"Template",
-             };
-}
-
-+ (NSValueTransformer *)rawJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESRawMessage class]];
-}
-
-+ (NSValueTransformer *)simpleJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESMessage class]];
-}
-
-+ (NSValueTransformer *)templateJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTemplate class]];
-}
-
-@end
-
-@implementation AWSSESEmailTemplateContent
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"html" : @"Html",
-             @"subject" : @"Subject",
-             @"text" : @"Text",
-             };
-}
-
-@end
-
-@implementation AWSSESEmailTemplateMetadata
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"createdTimestamp" : @"CreatedTimestamp",
-             @"templateName" : @"TemplateName",
-             };
-}
-
-+ (NSValueTransformer *)createdTimestampJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-@end
-
 @implementation AWSSESEventDestination
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
@@ -1093,8 +799,7 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
              @"kinesisFirehoseDestination" : @"KinesisFirehoseDestination",
              @"matchingEventTypes" : @"MatchingEventTypes",
              @"name" : @"Name",
-             @"pinpointDestination" : @"PinpointDestination",
-             @"snsDestination" : @"SnsDestination",
+             @"SNSDestination" : @"SNSDestination",
              };
 }
 
@@ -1106,188 +811,29 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
     return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESKinesisFirehoseDestination class]];
 }
 
-+ (NSValueTransformer *)pinpointDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESPinpointDestination class]];
-}
-
-+ (NSValueTransformer *)snsDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSnsDestination class]];
++ (NSValueTransformer *)SNSDestinationJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSNSDestination class]];
 }
 
 @end
 
-@implementation AWSSESEventDestinationDefinition
+@implementation AWSSESExtensionField
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"cloudWatchDestination" : @"CloudWatchDestination",
+             @"name" : @"Name",
+             @"value" : @"Value",
+             };
+}
+
+@end
+
+@implementation AWSSESGetAccountSendingEnabledResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
              @"enabled" : @"Enabled",
-             @"kinesisFirehoseDestination" : @"KinesisFirehoseDestination",
-             @"matchingEventTypes" : @"MatchingEventTypes",
-             @"pinpointDestination" : @"PinpointDestination",
-             @"snsDestination" : @"SnsDestination",
              };
-}
-
-+ (NSValueTransformer *)cloudWatchDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESCloudWatchDestination class]];
-}
-
-+ (NSValueTransformer *)kinesisFirehoseDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESKinesisFirehoseDestination class]];
-}
-
-+ (NSValueTransformer *)pinpointDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESPinpointDestination class]];
-}
-
-+ (NSValueTransformer *)snsDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSnsDestination class]];
-}
-
-@end
-
-@implementation AWSSESFailureInfo
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"errorMessage" : @"ErrorMessage",
-             @"failedRecordsS3Url" : @"FailedRecordsS3Url",
-             };
-}
-
-@end
-
-@implementation AWSSESGetAccountRequest
-
-@end
-
-@implementation AWSSESGetAccountResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dedicatedIpAutoWarmupEnabled" : @"DedicatedIpAutoWarmupEnabled",
-             @"details" : @"Details",
-             @"enforcementStatus" : @"EnforcementStatus",
-             @"productionAccessEnabled" : @"ProductionAccessEnabled",
-             @"sendQuota" : @"SendQuota",
-             @"sendingEnabled" : @"SendingEnabled",
-             @"suppressionAttributes" : @"SuppressionAttributes",
-             };
-}
-
-+ (NSValueTransformer *)detailsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESAccountDetails class]];
-}
-
-+ (NSValueTransformer *)sendQuotaJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSendQuota class]];
-}
-
-+ (NSValueTransformer *)suppressionAttributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSuppressionAttributes class]];
-}
-
-@end
-
-@implementation AWSSESGetBlacklistReportsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"blacklistItemNames" : @"BlacklistItemNames",
-             };
-}
-
-@end
-
-@implementation AWSSESGetBlacklistReportsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"blacklistReport" : @"BlacklistReport",
-             };
-}
-
-+ (NSValueTransformer *)blacklistReportJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(id JSONDictionary) {
-        return [AWSModelUtility mapMTLDictionaryFromJSONArrayDictionary:JSONDictionary arrayElementType:@"structure" withModelClass:[AWSSESBlacklistEntry class]];
-    } reverseBlock:^id(id mapMTLDictionary) {
-        return [AWSModelUtility JSONArrayDictionaryFromMapMTLDictionary:mapMTLDictionary arrayElementType:@"structure"];
-    }];
-}
-
-@end
-
-@implementation AWSSESGetConfigurationSetEventDestinationsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             };
-}
-
-@end
-
-@implementation AWSSESGetConfigurationSetEventDestinationsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"eventDestinations" : @"EventDestinations",
-             };
-}
-
-+ (NSValueTransformer *)eventDestinationsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESEventDestination class]];
-}
-
-@end
-
-@implementation AWSSESGetConfigurationSetRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             };
-}
-
-@end
-
-@implementation AWSSESGetConfigurationSetResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"deliveryOptions" : @"DeliveryOptions",
-             @"reputationOptions" : @"ReputationOptions",
-             @"sendingOptions" : @"SendingOptions",
-             @"suppressionOptions" : @"SuppressionOptions",
-             @"tags" : @"Tags",
-             @"trackingOptions" : @"TrackingOptions",
-             };
-}
-
-+ (NSValueTransformer *)deliveryOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDeliveryOptions class]];
-}
-
-+ (NSValueTransformer *)reputationOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReputationOptions class]];
-}
-
-+ (NSValueTransformer *)sendingOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSendingOptions class]];
-}
-
-+ (NSValueTransformer *)suppressionOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSuppressionOptions class]];
-}
-
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
-}
-
-+ (NSValueTransformer *)trackingOptionsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTrackingOptions class]];
 }
 
 @end
@@ -1317,313 +863,166 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESGetDedicatedIpRequest
+@implementation AWSSESGetIdentityDkimAttributesRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"ip" : @"Ip",
+             @"identities" : @"Identities",
              };
 }
 
 @end
 
-@implementation AWSSESGetDedicatedIpResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dedicatedIp" : @"DedicatedIp",
-             };
-}
-
-+ (NSValueTransformer *)dedicatedIpJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDedicatedIp class]];
-}
-
-@end
-
-@implementation AWSSESGetDedicatedIpsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
-             @"poolName" : @"PoolName",
-             };
-}
-
-@end
-
-@implementation AWSSESGetDedicatedIpsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dedicatedIps" : @"DedicatedIps",
-             @"nextToken" : @"NextToken",
-             };
-}
-
-+ (NSValueTransformer *)dedicatedIpsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDedicatedIp class]];
-}
-
-@end
-
-@implementation AWSSESGetDeliverabilityDashboardOptionsRequest
-
-@end
-
-@implementation AWSSESGetDeliverabilityDashboardOptionsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"accountStatus" : @"AccountStatus",
-             @"activeSubscribedDomains" : @"ActiveSubscribedDomains",
-             @"dashboardEnabled" : @"DashboardEnabled",
-             @"pendingExpirationSubscribedDomains" : @"PendingExpirationSubscribedDomains",
-             @"subscriptionExpiryDate" : @"SubscriptionExpiryDate",
-             };
-}
-
-+ (NSValueTransformer *)accountStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"ACTIVE"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityDashboardAccountStatusActive);
-        }
-        if ([value caseInsensitiveCompare:@"PENDING_EXPIRATION"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityDashboardAccountStatusPendingExpiration);
-        }
-        if ([value caseInsensitiveCompare:@"DISABLED"] == NSOrderedSame) {
-            return @(AWSSESDeliverabilityDashboardAccountStatusDisabled);
-        }
-        return @(AWSSESDeliverabilityDashboardAccountStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDeliverabilityDashboardAccountStatusActive:
-                return @"ACTIVE";
-            case AWSSESDeliverabilityDashboardAccountStatusPendingExpiration:
-                return @"PENDING_EXPIRATION";
-            case AWSSESDeliverabilityDashboardAccountStatusDisabled:
-                return @"DISABLED";
-            default:
-                return nil;
-        }
-    }];
-}
-
-+ (NSValueTransformer *)activeSubscribedDomainsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDomainDeliverabilityTrackingOption class]];
-}
-
-+ (NSValueTransformer *)pendingExpirationSubscribedDomainsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDomainDeliverabilityTrackingOption class]];
-}
-
-+ (NSValueTransformer *)subscriptionExpiryDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-@end
-
-@implementation AWSSESGetDeliverabilityTestReportRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"reportId" : @"ReportId",
-             };
-}
-
-@end
-
-@implementation AWSSESGetDeliverabilityTestReportResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"deliverabilityTestReport" : @"DeliverabilityTestReport",
-             @"ispPlacements" : @"IspPlacements",
-             @"message" : @"Message",
-             @"overallPlacement" : @"OverallPlacement",
-             @"tags" : @"Tags",
-             };
-}
-
-+ (NSValueTransformer *)deliverabilityTestReportJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDeliverabilityTestReport class]];
-}
-
-+ (NSValueTransformer *)ispPlacementsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESIspPlacement class]];
-}
-
-+ (NSValueTransformer *)overallPlacementJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESPlacementStatistics class]];
-}
-
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
-}
-
-@end
-
-@implementation AWSSESGetDomainDeliverabilityCampaignRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"campaignId" : @"CampaignId",
-             };
-}
-
-@end
-
-@implementation AWSSESGetDomainDeliverabilityCampaignResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"domainDeliverabilityCampaign" : @"DomainDeliverabilityCampaign",
-             };
-}
-
-+ (NSValueTransformer *)domainDeliverabilityCampaignJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDomainDeliverabilityCampaign class]];
-}
-
-@end
-
-@implementation AWSSESGetDomainStatisticsReportRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"domain" : @"Domain",
-             @"endDate" : @"EndDate",
-             @"startDate" : @"StartDate",
-             };
-}
-
-+ (NSValueTransformer *)endDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)startDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-@end
-
-@implementation AWSSESGetDomainStatisticsReportResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dailyVolumes" : @"DailyVolumes",
-             @"overallVolume" : @"OverallVolume",
-             };
-}
-
-+ (NSValueTransformer *)dailyVolumesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDailyVolume class]];
-}
-
-+ (NSValueTransformer *)overallVolumeJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESOverallVolume class]];
-}
-
-@end
-
-@implementation AWSSESGetEmailIdentityPoliciesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailIdentity" : @"EmailIdentity",
-             };
-}
-
-@end
-
-@implementation AWSSESGetEmailIdentityPoliciesResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"policies" : @"Policies",
-             };
-}
-
-@end
-
-@implementation AWSSESGetEmailIdentityRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailIdentity" : @"EmailIdentity",
-             };
-}
-
-@end
-
-@implementation AWSSESGetEmailIdentityResponse
+@implementation AWSSESGetIdentityDkimAttributesResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"dkimAttributes" : @"DkimAttributes",
-             @"feedbackForwardingStatus" : @"FeedbackForwardingStatus",
-             @"identityType" : @"IdentityType",
-             @"mailFromAttributes" : @"MailFromAttributes",
-             @"policies" : @"Policies",
-             @"tags" : @"Tags",
-             @"verifiedForSendingStatus" : @"VerifiedForSendingStatus",
              };
 }
 
 + (NSValueTransformer *)dkimAttributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDkimAttributes class]];
-}
-
-+ (NSValueTransformer *)identityTypeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"EMAIL_ADDRESS"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeEmailAddress);
-        }
-        if ([value caseInsensitiveCompare:@"DOMAIN"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeDomain);
-        }
-        if ([value caseInsensitiveCompare:@"MANAGED_DOMAIN"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeManagedDomain);
-        }
-        return @(AWSSESIdentityTypeUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESIdentityTypeEmailAddress:
-                return @"EMAIL_ADDRESS";
-            case AWSSESIdentityTypeDomain:
-                return @"DOMAIN";
-            case AWSSESIdentityTypeManagedDomain:
-                return @"MANAGED_DOMAIN";
-            default:
-                return nil;
-        }
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(id JSONDictionary) {
+        return [AWSModelUtility mapMTLDictionaryFromJSONDictionary:JSONDictionary withModelClass:[AWSSESIdentityDkimAttributes class]];
+    } reverseBlock:^id(id mapMTLDictionary) {
+        return [AWSModelUtility JSONDictionaryFromMapMTLDictionary:mapMTLDictionary];
     }];
-}
-
-+ (NSValueTransformer *)mailFromAttributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESMailFromAttributes class]];
-}
-
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
 }
 
 @end
 
-@implementation AWSSESGetEmailTemplateRequest
+@implementation AWSSESGetIdentityMailFromDomainAttributesRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"identities" : @"Identities",
+             };
+}
+
+@end
+
+@implementation AWSSESGetIdentityMailFromDomainAttributesResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"mailFromDomainAttributes" : @"MailFromDomainAttributes",
+             };
+}
+
++ (NSValueTransformer *)mailFromDomainAttributesJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(id JSONDictionary) {
+        return [AWSModelUtility mapMTLDictionaryFromJSONDictionary:JSONDictionary withModelClass:[AWSSESIdentityMailFromDomainAttributes class]];
+    } reverseBlock:^id(id mapMTLDictionary) {
+        return [AWSModelUtility JSONDictionaryFromMapMTLDictionary:mapMTLDictionary];
+    }];
+}
+
+@end
+
+@implementation AWSSESGetIdentityNotificationAttributesRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"identities" : @"Identities",
+             };
+}
+
+@end
+
+@implementation AWSSESGetIdentityNotificationAttributesResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"notificationAttributes" : @"NotificationAttributes",
+             };
+}
+
++ (NSValueTransformer *)notificationAttributesJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(id JSONDictionary) {
+        return [AWSModelUtility mapMTLDictionaryFromJSONDictionary:JSONDictionary withModelClass:[AWSSESIdentityNotificationAttributes class]];
+    } reverseBlock:^id(id mapMTLDictionary) {
+        return [AWSModelUtility JSONDictionaryFromMapMTLDictionary:mapMTLDictionary];
+    }];
+}
+
+@end
+
+@implementation AWSSESGetIdentityPoliciesRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"identity" : @"Identity",
+             @"policyNames" : @"PolicyNames",
+             };
+}
+
+@end
+
+@implementation AWSSESGetIdentityPoliciesResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"policies" : @"Policies",
+             };
+}
+
+@end
+
+@implementation AWSSESGetIdentityVerificationAttributesRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"identities" : @"Identities",
+             };
+}
+
+@end
+
+@implementation AWSSESGetIdentityVerificationAttributesResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"verificationAttributes" : @"VerificationAttributes",
+             };
+}
+
++ (NSValueTransformer *)verificationAttributesJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(id JSONDictionary) {
+        return [AWSModelUtility mapMTLDictionaryFromJSONDictionary:JSONDictionary withModelClass:[AWSSESIdentityVerificationAttributes class]];
+    } reverseBlock:^id(id mapMTLDictionary) {
+        return [AWSModelUtility JSONDictionaryFromMapMTLDictionary:mapMTLDictionary];
+    }];
+}
+
+@end
+
+@implementation AWSSESGetSendQuotaResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"max24HourSend" : @"Max24HourSend",
+             @"maxSendRate" : @"MaxSendRate",
+             @"sentLast24Hours" : @"SentLast24Hours",
+             };
+}
+
+@end
+
+@implementation AWSSESGetSendStatisticsResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"sendDataPoints" : @"SendDataPoints",
+             };
+}
+
++ (NSValueTransformer *)sendDataPointsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESSendDataPoint class]];
+}
+
+@end
+
+@implementation AWSSESGetTemplateRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -1633,100 +1032,60 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESGetEmailTemplateResponse
+@implementation AWSSESGetTemplateResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"templateContent" : @"TemplateContent",
-             @"templateName" : @"TemplateName",
+             @"template" : @"Template",
              };
 }
 
-+ (NSValueTransformer *)templateContentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEmailTemplateContent class]];
++ (NSValueTransformer *)templateJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTemplate class]];
 }
 
 @end
 
-@implementation AWSSESGetImportJobRequest
+@implementation AWSSESIdentityDkimAttributes
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"jobId" : @"JobId",
+             @"dkimEnabled" : @"DkimEnabled",
+             @"dkimTokens" : @"DkimTokens",
+             @"dkimVerificationStatus" : @"DkimVerificationStatus",
              };
 }
 
-@end
-
-@implementation AWSSESGetImportJobResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"completedTimestamp" : @"CompletedTimestamp",
-             @"createdTimestamp" : @"CreatedTimestamp",
-             @"failedRecordsCount" : @"FailedRecordsCount",
-             @"failureInfo" : @"FailureInfo",
-             @"importDataSource" : @"ImportDataSource",
-             @"importDestination" : @"ImportDestination",
-             @"jobId" : @"JobId",
-             @"jobStatus" : @"JobStatus",
-             @"processedRecordsCount" : @"ProcessedRecordsCount",
-             };
-}
-
-+ (NSValueTransformer *)completedTimestampJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)createdTimestampJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)failureInfoJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESFailureInfo class]];
-}
-
-+ (NSValueTransformer *)importDataSourceJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESImportDataSource class]];
-}
-
-+ (NSValueTransformer *)importDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESImportDestination class]];
-}
-
-+ (NSValueTransformer *)jobStatusJSONTransformer {
++ (NSValueTransformer *)dkimVerificationStatusJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"CREATED"] == NSOrderedSame) {
-            return @(AWSSESJobStatusCreated);
+        if ([value caseInsensitiveCompare:@"Pending"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusPending);
         }
-        if ([value caseInsensitiveCompare:@"PROCESSING"] == NSOrderedSame) {
-            return @(AWSSESJobStatusProcessing);
+        if ([value caseInsensitiveCompare:@"Success"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusSuccess);
         }
-        if ([value caseInsensitiveCompare:@"COMPLETED"] == NSOrderedSame) {
-            return @(AWSSESJobStatusCompleted);
+        if ([value caseInsensitiveCompare:@"Failed"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusFailed);
         }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
-            return @(AWSSESJobStatusFailed);
+        if ([value caseInsensitiveCompare:@"TemporaryFailure"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusTemporaryFailure);
         }
-        return @(AWSSESJobStatusUnknown);
+        if ([value caseInsensitiveCompare:@"NotStarted"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusNotStarted);
+        }
+        return @(AWSSESVerificationStatusUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
-            case AWSSESJobStatusCreated:
-                return @"CREATED";
-            case AWSSESJobStatusProcessing:
-                return @"PROCESSING";
-            case AWSSESJobStatusCompleted:
-                return @"COMPLETED";
-            case AWSSESJobStatusFailed:
-                return @"FAILED";
+            case AWSSESVerificationStatusPending:
+                return @"Pending";
+            case AWSSESVerificationStatusSuccess:
+                return @"Success";
+            case AWSSESVerificationStatusFailed:
+                return @"Failed";
+            case AWSSESVerificationStatusTemporaryFailure:
+                return @"TemporaryFailure";
+            case AWSSESVerificationStatusNotStarted:
+                return @"NotStarted";
             default:
                 return nil;
         }
@@ -1735,60 +1094,62 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESGetSuppressedDestinationRequest
+@implementation AWSSESIdentityMailFromDomainAttributes
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"emailAddress" : @"EmailAddress",
+             @"behaviorOnMXFailure" : @"BehaviorOnMXFailure",
+             @"mailFromDomain" : @"MailFromDomain",
+             @"mailFromDomainStatus" : @"MailFromDomainStatus",
              };
 }
 
-@end
-
-@implementation AWSSESGetSuppressedDestinationResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"suppressedDestination" : @"SuppressedDestination",
-             };
-}
-
-+ (NSValueTransformer *)suppressedDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSuppressedDestination class]];
-}
-
-@end
-
-@implementation AWSSESIdentityInfo
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"identityName" : @"IdentityName",
-             @"identityType" : @"IdentityType",
-             @"sendingEnabled" : @"SendingEnabled",
-             };
-}
-
-+ (NSValueTransformer *)identityTypeJSONTransformer {
++ (NSValueTransformer *)behaviorOnMXFailureJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"EMAIL_ADDRESS"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeEmailAddress);
+        if ([value caseInsensitiveCompare:@"UseDefaultValue"] == NSOrderedSame) {
+            return @(AWSSESBehaviorOnMXFailureUseDefaultValue);
         }
-        if ([value caseInsensitiveCompare:@"DOMAIN"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeDomain);
+        if ([value caseInsensitiveCompare:@"RejectMessage"] == NSOrderedSame) {
+            return @(AWSSESBehaviorOnMXFailureRejectMessage);
         }
-        if ([value caseInsensitiveCompare:@"MANAGED_DOMAIN"] == NSOrderedSame) {
-            return @(AWSSESIdentityTypeManagedDomain);
-        }
-        return @(AWSSESIdentityTypeUnknown);
+        return @(AWSSESBehaviorOnMXFailureUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
-            case AWSSESIdentityTypeEmailAddress:
-                return @"EMAIL_ADDRESS";
-            case AWSSESIdentityTypeDomain:
-                return @"DOMAIN";
-            case AWSSESIdentityTypeManagedDomain:
-                return @"MANAGED_DOMAIN";
+            case AWSSESBehaviorOnMXFailureUseDefaultValue:
+                return @"UseDefaultValue";
+            case AWSSESBehaviorOnMXFailureRejectMessage:
+                return @"RejectMessage";
+            default:
+                return nil;
+        }
+    }];
+}
+
++ (NSValueTransformer *)mailFromDomainStatusJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"Pending"] == NSOrderedSame) {
+            return @(AWSSESCustomMailFromStatusPending);
+        }
+        if ([value caseInsensitiveCompare:@"Success"] == NSOrderedSame) {
+            return @(AWSSESCustomMailFromStatusSuccess);
+        }
+        if ([value caseInsensitiveCompare:@"Failed"] == NSOrderedSame) {
+            return @(AWSSESCustomMailFromStatusFailed);
+        }
+        if ([value caseInsensitiveCompare:@"TemporaryFailure"] == NSOrderedSame) {
+            return @(AWSSESCustomMailFromStatusTemporaryFailure);
+        }
+        return @(AWSSESCustomMailFromStatusUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESCustomMailFromStatusPending:
+                return @"Pending";
+            case AWSSESCustomMailFromStatusSuccess:
+                return @"Success";
+            case AWSSESCustomMailFromStatusFailed:
+                return @"Failed";
+            case AWSSESCustomMailFromStatusTemporaryFailure:
+                return @"TemporaryFailure";
             default:
                 return nil;
         }
@@ -1797,130 +1158,65 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESImportDataSource
+@implementation AWSSESIdentityNotificationAttributes
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"dataFormat" : @"DataFormat",
-             @"s3Url" : @"S3Url",
+             @"bounceTopic" : @"BounceTopic",
+             @"complaintTopic" : @"ComplaintTopic",
+             @"deliveryTopic" : @"DeliveryTopic",
+             @"forwardingEnabled" : @"ForwardingEnabled",
+             @"headersInBounceNotificationsEnabled" : @"HeadersInBounceNotificationsEnabled",
+             @"headersInComplaintNotificationsEnabled" : @"HeadersInComplaintNotificationsEnabled",
+             @"headersInDeliveryNotificationsEnabled" : @"HeadersInDeliveryNotificationsEnabled",
              };
 }
 
-+ (NSValueTransformer *)dataFormatJSONTransformer {
+@end
+
+@implementation AWSSESIdentityVerificationAttributes
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"verificationStatus" : @"VerificationStatus",
+             @"verificationToken" : @"VerificationToken",
+             };
+}
+
++ (NSValueTransformer *)verificationStatusJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"CSV"] == NSOrderedSame) {
-            return @(AWSSESDataFormatCsv);
+        if ([value caseInsensitiveCompare:@"Pending"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusPending);
         }
-        if ([value caseInsensitiveCompare:@"JSON"] == NSOrderedSame) {
-            return @(AWSSESDataFormatJson);
+        if ([value caseInsensitiveCompare:@"Success"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusSuccess);
         }
-        return @(AWSSESDataFormatUnknown);
+        if ([value caseInsensitiveCompare:@"Failed"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusFailed);
+        }
+        if ([value caseInsensitiveCompare:@"TemporaryFailure"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusTemporaryFailure);
+        }
+        if ([value caseInsensitiveCompare:@"NotStarted"] == NSOrderedSame) {
+            return @(AWSSESVerificationStatusNotStarted);
+        }
+        return @(AWSSESVerificationStatusUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
-            case AWSSESDataFormatCsv:
-                return @"CSV";
-            case AWSSESDataFormatJson:
-                return @"JSON";
+            case AWSSESVerificationStatusPending:
+                return @"Pending";
+            case AWSSESVerificationStatusSuccess:
+                return @"Success";
+            case AWSSESVerificationStatusFailed:
+                return @"Failed";
+            case AWSSESVerificationStatusTemporaryFailure:
+                return @"TemporaryFailure";
+            case AWSSESVerificationStatusNotStarted:
+                return @"NotStarted";
             default:
                 return nil;
         }
     }];
-}
-
-@end
-
-@implementation AWSSESImportDestination
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"suppressionListDestination" : @"SuppressionListDestination",
-             };
-}
-
-+ (NSValueTransformer *)suppressionListDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSuppressionListDestination class]];
-}
-
-@end
-
-@implementation AWSSESImportJobSummary
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"createdTimestamp" : @"CreatedTimestamp",
-             @"importDestination" : @"ImportDestination",
-             @"jobId" : @"JobId",
-             @"jobStatus" : @"JobStatus",
-             };
-}
-
-+ (NSValueTransformer *)createdTimestampJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)importDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESImportDestination class]];
-}
-
-+ (NSValueTransformer *)jobStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"CREATED"] == NSOrderedSame) {
-            return @(AWSSESJobStatusCreated);
-        }
-        if ([value caseInsensitiveCompare:@"PROCESSING"] == NSOrderedSame) {
-            return @(AWSSESJobStatusProcessing);
-        }
-        if ([value caseInsensitiveCompare:@"COMPLETED"] == NSOrderedSame) {
-            return @(AWSSESJobStatusCompleted);
-        }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
-            return @(AWSSESJobStatusFailed);
-        }
-        return @(AWSSESJobStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESJobStatusCreated:
-                return @"CREATED";
-            case AWSSESJobStatusProcessing:
-                return @"PROCESSING";
-            case AWSSESJobStatusCompleted:
-                return @"COMPLETED";
-            case AWSSESJobStatusFailed:
-                return @"FAILED";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESInboxPlacementTrackingOption
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"global" : @"Global",
-             @"trackedIsps" : @"TrackedIsps",
-             };
-}
-
-@end
-
-@implementation AWSSESIspPlacement
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"ispName" : @"IspName",
-             @"placementStatistics" : @"PlacementStatistics",
-             };
-}
-
-+ (NSValueTransformer *)placementStatisticsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESPlacementStatistics class]];
 }
 
 @end
@@ -1929,9 +1225,42 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"deliveryStreamArn" : @"DeliveryStreamArn",
-             @"iamRoleArn" : @"IamRoleArn",
+             @"deliveryStreamARN" : @"DeliveryStreamARN",
+             @"IAMRoleARN" : @"IAMRoleARN",
              };
+}
+
+@end
+
+@implementation AWSSESLambdaAction
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"functionArn" : @"FunctionArn",
+             @"invocationType" : @"InvocationType",
+             @"topicArn" : @"TopicArn",
+             };
+}
+
++ (NSValueTransformer *)invocationTypeJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"Event"] == NSOrderedSame) {
+            return @(AWSSESInvocationTypeEvent);
+        }
+        if ([value caseInsensitiveCompare:@"RequestResponse"] == NSOrderedSame) {
+            return @(AWSSESInvocationTypeRequestResponse);
+        }
+        return @(AWSSESInvocationTypeUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESInvocationTypeEvent:
+                return @"Event";
+            case AWSSESInvocationTypeRequestResponse:
+                return @"RequestResponse";
+            default:
+                return nil;
+        }
+    }];
 }
 
 @end
@@ -1940,8 +1269,8 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
+             @"maxItems" : @"MaxItems",
              @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
              };
 }
 
@@ -1956,14 +1285,18 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
              };
 }
 
++ (NSValueTransformer *)configurationSetsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESConfigurationSet class]];
+}
+
 @end
 
 @implementation AWSSESListCustomVerificationEmailTemplatesRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
+             @"maxResults" : @"MaxResults",
              @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
              };
 }
 
@@ -1979,142 +1312,130 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 }
 
 + (NSValueTransformer *)customVerificationEmailTemplatesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESCustomVerificationEmailTemplateMetadata class]];
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESCustomVerificationEmailTemplate class]];
 }
 
 @end
 
-@implementation AWSSESListDedicatedIpPoolsRequest
+@implementation AWSSESListIdentitiesRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
-             };
-}
-
-@end
-
-@implementation AWSSESListDedicatedIpPoolsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dedicatedIpPools" : @"DedicatedIpPools",
+             @"identityType" : @"IdentityType",
+             @"maxItems" : @"MaxItems",
              @"nextToken" : @"NextToken",
              };
 }
 
-@end
-
-@implementation AWSSESListDeliverabilityTestReportsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
-             };
-}
-
-@end
-
-@implementation AWSSESListDeliverabilityTestReportsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"deliverabilityTestReports" : @"DeliverabilityTestReports",
-             @"nextToken" : @"NextToken",
-             };
-}
-
-+ (NSValueTransformer *)deliverabilityTestReportsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDeliverabilityTestReport class]];
-}
-
-@end
-
-@implementation AWSSESListDomainDeliverabilityCampaignsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"endDate" : @"EndDate",
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
-             @"startDate" : @"StartDate",
-             @"subscribedDomain" : @"SubscribedDomain",
-             };
-}
-
-+ (NSValueTransformer *)endDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)startDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
++ (NSValueTransformer *)identityTypeJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"EmailAddress"] == NSOrderedSame) {
+            return @(AWSSESIdentityTypeEmailAddress);
+        }
+        if ([value caseInsensitiveCompare:@"Domain"] == NSOrderedSame) {
+            return @(AWSSESIdentityTypeDomain);
+        }
+        return @(AWSSESIdentityTypeUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESIdentityTypeEmailAddress:
+                return @"EmailAddress";
+            case AWSSESIdentityTypeDomain:
+                return @"Domain";
+            default:
+                return nil;
+        }
     }];
 }
 
 @end
 
-@implementation AWSSESListDomainDeliverabilityCampaignsResponse
+@implementation AWSSESListIdentitiesResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"domainDeliverabilityCampaigns" : @"DomainDeliverabilityCampaigns",
+             @"identities" : @"Identities",
              @"nextToken" : @"NextToken",
-             };
-}
-
-+ (NSValueTransformer *)domainDeliverabilityCampaignsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDomainDeliverabilityCampaign class]];
-}
-
-@end
-
-@implementation AWSSESListEmailIdentitiesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
              };
 }
 
 @end
 
-@implementation AWSSESListEmailIdentitiesResponse
+@implementation AWSSESListIdentityPoliciesRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"emailIdentities" : @"EmailIdentities",
-             @"nextToken" : @"NextToken",
-             };
-}
-
-+ (NSValueTransformer *)emailIdentitiesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESIdentityInfo class]];
-}
-
-@end
-
-@implementation AWSSESListEmailTemplatesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
+             @"identity" : @"Identity",
              };
 }
 
 @end
 
-@implementation AWSSESListEmailTemplatesResponse
+@implementation AWSSESListIdentityPoliciesResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"policyNames" : @"PolicyNames",
+             };
+}
+
+@end
+
+@implementation AWSSESListReceiptFiltersRequest
+
+@end
+
+@implementation AWSSESListReceiptFiltersResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"filters" : @"Filters",
+             };
+}
+
++ (NSValueTransformer *)filtersJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESReceiptFilter class]];
+}
+
+@end
+
+@implementation AWSSESListReceiptRuleSetsRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"nextToken" : @"NextToken",
+             };
+}
+
+@end
+
+@implementation AWSSESListReceiptRuleSetsResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"nextToken" : @"NextToken",
+             @"ruleSets" : @"RuleSets",
+             };
+}
+
++ (NSValueTransformer *)ruleSetsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESReceiptRuleSetMetadata class]];
+}
+
+@end
+
+@implementation AWSSESListTemplatesRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"maxItems" : @"MaxItems",
+             @"nextToken" : @"NextToken",
+             };
+}
+
+@end
+
+@implementation AWSSESListTemplatesResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -2124,183 +1445,17 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 }
 
 + (NSValueTransformer *)templatesMetadataJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESEmailTemplateMetadata class]];
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTemplateMetadata class]];
 }
 
 @end
 
-@implementation AWSSESListImportJobsRequest
+@implementation AWSSESListVerifiedEmailAddressesResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"importDestinationType" : @"ImportDestinationType",
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
+             @"verifiedEmailAddresses" : @"VerifiedEmailAddresses",
              };
-}
-
-+ (NSValueTransformer *)importDestinationTypeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"SUPPRESSION_LIST"] == NSOrderedSame) {
-            return @(AWSSESImportDestinationTypeSuppressionList);
-        }
-        return @(AWSSESImportDestinationTypeUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESImportDestinationTypeSuppressionList:
-                return @"SUPPRESSION_LIST";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESListImportJobsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"importJobs" : @"ImportJobs",
-             @"nextToken" : @"NextToken",
-             };
-}
-
-+ (NSValueTransformer *)importJobsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESImportJobSummary class]];
-}
-
-@end
-
-@implementation AWSSESListSuppressedDestinationsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"endDate" : @"EndDate",
-             @"nextToken" : @"NextToken",
-             @"pageSize" : @"PageSize",
-             @"reasons" : @"Reasons",
-             @"startDate" : @"StartDate",
-             };
-}
-
-+ (NSValueTransformer *)endDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)startDateJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-@end
-
-@implementation AWSSESListSuppressedDestinationsResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"nextToken" : @"NextToken",
-             @"suppressedDestinationSummaries" : @"SuppressedDestinationSummaries",
-             };
-}
-
-+ (NSValueTransformer *)suppressedDestinationSummariesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESSuppressedDestinationSummary class]];
-}
-
-@end
-
-@implementation AWSSESListTagsForResourceRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"resourceArn" : @"ResourceArn",
-             };
-}
-
-@end
-
-@implementation AWSSESListTagsForResourceResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"tags" : @"Tags",
-             };
-}
-
-+ (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
-}
-
-@end
-
-@implementation AWSSESMailFromAttributes
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"behaviorOnMxFailure" : @"BehaviorOnMxFailure",
-             @"mailFromDomain" : @"MailFromDomain",
-             @"mailFromDomainStatus" : @"MailFromDomainStatus",
-             };
-}
-
-+ (NSValueTransformer *)behaviorOnMxFailureJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"USE_DEFAULT_VALUE"] == NSOrderedSame) {
-            return @(AWSSESBehaviorOnMxFailureUseDefaultValue);
-        }
-        if ([value caseInsensitiveCompare:@"REJECT_MESSAGE"] == NSOrderedSame) {
-            return @(AWSSESBehaviorOnMxFailureRejectMessage);
-        }
-        return @(AWSSESBehaviorOnMxFailureUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESBehaviorOnMxFailureUseDefaultValue:
-                return @"USE_DEFAULT_VALUE";
-            case AWSSESBehaviorOnMxFailureRejectMessage:
-                return @"REJECT_MESSAGE";
-            default:
-                return nil;
-        }
-    }];
-}
-
-+ (NSValueTransformer *)mailFromDomainStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"PENDING"] == NSOrderedSame) {
-            return @(AWSSESMailFromDomainStatusPending);
-        }
-        if ([value caseInsensitiveCompare:@"SUCCESS"] == NSOrderedSame) {
-            return @(AWSSESMailFromDomainStatusSuccess);
-        }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
-            return @(AWSSESMailFromDomainStatusFailed);
-        }
-        if ([value caseInsensitiveCompare:@"TEMPORARY_FAILURE"] == NSOrderedSame) {
-            return @(AWSSESMailFromDomainStatusTemporaryFailure);
-        }
-        return @(AWSSESMailFromDomainStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESMailFromDomainStatusPending:
-                return @"PENDING";
-            case AWSSESMailFromDomainStatusSuccess:
-                return @"SUCCESS";
-            case AWSSESMailFromDomainStatusFailed:
-                return @"FAILED";
-            case AWSSESMailFromDomainStatusTemporaryFailure:
-                return @"TEMPORARY_FAILURE";
-            default:
-                return nil;
-        }
-    }];
 }
 
 @end
@@ -2324,6 +1479,30 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
+@implementation AWSSESMessageDsn
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"arrivalDate" : @"ArrivalDate",
+             @"extensionFields" : @"ExtensionFields",
+             @"reportingMta" : @"ReportingMta",
+             };
+}
+
++ (NSValueTransformer *)arrivalDateJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSString *str) {
+        return [NSDate aws_dateFromString:str];
+    } reverseBlock:^id(NSDate *date) {
+return [date aws_stringValue:AWSDateISO8601DateFormat1];
+    }];
+}
+
++ (NSValueTransformer *)extensionFieldsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESExtensionField class]];
+}
+
+@end
+
 @implementation AWSSESMessageTag
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
@@ -2335,182 +1514,17 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESOverallVolume
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"domainIspPlacements" : @"DomainIspPlacements",
-             @"readRatePercent" : @"ReadRatePercent",
-             @"volumeStatistics" : @"VolumeStatistics",
-             };
-}
-
-+ (NSValueTransformer *)domainIspPlacementsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDomainIspPlacement class]];
-}
-
-+ (NSValueTransformer *)volumeStatisticsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESVolumeStatistics class]];
-}
-
-@end
-
-@implementation AWSSESPinpointDestination
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"applicationArn" : @"ApplicationArn",
-             };
-}
-
-@end
-
-@implementation AWSSESPlacementStatistics
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dkimPercentage" : @"DkimPercentage",
-             @"inboxPercentage" : @"InboxPercentage",
-             @"missingPercentage" : @"MissingPercentage",
-             @"spamPercentage" : @"SpamPercentage",
-             @"spfPercentage" : @"SpfPercentage",
-             };
-}
-
-@end
-
-@implementation AWSSESPutAccountDedicatedIpWarmupAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"autoWarmupEnabled" : @"AutoWarmupEnabled",
-             };
-}
-
-@end
-
-@implementation AWSSESPutAccountDedicatedIpWarmupAttributesResponse
-
-@end
-
-@implementation AWSSESPutAccountDetailsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"additionalContactEmailAddresses" : @"AdditionalContactEmailAddresses",
-             @"contactLanguage" : @"ContactLanguage",
-             @"mailType" : @"MailType",
-             @"productionAccessEnabled" : @"ProductionAccessEnabled",
-             @"useCaseDescription" : @"UseCaseDescription",
-             @"websiteURL" : @"WebsiteURL",
-             };
-}
-
-+ (NSValueTransformer *)contactLanguageJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"EN"] == NSOrderedSame) {
-            return @(AWSSESContactLanguageEn);
-        }
-        if ([value caseInsensitiveCompare:@"JA"] == NSOrderedSame) {
-            return @(AWSSESContactLanguageJa);
-        }
-        return @(AWSSESContactLanguageUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESContactLanguageEn:
-                return @"EN";
-            case AWSSESContactLanguageJa:
-                return @"JA";
-            default:
-                return nil;
-        }
-    }];
-}
-
-+ (NSValueTransformer *)mailTypeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"MARKETING"] == NSOrderedSame) {
-            return @(AWSSESMailTypeMarketing);
-        }
-        if ([value caseInsensitiveCompare:@"TRANSACTIONAL"] == NSOrderedSame) {
-            return @(AWSSESMailTypeTransactional);
-        }
-        return @(AWSSESMailTypeUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESMailTypeMarketing:
-                return @"MARKETING";
-            case AWSSESMailTypeTransactional:
-                return @"TRANSACTIONAL";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESPutAccountDetailsResponse
-
-@end
-
-@implementation AWSSESPutAccountSendingAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"sendingEnabled" : @"SendingEnabled",
-             };
-}
-
-@end
-
-@implementation AWSSESPutAccountSendingAttributesResponse
-
-@end
-
-@implementation AWSSESPutAccountSuppressionAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"suppressedReasons" : @"SuppressedReasons",
-             };
-}
-
-@end
-
-@implementation AWSSESPutAccountSuppressionAttributesResponse
-
-@end
-
 @implementation AWSSESPutConfigurationSetDeliveryOptionsRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"configurationSetName" : @"ConfigurationSetName",
-             @"sendingPoolName" : @"SendingPoolName",
-             @"tlsPolicy" : @"TlsPolicy",
+             @"deliveryOptions" : @"DeliveryOptions",
              };
 }
 
-+ (NSValueTransformer *)tlsPolicyJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"REQUIRE"] == NSOrderedSame) {
-            return @(AWSSESTlsPolicyRequire);
-        }
-        if ([value caseInsensitiveCompare:@"OPTIONAL"] == NSOrderedSame) {
-            return @(AWSSESTlsPolicyOptional);
-        }
-        return @(AWSSESTlsPolicyUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESTlsPolicyRequire:
-                return @"REQUIRE";
-            case AWSSESTlsPolicyOptional:
-                return @"OPTIONAL";
-            default:
-                return nil;
-        }
-    }];
++ (NSValueTransformer *)deliveryOptionsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDeliveryOptions class]];
 }
 
 @end
@@ -2519,299 +1533,19 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESPutConfigurationSetReputationOptionsRequest
+@implementation AWSSESPutIdentityPolicyRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"reputationMetricsEnabled" : @"ReputationMetricsEnabled",
+             @"identity" : @"Identity",
+             @"policy" : @"Policy",
+             @"policyName" : @"PolicyName",
              };
 }
 
 @end
 
-@implementation AWSSESPutConfigurationSetReputationOptionsResponse
-
-@end
-
-@implementation AWSSESPutConfigurationSetSendingOptionsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"sendingEnabled" : @"SendingEnabled",
-             };
-}
-
-@end
-
-@implementation AWSSESPutConfigurationSetSendingOptionsResponse
-
-@end
-
-@implementation AWSSESPutConfigurationSetSuppressionOptionsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"suppressedReasons" : @"SuppressedReasons",
-             };
-}
-
-@end
-
-@implementation AWSSESPutConfigurationSetSuppressionOptionsResponse
-
-@end
-
-@implementation AWSSESPutConfigurationSetTrackingOptionsRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"customRedirectDomain" : @"CustomRedirectDomain",
-             };
-}
-
-@end
-
-@implementation AWSSESPutConfigurationSetTrackingOptionsResponse
-
-@end
-
-@implementation AWSSESPutDedicatedIpInPoolRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"destinationPoolName" : @"DestinationPoolName",
-             @"ip" : @"Ip",
-             };
-}
-
-@end
-
-@implementation AWSSESPutDedicatedIpInPoolResponse
-
-@end
-
-@implementation AWSSESPutDedicatedIpWarmupAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"ip" : @"Ip",
-             @"warmupPercentage" : @"WarmupPercentage",
-             };
-}
-
-@end
-
-@implementation AWSSESPutDedicatedIpWarmupAttributesResponse
-
-@end
-
-@implementation AWSSESPutDeliverabilityDashboardOptionRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dashboardEnabled" : @"DashboardEnabled",
-             @"subscribedDomains" : @"SubscribedDomains",
-             };
-}
-
-+ (NSValueTransformer *)subscribedDomainsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESDomainDeliverabilityTrackingOption class]];
-}
-
-@end
-
-@implementation AWSSESPutDeliverabilityDashboardOptionResponse
-
-@end
-
-@implementation AWSSESPutEmailIdentityDkimAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailIdentity" : @"EmailIdentity",
-             @"signingEnabled" : @"SigningEnabled",
-             };
-}
-
-@end
-
-@implementation AWSSESPutEmailIdentityDkimAttributesResponse
-
-@end
-
-@implementation AWSSESPutEmailIdentityDkimSigningAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailIdentity" : @"EmailIdentity",
-             @"signingAttributes" : @"SigningAttributes",
-             @"signingAttributesOrigin" : @"SigningAttributesOrigin",
-             };
-}
-
-+ (NSValueTransformer *)signingAttributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDkimSigningAttributes class]];
-}
-
-+ (NSValueTransformer *)signingAttributesOriginJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"AWS_SES"] == NSOrderedSame) {
-            return @(AWSSESDkimSigningAttributesOriginAwsSes);
-        }
-        if ([value caseInsensitiveCompare:@"EXTERNAL"] == NSOrderedSame) {
-            return @(AWSSESDkimSigningAttributesOriginExternal);
-        }
-        return @(AWSSESDkimSigningAttributesOriginUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDkimSigningAttributesOriginAwsSes:
-                return @"AWS_SES";
-            case AWSSESDkimSigningAttributesOriginExternal:
-                return @"EXTERNAL";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESPutEmailIdentityDkimSigningAttributesResponse
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"dkimStatus" : @"DkimStatus",
-             @"dkimTokens" : @"DkimTokens",
-             };
-}
-
-+ (NSValueTransformer *)dkimStatusJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"PENDING"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusPending);
-        }
-        if ([value caseInsensitiveCompare:@"SUCCESS"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusSuccess);
-        }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusFailed);
-        }
-        if ([value caseInsensitiveCompare:@"TEMPORARY_FAILURE"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusTemporaryFailure);
-        }
-        if ([value caseInsensitiveCompare:@"NOT_STARTED"] == NSOrderedSame) {
-            return @(AWSSESDkimStatusNotStarted);
-        }
-        return @(AWSSESDkimStatusUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESDkimStatusPending:
-                return @"PENDING";
-            case AWSSESDkimStatusSuccess:
-                return @"SUCCESS";
-            case AWSSESDkimStatusFailed:
-                return @"FAILED";
-            case AWSSESDkimStatusTemporaryFailure:
-                return @"TEMPORARY_FAILURE";
-            case AWSSESDkimStatusNotStarted:
-                return @"NOT_STARTED";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESPutEmailIdentityFeedbackAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailForwardingEnabled" : @"EmailForwardingEnabled",
-             @"emailIdentity" : @"EmailIdentity",
-             };
-}
-
-@end
-
-@implementation AWSSESPutEmailIdentityFeedbackAttributesResponse
-
-@end
-
-@implementation AWSSESPutEmailIdentityMailFromAttributesRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"behaviorOnMxFailure" : @"BehaviorOnMxFailure",
-             @"emailIdentity" : @"EmailIdentity",
-             @"mailFromDomain" : @"MailFromDomain",
-             };
-}
-
-+ (NSValueTransformer *)behaviorOnMxFailureJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"USE_DEFAULT_VALUE"] == NSOrderedSame) {
-            return @(AWSSESBehaviorOnMxFailureUseDefaultValue);
-        }
-        if ([value caseInsensitiveCompare:@"REJECT_MESSAGE"] == NSOrderedSame) {
-            return @(AWSSESBehaviorOnMxFailureRejectMessage);
-        }
-        return @(AWSSESBehaviorOnMxFailureUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESBehaviorOnMxFailureUseDefaultValue:
-                return @"USE_DEFAULT_VALUE";
-            case AWSSESBehaviorOnMxFailureRejectMessage:
-                return @"REJECT_MESSAGE";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESPutEmailIdentityMailFromAttributesResponse
-
-@end
-
-@implementation AWSSESPutSuppressedDestinationRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"emailAddress" : @"EmailAddress",
-             @"reason" : @"Reason",
-             };
-}
-
-+ (NSValueTransformer *)reasonJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"BOUNCE"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListReasonBounce);
-        }
-        if ([value caseInsensitiveCompare:@"COMPLAINT"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListReasonComplaint);
-        }
-        return @(AWSSESSuppressionListReasonUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESSuppressionListReasonBounce:
-                return @"BOUNCE";
-            case AWSSESSuppressionListReasonComplaint:
-                return @"COMPLAINT";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESPutSuppressedDestinationResponse
+@implementation AWSSESPutIdentityPolicyResponse
 
 @end
 
@@ -2825,27 +1559,232 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESReplacementEmailContent
+@implementation AWSSESReceiptAction
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"replacementTemplate" : @"ReplacementTemplate",
+             @"addHeaderAction" : @"AddHeaderAction",
+             @"bounceAction" : @"BounceAction",
+             @"lambdaAction" : @"LambdaAction",
+             @"s3Action" : @"S3Action",
+             @"SNSAction" : @"SNSAction",
+             @"stopAction" : @"StopAction",
+             @"workmailAction" : @"WorkmailAction",
              };
 }
 
-+ (NSValueTransformer *)replacementTemplateJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReplacementTemplate class]];
++ (NSValueTransformer *)addHeaderActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESAddHeaderAction class]];
+}
+
++ (NSValueTransformer *)bounceActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESBounceAction class]];
+}
+
++ (NSValueTransformer *)lambdaActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESLambdaAction class]];
+}
+
++ (NSValueTransformer *)s3ActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESS3Action class]];
+}
+
++ (NSValueTransformer *)SNSActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSNSAction class]];
+}
+
++ (NSValueTransformer *)stopActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESStopAction class]];
+}
+
++ (NSValueTransformer *)workmailActionJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESWorkmailAction class]];
 }
 
 @end
 
-@implementation AWSSESReplacementTemplate
+@implementation AWSSESReceiptFilter
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"replacementTemplateData" : @"ReplacementTemplateData",
+             @"ipFilter" : @"IpFilter",
+             @"name" : @"Name",
              };
 }
+
++ (NSValueTransformer *)ipFilterJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptIpFilter class]];
+}
+
+@end
+
+@implementation AWSSESReceiptIpFilter
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"cidr" : @"Cidr",
+             @"policy" : @"Policy",
+             };
+}
+
++ (NSValueTransformer *)policyJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"Block"] == NSOrderedSame) {
+            return @(AWSSESReceiptFilterPolicyBlock);
+        }
+        if ([value caseInsensitiveCompare:@"Allow"] == NSOrderedSame) {
+            return @(AWSSESReceiptFilterPolicyAllow);
+        }
+        return @(AWSSESReceiptFilterPolicyUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESReceiptFilterPolicyBlock:
+                return @"Block";
+            case AWSSESReceiptFilterPolicyAllow:
+                return @"Allow";
+            default:
+                return nil;
+        }
+    }];
+}
+
+@end
+
+@implementation AWSSESReceiptRule
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"actions" : @"Actions",
+             @"enabled" : @"Enabled",
+             @"name" : @"Name",
+             @"recipients" : @"Recipients",
+             @"scanEnabled" : @"ScanEnabled",
+             @"tlsPolicy" : @"TlsPolicy",
+             };
+}
+
++ (NSValueTransformer *)actionsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESReceiptAction class]];
+}
+
++ (NSValueTransformer *)tlsPolicyJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"Require"] == NSOrderedSame) {
+            return @(AWSSESTlsPolicyRequire);
+        }
+        if ([value caseInsensitiveCompare:@"Optional"] == NSOrderedSame) {
+            return @(AWSSESTlsPolicyOptional);
+        }
+        return @(AWSSESTlsPolicyUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESTlsPolicyRequire:
+                return @"Require";
+            case AWSSESTlsPolicyOptional:
+                return @"Optional";
+            default:
+                return nil;
+        }
+    }];
+}
+
+@end
+
+@implementation AWSSESReceiptRuleSetMetadata
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"createdTimestamp" : @"CreatedTimestamp",
+             @"name" : @"Name",
+             };
+}
+
++ (NSValueTransformer *)createdTimestampJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSString *str) {
+        return [NSDate aws_dateFromString:str];
+    } reverseBlock:^id(NSDate *date) {
+return [date aws_stringValue:AWSDateISO8601DateFormat1];
+    }];
+}
+
+@end
+
+@implementation AWSSESRecipientDsnFields
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"action" : @"Action",
+             @"diagnosticCode" : @"DiagnosticCode",
+             @"extensionFields" : @"ExtensionFields",
+             @"finalRecipient" : @"FinalRecipient",
+             @"lastAttemptDate" : @"LastAttemptDate",
+             @"remoteMta" : @"RemoteMta",
+             @"status" : @"Status",
+             };
+}
+
++ (NSValueTransformer *)actionJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"failed"] == NSOrderedSame) {
+            return @(AWSSESDsnActionFailed);
+        }
+        if ([value caseInsensitiveCompare:@"delayed"] == NSOrderedSame) {
+            return @(AWSSESDsnActionDelayed);
+        }
+        if ([value caseInsensitiveCompare:@"delivered"] == NSOrderedSame) {
+            return @(AWSSESDsnActionDelivered);
+        }
+        if ([value caseInsensitiveCompare:@"relayed"] == NSOrderedSame) {
+            return @(AWSSESDsnActionRelayed);
+        }
+        if ([value caseInsensitiveCompare:@"expanded"] == NSOrderedSame) {
+            return @(AWSSESDsnActionExpanded);
+        }
+        return @(AWSSESDsnActionUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESDsnActionFailed:
+                return @"failed";
+            case AWSSESDsnActionDelayed:
+                return @"delayed";
+            case AWSSESDsnActionDelivered:
+                return @"delivered";
+            case AWSSESDsnActionRelayed:
+                return @"relayed";
+            case AWSSESDsnActionExpanded:
+                return @"expanded";
+            default:
+                return nil;
+        }
+    }];
+}
+
++ (NSValueTransformer *)extensionFieldsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESExtensionField class]];
+}
+
++ (NSValueTransformer *)lastAttemptDateJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSString *str) {
+        return [NSDate aws_dateFromString:str];
+    } reverseBlock:^id(NSDate *date) {
+return [date aws_stringValue:AWSDateISO8601DateFormat1];
+    }];
+}
+
+@end
+
+@implementation AWSSESReorderReceiptRuleSetRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"ruleNames" : @"RuleNames",
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESReorderReceiptRuleSetResponse
 
 @end
 
@@ -2855,53 +1794,57 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 	return @{
              @"lastFreshStart" : @"LastFreshStart",
              @"reputationMetricsEnabled" : @"ReputationMetricsEnabled",
+             @"sendingEnabled" : @"SendingEnabled",
              };
 }
 
 + (NSValueTransformer *)lastFreshStartJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSString *str) {
+        return [NSDate aws_dateFromString:str];
     } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
+return [date aws_stringValue:AWSDateISO8601DateFormat1];
     }];
 }
 
 @end
 
-@implementation AWSSESReviewDetails
+@implementation AWSSESS3Action
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"caseId" : @"CaseId",
-             @"status" : @"Status",
+             @"bucketName" : @"BucketName",
+             @"kmsKeyArn" : @"KmsKeyArn",
+             @"objectKeyPrefix" : @"ObjectKeyPrefix",
+             @"topicArn" : @"TopicArn",
              };
 }
 
-+ (NSValueTransformer *)statusJSONTransformer {
+@end
+
+@implementation AWSSESSNSAction
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"encoding" : @"Encoding",
+             @"topicArn" : @"TopicArn",
+             };
+}
+
++ (NSValueTransformer *)encodingJSONTransformer {
     return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"PENDING"] == NSOrderedSame) {
-            return @(AWSSESReviewStatusPending);
+        if ([value caseInsensitiveCompare:@"UTF-8"] == NSOrderedSame) {
+            return @(AWSSESSNSActionEncodingUtf8);
         }
-        if ([value caseInsensitiveCompare:@"FAILED"] == NSOrderedSame) {
-            return @(AWSSESReviewStatusFailed);
+        if ([value caseInsensitiveCompare:@"Base64"] == NSOrderedSame) {
+            return @(AWSSESSNSActionEncodingBase64);
         }
-        if ([value caseInsensitiveCompare:@"GRANTED"] == NSOrderedSame) {
-            return @(AWSSESReviewStatusGranted);
-        }
-        if ([value caseInsensitiveCompare:@"DENIED"] == NSOrderedSame) {
-            return @(AWSSESReviewStatusDenied);
-        }
-        return @(AWSSESReviewStatusUnknown);
+        return @(AWSSESSNSActionEncodingUnknown);
     } reverseBlock:^NSString *(NSNumber *value) {
         switch ([value integerValue]) {
-            case AWSSESReviewStatusPending:
-                return @"PENDING";
-            case AWSSESReviewStatusFailed:
-                return @"FAILED";
-            case AWSSESReviewStatusGranted:
-                return @"GRANTED";
-            case AWSSESReviewStatusDenied:
-                return @"DENIED";
+            case AWSSESSNSActionEncodingUtf8:
+                return @"UTF-8";
+            case AWSSESSNSActionEncodingBase64:
+                return @"Base64";
             default:
                 return nil;
         }
@@ -2910,46 +1853,87 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESSendBulkEmailRequest
+@implementation AWSSESSNSDestination
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"bulkEmailEntries" : @"BulkEmailEntries",
-             @"configurationSetName" : @"ConfigurationSetName",
-             @"defaultContent" : @"DefaultContent",
-             @"defaultEmailTags" : @"DefaultEmailTags",
-             @"feedbackForwardingEmailAddress" : @"FeedbackForwardingEmailAddress",
-             @"feedbackForwardingEmailAddressIdentityArn" : @"FeedbackForwardingEmailAddressIdentityArn",
-             @"fromEmailAddress" : @"FromEmailAddress",
-             @"fromEmailAddressIdentityArn" : @"FromEmailAddressIdentityArn",
-             @"replyToAddresses" : @"ReplyToAddresses",
+             @"topicARN" : @"TopicARN",
              };
-}
-
-+ (NSValueTransformer *)bulkEmailEntriesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESBulkEmailEntry class]];
-}
-
-+ (NSValueTransformer *)defaultContentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESBulkEmailContent class]];
-}
-
-+ (NSValueTransformer *)defaultEmailTagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESMessageTag class]];
 }
 
 @end
 
-@implementation AWSSESSendBulkEmailResponse
+@implementation AWSSESSendBounceRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"bulkEmailEntryResults" : @"BulkEmailEntryResults",
+             @"bounceSender" : @"BounceSender",
+             @"bounceSenderArn" : @"BounceSenderArn",
+             @"bouncedRecipientInfoList" : @"BouncedRecipientInfoList",
+             @"explanation" : @"Explanation",
+             @"messageDsn" : @"MessageDsn",
+             @"originalMessageId" : @"OriginalMessageId",
              };
 }
 
-+ (NSValueTransformer *)bulkEmailEntryResultsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESBulkEmailEntryResult class]];
++ (NSValueTransformer *)bouncedRecipientInfoListJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESBouncedRecipientInfo class]];
+}
+
++ (NSValueTransformer *)messageDsnJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESMessageDsn class]];
+}
+
+@end
+
+@implementation AWSSESSendBounceResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"messageId" : @"MessageId",
+             };
+}
+
+@end
+
+@implementation AWSSESSendBulkTemplatedEmailRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"defaultTags" : @"DefaultTags",
+             @"defaultTemplateData" : @"DefaultTemplateData",
+             @"destinations" : @"Destinations",
+             @"replyToAddresses" : @"ReplyToAddresses",
+             @"returnPath" : @"ReturnPath",
+             @"returnPathArn" : @"ReturnPathArn",
+             @"source" : @"Source",
+             @"sourceArn" : @"SourceArn",
+             @"template" : @"Template",
+             @"templateArn" : @"TemplateArn",
+             };
+}
+
++ (NSValueTransformer *)defaultTagsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESMessageTag class]];
+}
+
++ (NSValueTransformer *)destinationsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESBulkEmailDestination class]];
+}
+
+@end
+
+@implementation AWSSESSendBulkTemplatedEmailResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"status" : @"Status",
+             };
+}
+
++ (NSValueTransformer *)statusJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESBulkEmailDestinationStatus class]];
 }
 
 @end
@@ -2976,31 +1960,53 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
+@implementation AWSSESSendDataPoint
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"bounces" : @"Bounces",
+             @"complaints" : @"Complaints",
+             @"deliveryAttempts" : @"DeliveryAttempts",
+             @"rejects" : @"Rejects",
+             @"timestamp" : @"Timestamp",
+             };
+}
+
++ (NSValueTransformer *)timestampJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSString *str) {
+        return [NSDate aws_dateFromString:str];
+    } reverseBlock:^id(NSDate *date) {
+return [date aws_stringValue:AWSDateISO8601DateFormat1];
+    }];
+}
+
+@end
+
 @implementation AWSSESSendEmailRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"configurationSetName" : @"ConfigurationSetName",
-             @"content" : @"Content",
              @"destination" : @"Destination",
-             @"emailTags" : @"EmailTags",
-             @"feedbackForwardingEmailAddress" : @"FeedbackForwardingEmailAddress",
-             @"feedbackForwardingEmailAddressIdentityArn" : @"FeedbackForwardingEmailAddressIdentityArn",
-             @"fromEmailAddress" : @"FromEmailAddress",
-             @"fromEmailAddressIdentityArn" : @"FromEmailAddressIdentityArn",
+             @"message" : @"Message",
              @"replyToAddresses" : @"ReplyToAddresses",
+             @"returnPath" : @"ReturnPath",
+             @"returnPathArn" : @"ReturnPathArn",
+             @"source" : @"Source",
+             @"sourceArn" : @"SourceArn",
+             @"tags" : @"Tags",
              };
-}
-
-+ (NSValueTransformer *)contentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEmailContent class]];
 }
 
 + (NSValueTransformer *)destinationJSONTransformer {
     return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDestination class]];
 }
 
-+ (NSValueTransformer *)emailTagsJSONTransformer {
++ (NSValueTransformer *)messageJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESMessage class]];
+}
+
++ (NSValueTransformer *)tagsJSONTransformer {
     return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESMessageTag class]];
 }
 
@@ -3016,214 +2022,284 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESSendQuota
+@implementation AWSSESSendRawEmailRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"max24HourSend" : @"Max24HourSend",
-             @"maxSendRate" : @"MaxSendRate",
-             @"sentLast24Hours" : @"SentLast24Hours",
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"destinations" : @"Destinations",
+             @"fromArn" : @"FromArn",
+             @"rawMessage" : @"RawMessage",
+             @"returnPathArn" : @"ReturnPathArn",
+             @"source" : @"Source",
+             @"sourceArn" : @"SourceArn",
+             @"tags" : @"Tags",
              };
+}
+
++ (NSValueTransformer *)rawMessageJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESRawMessage class]];
+}
+
++ (NSValueTransformer *)tagsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESMessageTag class]];
 }
 
 @end
 
-@implementation AWSSESSendingOptions
+@implementation AWSSESSendRawEmailResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"sendingEnabled" : @"SendingEnabled",
-             };
-}
-
-@end
-
-@implementation AWSSESSnsDestination
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"topicArn" : @"TopicArn",
-             };
-}
-
-@end
-
-@implementation AWSSESSuppressedDestination
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"attributes" : @"Attributes",
-             @"emailAddress" : @"EmailAddress",
-             @"lastUpdateTime" : @"LastUpdateTime",
-             @"reason" : @"Reason",
-             };
-}
-
-+ (NSValueTransformer *)attributesJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESSuppressedDestinationAttributes class]];
-}
-
-+ (NSValueTransformer *)lastUpdateTimeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)reasonJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"BOUNCE"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListReasonBounce);
-        }
-        if ([value caseInsensitiveCompare:@"COMPLAINT"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListReasonComplaint);
-        }
-        return @(AWSSESSuppressionListReasonUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESSuppressionListReasonBounce:
-                return @"BOUNCE";
-            case AWSSESSuppressionListReasonComplaint:
-                return @"COMPLAINT";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESSuppressedDestinationAttributes
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"feedbackId" : @"FeedbackId",
              @"messageId" : @"MessageId",
              };
 }
 
 @end
 
-@implementation AWSSESSuppressedDestinationSummary
+@implementation AWSSESSendTemplatedEmailRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"emailAddress" : @"EmailAddress",
-             @"lastUpdateTime" : @"LastUpdateTime",
-             @"reason" : @"Reason",
-             };
-}
-
-+ (NSValueTransformer *)lastUpdateTimeJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSNumber *number) {
-        return [NSDate dateWithTimeIntervalSince1970:[number doubleValue]];
-    } reverseBlock:^id(NSDate *date) {
-        return [NSString stringWithFormat:@"%f", [date timeIntervalSince1970]];
-    }];
-}
-
-+ (NSValueTransformer *)reasonJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"BOUNCE"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListReasonBounce);
-        }
-        if ([value caseInsensitiveCompare:@"COMPLAINT"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListReasonComplaint);
-        }
-        return @(AWSSESSuppressionListReasonUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESSuppressionListReasonBounce:
-                return @"BOUNCE";
-            case AWSSESSuppressionListReasonComplaint:
-                return @"COMPLAINT";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESSuppressionAttributes
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"suppressedReasons" : @"SuppressedReasons",
-             };
-}
-
-@end
-
-@implementation AWSSESSuppressionListDestination
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"suppressionListImportAction" : @"SuppressionListImportAction",
-             };
-}
-
-+ (NSValueTransformer *)suppressionListImportActionJSONTransformer {
-    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
-        if ([value caseInsensitiveCompare:@"DELETE"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListImportActionDelete);
-        }
-        if ([value caseInsensitiveCompare:@"PUT"] == NSOrderedSame) {
-            return @(AWSSESSuppressionListImportActionPut);
-        }
-        return @(AWSSESSuppressionListImportActionUnknown);
-    } reverseBlock:^NSString *(NSNumber *value) {
-        switch ([value integerValue]) {
-            case AWSSESSuppressionListImportActionDelete:
-                return @"DELETE";
-            case AWSSESSuppressionListImportActionPut:
-                return @"PUT";
-            default:
-                return nil;
-        }
-    }];
-}
-
-@end
-
-@implementation AWSSESSuppressionOptions
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"suppressedReasons" : @"SuppressedReasons",
-             };
-}
-
-@end
-
-@implementation AWSSESTag
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"key" : @"Key",
-             @"value" : @"Value",
-             };
-}
-
-@end
-
-@implementation AWSSESTagResourceRequest
-
-+ (NSDictionary *)JSONKeyPathsByPropertyKey {
-	return @{
-             @"resourceArn" : @"ResourceArn",
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"destination" : @"Destination",
+             @"replyToAddresses" : @"ReplyToAddresses",
+             @"returnPath" : @"ReturnPath",
+             @"returnPathArn" : @"ReturnPathArn",
+             @"source" : @"Source",
+             @"sourceArn" : @"SourceArn",
              @"tags" : @"Tags",
+             @"template" : @"Template",
+             @"templateArn" : @"TemplateArn",
+             @"templateData" : @"TemplateData",
              };
+}
+
++ (NSValueTransformer *)destinationJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESDestination class]];
 }
 
 + (NSValueTransformer *)tagsJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESTag class]];
+    return [NSValueTransformer awsmtl_JSONArrayTransformerWithModelClass:[AWSSESMessageTag class]];
 }
 
 @end
 
-@implementation AWSSESTagResourceResponse
+@implementation AWSSESSendTemplatedEmailResponse
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"messageId" : @"MessageId",
+             };
+}
+
+@end
+
+@implementation AWSSESSetActiveReceiptRuleSetRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESSetActiveReceiptRuleSetResponse
+
+@end
+
+@implementation AWSSESSetIdentityDkimEnabledRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"dkimEnabled" : @"DkimEnabled",
+             @"identity" : @"Identity",
+             };
+}
+
+@end
+
+@implementation AWSSESSetIdentityDkimEnabledResponse
+
+@end
+
+@implementation AWSSESSetIdentityFeedbackForwardingEnabledRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"forwardingEnabled" : @"ForwardingEnabled",
+             @"identity" : @"Identity",
+             };
+}
+
+@end
+
+@implementation AWSSESSetIdentityFeedbackForwardingEnabledResponse
+
+@end
+
+@implementation AWSSESSetIdentityHeadersInNotificationsEnabledRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"enabled" : @"Enabled",
+             @"identity" : @"Identity",
+             @"notificationType" : @"NotificationType",
+             };
+}
+
++ (NSValueTransformer *)notificationTypeJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"Bounce"] == NSOrderedSame) {
+            return @(AWSSESNotificationTypeBounce);
+        }
+        if ([value caseInsensitiveCompare:@"Complaint"] == NSOrderedSame) {
+            return @(AWSSESNotificationTypeComplaint);
+        }
+        if ([value caseInsensitiveCompare:@"Delivery"] == NSOrderedSame) {
+            return @(AWSSESNotificationTypeDelivery);
+        }
+        return @(AWSSESNotificationTypeUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESNotificationTypeBounce:
+                return @"Bounce";
+            case AWSSESNotificationTypeComplaint:
+                return @"Complaint";
+            case AWSSESNotificationTypeDelivery:
+                return @"Delivery";
+            default:
+                return nil;
+        }
+    }];
+}
+
+@end
+
+@implementation AWSSESSetIdentityHeadersInNotificationsEnabledResponse
+
+@end
+
+@implementation AWSSESSetIdentityMailFromDomainRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"behaviorOnMXFailure" : @"BehaviorOnMXFailure",
+             @"identity" : @"Identity",
+             @"mailFromDomain" : @"MailFromDomain",
+             };
+}
+
++ (NSValueTransformer *)behaviorOnMXFailureJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"UseDefaultValue"] == NSOrderedSame) {
+            return @(AWSSESBehaviorOnMXFailureUseDefaultValue);
+        }
+        if ([value caseInsensitiveCompare:@"RejectMessage"] == NSOrderedSame) {
+            return @(AWSSESBehaviorOnMXFailureRejectMessage);
+        }
+        return @(AWSSESBehaviorOnMXFailureUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESBehaviorOnMXFailureUseDefaultValue:
+                return @"UseDefaultValue";
+            case AWSSESBehaviorOnMXFailureRejectMessage:
+                return @"RejectMessage";
+            default:
+                return nil;
+        }
+    }];
+}
+
+@end
+
+@implementation AWSSESSetIdentityMailFromDomainResponse
+
+@end
+
+@implementation AWSSESSetIdentityNotificationTopicRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"identity" : @"Identity",
+             @"notificationType" : @"NotificationType",
+             @"snsTopic" : @"SnsTopic",
+             };
+}
+
++ (NSValueTransformer *)notificationTypeJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"Bounce"] == NSOrderedSame) {
+            return @(AWSSESNotificationTypeBounce);
+        }
+        if ([value caseInsensitiveCompare:@"Complaint"] == NSOrderedSame) {
+            return @(AWSSESNotificationTypeComplaint);
+        }
+        if ([value caseInsensitiveCompare:@"Delivery"] == NSOrderedSame) {
+            return @(AWSSESNotificationTypeDelivery);
+        }
+        return @(AWSSESNotificationTypeUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESNotificationTypeBounce:
+                return @"Bounce";
+            case AWSSESNotificationTypeComplaint:
+                return @"Complaint";
+            case AWSSESNotificationTypeDelivery:
+                return @"Delivery";
+            default:
+                return nil;
+        }
+    }];
+}
+
+@end
+
+@implementation AWSSESSetIdentityNotificationTopicResponse
+
+@end
+
+@implementation AWSSESSetReceiptRulePositionRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"after" : @"After",
+             @"ruleName" : @"RuleName",
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
+@end
+
+@implementation AWSSESSetReceiptRulePositionResponse
+
+@end
+
+@implementation AWSSESStopAction
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"scope" : @"Scope",
+             @"topicArn" : @"TopicArn",
+             };
+}
+
++ (NSValueTransformer *)scopeJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^NSNumber *(NSString *value) {
+        if ([value caseInsensitiveCompare:@"RuleSet"] == NSOrderedSame) {
+            return @(AWSSESStopScopeRuleSet);
+        }
+        return @(AWSSESStopScopeUnknown);
+    } reverseBlock:^NSString *(NSNumber *value) {
+        switch ([value integerValue]) {
+            case AWSSESStopScopeRuleSet:
+                return @"RuleSet";
+            default:
+                return nil;
+        }
+    }];
+}
 
 @end
 
@@ -3231,15 +2307,35 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"templateArn" : @"TemplateArn",
-             @"templateData" : @"TemplateData",
+             @"htmlPart" : @"HtmlPart",
+             @"subjectPart" : @"SubjectPart",
              @"templateName" : @"TemplateName",
+             @"textPart" : @"TextPart",
              };
 }
 
 @end
 
-@implementation AWSSESTestRenderEmailTemplateRequest
+@implementation AWSSESTemplateMetadata
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"createdTimestamp" : @"CreatedTimestamp",
+             @"name" : @"Name",
+             };
+}
+
++ (NSValueTransformer *)createdTimestampJSONTransformer {
+    return [AWSMTLValueTransformer reversibleTransformerWithForwardBlock:^id(NSString *str) {
+        return [NSDate aws_dateFromString:str];
+    } reverseBlock:^id(NSDate *date) {
+return [date aws_stringValue:AWSDateISO8601DateFormat1];
+    }];
+}
+
+@end
+
+@implementation AWSSESTestRenderTemplateRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -3250,7 +2346,7 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESTestRenderEmailTemplateResponse
+@implementation AWSSESTestRenderTemplateResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -3270,18 +2366,13 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESUntagResourceRequest
+@implementation AWSSESUpdateAccountSendingEnabledRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"resourceArn" : @"ResourceArn",
-             @"tagKeys" : @"TagKeys",
+             @"enabled" : @"Enabled",
              };
 }
-
-@end
-
-@implementation AWSSESUntagResourceResponse
 
 @end
 
@@ -3291,17 +2382,57 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 	return @{
              @"configurationSetName" : @"ConfigurationSetName",
              @"eventDestination" : @"EventDestination",
-             @"eventDestinationName" : @"EventDestinationName",
              };
 }
 
 + (NSValueTransformer *)eventDestinationJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEventDestinationDefinition class]];
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEventDestination class]];
 }
 
 @end
 
 @implementation AWSSESUpdateConfigurationSetEventDestinationResponse
+
+@end
+
+@implementation AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"enabled" : @"Enabled",
+             };
+}
+
+@end
+
+@implementation AWSSESUpdateConfigurationSetSendingEnabledRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"enabled" : @"Enabled",
+             };
+}
+
+@end
+
+@implementation AWSSESUpdateConfigurationSetTrackingOptionsRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"configurationSetName" : @"ConfigurationSetName",
+             @"trackingOptions" : @"TrackingOptions",
+             };
+}
+
++ (NSValueTransformer *)trackingOptionsJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTrackingOptions class]];
+}
+
+@end
+
+@implementation AWSSESUpdateConfigurationSetTrackingOptionsResponse
 
 @end
 
@@ -3320,53 +2451,113 @@ NSString *const AWSSESErrorDomain = @"com.amazonaws.AWSSESErrorDomain";
 
 @end
 
-@implementation AWSSESUpdateCustomVerificationEmailTemplateResponse
-
-@end
-
-@implementation AWSSESUpdateEmailIdentityPolicyRequest
+@implementation AWSSESUpdateReceiptRuleRequest
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"emailIdentity" : @"EmailIdentity",
-             @"policy" : @"Policy",
-             @"policyName" : @"PolicyName",
+             @"rule" : @"Rule",
+             @"ruleSetName" : @"RuleSetName",
+             };
+}
+
++ (NSValueTransformer *)ruleJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESReceiptRule class]];
+}
+
+@end
+
+@implementation AWSSESUpdateReceiptRuleResponse
+
+@end
+
+@implementation AWSSESUpdateTemplateRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"template" : @"Template",
+             };
+}
+
++ (NSValueTransformer *)templateJSONTransformer {
+    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESTemplate class]];
+}
+
+@end
+
+@implementation AWSSESUpdateTemplateResponse
+
+@end
+
+@implementation AWSSESVerifyDomainDkimRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"domain" : @"Domain",
              };
 }
 
 @end
 
-@implementation AWSSESUpdateEmailIdentityPolicyResponse
-
-@end
-
-@implementation AWSSESUpdateEmailTemplateRequest
+@implementation AWSSESVerifyDomainDkimResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"templateContent" : @"TemplateContent",
-             @"templateName" : @"TemplateName",
+             @"dkimTokens" : @"DkimTokens",
              };
 }
 
-+ (NSValueTransformer *)templateContentJSONTransformer {
-    return [NSValueTransformer awsmtl_JSONDictionaryTransformerWithModelClass:[AWSSESEmailTemplateContent class]];
+@end
+
+@implementation AWSSESVerifyDomainIdentityRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"domain" : @"Domain",
+             };
 }
 
 @end
 
-@implementation AWSSESUpdateEmailTemplateResponse
-
-@end
-
-@implementation AWSSESVolumeStatistics
+@implementation AWSSESVerifyDomainIdentityResponse
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
-             @"inboxRawCount" : @"InboxRawCount",
-             @"projectedInbox" : @"ProjectedInbox",
-             @"projectedSpam" : @"ProjectedSpam",
-             @"spamRawCount" : @"SpamRawCount",
+             @"verificationToken" : @"VerificationToken",
+             };
+}
+
+@end
+
+@implementation AWSSESVerifyEmailAddressRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"emailAddress" : @"EmailAddress",
+             };
+}
+
+@end
+
+@implementation AWSSESVerifyEmailIdentityRequest
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"emailAddress" : @"EmailAddress",
+             };
+}
+
+@end
+
+@implementation AWSSESVerifyEmailIdentityResponse
+
+@end
+
+@implementation AWSSESWorkmailAction
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+	return @{
+             @"organizationArn" : @"OrganizationArn",
+             @"topicArn" : @"TopicArn",
              };
 }
 

--- a/AWSSES/AWSSESResources.m
+++ b/AWSSES/AWSSESResources.m
@@ -59,1318 +59,1348 @@
     return @"{\
   \"version\":\"2.0\",\
   \"metadata\":{\
-    \"apiVersion\":\"2019-09-27\",\
+    \"apiVersion\":\"2010-12-01\",\
     \"endpointPrefix\":\"email\",\
-    \"jsonVersion\":\"1.1\",\
-    \"protocol\":\"rest-json\",\
-    \"serviceAbbreviation\":\"Amazon SES V2\",\
+    \"protocol\":\"query\",\
+    \"serviceAbbreviation\":\"Amazon SES\",\
     \"serviceFullName\":\"Amazon Simple Email Service\",\
-    \"serviceId\":\"SESv2\",\
+    \"serviceId\":\"SES\",\
     \"signatureVersion\":\"v4\",\
     \"signingName\":\"ses\",\
-    \"uid\":\"sesv2-2019-09-27\"\
+    \"uid\":\"email-2010-12-01\",\
+    \"xmlNamespace\":\"http://ses.amazonaws.com/doc/2010-12-01/\"\
   },\
   \"operations\":{\
+    \"CloneReceiptRuleSet\":{\
+      \"name\":\"CloneReceiptRuleSet\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"CloneReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"CloneReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"CloneReceiptRuleSetResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"RuleSetDoesNotExistException\"},\
+        {\"shape\":\"AlreadyExistsException\"},\
+        {\"shape\":\"LimitExceededException\"}\
+      ],\
+      \"documentation\":\"<p>Creates a receipt rule set by cloning an existing one. All receipt rules and configurations are copied to the new receipt rule set and are completely independent of the source rule set.</p> <p>For information about setting up rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
     \"CreateConfigurationSet\":{\
       \"name\":\"CreateConfigurationSet\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/configuration-sets\"\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"CreateConfigurationSetRequest\"},\
-      \"output\":{\"shape\":\"CreateConfigurationSetResponse\"},\
+      \"output\":{\
+        \"shape\":\"CreateConfigurationSetResponse\",\
+        \"resultWrapper\":\"CreateConfigurationSetResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
+        {\"shape\":\"ConfigurationSetAlreadyExistsException\"},\
+        {\"shape\":\"InvalidConfigurationSetException\"},\
+        {\"shape\":\"LimitExceededException\"}\
       ],\
-      \"documentation\":\"<p>Create a configuration set. <i>Configuration sets</i> are groups of rules that you can apply to the emails that you send. You apply a configuration set to an email by specifying the name of the configuration set when you call the Amazon SES API v2. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email. </p>\"\
+      \"documentation\":\"<p>Creates a configuration set.</p> <p>Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
     \"CreateConfigurationSetEventDestination\":{\
       \"name\":\"CreateConfigurationSetEventDestination\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations\"\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"CreateConfigurationSetEventDestinationRequest\"},\
-      \"output\":{\"shape\":\"CreateConfigurationSetEventDestinationResponse\"},\
+      \"output\":{\
+        \"shape\":\"CreateConfigurationSetEventDestinationResponse\",\
+        \"resultWrapper\":\"CreateConfigurationSetEventDestinationResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"EventDestinationAlreadyExistsException\"},\
+        {\"shape\":\"InvalidCloudWatchDestinationException\"},\
+        {\"shape\":\"InvalidFirehoseDestinationException\"},\
+        {\"shape\":\"InvalidSNSDestinationException\"},\
+        {\"shape\":\"LimitExceededException\"}\
       ],\
-      \"documentation\":\"<p>Create an event destination. <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p> <p>A single configuration set can include more than one event destination.</p>\"\
+      \"documentation\":\"<p>Creates a configuration set event destination.</p> <note> <p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS).</p> </note> <p>An event destination is the AWS service to which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"CreateConfigurationSetTrackingOptions\":{\
+      \"name\":\"CreateConfigurationSetTrackingOptions\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"CreateConfigurationSetTrackingOptionsRequest\"},\
+      \"output\":{\
+        \"shape\":\"CreateConfigurationSetTrackingOptionsResponse\",\
+        \"resultWrapper\":\"CreateConfigurationSetTrackingOptionsResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"TrackingOptionsAlreadyExistsException\"},\
+        {\"shape\":\"InvalidTrackingOptionsException\"}\
+      ],\
+      \"documentation\":\"<p>Creates an association between a configuration set and a custom domain for open and click event tracking. </p> <p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"CreateCustomVerificationEmailTemplate\":{\
       \"name\":\"CreateCustomVerificationEmailTemplate\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/custom-verification-email-templates\"\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"CreateCustomVerificationEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"CreateCustomVerificationEmailTemplateResponse\"},\
       \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
+        {\"shape\":\"CustomVerificationEmailTemplateAlreadyExistsException\"},\
+        {\"shape\":\"FromEmailAddressNotVerifiedException\"},\
+        {\"shape\":\"CustomVerificationEmailInvalidContentException\"},\
         {\"shape\":\"LimitExceededException\"}\
       ],\
-      \"documentation\":\"<p>Creates a new custom verification email template.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+      \"documentation\":\"<p>Creates a new custom verification email template.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"CreateDedicatedIpPool\":{\
-      \"name\":\"CreateDedicatedIpPool\",\
+    \"CreateReceiptFilter\":{\
+      \"name\":\"CreateReceiptFilter\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/dedicated-ip-pools\"\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"CreateDedicatedIpPoolRequest\"},\
-      \"output\":{\"shape\":\"CreateDedicatedIpPoolResponse\"},\
+      \"input\":{\"shape\":\"CreateReceiptFilterRequest\"},\
+      \"output\":{\
+        \"shape\":\"CreateReceiptFilterResponse\",\
+        \"resultWrapper\":\"CreateReceiptFilterResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"LimitExceededException\"},\
+        {\"shape\":\"AlreadyExistsException\"}\
+      ],\
+      \"documentation\":\"<p>Creates a new IP address filter.</p> <p>For information about setting up IP address filters, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"CreateReceiptRule\":{\
+      \"name\":\"CreateReceiptRule\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"CreateReceiptRuleRequest\"},\
+      \"output\":{\
+        \"shape\":\"CreateReceiptRuleResponse\",\
+        \"resultWrapper\":\"CreateReceiptRuleResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"InvalidSnsTopicException\"},\
+        {\"shape\":\"InvalidS3ConfigurationException\"},\
+        {\"shape\":\"InvalidLambdaFunctionException\"},\
+        {\"shape\":\"AlreadyExistsException\"},\
+        {\"shape\":\"RuleDoesNotExistException\"},\
+        {\"shape\":\"RuleSetDoesNotExistException\"},\
+        {\"shape\":\"LimitExceededException\"}\
+      ],\
+      \"documentation\":\"<p>Creates a receipt rule.</p> <p>For information about setting up receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"CreateReceiptRuleSet\":{\
+      \"name\":\"CreateReceiptRuleSet\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"CreateReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"CreateReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"CreateReceiptRuleSetResult\"\
+      },\
       \"errors\":[\
         {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
+        {\"shape\":\"LimitExceededException\"}\
       ],\
-      \"documentation\":\"<p>Create a new pool of dedicated IP addresses. A pool can include one or more dedicated IP addresses that are associated with your AWS account. You can associate a pool with a configuration set. When you send an email that uses that configuration set, the message is sent from one of the addresses in the associated pool.</p>\"\
+      \"documentation\":\"<p>Creates an empty receipt rule set.</p> <p>For information about setting up receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"CreateDeliverabilityTestReport\":{\
-      \"name\":\"CreateDeliverabilityTestReport\",\
+    \"CreateTemplate\":{\
+      \"name\":\"CreateTemplate\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/test\"\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"CreateDeliverabilityTestReportRequest\"},\
-      \"output\":{\"shape\":\"CreateDeliverabilityTestReportResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"AccountSuspendedException\"},\
-        {\"shape\":\"SendingPausedException\"},\
-        {\"shape\":\"MessageRejected\"},\
-        {\"shape\":\"MailFromDomainNotVerifiedException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
-      ],\
-      \"documentation\":\"<p>Create a new predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will be handled by various email providers around the world. When you perform a predictive inbox placement test, you provide a sample message that contains the content that you plan to send to your customers. Amazon SES then sends that message to special email addresses spread across several major email providers. After about 24 hours, the test is complete, and you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.</p>\"\
-    },\
-    \"CreateEmailIdentity\":{\
-      \"name\":\"CreateEmailIdentity\",\
-      \"http\":{\
-        \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/identities\"\
+      \"input\":{\"shape\":\"CreateTemplateRequest\"},\
+      \"output\":{\
+        \"shape\":\"CreateTemplateResponse\",\
+        \"resultWrapper\":\"CreateTemplateResult\"\
       },\
-      \"input\":{\"shape\":\"CreateEmailIdentityRequest\"},\
-      \"output\":{\"shape\":\"CreateEmailIdentityResponse\"},\
       \"errors\":[\
         {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
-      ],\
-      \"documentation\":\"<p>Starts the process of verifying an email identity. An <i>identity</i> is an email address or domain that you use when you send email. Before you can use an identity to send email, you first have to verify it. By verifying an identity, you demonstrate that you're the owner of the identity, and that you've given Amazon SES API v2 permission to send email from the identity.</p> <p>When you verify an email address, Amazon SES sends an email to the address. Your email address is verified as soon as you follow the link in the verification email. </p> <p>When you verify a domain without specifying the <code>DkimSigningAttributes</code> object, this operation provides a set of DKIM tokens. You can convert these tokens into CNAME records, which you then add to the DNS configuration for your domain. Your domain is verified when Amazon SES detects these records in the DNS configuration for your domain. This verification method is known as <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a>.</p> <p>Alternatively, you can perform the verification process by providing your own public-private key pair. This verification method is known as Bring Your Own DKIM (BYODKIM). To use BYODKIM, your call to the <code>CreateEmailIdentity</code> operation has to include the <code>DkimSigningAttributes</code> object. When you specify this object, you provide a selector (a component of the DNS record name that identifies the public key that you want to use for DKIM authentication) and a private key.</p>\"\
-    },\
-    \"CreateEmailIdentityPolicy\":{\
-      \"name\":\"CreateEmailIdentityPolicy\",\
-      \"http\":{\
-        \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/policies/{PolicyName}\"\
-      },\
-      \"input\":{\"shape\":\"CreateEmailIdentityPolicyRequest\"},\
-      \"output\":{\"shape\":\"CreateEmailIdentityPolicyResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Creates the specified sending authorization policy for the given identity (an email address or a domain).</p> <note> <p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p> </note> <p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
-    },\
-    \"CreateEmailTemplate\":{\
-      \"name\":\"CreateEmailTemplate\",\
-      \"http\":{\
-        \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/templates\"\
-      },\
-      \"input\":{\"shape\":\"CreateEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"CreateEmailTemplateResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
+        {\"shape\":\"InvalidTemplateException\"},\
         {\"shape\":\"LimitExceededException\"}\
       ],\
       \"documentation\":\"<p>Creates an email template. Email templates enable you to send personalized email to one or more destinations in a single API operation. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"CreateImportJob\":{\
-      \"name\":\"CreateImportJob\",\
-      \"http\":{\
-        \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/import-jobs\"\
-      },\
-      \"input\":{\"shape\":\"CreateImportJobRequest\"},\
-      \"output\":{\"shape\":\"CreateImportJobResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
-      ],\
-      \"documentation\":\"<p>Creates an import job for a data destination.</p>\"\
-    },\
     \"DeleteConfigurationSet\":{\
       \"name\":\"DeleteConfigurationSet\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"DeleteConfigurationSetRequest\"},\
-      \"output\":{\"shape\":\"DeleteConfigurationSetResponse\"},\
+      \"output\":{\
+        \"shape\":\"DeleteConfigurationSetResponse\",\
+        \"resultWrapper\":\"DeleteConfigurationSetResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Delete an existing configuration set.</p> <p> <i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>\"\
+      \"documentation\":\"<p>Deletes a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
     \"DeleteConfigurationSetEventDestination\":{\
       \"name\":\"DeleteConfigurationSetEventDestination\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"DeleteConfigurationSetEventDestinationRequest\"},\
-      \"output\":{\"shape\":\"DeleteConfigurationSetEventDestinationResponse\"},\
+      \"output\":{\
+        \"shape\":\"DeleteConfigurationSetEventDestinationResponse\",\
+        \"resultWrapper\":\"DeleteConfigurationSetEventDestinationResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"EventDestinationDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Delete an event destination.</p> <p> <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>\"\
+      \"documentation\":\"<p>Deletes a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"DeleteConfigurationSetTrackingOptions\":{\
+      \"name\":\"DeleteConfigurationSetTrackingOptions\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"DeleteConfigurationSetTrackingOptionsRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteConfigurationSetTrackingOptionsResponse\",\
+        \"resultWrapper\":\"DeleteConfigurationSetTrackingOptionsResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"TrackingOptionsDoesNotExistException\"}\
+      ],\
+      \"documentation\":\"<p>Deletes an association between a configuration set and a custom domain for open and click event tracking.</p> <p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html\\\">Amazon SES Developer Guide</a>.</p> <note> <p>Deleting this kind of association will result in emails sent using the specified configuration set to capture open and click events using the standard, Amazon SES-operated domains.</p> </note>\"\
     },\
     \"DeleteCustomVerificationEmailTemplate\":{\
       \"name\":\"DeleteCustomVerificationEmailTemplate\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/custom-verification-email-templates/{TemplateName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"DeleteCustomVerificationEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"DeleteCustomVerificationEmailTemplateResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Deletes an existing custom verification email template.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/es/latest/DeveloperGuide/send-email-verify-address-custom.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+      \"documentation\":\"<p>Deletes an existing custom verification email template. </p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"DeleteDedicatedIpPool\":{\
-      \"name\":\"DeleteDedicatedIpPool\",\
+    \"DeleteIdentity\":{\
+      \"name\":\"DeleteIdentity\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/dedicated-ip-pools/{PoolName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"DeleteDedicatedIpPoolRequest\"},\
-      \"output\":{\"shape\":\"DeleteDedicatedIpPoolResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
-      ],\
-      \"documentation\":\"<p>Delete a dedicated IP pool.</p>\"\
+      \"input\":{\"shape\":\"DeleteIdentityRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteIdentityResponse\",\
+        \"resultWrapper\":\"DeleteIdentityResult\"\
+      },\
+      \"documentation\":\"<p>Deletes the specified identity (an email address or a domain) from the list of verified identities.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"DeleteEmailIdentity\":{\
-      \"name\":\"DeleteEmailIdentity\",\
+    \"DeleteIdentityPolicy\":{\
+      \"name\":\"DeleteIdentityPolicy\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"DeleteEmailIdentityRequest\"},\
-      \"output\":{\"shape\":\"DeleteEmailIdentityResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"}\
-      ],\
-      \"documentation\":\"<p>Deletes an email identity. An identity can be either an email address or a domain name.</p>\"\
-    },\
-    \"DeleteEmailIdentityPolicy\":{\
-      \"name\":\"DeleteEmailIdentityPolicy\",\
-      \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/policies/{PolicyName}\"\
+      \"input\":{\"shape\":\"DeleteIdentityPolicyRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteIdentityPolicyResponse\",\
+        \"resultWrapper\":\"DeleteIdentityPolicyResult\"\
       },\
-      \"input\":{\"shape\":\"DeleteEmailIdentityPolicyRequest\"},\
-      \"output\":{\"shape\":\"DeleteEmailIdentityPolicyResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
       \"documentation\":\"<p>Deletes the specified sending authorization policy for the given identity (an email address or a domain). This API returns successfully even if a policy with the specified name does not exist.</p> <note> <p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p> </note> <p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"DeleteEmailTemplate\":{\
-      \"name\":\"DeleteEmailTemplate\",\
+    \"DeleteReceiptFilter\":{\
+      \"name\":\"DeleteReceiptFilter\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/templates/{TemplateName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"DeleteEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"DeleteEmailTemplateResponse\"},\
+      \"input\":{\"shape\":\"DeleteReceiptFilterRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteReceiptFilterResponse\",\
+        \"resultWrapper\":\"DeleteReceiptFilterResult\"\
+      },\
+      \"documentation\":\"<p>Deletes the specified IP address filter.</p> <p>For information about managing IP address filters, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"DeleteReceiptRule\":{\
+      \"name\":\"DeleteReceiptRule\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"DeleteReceiptRuleRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteReceiptRuleResponse\",\
+        \"resultWrapper\":\"DeleteReceiptRuleResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"RuleSetDoesNotExistException\"}\
       ],\
+      \"documentation\":\"<p>Deletes the specified receipt rule.</p> <p>For information about managing receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"DeleteReceiptRuleSet\":{\
+      \"name\":\"DeleteReceiptRuleSet\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"DeleteReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"DeleteReceiptRuleSetResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"CannotDeleteException\"}\
+      ],\
+      \"documentation\":\"<p>Deletes the specified receipt rule set and all of the receipt rules it contains.</p> <note> <p>The currently active rule set cannot be deleted.</p> </note> <p>For information about managing receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"DeleteTemplate\":{\
+      \"name\":\"DeleteTemplate\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"DeleteTemplateRequest\"},\
+      \"output\":{\
+        \"shape\":\"DeleteTemplateResponse\",\
+        \"resultWrapper\":\"DeleteTemplateResult\"\
+      },\
       \"documentation\":\"<p>Deletes an email template.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"DeleteSuppressedDestination\":{\
-      \"name\":\"DeleteSuppressedDestination\",\
+    \"DeleteVerifiedEmailAddress\":{\
+      \"name\":\"DeleteVerifiedEmailAddress\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/suppression/addresses/{EmailAddress}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"DeleteSuppressedDestinationRequest\"},\
-      \"output\":{\"shape\":\"DeleteSuppressedDestinationResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
-      ],\
-      \"documentation\":\"<p>Removes an email address from the suppression list for your account.</p>\"\
+      \"input\":{\"shape\":\"DeleteVerifiedEmailAddressRequest\"},\
+      \"documentation\":\"<p>Deprecated. Use the <code>DeleteIdentity</code> operation to delete email addresses and domains.</p>\"\
     },\
-    \"GetAccount\":{\
-      \"name\":\"GetAccount\",\
+    \"DescribeActiveReceiptRuleSet\":{\
+      \"name\":\"DescribeActiveReceiptRuleSet\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/account\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetAccountRequest\"},\
-      \"output\":{\"shape\":\"GetAccountResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Obtain information about the email-sending status and capabilities of your Amazon SES account in the current AWS Region.</p>\"\
+      \"input\":{\"shape\":\"DescribeActiveReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"DescribeActiveReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"DescribeActiveReceiptRuleSetResult\"\
+      },\
+      \"documentation\":\"<p>Returns the metadata and receipt rules for the receipt rule set that is currently active.</p> <p>For information about setting up receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"GetBlacklistReports\":{\
-      \"name\":\"GetBlacklistReports\",\
+    \"DescribeConfigurationSet\":{\
+      \"name\":\"DescribeConfigurationSet\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/blacklist-report\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetBlacklistReportsRequest\"},\
-      \"output\":{\"shape\":\"GetBlacklistReportsResponse\"},\
+      \"input\":{\"shape\":\"DescribeConfigurationSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"DescribeConfigurationSetResponse\",\
+        \"resultWrapper\":\"DescribeConfigurationSetResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Retrieve a list of the blacklists that your dedicated IP addresses appear on.</p>\"\
+      \"documentation\":\"<p>Returns the details of the specified configuration set. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"GetConfigurationSet\":{\
-      \"name\":\"GetConfigurationSet\",\
+    \"DescribeReceiptRule\":{\
+      \"name\":\"DescribeReceiptRule\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetConfigurationSetRequest\"},\
-      \"output\":{\"shape\":\"GetConfigurationSetResponse\"},\
+      \"input\":{\"shape\":\"DescribeReceiptRuleRequest\"},\
+      \"output\":{\
+        \"shape\":\"DescribeReceiptRuleResponse\",\
+        \"resultWrapper\":\"DescribeReceiptRuleResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"RuleDoesNotExistException\"},\
+        {\"shape\":\"RuleSetDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Get information about an existing configuration set, including the dedicated IP pool that it's associated with, whether or not it's enabled for sending email, and more.</p> <p> <i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>\"\
+      \"documentation\":\"<p>Returns the details of the specified receipt rule.</p> <p>For information about setting up receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"GetConfigurationSetEventDestinations\":{\
-      \"name\":\"GetConfigurationSetEventDestinations\",\
+    \"DescribeReceiptRuleSet\":{\
+      \"name\":\"DescribeReceiptRuleSet\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetConfigurationSetEventDestinationsRequest\"},\
-      \"output\":{\"shape\":\"GetConfigurationSetEventDestinationsResponse\"},\
+      \"input\":{\"shape\":\"DescribeReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"DescribeReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"DescribeReceiptRuleSetResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"RuleSetDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Retrieve a list of event destinations that are associated with a configuration set.</p> <p> <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>\"\
+      \"documentation\":\"<p>Returns the details of the specified receipt rule set.</p> <p>For information about managing receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"GetAccountSendingEnabled\":{\
+      \"name\":\"GetAccountSendingEnabled\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"output\":{\
+        \"shape\":\"GetAccountSendingEnabledResponse\",\
+        \"resultWrapper\":\"GetAccountSendingEnabledResult\"\
+      },\
+      \"documentation\":\"<p>Returns the email sending status of the Amazon SES account for the current region.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
     \"GetCustomVerificationEmailTemplate\":{\
       \"name\":\"GetCustomVerificationEmailTemplate\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/custom-verification-email-templates/{TemplateName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"GetCustomVerificationEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"GetCustomVerificationEmailTemplateResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Returns the custom email verification template for the template name you specify.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
-    },\
-    \"GetDedicatedIp\":{\
-      \"name\":\"GetDedicatedIp\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/dedicated-ips/{IP}\"\
+      \"output\":{\
+        \"shape\":\"GetCustomVerificationEmailTemplateResponse\",\
+        \"resultWrapper\":\"GetCustomVerificationEmailTemplateResult\"\
       },\
-      \"input\":{\"shape\":\"GetDedicatedIpRequest\"},\
-      \"output\":{\"shape\":\"GetDedicatedIpResponse\"},\
       \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"CustomVerificationEmailTemplateDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Get information about a dedicated IP address, including the name of the dedicated IP pool that it's associated with, as well information about the automatic warm-up process for the address.</p>\"\
+      \"documentation\":\"<p>Returns the custom email verification template for the template name you specify.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"GetDedicatedIps\":{\
-      \"name\":\"GetDedicatedIps\",\
+    \"GetIdentityDkimAttributes\":{\
+      \"name\":\"GetIdentityDkimAttributes\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/dedicated-ips\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetDedicatedIpsRequest\"},\
-      \"output\":{\"shape\":\"GetDedicatedIpsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>List the dedicated IP addresses that are associated with your AWS account.</p>\"\
+      \"input\":{\"shape\":\"GetIdentityDkimAttributesRequest\"},\
+      \"output\":{\
+        \"shape\":\"GetIdentityDkimAttributesResponse\",\
+        \"resultWrapper\":\"GetIdentityDkimAttributesResult\"\
+      },\
+      \"documentation\":\"<p>Returns the current status of Easy DKIM signing for an entity. For domain name identities, this operation also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES has successfully verified that these tokens have been published.</p> <p>This operation takes a list of identities as input and returns the following information for each:</p> <ul> <li> <p>Whether Easy DKIM signing is enabled or disabled.</p> </li> <li> <p>A set of DKIM tokens that represent the identity. If the identity is an email address, the tokens represent the domain of that address.</p> </li> <li> <p>Whether Amazon SES has successfully verified the DKIM tokens published in the domain's DNS. This information is only returned for domain name identities, not for email addresses.</p> </li> </ul> <p>This operation is throttled at one request per second and can only get DKIM attributes for up to 100 identities at a time.</p> <p>For more information about creating DNS records using DKIM tokens, go to the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"GetDeliverabilityDashboardOptions\":{\
-      \"name\":\"GetDeliverabilityDashboardOptions\",\
+    \"GetIdentityMailFromDomainAttributes\":{\
+      \"name\":\"GetIdentityMailFromDomainAttributes\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetDeliverabilityDashboardOptionsRequest\"},\
-      \"output\":{\"shape\":\"GetDeliverabilityDashboardOptionsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieve information about the status of the Deliverability dashboard for your account. When the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email. You also gain the ability to perform predictive inbox placement tests.</p> <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href=\\\"http://aws.amazon.com/ses/pricing/\\\">Amazon SES Pricing</a>.</p>\"\
+      \"input\":{\"shape\":\"GetIdentityMailFromDomainAttributesRequest\"},\
+      \"output\":{\
+        \"shape\":\"GetIdentityMailFromDomainAttributesResponse\",\
+        \"resultWrapper\":\"GetIdentityMailFromDomainAttributesResult\"\
+      },\
+      \"documentation\":\"<p>Returns the custom MAIL FROM attributes for a list of identities (email addresses : domains).</p> <p>This operation is throttled at one request per second and can only get custom MAIL FROM attributes for up to 100 identities at a time.</p>\"\
     },\
-    \"GetDeliverabilityTestReport\":{\
-      \"name\":\"GetDeliverabilityTestReport\",\
+    \"GetIdentityNotificationAttributes\":{\
+      \"name\":\"GetIdentityNotificationAttributes\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/test-reports/{ReportId}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetDeliverabilityTestReportRequest\"},\
-      \"output\":{\"shape\":\"GetDeliverabilityTestReportResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieve the results of a predictive inbox placement test.</p>\"\
+      \"input\":{\"shape\":\"GetIdentityNotificationAttributesRequest\"},\
+      \"output\":{\
+        \"shape\":\"GetIdentityNotificationAttributesResponse\",\
+        \"resultWrapper\":\"GetIdentityNotificationAttributesResult\"\
+      },\
+      \"documentation\":\"<p>Given a list of verified identities (email addresses and/or domains), returns a structure describing identity notification attributes.</p> <p>This operation is throttled at one request per second and can only get notification attributes for up to 100 identities at a time.</p> <p>For more information about using notifications with Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"GetDomainDeliverabilityCampaign\":{\
-      \"name\":\"GetDomainDeliverabilityCampaign\",\
+    \"GetIdentityPolicies\":{\
+      \"name\":\"GetIdentityPolicies\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/campaigns/{CampaignId}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetDomainDeliverabilityCampaignRequest\"},\
-      \"output\":{\"shape\":\"GetDomainDeliverabilityCampaignResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"NotFoundException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieve all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for.</p>\"\
-    },\
-    \"GetDomainStatisticsReport\":{\
-      \"name\":\"GetDomainStatisticsReport\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/statistics-report/{Domain}\"\
+      \"input\":{\"shape\":\"GetIdentityPoliciesRequest\"},\
+      \"output\":{\
+        \"shape\":\"GetIdentityPoliciesResponse\",\
+        \"resultWrapper\":\"GetIdentityPoliciesResult\"\
       },\
-      \"input\":{\"shape\":\"GetDomainStatisticsReportRequest\"},\
-      \"output\":{\"shape\":\"GetDomainStatisticsReportResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieve inbox placement and engagement rates for the domains that you use to send email.</p>\"\
-    },\
-    \"GetEmailIdentity\":{\
-      \"name\":\"GetEmailIdentity\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}\"\
-      },\
-      \"input\":{\"shape\":\"GetEmailIdentityRequest\"},\
-      \"output\":{\"shape\":\"GetEmailIdentityResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Provides information about a specific identity, including the identity's verification status, sending authorization policies, its DKIM authentication status, and its custom Mail-From settings.</p>\"\
-    },\
-    \"GetEmailIdentityPolicies\":{\
-      \"name\":\"GetEmailIdentityPolicies\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/policies\"\
-      },\
-      \"input\":{\"shape\":\"GetEmailIdentityPoliciesRequest\"},\
-      \"output\":{\"shape\":\"GetEmailIdentityPoliciesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
       \"documentation\":\"<p>Returns the requested sending authorization policies for the given identity (an email address or a domain). The policies are returned as a map of policy names to policy contents. You can retrieve a maximum of 20 policies at a time.</p> <note> <p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p> </note> <p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"GetEmailTemplate\":{\
-      \"name\":\"GetEmailTemplate\",\
+    \"GetIdentityVerificationAttributes\":{\
+      \"name\":\"GetIdentityVerificationAttributes\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/templates/{TemplateName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"GetEmailTemplateResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Displays the template object (which includes the subject line, HTML part and text part) for the template you specify.</p> <p>You can execute this operation no more than once per second.</p>\"\
+      \"input\":{\"shape\":\"GetIdentityVerificationAttributesRequest\"},\
+      \"output\":{\
+        \"shape\":\"GetIdentityVerificationAttributesResponse\",\
+        \"resultWrapper\":\"GetIdentityVerificationAttributesResult\"\
+      },\
+      \"documentation\":\"<p>Given a list of identities (email addresses and/or domains), returns the verification status and (for domain identities) the verification token for each identity.</p> <p>The verification status of an email address is \\\"Pending\\\" until the email address owner clicks the link within the verification email that Amazon SES sent to that address. If the email address owner clicks the link within 24 hours, the verification status of the email address changes to \\\"Success\\\". If the link is not clicked within 24 hours, the verification status changes to \\\"Failed.\\\" In that case, if you still want to verify the email address, you must restart the verification process from the beginning.</p> <p>For domain identities, the domain's verification status is \\\"Pending\\\" as Amazon SES searches for the required TXT record in the DNS settings of the domain. When Amazon SES detects the record, the domain's verification status changes to \\\"Success\\\". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to \\\"Failed.\\\" In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p> <p>This operation is throttled at one request per second and can only get verification attributes for up to 100 identities at a time.</p>\"\
     },\
-    \"GetImportJob\":{\
-      \"name\":\"GetImportJob\",\
+    \"GetSendQuota\":{\
+      \"name\":\"GetSendQuota\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/import-jobs/{JobId}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetImportJobRequest\"},\
-      \"output\":{\"shape\":\"GetImportJobResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
-      ],\
-      \"documentation\":\"<p>Provides information about an import job.</p>\"\
+      \"output\":{\
+        \"shape\":\"GetSendQuotaResponse\",\
+        \"resultWrapper\":\"GetSendQuotaResult\"\
+      },\
+      \"documentation\":\"<p>Provides the sending limits for the Amazon SES account. </p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"GetSuppressedDestination\":{\
-      \"name\":\"GetSuppressedDestination\",\
+    \"GetSendStatistics\":{\
+      \"name\":\"GetSendStatistics\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/suppression/addresses/{EmailAddress}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"GetSuppressedDestinationRequest\"},\
-      \"output\":{\"shape\":\"GetSuppressedDestinationResponse\"},\
+      \"output\":{\
+        \"shape\":\"GetSendStatisticsResponse\",\
+        \"resultWrapper\":\"GetSendStatisticsResult\"\
+      },\
+      \"documentation\":\"<p>Provides sending statistics for the current AWS Region. The result is a list of data points, representing the last two weeks of sending activity. Each data point in the list contains statistics for a 15-minute period of time.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"GetTemplate\":{\
+      \"name\":\"GetTemplate\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"GetTemplateRequest\"},\
+      \"output\":{\
+        \"shape\":\"GetTemplateResponse\",\
+        \"resultWrapper\":\"GetTemplateResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"}\
+        {\"shape\":\"TemplateDoesNotExistException\"}\
       ],\
-      \"documentation\":\"<p>Retrieves information about a specific email address that's on the suppression list for your account.</p>\"\
+      \"documentation\":\"<p>Displays the template object (which includes the Subject line, HTML part and text part) for the template you specify.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
     \"ListConfigurationSets\":{\
       \"name\":\"ListConfigurationSets\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/configuration-sets\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"ListConfigurationSetsRequest\"},\
-      \"output\":{\"shape\":\"ListConfigurationSetsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>List all of the configuration sets associated with your account in the current region.</p> <p> <i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>\"\
+      \"output\":{\
+        \"shape\":\"ListConfigurationSetsResponse\",\
+        \"resultWrapper\":\"ListConfigurationSetsResult\"\
+      },\
+      \"documentation\":\"<p>Provides a list of the configuration sets associated with your Amazon SES account in the current AWS Region. For information about using configuration sets, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Monitoring Your Amazon SES Sending Activity</a> in the <i>Amazon SES Developer Guide.</i> </p> <p>You can execute this operation no more than once per second. This operation will return up to 1,000 configuration sets each time it is run. If your Amazon SES account has more than 1,000 configuration sets, this operation will also return a NextToken element. You can then execute the <code>ListConfigurationSets</code> operation again, passing the <code>NextToken</code> parameter and the value of the NextToken element to retrieve additional results.</p>\"\
     },\
     \"ListCustomVerificationEmailTemplates\":{\
       \"name\":\"ListCustomVerificationEmailTemplates\",\
       \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/custom-verification-email-templates\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"ListCustomVerificationEmailTemplatesRequest\"},\
-      \"output\":{\"shape\":\"ListCustomVerificationEmailTemplatesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Lists the existing custom verification email templates for your account in the current AWS Region.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
-    },\
-    \"ListDedicatedIpPools\":{\
-      \"name\":\"ListDedicatedIpPools\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/dedicated-ip-pools\"\
+      \"output\":{\
+        \"shape\":\"ListCustomVerificationEmailTemplatesResponse\",\
+        \"resultWrapper\":\"ListCustomVerificationEmailTemplatesResult\"\
       },\
-      \"input\":{\"shape\":\"ListDedicatedIpPoolsRequest\"},\
-      \"output\":{\"shape\":\"ListDedicatedIpPoolsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>List all of the dedicated IP pools that exist in your AWS account in the current Region.</p>\"\
+      \"documentation\":\"<p>Lists the existing custom verification email templates for your account in the current AWS Region.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"ListDeliverabilityTestReports\":{\
-      \"name\":\"ListDeliverabilityTestReports\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/test-reports\"\
-      },\
-      \"input\":{\"shape\":\"ListDeliverabilityTestReportsRequest\"},\
-      \"output\":{\"shape\":\"ListDeliverabilityTestReportsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Show a list of the predictive inbox placement tests that you've performed, regardless of their statuses. For predictive inbox placement tests that are complete, you can use the <code>GetDeliverabilityTestReport</code> operation to view the results.</p>\"\
-    },\
-    \"ListDomainDeliverabilityCampaigns\":{\
-      \"name\":\"ListDomainDeliverabilityCampaigns\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard/domains/{SubscribedDomain}/campaigns\"\
-      },\
-      \"input\":{\"shape\":\"ListDomainDeliverabilityCampaignsRequest\"},\
-      \"output\":{\"shape\":\"ListDomainDeliverabilityCampaignsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"NotFoundException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieve deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard for the domain.</p>\"\
-    },\
-    \"ListEmailIdentities\":{\
-      \"name\":\"ListEmailIdentities\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/identities\"\
-      },\
-      \"input\":{\"shape\":\"ListEmailIdentitiesRequest\"},\
-      \"output\":{\"shape\":\"ListEmailIdentitiesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Returns a list of all of the email identities that are associated with your AWS account. An identity can be either an email address or a domain. This operation returns identities that are verified as well as those that aren't. This operation returns identities that are associated with Amazon SES and Amazon Pinpoint.</p>\"\
-    },\
-    \"ListEmailTemplates\":{\
-      \"name\":\"ListEmailTemplates\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/templates\"\
-      },\
-      \"input\":{\"shape\":\"ListEmailTemplatesRequest\"},\
-      \"output\":{\"shape\":\"ListEmailTemplatesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Lists the email templates present in your Amazon SES account in the current AWS Region.</p> <p>You can execute this operation no more than once per second.</p>\"\
-    },\
-    \"ListImportJobs\":{\
-      \"name\":\"ListImportJobs\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/import-jobs\"\
-      },\
-      \"input\":{\"shape\":\"ListImportJobsRequest\"},\
-      \"output\":{\"shape\":\"ListImportJobsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Lists all of the import jobs.</p>\"\
-    },\
-    \"ListSuppressedDestinations\":{\
-      \"name\":\"ListSuppressedDestinations\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/suppression/addresses\"\
-      },\
-      \"input\":{\"shape\":\"ListSuppressedDestinationsRequest\"},\
-      \"output\":{\"shape\":\"ListSuppressedDestinationsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"InvalidNextTokenException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieves a list of email addresses that are on the suppression list for your account.</p>\"\
-    },\
-    \"ListTagsForResource\":{\
-      \"name\":\"ListTagsForResource\",\
-      \"http\":{\
-        \"method\":\"GET\",\
-        \"requestUri\":\"/v2/email/tags\"\
-      },\
-      \"input\":{\"shape\":\"ListTagsForResourceRequest\"},\
-      \"output\":{\"shape\":\"ListTagsForResourceResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
-      ],\
-      \"documentation\":\"<p>Retrieve a list of the tags (keys and values) that are associated with a specified resource. AÂ <i>tag</i>Â is a label that you optionally define and associate with a resource. Each tag consists of a requiredÂ <i>tag key</i>Â and an optional associatedÂ <i>tag value</i>. A tag key is a general label that acts as a category for more specific tag values. A tag value acts as a descriptor within a tag key.</p>\"\
-    },\
-    \"PutAccountDedicatedIpWarmupAttributes\":{\
-      \"name\":\"PutAccountDedicatedIpWarmupAttributes\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/account/dedicated-ips/warmup\"\
-      },\
-      \"input\":{\"shape\":\"PutAccountDedicatedIpWarmupAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutAccountDedicatedIpWarmupAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Enable or disable the automatic warm-up feature for dedicated IP addresses.</p>\"\
-    },\
-    \"PutAccountDetails\":{\
-      \"name\":\"PutAccountDetails\",\
+    \"ListIdentities\":{\
+      \"name\":\"ListIdentities\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/account/details\"\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"PutAccountDetailsRequest\"},\
-      \"output\":{\"shape\":\"PutAccountDetailsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConflictException\"}\
-      ],\
-      \"documentation\":\"<p>Update your Amazon SES account details.</p>\"\
+      \"input\":{\"shape\":\"ListIdentitiesRequest\"},\
+      \"output\":{\
+        \"shape\":\"ListIdentitiesResponse\",\
+        \"resultWrapper\":\"ListIdentitiesResult\"\
+      },\
+      \"documentation\":\"<p>Returns a list containing all of the identities (email addresses and domains) for your AWS account in the current AWS Region, regardless of verification status.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"PutAccountSendingAttributes\":{\
-      \"name\":\"PutAccountSendingAttributes\",\
+    \"ListIdentityPolicies\":{\
+      \"name\":\"ListIdentityPolicies\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/account/sending\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"PutAccountSendingAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutAccountSendingAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Enable or disable the ability of your account to send email.</p>\"\
+      \"input\":{\"shape\":\"ListIdentityPoliciesRequest\"},\
+      \"output\":{\
+        \"shape\":\"ListIdentityPoliciesResponse\",\
+        \"resultWrapper\":\"ListIdentityPoliciesResult\"\
+      },\
+      \"documentation\":\"<p>Returns a list of sending authorization policies that are attached to the given identity (an email address or a domain). This API returns only a list. If you want the actual policy content, you can use <code>GetIdentityPolicies</code>.</p> <note> <p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p> </note> <p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"PutAccountSuppressionAttributes\":{\
-      \"name\":\"PutAccountSuppressionAttributes\",\
+    \"ListReceiptFilters\":{\
+      \"name\":\"ListReceiptFilters\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/account/suppression\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"PutAccountSuppressionAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutAccountSuppressionAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Change the settings for the account-level suppression list.</p>\"\
+      \"input\":{\"shape\":\"ListReceiptFiltersRequest\"},\
+      \"output\":{\
+        \"shape\":\"ListReceiptFiltersResponse\",\
+        \"resultWrapper\":\"ListReceiptFiltersResult\"\
+      },\
+      \"documentation\":\"<p>Lists the IP address filters associated with your AWS account in the current AWS Region.</p> <p>For information about managing IP address filters, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"ListReceiptRuleSets\":{\
+      \"name\":\"ListReceiptRuleSets\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"ListReceiptRuleSetsRequest\"},\
+      \"output\":{\
+        \"shape\":\"ListReceiptRuleSetsResponse\",\
+        \"resultWrapper\":\"ListReceiptRuleSetsResult\"\
+      },\
+      \"documentation\":\"<p>Lists the receipt rule sets that exist under your AWS account in the current AWS Region. If there are additional receipt rule sets to be retrieved, you will receive a <code>NextToken</code> that you can provide to the next call to <code>ListReceiptRuleSets</code> to retrieve the additional entries.</p> <p>For information about managing receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"ListTemplates\":{\
+      \"name\":\"ListTemplates\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"ListTemplatesRequest\"},\
+      \"output\":{\
+        \"shape\":\"ListTemplatesResponse\",\
+        \"resultWrapper\":\"ListTemplatesResult\"\
+      },\
+      \"documentation\":\"<p>Lists the email templates present in your Amazon SES account in the current AWS Region.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"ListVerifiedEmailAddresses\":{\
+      \"name\":\"ListVerifiedEmailAddresses\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"output\":{\
+        \"shape\":\"ListVerifiedEmailAddressesResponse\",\
+        \"resultWrapper\":\"ListVerifiedEmailAddressesResult\"\
+      },\
+      \"documentation\":\"<p>Deprecated. Use the <code>ListIdentities</code> operation to list the email addresses and domains associated with your account.</p>\"\
     },\
     \"PutConfigurationSetDeliveryOptions\":{\
       \"name\":\"PutConfigurationSetDeliveryOptions\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/delivery-options\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"PutConfigurationSetDeliveryOptionsRequest\"},\
-      \"output\":{\"shape\":\"PutConfigurationSetDeliveryOptionsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Associate a configuration set with a dedicated IP pool. You can use dedicated IP pools to create groups of dedicated IP addresses for sending specific types of email.</p>\"\
-    },\
-    \"PutConfigurationSetReputationOptions\":{\
-      \"name\":\"PutConfigurationSetReputationOptions\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/reputation-options\"\
+      \"output\":{\
+        \"shape\":\"PutConfigurationSetDeliveryOptionsResponse\",\
+        \"resultWrapper\":\"PutConfigurationSetDeliveryOptionsResult\"\
       },\
-      \"input\":{\"shape\":\"PutConfigurationSetReputationOptionsRequest\"},\
-      \"output\":{\"shape\":\"PutConfigurationSetReputationOptionsResponse\"},\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"InvalidDeliveryOptionsException\"}\
       ],\
-      \"documentation\":\"<p>Enable or disable collection of reputation metrics for emails that you send using a particular configuration set in a specific AWS Region.</p>\"\
+      \"documentation\":\"<p>Adds or updates the delivery options for a configuration set.</p>\"\
     },\
-    \"PutConfigurationSetSendingOptions\":{\
-      \"name\":\"PutConfigurationSetSendingOptions\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/sending\"\
-      },\
-      \"input\":{\"shape\":\"PutConfigurationSetSendingOptionsRequest\"},\
-      \"output\":{\"shape\":\"PutConfigurationSetSendingOptionsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Enable or disable email sending for messages that use a particular configuration set in a specific AWS Region.</p>\"\
-    },\
-    \"PutConfigurationSetSuppressionOptions\":{\
-      \"name\":\"PutConfigurationSetSuppressionOptions\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/suppression-options\"\
-      },\
-      \"input\":{\"shape\":\"PutConfigurationSetSuppressionOptionsRequest\"},\
-      \"output\":{\"shape\":\"PutConfigurationSetSuppressionOptionsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Specify the account suppression list preferences for a configuration set.</p>\"\
-    },\
-    \"PutConfigurationSetTrackingOptions\":{\
-      \"name\":\"PutConfigurationSetTrackingOptions\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/tracking-options\"\
-      },\
-      \"input\":{\"shape\":\"PutConfigurationSetTrackingOptionsRequest\"},\
-      \"output\":{\"shape\":\"PutConfigurationSetTrackingOptionsResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Specify a custom domain to use for open and click tracking elements in email that you send.</p>\"\
-    },\
-    \"PutDedicatedIpInPool\":{\
-      \"name\":\"PutDedicatedIpInPool\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/dedicated-ips/{IP}/pool\"\
-      },\
-      \"input\":{\"shape\":\"PutDedicatedIpInPoolRequest\"},\
-      \"output\":{\"shape\":\"PutDedicatedIpInPoolResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Move a dedicated IP address to an existing dedicated IP pool.</p> <note> <p>The dedicated IP address that you specify must already exist, and must be associated with your AWS account. </p> <p>The dedicated IP pool you specify must already exist. You can create a new pool by using the <code>CreateDedicatedIpPool</code> operation.</p> </note>\"\
-    },\
-    \"PutDedicatedIpWarmupAttributes\":{\
-      \"name\":\"PutDedicatedIpWarmupAttributes\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/dedicated-ips/{IP}/warmup\"\
-      },\
-      \"input\":{\"shape\":\"PutDedicatedIpWarmupAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutDedicatedIpWarmupAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p/>\"\
-    },\
-    \"PutDeliverabilityDashboardOption\":{\
-      \"name\":\"PutDeliverabilityDashboardOption\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/deliverability-dashboard\"\
-      },\
-      \"input\":{\"shape\":\"PutDeliverabilityDashboardOptionRequest\"},\
-      \"output\":{\"shape\":\"PutDeliverabilityDashboardOptionResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"AlreadyExistsException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email. You also gain the ability to perform predictive inbox placement tests.</p> <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href=\\\"http://aws.amazon.com/ses/pricing/\\\">Amazon SES Pricing</a>.</p>\"\
-    },\
-    \"PutEmailIdentityDkimAttributes\":{\
-      \"name\":\"PutEmailIdentityDkimAttributes\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/dkim\"\
-      },\
-      \"input\":{\"shape\":\"PutEmailIdentityDkimAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutEmailIdentityDkimAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Used to enable or disable DKIM authentication for an email identity.</p>\"\
-    },\
-    \"PutEmailIdentityDkimSigningAttributes\":{\
-      \"name\":\"PutEmailIdentityDkimSigningAttributes\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v1/email/identities/{EmailIdentity}/dkim/signing\"\
-      },\
-      \"input\":{\"shape\":\"PutEmailIdentityDkimSigningAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutEmailIdentityDkimSigningAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Used to configure or change the DKIM authentication settings for an email domain identity. You can use this operation to do any of the following:</p> <ul> <li> <p>Update the signing attributes for an identity that uses Bring Your Own DKIM (BYODKIM).</p> </li> <li> <p>Change from using no DKIM authentication to using Easy DKIM.</p> </li> <li> <p>Change from using no DKIM authentication to using BYODKIM.</p> </li> <li> <p>Change from using Easy DKIM to using BYODKIM.</p> </li> <li> <p>Change from using BYODKIM to using Easy DKIM.</p> </li> </ul>\"\
-    },\
-    \"PutEmailIdentityFeedbackAttributes\":{\
-      \"name\":\"PutEmailIdentityFeedbackAttributes\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/feedback\"\
-      },\
-      \"input\":{\"shape\":\"PutEmailIdentityFeedbackAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutEmailIdentityFeedbackAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Used to enable or disable feedback forwarding for an identity. This setting determines what happens when an identity is used to send an email that results in a bounce or complaint event.</p> <p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p> <p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>\"\
-    },\
-    \"PutEmailIdentityMailFromAttributes\":{\
-      \"name\":\"PutEmailIdentityMailFromAttributes\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/mail-from\"\
-      },\
-      \"input\":{\"shape\":\"PutEmailIdentityMailFromAttributesRequest\"},\
-      \"output\":{\"shape\":\"PutEmailIdentityMailFromAttributesResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
-      ],\
-      \"documentation\":\"<p>Used to enable or disable the custom Mail-From domain configuration for an email identity.</p>\"\
-    },\
-    \"PutSuppressedDestination\":{\
-      \"name\":\"PutSuppressedDestination\",\
-      \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/suppression/addresses\"\
-      },\
-      \"input\":{\"shape\":\"PutSuppressedDestinationRequest\"},\
-      \"output\":{\"shape\":\"PutSuppressedDestinationResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
-      ],\
-      \"documentation\":\"<p>Adds an email address to the suppression list for your account.</p>\"\
-    },\
-    \"SendBulkEmail\":{\
-      \"name\":\"SendBulkEmail\",\
+    \"PutIdentityPolicy\":{\
+      \"name\":\"PutIdentityPolicy\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/outbound-bulk-emails\"\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"SendBulkEmailRequest\"},\
-      \"output\":{\"shape\":\"SendBulkEmailResponse\"},\
+      \"input\":{\"shape\":\"PutIdentityPolicyRequest\"},\
+      \"output\":{\
+        \"shape\":\"PutIdentityPolicyResponse\",\
+        \"resultWrapper\":\"PutIdentityPolicyResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"AccountSuspendedException\"},\
-        {\"shape\":\"SendingPausedException\"},\
+        {\"shape\":\"InvalidPolicyException\"}\
+      ],\
+      \"documentation\":\"<p>Adds or updates a sending authorization policy for the specified identity (an email address or a domain).</p> <note> <p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p> </note> <p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"ReorderReceiptRuleSet\":{\
+      \"name\":\"ReorderReceiptRuleSet\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"ReorderReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"ReorderReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"ReorderReceiptRuleSetResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"RuleSetDoesNotExistException\"},\
+        {\"shape\":\"RuleDoesNotExistException\"}\
+      ],\
+      \"documentation\":\"<p>Reorders the receipt rules within a receipt rule set.</p> <note> <p>All of the rules in the rule set must be represented in this request. That is, this API will return an error if the reorder request doesn't explicitly position all of the rules.</p> </note> <p>For information about managing receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"SendBounce\":{\
+      \"name\":\"SendBounce\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SendBounceRequest\"},\
+      \"output\":{\
+        \"shape\":\"SendBounceResponse\",\
+        \"resultWrapper\":\"SendBounceResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"MessageRejected\"}\
+      ],\
+      \"documentation\":\"<p>Generates and sends a bounce message to the sender of an email you received through Amazon SES. You can only use this API on an email up to 24 hours after you receive it.</p> <note> <p>You cannot use this API to send generic bounces for mail that was not received by Amazon SES.</p> </note> <p>For information about receiving email through Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"SendBulkTemplatedEmail\":{\
+      \"name\":\"SendBulkTemplatedEmail\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SendBulkTemplatedEmailRequest\"},\
+      \"output\":{\
+        \"shape\":\"SendBulkTemplatedEmailResponse\",\
+        \"resultWrapper\":\"SendBulkTemplatedEmailResult\"\
+      },\
+      \"errors\":[\
         {\"shape\":\"MessageRejected\"},\
         {\"shape\":\"MailFromDomainNotVerifiedException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"TemplateDoesNotExistException\"},\
+        {\"shape\":\"ConfigurationSetSendingPausedException\"},\
+        {\"shape\":\"AccountSendingPausedException\"}\
       ],\
-      \"documentation\":\"<p>Composes an email message to multiple destinations.</p>\"\
+      \"documentation\":\"<p>Composes an email message to multiple destinations. The message body is created using an email template.</p> <p>In order to send email using the <code>SendBulkTemplatedEmail</code> operation, your call to the API must meet the following requirements:</p> <ul> <li> <p>The call must refer to an existing email template. You can create email templates using the <a>CreateTemplate</a> operation.</p> </li> <li> <p>The message must be sent from a verified email address or domain.</p> </li> <li> <p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i> </p> </li> <li> <p>The maximum message size is 10 MB.</p> </li> <li> <p>Each <code>Destination</code> parameter must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p> </li> <li> <p>The message may not include more than 50 recipients, across the To:, CC: and BCC: fields. If you need to send an email message to a larger audience, you can divide your recipient list into groups of 50 or fewer, and then call the <code>SendBulkTemplatedEmail</code> operation several times to send the message to each group.</p> </li> <li> <p>The number of destinations you can contact in a single call to the API may be limited by your account's maximum sending rate.</p> </li> </ul>\"\
     },\
     \"SendCustomVerificationEmail\":{\
       \"name\":\"SendCustomVerificationEmail\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/outbound-custom-verification-emails\"\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"SendCustomVerificationEmailRequest\"},\
-      \"output\":{\"shape\":\"SendCustomVerificationEmailResponse\"},\
+      \"output\":{\
+        \"shape\":\"SendCustomVerificationEmailResponse\",\
+        \"resultWrapper\":\"SendCustomVerificationEmailResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
         {\"shape\":\"MessageRejected\"},\
-        {\"shape\":\"SendingPausedException\"},\
-        {\"shape\":\"MailFromDomainNotVerifiedException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"CustomVerificationEmailTemplateDoesNotExistException\"},\
+        {\"shape\":\"FromEmailAddressNotVerifiedException\"},\
+        {\"shape\":\"ProductionAccessNotGrantedException\"}\
       ],\
-      \"documentation\":\"<p>Adds an email address to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. As a result of executing this operation, a customized verification email is sent to the specified address.</p> <p>To use this operation, you must first create a custom verification email template. For more information about creating and using custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+      \"documentation\":\"<p>Adds an email address to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. As a result of executing this operation, a customized verification email is sent to the specified address.</p> <p>To use this operation, you must first create a custom verification email template. For more information about creating and using custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
     \"SendEmail\":{\
       \"name\":\"SendEmail\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/outbound-emails\"\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"SendEmailRequest\"},\
-      \"output\":{\"shape\":\"SendEmailResponse\"},\
+      \"output\":{\
+        \"shape\":\"SendEmailResponse\",\
+        \"resultWrapper\":\"SendEmailResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"LimitExceededException\"},\
-        {\"shape\":\"AccountSuspendedException\"},\
-        {\"shape\":\"SendingPausedException\"},\
         {\"shape\":\"MessageRejected\"},\
         {\"shape\":\"MailFromDomainNotVerifiedException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"ConfigurationSetSendingPausedException\"},\
+        {\"shape\":\"AccountSendingPausedException\"}\
       ],\
-      \"documentation\":\"<p>Sends an email message. You can use the Amazon SES API v2 to send two types of messages:</p> <ul> <li> <p> <b>Simple</b> â A standard email message. When you create this type of message, you specify the sender, the recipient, and the message body, and Amazon SES assembles the message for you.</p> </li> <li> <p> <b>Raw</b> â A raw, MIME-formatted email message. When you send this type of email, you have to specify all of the message headers, as well as the message body. You can use this message type to send messages that contain attachments. The message that you specify has to be a valid MIME message.</p> </li> <li> <p> <b>Templated</b> â A message that contains personalization tags. When you send this type of email, Amazon SES API v2 automatically replaces the tags with values that you specify.</p> </li> </ul>\"\
+      \"documentation\":\"<p>Composes an email message and immediately queues it for sending. In order to send email using the <code>SendEmail</code> operation, your message must meet the following requirements:</p> <ul> <li> <p>The message must be sent from a verified email address or domain. If you attempt to send email using a non-verified address or domain, the operation will result in an \\\"Email address not verified\\\" error. </p> </li> <li> <p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i> </p> </li> <li> <p>The maximum message size is 10 MB.</p> </li> <li> <p>The message must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p> </li> <li> <p>The message may not include more than 50 recipients, across the To:, CC: and BCC: fields. If you need to send an email message to a larger audience, you can divide your recipient list into groups of 50 or fewer, and then call the <code>SendEmail</code> operation several times to send the message to each group.</p> </li> </ul> <important> <p>For every message that you send, the total number of recipients (including each recipient in the To:, CC: and BCC: fields) is counted against the maximum number of emails you can send in a 24-hour period (your <i>sending quota</i>). For more information about sending quotas in Amazon SES, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html\\\">Managing Your Amazon SES Sending Limits</a> in the <i>Amazon SES Developer Guide.</i> </p> </important>\"\
     },\
-    \"TagResource\":{\
-      \"name\":\"TagResource\",\
+    \"SendRawEmail\":{\
+      \"name\":\"SendRawEmail\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/tags\"\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"TagResourceRequest\"},\
-      \"output\":{\"shape\":\"TagResourceResponse\"},\
+      \"input\":{\"shape\":\"SendRawEmailRequest\"},\
+      \"output\":{\
+        \"shape\":\"SendRawEmailResponse\",\
+        \"resultWrapper\":\"SendRawEmailResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
+        {\"shape\":\"MessageRejected\"},\
+        {\"shape\":\"MailFromDomainNotVerifiedException\"},\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"ConfigurationSetSendingPausedException\"},\
+        {\"shape\":\"AccountSendingPausedException\"}\
       ],\
-      \"documentation\":\"<p>Add one or more tags (keys and values) to a specified resource. A <i>tag</i>Â is a label that you optionally define and associate with a resource. Tags can help you categorize and manage resources in different ways, such as by purpose, owner, environment, or other criteria. A resource can have as many as 50 tags.</p> <p>Each tag consists of a requiredÂ <i>tag key</i>Â and an associatedÂ <i>tag value</i>, both of which you define. A tag key is a general label that acts as a category for more specific tag values. A tag value acts as a descriptor within a tag key.</p>\"\
+      \"documentation\":\"<p>Composes an email message and immediately queues it for sending.</p> <p>This operation is more flexible than the <code>SendEmail</code> API operation. When you use the <code>SendRawEmail</code> operation, you can specify the headers of the message as well as its content. This flexibility is useful, for example, when you want to send a multipart MIME email (such a message that contains both a text and an HTML version). You can also use this operation to send messages that include attachments.</p> <p>The <code>SendRawEmail</code> operation has the following requirements:</p> <ul> <li> <p>You can only send email from <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">verified email addresses or domains</a>. If you try to send email from an address that isn't verified, the operation results in an \\\"Email address not verified\\\" error.</p> </li> <li> <p>If your account is still in the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html\\\">Amazon SES sandbox</a>, you can only send email to other verified addresses in your account, or to addresses that are associated with the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html\\\">Amazon SES mailbox simulator</a>.</p> </li> <li> <p>The maximum message size, including attachments, is 10 MB.</p> </li> <li> <p>Each message has to include at least one recipient address. A recipient address includes any address on the To:, CC:, or BCC: lines.</p> </li> <li> <p>If you send a single message to more than one recipient address, and one of the recipient addresses isn't in a valid format (that is, it's not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), Amazon SES rejects the entire message, even if the other addresses are valid.</p> </li> <li> <p>Each message can include up to 50 recipient addresses across the To:, CC:, or BCC: lines. If you need to send a single message to more than 50 recipients, you have to split the list of recipient addresses into groups of less than 50 recipients, and send separate messages to each group.</p> </li> <li> <p>Amazon SES allows you to specify 8-bit Content-Transfer-Encoding for MIME message parts. However, if Amazon SES has to modify the contents of your message (for example, if you use open and click tracking), 8-bit content isn't preserved. For this reason, we highly recommend that you encode all content that isn't 7-bit ASCII. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html#send-email-mime-encoding\\\">MIME Encoding</a> in the <i>Amazon SES Developer Guide</i>.</p> </li> </ul> <p>Additionally, keep the following considerations in mind when using the <code>SendRawEmail</code> operation:</p> <ul> <li> <p>Although you can customize the message headers when using the <code>SendRawEmail</code> operation, Amazon SES will automatically apply its own <code>Message-ID</code> and <code>Date</code> headers; if you passed these headers when creating the message, they will be overwritten by the values that Amazon SES provides.</p> </li> <li> <p>If you are using sending authorization to send on behalf of another user, <code>SendRawEmail</code> enables you to specify the cross-account identity for the email's Source, From, and Return-Path parameters in one of two ways: you can pass optional parameters <code>SourceArn</code>, <code>FromArn</code>, and/or <code>ReturnPathArn</code> to the API, or you can include the following X-headers in the header of your raw email:</p> <ul> <li> <p> <code>X-SES-SOURCE-ARN</code> </p> </li> <li> <p> <code>X-SES-FROM-ARN</code> </p> </li> <li> <p> <code>X-SES-RETURN-PATH-ARN</code> </p> </li> </ul> <important> <p>Don't include these X-headers in the DKIM signature. Amazon SES removes these before it sends the email.</p> </important> <p>If you only specify the <code>SourceIdentityArn</code> parameter, Amazon SES sets the From and Return-Path addresses to the same identity that you specified.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Using Sending Authorization with Amazon SES</a> in the <i>Amazon SES Developer Guide.</i> </p> </li> <li> <p>For every message that you send, the total number of recipients (including each recipient in the To:, CC: and BCC: fields) is counted against the maximum number of emails you can send in a 24-hour period (your <i>sending quota</i>). For more information about sending quotas in Amazon SES, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html\\\">Managing Your Amazon SES Sending Limits</a> in the <i>Amazon SES Developer Guide.</i> </p> </li> </ul>\"\
     },\
-    \"TestRenderEmailTemplate\":{\
-      \"name\":\"TestRenderEmailTemplate\",\
+    \"SendTemplatedEmail\":{\
+      \"name\":\"SendTemplatedEmail\",\
       \"http\":{\
         \"method\":\"POST\",\
-        \"requestUri\":\"/v2/email/templates/{TemplateName}/render\"\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"TestRenderEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"TestRenderEmailTemplateResponse\"},\
+      \"input\":{\"shape\":\"SendTemplatedEmailRequest\"},\
+      \"output\":{\
+        \"shape\":\"SendTemplatedEmailResponse\",\
+        \"resultWrapper\":\"SendTemplatedEmailResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"MessageRejected\"},\
+        {\"shape\":\"MailFromDomainNotVerifiedException\"},\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"TemplateDoesNotExistException\"},\
+        {\"shape\":\"ConfigurationSetSendingPausedException\"},\
+        {\"shape\":\"AccountSendingPausedException\"}\
+      ],\
+      \"documentation\":\"<p>Composes an email message using an email template and immediately queues it for sending.</p> <p>In order to send email using the <code>SendTemplatedEmail</code> operation, your call to the API must meet the following requirements:</p> <ul> <li> <p>The call must refer to an existing email template. You can create email templates using the <a>CreateTemplate</a> operation.</p> </li> <li> <p>The message must be sent from a verified email address or domain.</p> </li> <li> <p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i> </p> </li> <li> <p>The maximum message size is 10 MB.</p> </li> <li> <p>Calls to the <code>SendTemplatedEmail</code> operation may only include one <code>Destination</code> parameter. A destination is a set of recipients who will receive the same version of the email. The <code>Destination</code> parameter can include up to 50 recipients, across the To:, CC: and BCC: fields.</p> </li> <li> <p>The <code>Destination</code> parameter must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p> </li> </ul> <important> <p>If your call to the <code>SendTemplatedEmail</code> operation includes all of the required parameters, Amazon SES accepts it and returns a Message ID. However, if Amazon SES can't render the email because the template contains errors, it doesn't send the email. Additionally, because it already accepted the message, Amazon SES doesn't return a message stating that it was unable to send the email.</p> <p>For these reasons, we highly recommend that you set up Amazon SES to send you notifications when Rendering Failure events occur. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Sending Personalized Email Using the Amazon SES API</a> in the <i>Amazon Simple Email Service Developer Guide</i>.</p> </important>\"\
+    },\
+    \"SetActiveReceiptRuleSet\":{\
+      \"name\":\"SetActiveReceiptRuleSet\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetActiveReceiptRuleSetRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetActiveReceiptRuleSetResponse\",\
+        \"resultWrapper\":\"SetActiveReceiptRuleSetResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"RuleSetDoesNotExistException\"}\
+      ],\
+      \"documentation\":\"<p>Sets the specified receipt rule set as the active receipt rule set.</p> <note> <p>To disable your email-receiving through Amazon SES completely, you can call this API with RuleSetName set to null.</p> </note> <p>For information about managing receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"SetIdentityDkimEnabled\":{\
+      \"name\":\"SetIdentityDkimEnabled\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetIdentityDkimEnabledRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetIdentityDkimEnabledResponse\",\
+        \"resultWrapper\":\"SetIdentityDkimEnabledResult\"\
+      },\
+      \"documentation\":\"<p>Enables or disables Easy DKIM signing of email sent from an identity. If Easy DKIM signing is enabled for a domain, then Amazon SES uses DKIM to sign all email that it sends from addresses on that domain. If Easy DKIM signing is enabled for an email address, then Amazon SES uses DKIM to sign all email it sends from that address.</p> <note> <p>For email addresses (for example, <code>user@example.com</code>), you can only enable DKIM signing if the corresponding domain (in this case, <code>example.com</code>) has been set up to use Easy DKIM.</p> </note> <p>You can enable DKIM signing for an identity at any time after you start the verification process for the identity, even if the verification process isn't complete. </p> <p>You can execute this operation no more than once per second.</p> <p>For more information about Easy DKIM signing, go to the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityFeedbackForwardingEnabled\":{\
+      \"name\":\"SetIdentityFeedbackForwardingEnabled\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetIdentityFeedbackForwardingEnabledRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetIdentityFeedbackForwardingEnabledResponse\",\
+        \"resultWrapper\":\"SetIdentityFeedbackForwardingEnabledResult\"\
+      },\
+      \"documentation\":\"<p>Given an identity (an email address or a domain), enables or disables whether Amazon SES forwards bounce and complaint notifications as email. Feedback forwarding can only be disabled when Amazon Simple Notification Service (Amazon SNS) topics are specified for both bounces and complaints.</p> <note> <p>Feedback forwarding does not apply to delivery notifications. Delivery notifications are only available through Amazon SNS.</p> </note> <p>You can execute this operation no more than once per second.</p> <p>For more information about using notifications with Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityHeadersInNotificationsEnabled\":{\
+      \"name\":\"SetIdentityHeadersInNotificationsEnabled\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetIdentityHeadersInNotificationsEnabledRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetIdentityHeadersInNotificationsEnabledResponse\",\
+        \"resultWrapper\":\"SetIdentityHeadersInNotificationsEnabledResult\"\
+      },\
+      \"documentation\":\"<p>Given an identity (an email address or a domain), sets whether Amazon SES includes the original email headers in the Amazon Simple Notification Service (Amazon SNS) notifications of a specified type.</p> <p>You can execute this operation no more than once per second.</p> <p>For more information about using notifications with Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityMailFromDomain\":{\
+      \"name\":\"SetIdentityMailFromDomain\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetIdentityMailFromDomainRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetIdentityMailFromDomainResponse\",\
+        \"resultWrapper\":\"SetIdentityMailFromDomainResult\"\
+      },\
+      \"documentation\":\"<p>Enables or disables the custom MAIL FROM domain setup for a verified identity (an email address or a domain).</p> <important> <p>To send emails using the specified MAIL FROM domain, you must add an MX record to your MAIL FROM domain's DNS settings. If you want your emails to pass Sender Policy Framework (SPF) checks, you must also add or update an SPF record. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-set.html\\\">Amazon SES Developer Guide</a>.</p> </important> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"SetIdentityNotificationTopic\":{\
+      \"name\":\"SetIdentityNotificationTopic\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetIdentityNotificationTopicRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetIdentityNotificationTopicResponse\",\
+        \"resultWrapper\":\"SetIdentityNotificationTopicResult\"\
+      },\
+      \"documentation\":\"<p>Sets an Amazon Simple Notification Service (Amazon SNS) topic to use when delivering notifications. When you use this operation, you specify a verified identity, such as an email address or domain. When you send an email that uses the chosen identity in the Source field, Amazon SES sends notifications to the topic you specified. You can send bounce, complaint, or delivery notifications (or any combination of the three) to the Amazon SNS topic that you specify.</p> <p>You can execute this operation no more than once per second.</p> <p>For more information about feedback notification, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetReceiptRulePosition\":{\
+      \"name\":\"SetReceiptRulePosition\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"SetReceiptRulePositionRequest\"},\
+      \"output\":{\
+        \"shape\":\"SetReceiptRulePositionResponse\",\
+        \"resultWrapper\":\"SetReceiptRulePositionResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"RuleSetDoesNotExistException\"},\
+        {\"shape\":\"RuleDoesNotExistException\"}\
+      ],\
+      \"documentation\":\"<p>Sets the position of the specified receipt rule in the receipt rule set.</p> <p>For information about managing receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"TestRenderTemplate\":{\
+      \"name\":\"TestRenderTemplate\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"TestRenderTemplateRequest\"},\
+      \"output\":{\
+        \"shape\":\"TestRenderTemplateResponse\",\
+        \"resultWrapper\":\"TestRenderTemplateResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"TemplateDoesNotExistException\"},\
+        {\"shape\":\"InvalidRenderingParameterException\"},\
+        {\"shape\":\"MissingRenderingAttributeException\"}\
       ],\
       \"documentation\":\"<p>Creates a preview of the MIME content of an email when provided with a template and a set of replacement data.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"UntagResource\":{\
-      \"name\":\"UntagResource\",\
+    \"UpdateAccountSendingEnabled\":{\
+      \"name\":\"UpdateAccountSendingEnabled\",\
       \"http\":{\
-        \"method\":\"DELETE\",\
-        \"requestUri\":\"/v2/email/tags\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"UntagResourceRequest\"},\
-      \"output\":{\"shape\":\"UntagResourceResponse\"},\
-      \"errors\":[\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"ConcurrentModificationException\"},\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
-      ],\
-      \"documentation\":\"<p>Remove one or more tags (keys and values) from a specified resource.</p>\"\
+      \"input\":{\"shape\":\"UpdateAccountSendingEnabledRequest\"},\
+      \"documentation\":\"<p>Enables or disables email sending across your entire Amazon SES account in the current AWS Region. You can use this operation in conjunction with Amazon CloudWatch alarms to temporarily pause email sending across your Amazon SES account in a given AWS Region when reputation metrics (such as your bounce or complaint rates) reach certain thresholds.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
     \"UpdateConfigurationSetEventDestination\":{\
       \"name\":\"UpdateConfigurationSetEventDestination\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/configuration-sets/{ConfigurationSetName}/event-destinations/{EventDestinationName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"UpdateConfigurationSetEventDestinationRequest\"},\
-      \"output\":{\"shape\":\"UpdateConfigurationSetEventDestinationResponse\"},\
+      \"output\":{\
+        \"shape\":\"UpdateConfigurationSetEventDestinationResponse\",\
+        \"resultWrapper\":\"UpdateConfigurationSetEventDestinationResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"EventDestinationDoesNotExistException\"},\
+        {\"shape\":\"InvalidCloudWatchDestinationException\"},\
+        {\"shape\":\"InvalidFirehoseDestinationException\"},\
+        {\"shape\":\"InvalidSNSDestinationException\"}\
       ],\
-      \"documentation\":\"<p>Update the configuration of an event destination for a configuration set.</p> <p> <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>\"\
+      \"documentation\":\"<p>Updates the event destination of a configuration set. Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Monitoring Your Amazon SES Sending Activity</a> in the <i>Amazon SES Developer Guide.</i> </p> <note> <p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS).</p> </note> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"UpdateConfigurationSetReputationMetricsEnabled\":{\
+      \"name\":\"UpdateConfigurationSetReputationMetricsEnabled\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"UpdateConfigurationSetReputationMetricsEnabledRequest\"},\
+      \"errors\":[\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"}\
+      ],\
+      \"documentation\":\"<p>Enables or disables the publishing of reputation metrics for emails sent using a specific configuration set in a given AWS Region. Reputation metrics include bounce and complaint rates. These metrics are published to Amazon CloudWatch. By using CloudWatch, you can create alarms when bounce or complaint rates exceed certain thresholds.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"UpdateConfigurationSetSendingEnabled\":{\
+      \"name\":\"UpdateConfigurationSetSendingEnabled\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"UpdateConfigurationSetSendingEnabledRequest\"},\
+      \"errors\":[\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"}\
+      ],\
+      \"documentation\":\"<p>Enables or disables email sending for messages sent using a specific configuration set in a given AWS Region. You can use this operation in conjunction with Amazon CloudWatch alarms to temporarily pause email sending for a configuration set when the reputation metrics for that configuration set (such as your bounce on complaint rate) exceed certain thresholds.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"UpdateConfigurationSetTrackingOptions\":{\
+      \"name\":\"UpdateConfigurationSetTrackingOptions\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"UpdateConfigurationSetTrackingOptionsRequest\"},\
+      \"output\":{\
+        \"shape\":\"UpdateConfigurationSetTrackingOptionsResponse\",\
+        \"resultWrapper\":\"UpdateConfigurationSetTrackingOptionsResult\"\
+      },\
+      \"errors\":[\
+        {\"shape\":\"ConfigurationSetDoesNotExistException\"},\
+        {\"shape\":\"TrackingOptionsDoesNotExistException\"},\
+        {\"shape\":\"InvalidTrackingOptionsException\"}\
+      ],\
+      \"documentation\":\"<p>Modifies an association between a configuration set and a custom domain for open and click event tracking. </p> <p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"UpdateCustomVerificationEmailTemplate\":{\
       \"name\":\"UpdateCustomVerificationEmailTemplate\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/custom-verification-email-templates/{TemplateName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
       \"input\":{\"shape\":\"UpdateCustomVerificationEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"UpdateCustomVerificationEmailTemplateResponse\"},\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"BadRequestException\"},\
-        {\"shape\":\"TooManyRequestsException\"}\
+        {\"shape\":\"CustomVerificationEmailTemplateDoesNotExistException\"},\
+        {\"shape\":\"FromEmailAddressNotVerifiedException\"},\
+        {\"shape\":\"CustomVerificationEmailInvalidContentException\"}\
       ],\
-      \"documentation\":\"<p>Updates an existing custom verification email template.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+      \"documentation\":\"<p>Updates an existing custom verification email template.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"UpdateEmailIdentityPolicy\":{\
-      \"name\":\"UpdateEmailIdentityPolicy\",\
+    \"UpdateReceiptRule\":{\
+      \"name\":\"UpdateReceiptRule\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/identities/{EmailIdentity}/policies/{PolicyName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"UpdateEmailIdentityPolicyRequest\"},\
-      \"output\":{\"shape\":\"UpdateEmailIdentityPolicyResponse\"},\
+      \"input\":{\"shape\":\"UpdateReceiptRuleRequest\"},\
+      \"output\":{\
+        \"shape\":\"UpdateReceiptRuleResponse\",\
+        \"resultWrapper\":\"UpdateReceiptRuleResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"InvalidSnsTopicException\"},\
+        {\"shape\":\"InvalidS3ConfigurationException\"},\
+        {\"shape\":\"InvalidLambdaFunctionException\"},\
+        {\"shape\":\"RuleSetDoesNotExistException\"},\
+        {\"shape\":\"RuleDoesNotExistException\"},\
+        {\"shape\":\"LimitExceededException\"}\
       ],\
-      \"documentation\":\"<p>Updates the specified sending authorization policy for the given identity (an email address or a domain). This API returns successfully even if a policy with the specified name does not exist.</p> <note> <p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p> </note> <p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+      \"documentation\":\"<p>Updates a receipt rule.</p> <p>For information about managing receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
     },\
-    \"UpdateEmailTemplate\":{\
-      \"name\":\"UpdateEmailTemplate\",\
+    \"UpdateTemplate\":{\
+      \"name\":\"UpdateTemplate\",\
       \"http\":{\
-        \"method\":\"PUT\",\
-        \"requestUri\":\"/v2/email/templates/{TemplateName}\"\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
       },\
-      \"input\":{\"shape\":\"UpdateEmailTemplateRequest\"},\
-      \"output\":{\"shape\":\"UpdateEmailTemplateResponse\"},\
+      \"input\":{\"shape\":\"UpdateTemplateRequest\"},\
+      \"output\":{\
+        \"shape\":\"UpdateTemplateResponse\",\
+        \"resultWrapper\":\"UpdateTemplateResult\"\
+      },\
       \"errors\":[\
-        {\"shape\":\"NotFoundException\"},\
-        {\"shape\":\"TooManyRequestsException\"},\
-        {\"shape\":\"BadRequestException\"}\
+        {\"shape\":\"TemplateDoesNotExistException\"},\
+        {\"shape\":\"InvalidTemplateException\"}\
       ],\
       \"documentation\":\"<p>Updates an email template. Email templates enable you to send personalized email to one or more destinations in a single API operation. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"VerifyDomainDkim\":{\
+      \"name\":\"VerifyDomainDkim\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"VerifyDomainDkimRequest\"},\
+      \"output\":{\
+        \"shape\":\"VerifyDomainDkimResponse\",\
+        \"resultWrapper\":\"VerifyDomainDkimResult\"\
+      },\
+      \"documentation\":\"<p>Returns a set of DKIM tokens for a domain identity.</p> <important> <p>When you execute the <code>VerifyDomainDkim</code> operation, the domain that you specify is added to the list of identities that are associated with your account. This is true even if you haven't already associated the domain with your account by using the <code>VerifyDomainIdentity</code> operation. However, you can't send email from the domain until you either successfully <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html\\\">verify it</a> or you successfully <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">set up DKIM for it</a>.</p> </important> <p>You use the tokens that are generated by this operation to create CNAME records. When Amazon SES detects that you've added these records to the DNS configuration for a domain, you can start sending email from that domain. You can start sending email even if you haven't added the TXT record provided by the VerifyDomainIdentity operation to the DNS configuration for your domain. All email that you send from the domain is authenticated using DKIM.</p> <p>To create the CNAME records for DKIM authentication, use the following values:</p> <ul> <li> <p> <b>Name</b>: <i>token</i>._domainkey.<i>example.com</i> </p> </li> <li> <p> <b>Type</b>: CNAME</p> </li> <li> <p> <b>Value</b>: <i>token</i>.dkim.amazonses.com</p> </li> </ul> <p>In the preceding example, replace <i>token</i> with one of the tokens that are generated when you execute this operation. Replace <i>example.com</i> with your domain. Repeat this process for each token that's generated by this operation.</p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"VerifyDomainIdentity\":{\
+      \"name\":\"VerifyDomainIdentity\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"VerifyDomainIdentityRequest\"},\
+      \"output\":{\
+        \"shape\":\"VerifyDomainIdentityResponse\",\
+        \"resultWrapper\":\"VerifyDomainIdentityResult\"\
+      },\
+      \"documentation\":\"<p>Adds a domain to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. For more information about verifying domains, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i> </p> <p>You can execute this operation no more than once per second.</p>\"\
+    },\
+    \"VerifyEmailAddress\":{\
+      \"name\":\"VerifyEmailAddress\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"VerifyEmailAddressRequest\"},\
+      \"documentation\":\"<p>Deprecated. Use the <code>VerifyEmailIdentity</code> operation to verify a new email address.</p>\"\
+    },\
+    \"VerifyEmailIdentity\":{\
+      \"name\":\"VerifyEmailIdentity\",\
+      \"http\":{\
+        \"method\":\"POST\",\
+        \"requestUri\":\"/\"\
+      },\
+      \"input\":{\"shape\":\"VerifyEmailIdentityRequest\"},\
+      \"output\":{\
+        \"shape\":\"VerifyEmailIdentityResponse\",\
+        \"resultWrapper\":\"VerifyEmailIdentityResult\"\
+      },\
+      \"documentation\":\"<p>Adds an email address to the list of identities for your Amazon SES account in the current AWS region and attempts to verify it. As a result of executing this operation, a verification email is sent to the specified address.</p> <p>You can execute this operation no more than once per second.</p>\"\
     }\
   },\
   \"shapes\":{\
-    \"AccountDetails\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"MailType\":{\
-          \"shape\":\"MailType\",\
-          \"documentation\":\"<p>The type of email your account is sending. The mail type can be one of the following:</p> <ul> <li> <p> <code>MARKETING</code> â Most of your sending traffic is to keep your customers informed of your latest offering.</p> </li> <li> <p> <code>TRANSACTIONAL</code> â Most of your sending traffic is to communicate during a transaction with a customer.</p> </li> </ul>\"\
-        },\
-        \"WebsiteURL\":{\
-          \"shape\":\"WebsiteURL\",\
-          \"documentation\":\"<p>The URL of your website. This information helps us better understand the type of content that you plan to send.</p>\"\
-        },\
-        \"ContactLanguage\":{\
-          \"shape\":\"ContactLanguage\",\
-          \"documentation\":\"<p>The language you would prefer for the case. The contact language can be one of <code>ENGLISH</code> or <code>JAPANESE</code>.</p>\"\
-        },\
-        \"UseCaseDescription\":{\
-          \"shape\":\"UseCaseDescription\",\
-          \"documentation\":\"<p>A description of the types of email that you plan to send.</p>\"\
-        },\
-        \"AdditionalContactEmailAddresses\":{\
-          \"shape\":\"AdditionalContactEmailAddresses\",\
-          \"documentation\":\"<p>Additional email addresses where updates are sent about your account review process.</p>\"\
-        },\
-        \"ReviewDetails\":{\
-          \"shape\":\"ReviewDetails\",\
-          \"documentation\":\"<p>Information about the review of the latest details you submitted.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about your account details.</p>\"\
-    },\
-    \"AccountSuspendedException\":{\
+    \"AccountSendingPausedException\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>The message can't be sent because the account's ability to send email has been permanently restricted.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
+      \"documentation\":\"<p>Indicates that email sending is disabled for your entire Amazon SES account.</p> <p>You can enable or disable email sending for your Amazon SES account using <a>UpdateAccountSendingEnabled</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"AccountSendingPausedException\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
       \"exception\":true\
     },\
-    \"AdditionalContactEmailAddress\":{\
-      \"type\":\"string\",\
-      \"max\":254,\
-      \"min\":6,\
-      \"pattern\":\"^(.+)@(.+)$\",\
-      \"sensitive\":true\
+    \"AddHeaderAction\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"HeaderName\",\
+        \"HeaderValue\"\
+      ],\
+      \"members\":{\
+        \"HeaderName\":{\
+          \"shape\":\"HeaderName\",\
+          \"documentation\":\"<p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>\"\
+        },\
+        \"HeaderValue\":{\
+          \"shape\":\"HeaderValue\",\
+          \"documentation\":\"<p>Must be less than 2048 characters, and must not contain newline characters (\\\"\\\\r\\\" or \\\"\\\\n\\\").</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>When included in a receipt rule, this action adds a header to the received email.</p> <p>For information about adding a header using a receipt rule, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-add-header.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"AdditionalContactEmailAddresses\":{\
+    \"Address\":{\"type\":\"string\"},\
+    \"AddressList\":{\
       \"type\":\"list\",\
-      \"member\":{\"shape\":\"AdditionalContactEmailAddress\"},\
-      \"max\":4,\
-      \"min\":1,\
-      \"sensitive\":true\
+      \"member\":{\"shape\":\"Address\"}\
     },\
     \"AlreadyExistsException\":{\
       \"type\":\"structure\",\
       \"members\":{\
+        \"Name\":{\
+          \"shape\":\"RuleOrRuleSetName\",\
+          \"documentation\":\"<p>Indicates that a resource could not be created because the resource name already exists.</p>\"\
+        }\
       },\
-      \"documentation\":\"<p>The resource specified in your request already exists.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
+      \"documentation\":\"<p>Indicates that a resource could not be created because of a naming conflict.</p>\",\
+      \"error\":{\
+        \"code\":\"AlreadyExists\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
       \"exception\":true\
     },\
     \"AmazonResourceName\":{\"type\":\"string\"},\
-    \"BadRequestException\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>The input you provided is invalid.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
-      \"exception\":true\
-    },\
-    \"BehaviorOnMxFailure\":{\
+    \"ArrivalDate\":{\"type\":\"timestamp\"},\
+    \"BehaviorOnMXFailure\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The action that you want to take if the required MX record can't be found when you send an email. When you set this value to <code>UseDefaultValue</code>, the mail is sent using <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, the Amazon SES API v2 returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.</p> <p>These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>\",\
       \"enum\":[\
-        \"USE_DEFAULT_VALUE\",\
-        \"REJECT_MESSAGE\"\
+        \"UseDefaultValue\",\
+        \"RejectMessage\"\
       ]\
-    },\
-    \"BlacklistEntries\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"BlacklistEntry\"}\
-    },\
-    \"BlacklistEntry\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"RblName\":{\
-          \"shape\":\"RblName\",\
-          \"documentation\":\"<p>The name of the blacklist that the IP address appears on.</p>\"\
-        },\
-        \"ListingTime\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The time when the blacklisting event occurred, shown in Unix time format.</p>\"\
-        },\
-        \"Description\":{\
-          \"shape\":\"BlacklistingDescription\",\
-          \"documentation\":\"<p>Additional information about the blacklisting event, as provided by the blacklist maintainer.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about a blacklisting event that impacts one of the dedicated IP addresses that is associated with your account.</p>\"\
-    },\
-    \"BlacklistItemName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>An IP address that you want to obtain blacklist information for.</p>\"\
-    },\
-    \"BlacklistItemNames\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"BlacklistItemName\"}\
-    },\
-    \"BlacklistReport\":{\
-      \"type\":\"map\",\
-      \"key\":{\"shape\":\"BlacklistItemName\"},\
-      \"value\":{\"shape\":\"BlacklistEntries\"}\
-    },\
-    \"BlacklistingDescription\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>A description of the blacklisting event.</p>\"\
     },\
     \"Body\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"Text\":{\
           \"shape\":\"Content\",\
-          \"documentation\":\"<p>An object that represents the version of the message that is displayed in email clients that don't support HTML, or clients where the recipient has disabled HTML rendering.</p>\"\
+          \"documentation\":\"<p>The content of the message, in text format. Use this for text-based email clients, or clients on high-latency networks (such as mobile devices).</p>\"\
         },\
         \"Html\":{\
           \"shape\":\"Content\",\
-          \"documentation\":\"<p>An object that represents the version of the message that is displayed in email clients that support HTML. HTML messages can include formatted text, hyperlinks, images, and more. </p>\"\
+          \"documentation\":\"<p>The content of the message, in HTML format. Use this for email clients that can process HTML. You can include clickable links, formatted text, and much more in an HTML message.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents the body of the email message.</p>\"\
+      \"documentation\":\"<p>Represents the body of the message. You can specify text, HTML, or both. If you use both, then the message should display correctly in the widest variety of email clients.</p>\"\
     },\
-    \"BulkEmailContent\":{\
+    \"BounceAction\":{\
       \"type\":\"structure\",\
+      \"required\":[\
+        \"SmtpReplyCode\",\
+        \"Message\",\
+        \"Sender\"\
+      ],\
       \"members\":{\
-        \"Template\":{\
-          \"shape\":\"Template\",\
-          \"documentation\":\"<p>The template to use for the bulk email message.</p>\"\
+        \"TopicArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the bounce action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        },\
+        \"SmtpReplyCode\":{\
+          \"shape\":\"BounceSmtpReplyCode\",\
+          \"documentation\":\"<p>The SMTP reply code, as defined by <a href=\\\"https://tools.ietf.org/html/rfc5321\\\">RFC 5321</a>.</p>\"\
+        },\
+        \"StatusCode\":{\
+          \"shape\":\"BounceStatusCode\",\
+          \"documentation\":\"<p>The SMTP enhanced status code, as defined by <a href=\\\"https://tools.ietf.org/html/rfc3463\\\">RFC 3463</a>.</p>\"\
+        },\
+        \"Message\":{\
+          \"shape\":\"BounceMessage\",\
+          \"documentation\":\"<p>Human-readable text to include in the bounce message.</p>\"\
+        },\
+        \"Sender\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address of the sender of the bounced email. This is the address from which the bounce message will be sent.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that contains the body of the message. You can specify a template message.</p>\"\
+      \"documentation\":\"<p>When included in a receipt rule, this action rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>For information about sending a bounce message in response to a received email, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-bounce.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"BulkEmailEntry\":{\
+    \"BounceMessage\":{\"type\":\"string\"},\
+    \"BounceSmtpReplyCode\":{\"type\":\"string\"},\
+    \"BounceStatusCode\":{\"type\":\"string\"},\
+    \"BounceType\":{\
+      \"type\":\"string\",\
+      \"enum\":[\
+        \"DoesNotExist\",\
+        \"MessageTooLarge\",\
+        \"ExceededQuota\",\
+        \"ContentRejected\",\
+        \"Undefined\",\
+        \"TemporaryFailure\"\
+      ]\
+    },\
+    \"BouncedRecipientInfo\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Recipient\"],\
+      \"members\":{\
+        \"Recipient\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address of the recipient of the bounced email.</p>\"\
+        },\
+        \"RecipientArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to receive email for the recipient of the bounced email. For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        },\
+        \"BounceType\":{\
+          \"shape\":\"BounceType\",\
+          \"documentation\":\"<p>The reason for the bounce. You must provide either this parameter or <code>RecipientDsnFields</code>.</p>\"\
+        },\
+        \"RecipientDsnFields\":{\
+          \"shape\":\"RecipientDsnFields\",\
+          \"documentation\":\"<p>Recipient-related DSN fields, most of which would normally be filled in automatically when provided with a <code>BounceType</code>. You must provide either this parameter or <code>BounceType</code>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"BouncedRecipientInfoList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"BouncedRecipientInfo\"}\
+    },\
+    \"BulkEmailDestination\":{\
       \"type\":\"structure\",\
       \"required\":[\"Destination\"],\
       \"members\":{\
-        \"Destination\":{\
-          \"shape\":\"Destination\",\
-          \"documentation\":\"<p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\\\"https://tools.ietf.org/html/rfc6531\\\">RFC6531</a>. For this reason, the local part of a destination email address (the part of the email address that precedes the @ sign) may only contain <a href=\\\"https://en.wikipedia.org/wiki/Email_address#Local-part\\\">7-bit ASCII characters</a>. If the domain part of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href=\\\"https://tools.ietf.org/html/rfc3492.html\\\">RFC3492</a>.</p> </note>\"\
-        },\
+        \"Destination\":{\"shape\":\"Destination\"},\
         \"ReplacementTags\":{\
           \"shape\":\"MessageTagList\",\
-          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using the <code>SendBulkTemplatedEmail</code> operation. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>\"\
+          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendBulkTemplatedEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>\"\
         },\
-        \"ReplacementEmailContent\":{\
-          \"shape\":\"ReplacementEmailContent\",\
-          \"documentation\":\"<p>The <code>ReplacementEmailContent</code> associated with a <code>BulkEmailEntry</code>.</p>\"\
+        \"ReplacementTemplateData\":{\
+          \"shape\":\"TemplateData\",\
+          \"documentation\":\"<p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>\"\
         }\
-      }\
+      },\
+      \"documentation\":\"<p>An array that contains one or more Destinations, as well as the tags and replacement data associated with each of those Destinations.</p>\"\
     },\
-    \"BulkEmailEntryList\":{\
+    \"BulkEmailDestinationList\":{\
       \"type\":\"list\",\
-      \"member\":{\"shape\":\"BulkEmailEntry\"},\
-      \"documentation\":\"<p>A list of <code>BulkEmailEntry</code> objects.</p>\"\
+      \"member\":{\"shape\":\"BulkEmailDestination\"}\
     },\
-    \"BulkEmailEntryResult\":{\
+    \"BulkEmailDestinationStatus\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"Status\":{\
           \"shape\":\"BulkEmailStatus\",\
-          \"documentation\":\"<p>The status of a message sent using the <code>SendBulkTemplatedEmail</code> operation.</p> <p>Possible values for this parameter include:</p> <ul> <li> <p>SUCCESS: Amazon SES accepted the message, and will attempt to deliver it to the recipients.</p> </li> <li> <p>MESSAGE_REJECTED: The message was rejected because it contained a virus.</p> </li> <li> <p>MAIL_FROM_DOMAIN_NOT_VERIFIED: The sender's email address or domain was not verified.</p> </li> <li> <p>CONFIGURATION_SET_DOES_NOT_EXIST: The configuration set you specified does not exist.</p> </li> <li> <p>TEMPLATE_DOES_NOT_EXIST: The template you specified does not exist.</p> </li> <li> <p>ACCOUNT_SUSPENDED: Your account has been shut down because of issues related to your email sending practices.</p> </li> <li> <p>ACCOUNT_THROTTLED: The number of emails you can send has been reduced because your account has exceeded its allocated sending limit.</p> </li> <li> <p>ACCOUNT_DAILY_QUOTA_EXCEEDED: You have reached or exceeded the maximum number of emails you can send from your account in a 24-hour period.</p> </li> <li> <p>INVALID_SENDING_POOL_NAME: The configuration set you specified refers to an IP pool that does not exist.</p> </li> <li> <p>ACCOUNT_SENDING_PAUSED: Email sending for the Amazon SES account was disabled using the <a href=\\\"https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateAccountSendingEnabled.html\\\">UpdateAccountSendingEnabled</a> operation.</p> </li> <li> <p>CONFIGURATION_SET_SENDING_PAUSED: Email sending for this configuration set was disabled using the <a href=\\\"https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateConfigurationSetSendingEnabled.html\\\">UpdateConfigurationSetSendingEnabled</a> operation.</p> </li> <li> <p>INVALID_PARAMETER_VALUE: One or more of the parameters you specified when calling this operation was invalid. See the error message for additional information.</p> </li> <li> <p>TRANSIENT_FAILURE: Amazon SES was unable to process your request because of a temporary issue.</p> </li> <li> <p>FAILED: Amazon SES was unable to process your request. See the error message for additional information.</p> </li> </ul>\"\
+          \"documentation\":\"<p>The status of a message sent using the <code>SendBulkTemplatedEmail</code> operation.</p> <p>Possible values for this parameter include:</p> <ul> <li> <p> <code>Success</code>: Amazon SES accepted the message, and will attempt to deliver it to the recipients.</p> </li> <li> <p> <code>MessageRejected</code>: The message was rejected because it contained a virus.</p> </li> <li> <p> <code>MailFromDomainNotVerified</code>: The sender's email address or domain was not verified.</p> </li> <li> <p> <code>ConfigurationSetDoesNotExist</code>: The configuration set you specified does not exist.</p> </li> <li> <p> <code>TemplateDoesNotExist</code>: The template you specified does not exist.</p> </li> <li> <p> <code>AccountSuspended</code>: Your account has been shut down because of issues related to your email sending practices.</p> </li> <li> <p> <code>AccountThrottled</code>: The number of emails you can send has been reduced because your account has exceeded its allocated sending limit.</p> </li> <li> <p> <code>AccountDailyQuotaExceeded</code>: You have reached or exceeded the maximum number of emails you can send from your account in a 24-hour period.</p> </li> <li> <p> <code>InvalidSendingPoolName</code>: The configuration set you specified refers to an IP pool that does not exist.</p> </li> <li> <p> <code>AccountSendingPaused</code>: Email sending for the Amazon SES account was disabled using the <a>UpdateAccountSendingEnabled</a> operation.</p> </li> <li> <p> <code>ConfigurationSetSendingPaused</code>: Email sending for this configuration set was disabled using the <a>UpdateConfigurationSetSendingEnabled</a> operation.</p> </li> <li> <p> <code>InvalidParameterValue</code>: One or more of the parameters you specified when calling this operation was invalid. See the error message for additional information.</p> </li> <li> <p> <code>TransientFailure</code>: Amazon SES was unable to process your request because of a temporary issue.</p> </li> <li> <p> <code>Failed</code>: Amazon SES was unable to process your request. See the error message for additional information.</p> </li> </ul>\"\
         },\
         \"Error\":{\
-          \"shape\":\"ErrorMessage\",\
+          \"shape\":\"Error\",\
           \"documentation\":\"<p>A description of an error that prevented a message being sent using the <code>SendBulkTemplatedEmail</code> operation.</p>\"\
         },\
         \"MessageId\":{\
-          \"shape\":\"OutboundMessageId\",\
+          \"shape\":\"MessageId\",\
           \"documentation\":\"<p>The unique message identifier returned from the <code>SendBulkTemplatedEmail</code> operation.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>The result of the <code>SendBulkEmail</code> operation of each specified <code>BulkEmailEntry</code>.</p>\"\
+      \"documentation\":\"<p>An object that contains the response from the <code>SendBulkTemplatedEmail</code> operation.</p>\"\
     },\
-    \"BulkEmailEntryResultList\":{\
+    \"BulkEmailDestinationStatusList\":{\
       \"type\":\"list\",\
-      \"member\":{\"shape\":\"BulkEmailEntryResult\"},\
-      \"documentation\":\"<p>A list of <code>BulkMailEntry</code> objects.</p>\"\
+      \"member\":{\"shape\":\"BulkEmailDestinationStatus\"}\
     },\
     \"BulkEmailStatus\":{\
       \"type\":\"string\",\
       \"enum\":[\
-        \"SUCCESS\",\
-        \"MESSAGE_REJECTED\",\
-        \"MAIL_FROM_DOMAIN_NOT_VERIFIED\",\
-        \"CONFIGURATION_SET_NOT_FOUND\",\
-        \"TEMPLATE_NOT_FOUND\",\
-        \"ACCOUNT_SUSPENDED\",\
-        \"ACCOUNT_THROTTLED\",\
-        \"ACCOUNT_DAILY_QUOTA_EXCEEDED\",\
-        \"INVALID_SENDING_POOL_NAME\",\
-        \"ACCOUNT_SENDING_PAUSED\",\
-        \"CONFIGURATION_SET_SENDING_PAUSED\",\
-        \"INVALID_PARAMETER\",\
-        \"TRANSIENT_FAILURE\",\
-        \"FAILED\"\
+        \"Success\",\
+        \"MessageRejected\",\
+        \"MailFromDomainNotVerified\",\
+        \"ConfigurationSetDoesNotExist\",\
+        \"TemplateDoesNotExist\",\
+        \"AccountSuspended\",\
+        \"AccountThrottled\",\
+        \"AccountDailyQuotaExceeded\",\
+        \"InvalidSendingPoolName\",\
+        \"AccountSendingPaused\",\
+        \"ConfigurationSetSendingPaused\",\
+        \"InvalidParameterValue\",\
+        \"TransientFailure\",\
+        \"Failed\"\
       ]\
     },\
-    \"CampaignId\":{\"type\":\"string\"},\
-    \"CaseId\":{\"type\":\"string\"},\
+    \"CannotDeleteException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Name\":{\
+          \"shape\":\"RuleOrRuleSetName\",\
+          \"documentation\":\"<p>Indicates that a resource could not be deleted because no resource with the specified name exists.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the delete operation could not be completed.</p>\",\
+      \"error\":{\
+        \"code\":\"CannotDelete\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
     \"Charset\":{\"type\":\"string\"},\
+    \"Cidr\":{\"type\":\"string\"},\
+    \"CloneReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"RuleSetName\",\
+        \"OriginalRuleSetName\"\
+      ],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the rule set to create. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>\"\
+        },\
+        \"OriginalRuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the rule set to clone.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to create a receipt rule set by cloning an existing one. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"CloneReceiptRuleSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
     \"CloudWatchDestination\":{\
       \"type\":\"structure\",\
       \"required\":[\"DimensionConfigurations\"],\
       \"members\":{\
         \"DimensionConfigurations\":{\
           \"shape\":\"CloudWatchDimensionConfigurations\",\
-          \"documentation\":\"<p>An array of objects that define the dimensions to use when you send email events to Amazon CloudWatch.</p>\"\
+          \"documentation\":\"<p>A list of dimensions upon which to categorize your emails when you publish email sending events to Amazon CloudWatch.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to monitor and gain insights on your email sending metrics.</p>\"\
+      \"documentation\":\"<p>Contains information associated with an Amazon CloudWatch event destination to which email sending events are published.</p> <p>Event destinations, such as Amazon CloudWatch, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"CloudWatchDimensionConfiguration\":{\
       \"type\":\"structure\",\
@@ -1382,54 +1412,99 @@
       \"members\":{\
         \"DimensionName\":{\
           \"shape\":\"DimensionName\",\
-          \"documentation\":\"<p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
+          \"documentation\":\"<p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>\"\
         },\
         \"DimensionValueSource\":{\
           \"shape\":\"DimensionValueSource\",\
-          \"documentation\":\"<p>The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. If you want to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code> or <code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want to use your own email headers, choose <code>emailHeader</code>. If you want to use link tags, choose <code>linkTags</code>.</p>\"\
+          \"documentation\":\"<p>The place where Amazon SES finds the value of a dimension to publish to Amazon CloudWatch. If you want Amazon SES to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code>/<code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want Amazon SES to use your own email headers, choose <code>emailHeader</code>.</p>\"\
         },\
         \"DefaultDimensionValue\":{\
           \"shape\":\"DefaultDimensionValue\",\
-          \"documentation\":\"<p>The default value of the dimension that is published to Amazon CloudWatch if you don't provide the value of the dimension when you send an email. This value has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
+          \"documentation\":\"<p>The default value of the dimension that is published to Amazon CloudWatch if you do not provide the value of the dimension when you send an email. The default value must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that defines the dimension configuration to use when you send email events to Amazon CloudWatch.</p>\"\
+      \"documentation\":\"<p>Contains the dimension configuration to use when you publish email sending events to Amazon CloudWatch.</p> <p>For information about publishing email sending events to Amazon CloudWatch, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"CloudWatchDimensionConfigurations\":{\
       \"type\":\"list\",\
       \"member\":{\"shape\":\"CloudWatchDimensionConfiguration\"}\
     },\
-    \"ConcurrentModificationException\":{\
+    \"ConfigurationSet\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Name\"],\
+      \"members\":{\
+        \"Name\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set. The name must meet the following requirements:</p> <ul> <li> <p>Contain only letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain 64 characters or fewer.</p> </li> </ul>\"\
+        }\
+      },\
+      \"documentation\":\"<p>The name of the configuration set.</p> <p>Configuration sets let you create groups of rules that you can apply to the emails you send using Amazon SES. For more information about using configuration sets, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets.html\\\">Using Amazon SES Configuration Sets</a> in the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ConfigurationSetAlreadyExistsException\":{\
       \"type\":\"structure\",\
       \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
+        }\
       },\
-      \"documentation\":\"<p>The resource is being modified by another operation or thread.</p>\",\
-      \"error\":{\"httpStatusCode\":500},\
-      \"exception\":true,\
-      \"fault\":true\
-    },\
-    \"ConfigurationSetName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of a configuration set.</p> <p> <i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>\"\
-    },\
-    \"ConfigurationSetNameList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"ConfigurationSetName\"}\
-    },\
-    \"ConflictException\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
+      \"documentation\":\"<p>Indicates that the configuration set could not be created because of a naming conflict.</p>\",\
+      \"error\":{\
+        \"code\":\"ConfigurationSetAlreadyExists\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
       },\
-      \"documentation\":\"<p>If there is already an ongoing account details update under review.</p>\",\
-      \"error\":{\"httpStatusCode\":409},\
       \"exception\":true\
     },\
-    \"ContactLanguage\":{\
+    \"ConfigurationSetAttribute\":{\
       \"type\":\"string\",\
       \"enum\":[\
-        \"EN\",\
-        \"JA\"\
+        \"eventDestinations\",\
+        \"trackingOptions\",\
+        \"deliveryOptions\",\
+        \"reputationOptions\"\
       ]\
+    },\
+    \"ConfigurationSetAttributeList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ConfigurationSetAttribute\"}\
+    },\
+    \"ConfigurationSetDoesNotExistException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"ConfigurationSetDoesNotExist\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"ConfigurationSetName\":{\"type\":\"string\"},\
+    \"ConfigurationSetSendingPausedException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set for which email sending is disabled.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that email sending is disabled for the configuration set.</p> <p>You can enable or disable email sending for a configuration set using <a>UpdateConfigurationSetSendingEnabled</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"ConfigurationSetSendingPausedException\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"ConfigurationSets\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ConfigurationSet\"}\
     },\
     \"Content\":{\
       \"type\":\"structure\",\
@@ -1437,83 +1512,77 @@
       \"members\":{\
         \"Data\":{\
           \"shape\":\"MessageData\",\
-          \"documentation\":\"<p>The content of the message itself.</p>\"\
+          \"documentation\":\"<p>The textual data of the content.</p>\"\
         },\
         \"Charset\":{\
           \"shape\":\"Charset\",\
-          \"documentation\":\"<p>The character set for the content. Because of the constraints of the SMTP protocol, Amazon SES uses 7-bit ASCII by default. If the text includes characters outside of the ASCII range, you have to specify a character set. For example, you could specify <code>UTF-8</code>, <code>ISO-8859-1</code>, or <code>Shift_JIS</code>.</p>\"\
+          \"documentation\":\"<p>The character set of the content.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that represents the content of the email, and optionally a character set specification.</p>\"\
+      \"documentation\":\"<p>Represents textual data, plus an optional character set specification.</p> <p>By default, the text must be 7-bit ASCII, due to the constraints of the SMTP protocol. If the text must contain any other characters, then you must also specify a character set. Examples include UTF-8, ISO-8859-1, and Shift_JIS.</p>\"\
     },\
+    \"Counter\":{\"type\":\"long\"},\
     \"CreateConfigurationSetEventDestinationRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
         \"ConfigurationSetName\",\
-        \"EventDestinationName\",\
         \"EventDestination\"\
       ],\
       \"members\":{\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to add an event destination to.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        },\
-        \"EventDestinationName\":{\
-          \"shape\":\"EventDestinationName\",\
-          \"documentation\":\"<p>A name that identifies the event destination within the configuration set.</p>\"\
+          \"documentation\":\"<p>The name of the configuration set that the event destination should be associated with.</p>\"\
         },\
         \"EventDestination\":{\
-          \"shape\":\"EventDestinationDefinition\",\
-          \"documentation\":\"<p>An object that defines the event destination.</p>\"\
+          \"shape\":\"EventDestination\",\
+          \"documentation\":\"<p>An object that describes the AWS service that email sending event information will be published to.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to add an event destination to a configuration set.</p>\"\
+      \"documentation\":\"<p>Represents a request to create a configuration set event destination. A configuration set event destination, which can be either Amazon CloudWatch or Amazon Kinesis Firehose, describes an AWS service in which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"CreateConfigurationSetEventDestinationResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
     \"CreateConfigurationSetRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
+      \"required\":[\"ConfigurationSet\"],\
       \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set.</p>\"\
-        },\
-        \"TrackingOptions\":{\
-          \"shape\":\"TrackingOptions\",\
-          \"documentation\":\"<p>An object that defines the open and click tracking options for emails that you send using the configuration set.</p>\"\
-        },\
-        \"DeliveryOptions\":{\
-          \"shape\":\"DeliveryOptions\",\
-          \"documentation\":\"<p>An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set.</p>\"\
-        },\
-        \"ReputationOptions\":{\
-          \"shape\":\"ReputationOptions\",\
-          \"documentation\":\"<p>An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set.</p>\"\
-        },\
-        \"SendingOptions\":{\
-          \"shape\":\"SendingOptions\",\
-          \"documentation\":\"<p>An object that defines whether or not Amazon SES can send email that you send using the configuration set.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array of objects that define the tags (keys and values) that you want to associate with the configuration set.</p>\"\
-        },\
-        \"SuppressionOptions\":{\"shape\":\"SuppressionOptions\"}\
+        \"ConfigurationSet\":{\
+          \"shape\":\"ConfigurationSet\",\
+          \"documentation\":\"<p>A data structure that contains the name of the configuration set.</p>\"\
+        }\
       },\
-      \"documentation\":\"<p>A request to create a configuration set.</p>\"\
+      \"documentation\":\"<p>Represents a request to create a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"CreateConfigurationSetResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"CreateConfigurationSetTrackingOptionsRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"ConfigurationSetName\",\
+        \"TrackingOptions\"\
+      ],\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set that the tracking options should be associated with.</p>\"\
+        },\
+        \"TrackingOptions\":{\"shape\":\"TrackingOptions\"}\
+      },\
+      \"documentation\":\"<p>Represents a request to create an open and click tracking option object in a configuration set. </p>\"\
+    },\
+    \"CreateConfigurationSetTrackingOptionsResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
     \"CreateCustomVerificationEmailTemplateRequest\":{\
       \"type\":\"structure\",\
@@ -1527,20 +1596,20 @@
       ],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
+          \"shape\":\"TemplateName\",\
           \"documentation\":\"<p>The name of the custom verification email template.</p>\"\
         },\
         \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
+          \"shape\":\"FromAddress\",\
           \"documentation\":\"<p>The email address that the custom verification email is sent from.</p>\"\
         },\
         \"TemplateSubject\":{\
-          \"shape\":\"EmailTemplateSubject\",\
+          \"shape\":\"Subject\",\
           \"documentation\":\"<p>The subject line of the custom verification email.</p>\"\
         },\
         \"TemplateContent\":{\
           \"shape\":\"TemplateContent\",\
-          \"documentation\":\"<p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html#custom-verification-emails-faq\\\">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
+          \"documentation\":\"<p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html#custom-verification-emails-faq\\\">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
         },\
         \"SuccessRedirectionURL\":{\
           \"shape\":\"SuccessRedirectionURL\",\
@@ -1553,216 +1622,119 @@
       },\
       \"documentation\":\"<p>Represents a request to create a custom verification email template.</p>\"\
     },\
-    \"CreateCustomVerificationEmailTemplateResponse\":{\
+    \"CreateReceiptFilterRequest\":{\
       \"type\":\"structure\",\
+      \"required\":[\"Filter\"],\
       \"members\":{\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>\"\
-    },\
-    \"CreateDedicatedIpPoolRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"PoolName\"],\
-      \"members\":{\
-        \"PoolName\":{\
-          \"shape\":\"PoolName\",\
-          \"documentation\":\"<p>The name of the dedicated IP pool.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An object that defines the tags (keys and values) that you want to associate with the pool.</p>\"\
+        \"Filter\":{\
+          \"shape\":\"ReceiptFilter\",\
+          \"documentation\":\"<p>A data structure that describes the IP address filter to create, which consists of a name, an IP address range, and whether to allow or block mail from it.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to create a new dedicated IP pool.</p>\"\
+      \"documentation\":\"<p>Represents a request to create a new IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"CreateDedicatedIpPoolResponse\":{\
+    \"CreateReceiptFilterResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
-    \"CreateDeliverabilityTestReportRequest\":{\
+    \"CreateReceiptRuleRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"FromEmailAddress\",\
-        \"Content\"\
+        \"RuleSetName\",\
+        \"Rule\"\
       ],\
       \"members\":{\
-        \"ReportName\":{\
-          \"shape\":\"ReportName\",\
-          \"documentation\":\"<p>A unique name that helps you to identify the predictive inbox placement test when you retrieve the results.</p>\"\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the rule set that the receipt rule will be added to.</p>\"\
         },\
-        \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that the predictive inbox placement test email was sent from.</p>\"\
+        \"After\":{\
+          \"shape\":\"ReceiptRuleName\",\
+          \"documentation\":\"<p>The name of an existing rule after which the new rule will be placed. If this parameter is null, the new rule will be inserted at the beginning of the rule list.</p>\"\
         },\
-        \"Content\":{\
-          \"shape\":\"EmailContent\",\
-          \"documentation\":\"<p>The HTML body of the message that you sent when you performed the predictive inbox placement test.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array of objects that define the tags (keys and values) that you want to associate with the predictive inbox placement test.</p>\"\
+        \"Rule\":{\
+          \"shape\":\"ReceiptRule\",\
+          \"documentation\":\"<p>A data structure that contains the specified rule's name, actions, recipients, domains, enabled status, scan status, and TLS policy.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to perform a predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will be handled by various email providers around the world. When you perform a predictive inbox placement test, you provide a sample message that contains the content that you plan to send to your customers. We send that message to special email addresses spread across several major email providers around the world. The test takes about 24 hours to complete. When the test is complete, you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.</p>\"\
+      \"documentation\":\"<p>Represents a request to create a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"CreateDeliverabilityTestReportResponse\":{\
+    \"CreateReceiptRuleResponse\":{\
       \"type\":\"structure\",\
-      \"required\":[\
-        \"ReportId\",\
-        \"DeliverabilityTestStatus\"\
-      ],\
       \"members\":{\
-        \"ReportId\":{\
-          \"shape\":\"ReportId\",\
-          \"documentation\":\"<p>A unique string that identifies the predictive inbox placement test.</p>\"\
-        },\
-        \"DeliverabilityTestStatus\":{\
-          \"shape\":\"DeliverabilityTestStatus\",\
-          \"documentation\":\"<p>The status of the predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> to view the results of the test.</p>\"\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"CreateReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"RuleSetName\"],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the rule set to create. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>\"\
         }\
       },\
-      \"documentation\":\"<p>Information about the predictive inbox placement test that you created.</p>\"\
+      \"documentation\":\"<p>Represents a request to create an empty receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"CreateEmailIdentityPolicyRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"EmailIdentity\",\
-        \"PolicyName\",\
-        \"Policy\"\
-      ],\
-      \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity for which you want to create a policy.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
-        },\
-        \"PolicyName\":{\
-          \"shape\":\"PolicyName\",\
-          \"documentation\":\"<p>The name of the policy.</p> <p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"PolicyName\"\
-        },\
-        \"Policy\":{\
-          \"shape\":\"Policy\",\
-          \"documentation\":\"<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p> <p>For information about the syntax of sending authorization policies, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html\\\">Amazon SES Developer Guide</a>.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Represents a request to create a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html\\\">Amazon SES Developer Guide</a>.</p>\"\
-    },\
-    \"CreateEmailIdentityPolicyResponse\":{\
+    \"CreateReceiptRuleSetResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
-    \"CreateEmailIdentityRequest\":{\
+    \"CreateTemplateRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
+      \"required\":[\"Template\"],\
       \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email address or domain that you want to verify.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array of objects that define the tags (keys and values) that you want to associate with the email identity.</p>\"\
-        },\
-        \"DkimSigningAttributes\":{\
-          \"shape\":\"DkimSigningAttributes\",\
-          \"documentation\":\"<p>If your request includes this object, Amazon SES configures the identity to use Bring Your Own DKIM (BYODKIM) for DKIM authentication purposes, as opposed to the default method, <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a>.</p> <p>You can only specify this object if the email identity is a domain, as opposed to an address.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to begin the verification process for an email identity (an email address or domain).</p>\"\
-    },\
-    \"CreateEmailIdentityResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"IdentityType\":{\
-          \"shape\":\"IdentityType\",\
-          \"documentation\":\"<p>The email identity type.</p>\"\
-        },\
-        \"VerifiedForSendingStatus\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Specifies whether or not the identity is verified. You can only send email from verified email addresses or domains. For more information about verifying identities, see the <a href=\\\"https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-email-manage-verify.html\\\">Amazon Pinpoint User Guide</a>.</p>\"\
-        },\
-        \"DkimAttributes\":{\
-          \"shape\":\"DkimAttributes\",\
-          \"documentation\":\"<p>An object that contains information about the DKIM attributes for the identity.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>If the email identity is a domain, this object contains information about the DKIM verification status for the domain.</p> <p>If the email identity is an email address, this object is empty. </p>\"\
-    },\
-    \"CreateEmailTemplateRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"TemplateName\",\
-        \"TemplateContent\"\
-      ],\
-      \"members\":{\
-        \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template you want to create.</p>\"\
-        },\
-        \"TemplateContent\":{\
-          \"shape\":\"EmailTemplateContent\",\
-          \"documentation\":\"<p>The content of the email template, composed of a subject line, an HTML part, and a text-only part.</p>\"\
+        \"Template\":{\
+          \"shape\":\"Template\",\
+          \"documentation\":\"<p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>\"\
         }\
       },\
       \"documentation\":\"<p>Represents a request to create an email template. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"CreateEmailTemplateResponse\":{\
+    \"CreateTemplateResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>\"\
+      }\
     },\
-    \"CreateImportJobRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"ImportDestination\",\
-        \"ImportDataSource\"\
-      ],\
-      \"members\":{\
-        \"ImportDestination\":{\
-          \"shape\":\"ImportDestination\",\
-          \"documentation\":\"<p>The destination for the import job.</p>\"\
-        },\
-        \"ImportDataSource\":{\
-          \"shape\":\"ImportDataSource\",\
-          \"documentation\":\"<p>The data source for the import job.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Represents a request to create an import job from a data source for a data destination.</p>\"\
-    },\
-    \"CreateImportJobResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"JobId\":{\
-          \"shape\":\"JobId\",\
-          \"documentation\":\"<p>A string that represents the import job ID.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"CustomRedirectDomain\":{\
+    \"CustomMailFromStatus\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The domain that you want to use for tracking open and click events.</p>\"\
+      \"enum\":[\
+        \"Pending\",\
+        \"Success\",\
+        \"Failed\",\
+        \"TemporaryFailure\"\
+      ]\
     },\
-    \"CustomVerificationEmailTemplateMetadata\":{\
+    \"CustomRedirectDomain\":{\"type\":\"string\"},\
+    \"CustomVerificationEmailInvalidContentException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>Indicates that custom verification email template provided content is invalid.</p>\",\
+      \"error\":{\
+        \"code\":\"CustomVerificationEmailInvalidContent\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"CustomVerificationEmailTemplate\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
+          \"shape\":\"TemplateName\",\
           \"documentation\":\"<p>The name of the custom verification email template.</p>\"\
         },\
         \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
+          \"shape\":\"FromAddress\",\
           \"documentation\":\"<p>The email address that the custom verification email is sent from.</p>\"\
         },\
         \"TemplateSubject\":{\
-          \"shape\":\"EmailTemplateSubject\",\
+          \"shape\":\"Subject\",\
           \"documentation\":\"<p>The subject line of the custom verification email.</p>\"\
         },\
         \"SuccessRedirectionURL\":{\
@@ -1776,77 +1748,43 @@
       },\
       \"documentation\":\"<p>Contains information about a custom verification email template.</p>\"\
     },\
-    \"CustomVerificationEmailTemplatesList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"CustomVerificationEmailTemplateMetadata\"},\
-      \"documentation\":\"<p>A list of the custom verification email templates that exist in your account.</p>\"\
-    },\
-    \"DailyVolume\":{\
+    \"CustomVerificationEmailTemplateAlreadyExistsException\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"StartDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The date that the DailyVolume metrics apply to, in Unix time.</p>\"\
-        },\
-        \"VolumeStatistics\":{\
-          \"shape\":\"VolumeStatistics\",\
-          \"documentation\":\"<p>An object that contains inbox placement metrics for a specific day in the analysis period.</p>\"\
-        },\
-        \"DomainIspPlacements\":{\
-          \"shape\":\"DomainIspPlacements\",\
-          \"documentation\":\"<p>An object that contains inbox placement metrics for a specified day in the analysis period, broken out by the recipient's email provider.</p>\"\
+        \"CustomVerificationEmailTemplateName\":{\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>Indicates that the provided custom verification email template with the specified template name already exists.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that contains information about the volume of email sent on each day of the analysis period.</p>\"\
+      \"documentation\":\"<p>Indicates that a custom verification email template with the name you specified already exists.</p>\",\
+      \"error\":{\
+        \"code\":\"CustomVerificationEmailTemplateAlreadyExists\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"DailyVolumes\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"DailyVolume\"}\
-    },\
-    \"DataFormat\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The data format of the import job's data source.</p>\",\
-      \"enum\":[\
-        \"CSV\",\
-        \"JSON\"\
-      ]\
-    },\
-    \"DedicatedIp\":{\
+    \"CustomVerificationEmailTemplateDoesNotExistException\":{\
       \"type\":\"structure\",\
-      \"required\":[\
-        \"Ip\",\
-        \"WarmupStatus\",\
-        \"WarmupPercentage\"\
-      ],\
       \"members\":{\
-        \"Ip\":{\
-          \"shape\":\"Ip\",\
-          \"documentation\":\"<p>An IPv4 address.</p>\"\
-        },\
-        \"WarmupStatus\":{\
-          \"shape\":\"WarmupStatus\",\
-          \"documentation\":\"<p>The warm-up status of a dedicated IP address. The status can have one of the following values:</p> <ul> <li> <p> <code>IN_PROGRESS</code> â The IP address isn't ready to use because the dedicated IP warm-up process is ongoing.</p> </li> <li> <p> <code>DONE</code> â The dedicated IP warm-up process is complete, and the IP address is ready to use.</p> </li> </ul>\"\
-        },\
-        \"WarmupPercentage\":{\
-          \"shape\":\"Percentage100Wrapper\",\
-          \"documentation\":\"<p>Indicates how complete the dedicated IP warm-up process is. When this value equals 1, the address has completed the warm-up process and is ready for use.</p>\"\
-        },\
-        \"PoolName\":{\
-          \"shape\":\"PoolName\",\
-          \"documentation\":\"<p>The name of the dedicated IP pool that the IP address is associated with.</p>\"\
+        \"CustomVerificationEmailTemplateName\":{\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>Indicates that the provided custom verification email template does not exist.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Contains information about a dedicated IP address that is associated with your Amazon SES account.</p> <p>To learn more about requesting dedicated IP addresses, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/dedicated-ip-case.html\\\">Requesting and Relinquishing Dedicated IP Addresses</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
+      \"documentation\":\"<p>Indicates that a custom verification email template with the name you specified does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"CustomVerificationEmailTemplateDoesNotExist\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"DedicatedIpList\":{\
+    \"CustomVerificationEmailTemplates\":{\
       \"type\":\"list\",\
-      \"member\":{\"shape\":\"DedicatedIp\"},\
-      \"documentation\":\"<p>A list of dedicated IP addresses that are associated with your AWS account.</p>\"\
+      \"member\":{\"shape\":\"CustomVerificationEmailTemplate\"}\
     },\
-    \"DefaultDimensionValue\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The default value of the dimension that is published to Amazon CloudWatch if you don't provide the value of the dimension when you send an email. This value has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
-    },\
+    \"DefaultDimensionValue\":{\"type\":\"string\"},\
     \"DeleteConfigurationSetEventDestinationRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
@@ -1856,24 +1794,20 @@
       \"members\":{\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that contains the event destination that you want to delete.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
+          \"documentation\":\"<p>The name of the configuration set from which to delete the event destination.</p>\"\
         },\
         \"EventDestinationName\":{\
           \"shape\":\"EventDestinationName\",\
-          \"documentation\":\"<p>The name of the event destination that you want to delete.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EventDestinationName\"\
+          \"documentation\":\"<p>The name of the event destination to delete.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to delete an event destination from a configuration set.</p>\"\
+      \"documentation\":\"<p>Represents a request to delete a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"DeleteConfigurationSetEventDestinationResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
     \"DeleteConfigurationSetRequest\":{\
       \"type\":\"structure\",\
@@ -1881,196 +1815,170 @@
       \"members\":{\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to delete.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
+          \"documentation\":\"<p>The name of the configuration set to delete.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to delete a configuration set.</p>\"\
+      \"documentation\":\"<p>Represents a request to delete a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"DeleteConfigurationSetResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"DeleteConfigurationSetTrackingOptionsRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"ConfigurationSetName\"],\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set from which you want to delete the tracking options.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to delete open and click tracking options in a configuration set. </p>\"\
+    },\
+    \"DeleteConfigurationSetTrackingOptionsResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
     \"DeleteCustomVerificationEmailTemplateRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\"TemplateName\"],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the custom verification email template that you want to delete.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the custom verification email template that you want to delete.</p>\"\
         }\
       },\
       \"documentation\":\"<p>Represents a request to delete an existing custom verification email template.</p>\"\
     },\
-    \"DeleteCustomVerificationEmailTemplateResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>\"\
-    },\
-    \"DeleteDedicatedIpPoolRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"PoolName\"],\
-      \"members\":{\
-        \"PoolName\":{\
-          \"shape\":\"PoolName\",\
-          \"documentation\":\"<p>The name of the dedicated IP pool that you want to delete.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"PoolName\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to delete a dedicated IP pool.</p>\"\
-    },\
-    \"DeleteDedicatedIpPoolResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"DeleteEmailIdentityPolicyRequest\":{\
+    \"DeleteIdentityPolicyRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"EmailIdentity\",\
+        \"Identity\",\
         \"PolicyName\"\
       ],\
       \"members\":{\
-        \"EmailIdentity\":{\
+        \"Identity\":{\
           \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity for which you want to delete a policy.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
+          \"documentation\":\"<p>The identity that is associated with the policy that you want to delete. You can specify the identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>\"\
         },\
         \"PolicyName\":{\
           \"shape\":\"PolicyName\",\
-          \"documentation\":\"<p>The name of the policy.</p> <p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"PolicyName\"\
+          \"documentation\":\"<p>The name of the policy to be deleted.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents a request to delete a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+      \"documentation\":\"<p>Represents a request to delete a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"DeleteEmailIdentityPolicyResponse\":{\
+    \"DeleteIdentityPolicyResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
-    \"DeleteEmailIdentityRequest\":{\
+    \"DeleteIdentityRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
+      \"required\":[\"Identity\"],\
       \"members\":{\
-        \"EmailIdentity\":{\
+        \"Identity\":{\
           \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The identity (that is, the email address or domain) that you want to delete.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
+          \"documentation\":\"<p>The identity to be removed from the list of identities for the AWS Account.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to delete an existing email identity. When you delete an identity, you lose the ability to send email from that identity. You can restore your ability to send email by completing the verification process for the identity again.</p>\"\
+      \"documentation\":\"<p>Represents a request to delete one of your Amazon SES identities (an email address or domain).</p>\"\
     },\
-    \"DeleteEmailIdentityResponse\":{\
+    \"DeleteIdentityResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
-    \"DeleteEmailTemplateRequest\":{\
+    \"DeleteReceiptFilterRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"FilterName\"],\
+      \"members\":{\
+        \"FilterName\":{\
+          \"shape\":\"ReceiptFilterName\",\
+          \"documentation\":\"<p>The name of the IP address filter to delete.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to delete an IP address filter. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DeleteReceiptFilterResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"DeleteReceiptRuleRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"RuleSetName\",\
+        \"RuleName\"\
+      ],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set that contains the receipt rule to delete.</p>\"\
+        },\
+        \"RuleName\":{\
+          \"shape\":\"ReceiptRuleName\",\
+          \"documentation\":\"<p>The name of the receipt rule to delete.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to delete a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DeleteReceiptRuleResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"DeleteReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"RuleSetName\"],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set to delete.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to delete a receipt rule set and all of the receipt rules it contains. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DeleteReceiptRuleSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"DeleteTemplateRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\"TemplateName\"],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template to be deleted.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the template to be deleted.</p>\"\
         }\
       },\
       \"documentation\":\"<p>Represents a request to delete an email template. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"DeleteEmailTemplateResponse\":{\
+    \"DeleteTemplateResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>\"\
+      }\
     },\
-    \"DeleteSuppressedDestinationRequest\":{\
+    \"DeleteVerifiedEmailAddressRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\"EmailAddress\"],\
       \"members\":{\
         \"EmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The suppressed email destination to remove from the account suppression list.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailAddress\"\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>An email address to be removed from the list of verified addresses.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to remove an email address from the suppression list for your account.</p>\"\
-    },\
-    \"DeleteSuppressedDestinationResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"DeliverabilityDashboardAccountStatus\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The current status of your Deliverability dashboard subscription. If this value is <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end of the current calendar month.</p>\",\
-      \"enum\":[\
-        \"ACTIVE\",\
-        \"PENDING_EXPIRATION\",\
-        \"DISABLED\"\
-      ]\
-    },\
-    \"DeliverabilityTestReport\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"ReportId\":{\
-          \"shape\":\"ReportId\",\
-          \"documentation\":\"<p>A unique string that identifies the predictive inbox placement test.</p>\"\
-        },\
-        \"ReportName\":{\
-          \"shape\":\"ReportName\",\
-          \"documentation\":\"<p>A name that helps you identify a predictive inbox placement test report.</p>\"\
-        },\
-        \"Subject\":{\
-          \"shape\":\"DeliverabilityTestSubject\",\
-          \"documentation\":\"<p>The subject line for an email that you submitted in a predictive inbox placement test.</p>\"\
-        },\
-        \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The sender address that you specified for the predictive inbox placement test.</p>\"\
-        },\
-        \"CreateDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The date and time when the predictive inbox placement test was created, in Unix time format.</p>\"\
-        },\
-        \"DeliverabilityTestStatus\":{\
-          \"shape\":\"DeliverabilityTestStatus\",\
-          \"documentation\":\"<p>The status of the predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> to view the results of the test.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains metadata related to a predictive inbox placement test.</p>\"\
-    },\
-    \"DeliverabilityTestReports\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"DeliverabilityTestReport\"}\
-    },\
-    \"DeliverabilityTestStatus\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The status of a predictive inbox placement test. If the status is <code>IN_PROGRESS</code>, then the predictive inbox placement test is currently running. Predictive inbox placement tests are usually complete within 24 hours of creating the test. If the status is <code>COMPLETE</code>, then the test is finished, and you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.</p>\",\
-      \"enum\":[\
-        \"IN_PROGRESS\",\
-        \"COMPLETED\"\
-      ]\
-    },\
-    \"DeliverabilityTestSubject\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The subject line for an email that you submitted in a predictive inbox placement test.</p>\"\
+      \"documentation\":\"<p>Represents a request to delete an email address from the list of email addresses you have attempted to verify under your AWS account.</p>\"\
     },\
     \"DeliveryOptions\":{\
       \"type\":\"structure\",\
@@ -2078,319 +1986,168 @@
         \"TlsPolicy\":{\
           \"shape\":\"TlsPolicy\",\
           \"documentation\":\"<p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.</p>\"\
-        },\
-        \"SendingPoolName\":{\
-          \"shape\":\"PoolName\",\
-          \"documentation\":\"<p>The name of the dedicated IP pool that you want to associate with the configuration set.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Used to associate a configuration set with a dedicated IP pool.</p>\"\
+      \"documentation\":\"<p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS).</p>\"\
+    },\
+    \"DescribeActiveReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>Represents a request to return the metadata and receipt rules for the receipt rule set that is currently active. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DescribeActiveReceiptRuleSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Metadata\":{\
+          \"shape\":\"ReceiptRuleSetMetadata\",\
+          \"documentation\":\"<p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and a timestamp of when the rule set was created.</p>\"\
+        },\
+        \"Rules\":{\
+          \"shape\":\"ReceiptRulesList\",\
+          \"documentation\":\"<p>The receipt rules that belong to the active rule set.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the metadata and receipt rules for the receipt rule set that is currently active.</p>\"\
+    },\
+    \"DescribeConfigurationSetRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"ConfigurationSetName\"],\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set to describe.</p>\"\
+        },\
+        \"ConfigurationSetAttributeNames\":{\
+          \"shape\":\"ConfigurationSetAttributeList\",\
+          \"documentation\":\"<p>A list of configuration set attributes to return.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DescribeConfigurationSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"ConfigurationSet\":{\
+          \"shape\":\"ConfigurationSet\",\
+          \"documentation\":\"<p>The configuration set object associated with the specified configuration set.</p>\"\
+        },\
+        \"EventDestinations\":{\
+          \"shape\":\"EventDestinations\",\
+          \"documentation\":\"<p>A list of event destinations associated with the configuration set. </p>\"\
+        },\
+        \"TrackingOptions\":{\
+          \"shape\":\"TrackingOptions\",\
+          \"documentation\":\"<p>The name of the custom open and click tracking domain associated with the configuration set.</p>\"\
+        },\
+        \"DeliveryOptions\":{\"shape\":\"DeliveryOptions\"},\
+        \"ReputationOptions\":{\
+          \"shape\":\"ReputationOptions\",\
+          \"documentation\":\"<p>An object that represents the reputation settings for the configuration set. </p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the details of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DescribeReceiptRuleRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"RuleSetName\",\
+        \"RuleName\"\
+      ],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set that the receipt rule belongs to.</p>\"\
+        },\
+        \"RuleName\":{\
+          \"shape\":\"ReceiptRuleName\",\
+          \"documentation\":\"<p>The name of the receipt rule.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the details of a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DescribeReceiptRuleResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Rule\":{\
+          \"shape\":\"ReceiptRule\",\
+          \"documentation\":\"<p>A data structure that contains the specified receipt rule's name, actions, recipients, domains, enabled status, scan status, and Transport Layer Security (TLS) policy.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the details of a receipt rule.</p>\"\
+    },\
+    \"DescribeReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"RuleSetName\"],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set to describe.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the details of a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"DescribeReceiptRuleSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Metadata\":{\
+          \"shape\":\"ReceiptRuleSetMetadata\",\
+          \"documentation\":\"<p>The metadata for the receipt rule set, which consists of the rule set name and the timestamp of when the rule set was created.</p>\"\
+        },\
+        \"Rules\":{\
+          \"shape\":\"ReceiptRulesList\",\
+          \"documentation\":\"<p>A list of the receipt rules that belong to the specified receipt rule set.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the details of the specified receipt rule set.</p>\"\
     },\
     \"Destination\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"ToAddresses\":{\
-          \"shape\":\"EmailAddressList\",\
-          \"documentation\":\"<p>An array that contains the email addresses of the \\\"To\\\" recipients for the email.</p>\"\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>The recipients to place on the To: line of the message.</p>\"\
         },\
         \"CcAddresses\":{\
-          \"shape\":\"EmailAddressList\",\
-          \"documentation\":\"<p>An array that contains the email addresses of the \\\"CC\\\" (carbon copy) recipients for the email.</p>\"\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>The recipients to place on the CC: line of the message.</p>\"\
         },\
         \"BccAddresses\":{\
-          \"shape\":\"EmailAddressList\",\
-          \"documentation\":\"<p>An array that contains the email addresses of the \\\"BCC\\\" (blind carbon copy) recipients for the email.</p>\"\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>The recipients to place on the BCC: line of the message.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that describes the recipients for an email.</p>\"\
+      \"documentation\":\"<p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\\\"https://tools.ietf.org/html/rfc6531\\\">RFC6531</a>. For this reason, the <i>local part</i> of a destination email address (the part of the email address that precedes the @ sign) may only contain <a href=\\\"https://en.wikipedia.org/wiki/Email_address#Local-part\\\">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href=\\\"https://tools.ietf.org/html/rfc3492.html\\\">RFC3492</a>.</p> </note>\"\
     },\
-    \"DimensionName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of an Amazon CloudWatch dimension associated with an email sending metric. The name has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
-    },\
+    \"DiagnosticCode\":{\"type\":\"string\"},\
+    \"DimensionName\":{\"type\":\"string\"},\
     \"DimensionValueSource\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The location where the Amazon SES API v2 finds the value of a dimension to publish to Amazon CloudWatch. If you want to use the message tags that you specify using an <code>X-SES-MESSAGE-TAGS</code> header or a parameter to the <code>SendEmail</code> or <code>SendRawEmail</code> API, choose <code>messageTag</code>. If you want to use your own email headers, choose <code>emailHeader</code>. If you want to use link tags, choose <code>linkTags</code>.</p>\",\
       \"enum\":[\
-        \"MESSAGE_TAG\",\
-        \"EMAIL_HEADER\",\
-        \"LINK_TAG\"\
+        \"messageTag\",\
+        \"emailHeader\",\
+        \"linkTag\"\
       ]\
     },\
     \"DkimAttributes\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SigningEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If the value is <code>true</code>, then the messages that you send from the identity are signed using DKIM. If the value is <code>false</code>, then the messages that you send from the identity aren't DKIM-signed.</p>\"\
-        },\
-        \"Status\":{\
-          \"shape\":\"DkimStatus\",\
-          \"documentation\":\"<p>Describes whether or not Amazon SES has successfully located the DKIM records in the DNS records for the domain. The status can be one of the following:</p> <ul> <li> <p> <code>PENDING</code> â The verification process was initiated, but Amazon SES hasn't yet detected the DKIM records in the DNS configuration for the domain.</p> </li> <li> <p> <code>SUCCESS</code> â The verification process completed successfully.</p> </li> <li> <p> <code>FAILED</code> â The verification process failed. This typically occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the domain.</p> </li> <li> <p> <code>TEMPORARY_FAILURE</code> â A temporary issue is preventing Amazon SES from determining the DKIM authentication status of the domain.</p> </li> <li> <p> <code>NOT_STARTED</code> â The DKIM verification process hasn't been initiated for the domain.</p> </li> </ul>\"\
-        },\
-        \"Tokens\":{\
-          \"shape\":\"DnsTokenList\",\
-          \"documentation\":\"<p>If you used <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a> to configure DKIM authentication for the domain, then this object contains a set of unique strings that you use to create a set of CNAME records that you add to the DNS configuration for your domain. When Amazon SES detects these records in the DNS configuration for your domain, the DKIM authentication process is complete.</p> <p>If you configured DKIM authentication for the domain by providing your own public-private key pair, then this object contains the selector for the public key.</p> <p>Regardless of the DKIM authentication method you use, Amazon SES searches for the appropriate records in the DNS configuration of the domain for up to 72 hours.</p>\"\
-        },\
-        \"SigningAttributesOrigin\":{\
-          \"shape\":\"DkimSigningAttributesOrigin\",\
-          \"documentation\":\"<p>A string that indicates how DKIM was configured for the identity. There are two possible values:</p> <ul> <li> <p> <code>AWS_SES</code> â Indicates that DKIM was configured for the identity by using <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a>.</p> </li> <li> <p> <code>EXTERNAL</code> â Indicates that DKIM was configured for the identity by using Bring Your Own DKIM (BYODKIM).</p> </li> </ul>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the DKIM authentication status for an email identity.</p> <p>Amazon SES determines the authentication status by searching for specific records in the DNS configuration for the domain. If you used <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a> to set up DKIM authentication, Amazon SES tries to find three unique CNAME records in the DNS configuration for your domain. If you provided a public key to perform DKIM authentication, Amazon SES tries to find a TXT record that uses the selector that you specified. The value of the TXT record must be a public key that's paired with the private key that you specified in the process of creating the identity</p>\"\
-    },\
-    \"DkimSigningAttributes\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"DomainSigningSelector\",\
-        \"DomainSigningPrivateKey\"\
-      ],\
-      \"members\":{\
-        \"DomainSigningSelector\":{\
-          \"shape\":\"Selector\",\
-          \"documentation\":\"<p>A string that's used to identify a public key in the DNS configuration for a domain.</p>\"\
-        },\
-        \"DomainSigningPrivateKey\":{\
-          \"shape\":\"PrivateKey\",\
-          \"documentation\":\"<p>A private key that's used to generate a DKIM signature.</p> <p>The private key must use 1024-bit RSA encryption, and must be encoded using base64 encoding.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the tokens used for setting up Bring Your Own DKIM (BYODKIM).</p>\"\
-    },\
-    \"DkimSigningAttributesOrigin\":{\
-      \"type\":\"string\",\
-      \"enum\":[\
-        \"AWS_SES\",\
-        \"EXTERNAL\"\
-      ]\
-    },\
-    \"DkimStatus\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The DKIM authentication status of the identity. The status can be one of the following:</p> <ul> <li> <p> <code>PENDING</code> â The verification process was initiated, but Amazon SES hasn't yet detected the DKIM records in the DNS configuration for the domain.</p> </li> <li> <p> <code>SUCCESS</code> â The verification process completed successfully.</p> </li> <li> <p> <code>FAILED</code> â The verification process failed. This typically occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the domain.</p> </li> <li> <p> <code>TEMPORARY_FAILURE</code> â A temporary issue is preventing Amazon SES from determining the DKIM authentication status of the domain.</p> </li> <li> <p> <code>NOT_STARTED</code> â The DKIM verification process hasn't been initiated for the domain.</p> </li> </ul>\",\
-      \"enum\":[\
-        \"PENDING\",\
-        \"SUCCESS\",\
-        \"FAILED\",\
-        \"TEMPORARY_FAILURE\",\
-        \"NOT_STARTED\"\
-      ]\
-    },\
-    \"DnsToken\":{\"type\":\"string\"},\
-    \"DnsTokenList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"DnsToken\"}\
+      \"type\":\"map\",\
+      \"key\":{\"shape\":\"Identity\"},\
+      \"value\":{\"shape\":\"IdentityDkimAttributes\"}\
     },\
     \"Domain\":{\"type\":\"string\"},\
-    \"DomainDeliverabilityCampaign\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"CampaignId\":{\
-          \"shape\":\"CampaignId\",\
-          \"documentation\":\"<p>The unique identifier for the campaign. The Deliverability dashboard automatically generates and assigns this identifier to a campaign.</p>\"\
-        },\
-        \"ImageUrl\":{\
-          \"shape\":\"ImageUrl\",\
-          \"documentation\":\"<p>The URL of an image that contains a snapshot of the email message that was sent.</p>\"\
-        },\
-        \"Subject\":{\
-          \"shape\":\"Subject\",\
-          \"documentation\":\"<p>The subject line, or title, of the email message.</p>\"\
-        },\
-        \"FromAddress\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The verified email address that the email message was sent from.</p>\"\
-        },\
-        \"SendingIps\":{\
-          \"shape\":\"IpList\",\
-          \"documentation\":\"<p>The IP addresses that were used to send the email message.</p>\"\
-        },\
-        \"FirstSeenDateTime\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The first time, in Unix time format, when the email message was delivered to any recipient's inbox. This value can help you determine how long it took for a campaign to deliver an email message.</p>\"\
-        },\
-        \"LastSeenDateTime\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The last time, in Unix time format, when the email message was delivered to any recipient's inbox. This value can help you determine how long it took for a campaign to deliver an email message.</p>\"\
-        },\
-        \"InboxCount\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The number of email messages that were delivered to recipientsâ inboxes.</p>\"\
-        },\
-        \"SpamCount\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The number of email messages that were delivered to recipients' spam or junk mail folders.</p>\"\
-        },\
-        \"ReadRate\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of email messages that were opened by recipients. Due to technical limitations, this value only includes recipients who opened the message by using an email client that supports images.</p>\"\
-        },\
-        \"DeleteRate\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of email messages that were deleted by recipients, without being opened first. Due to technical limitations, this value only includes recipients who opened the message by using an email client that supports images.</p>\"\
-        },\
-        \"ReadDeleteRate\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of email messages that were opened and then deleted by recipients. Due to technical limitations, this value only includes recipients who opened the message by using an email client that supports images.</p>\"\
-        },\
-        \"ProjectedVolume\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The projected number of recipients that the email message was sent to.</p>\"\
-        },\
-        \"Esps\":{\
-          \"shape\":\"Esps\",\
-          \"documentation\":\"<p>The major email providers who handled the email message.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for (<code>PutDeliverabilityDashboardOption</code> operation).</p>\"\
-    },\
-    \"DomainDeliverabilityCampaignList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"DomainDeliverabilityCampaign\"},\
-      \"documentation\":\"<p/>\"\
-    },\
-    \"DomainDeliverabilityTrackingOption\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"Domain\":{\
-          \"shape\":\"Domain\",\
-          \"documentation\":\"<p>A verified domain thatâs associated with your AWS account and currently has an active Deliverability dashboard subscription.</p>\"\
-        },\
-        \"SubscriptionStartDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The date, in Unix time format, when you enabled the Deliverability dashboard for the domain.</p>\"\
-        },\
-        \"InboxPlacementTrackingOption\":{\
-          \"shape\":\"InboxPlacementTrackingOption\",\
-          \"documentation\":\"<p>An object that contains information about the inbox placement data settings for the domain.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the Deliverability dashboard subscription for a verified domain that you use to send email and currently has an active Deliverability dashboard subscription. If a Deliverability dashboard subscription is active for a domain, you gain access to reputation, inbox placement, and other metrics for the domain.</p>\"\
-    },\
-    \"DomainDeliverabilityTrackingOptions\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"DomainDeliverabilityTrackingOption\"},\
-      \"documentation\":\"<p>An object that contains information about the Deliverability dashboard subscription for a verified domain that you use to send email and currently has an active Deliverability dashboard subscription. If a Deliverability dashboard subscription is active for a domain, you gain access to reputation, inbox placement, and other metrics for the domain.</p>\"\
-    },\
-    \"DomainIspPlacement\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"IspName\":{\
-          \"shape\":\"IspName\",\
-          \"documentation\":\"<p>The name of the email provider that the inbox placement data applies to.</p>\"\
-        },\
-        \"InboxRawCount\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The total number of messages that were sent from the selected domain to the specified email provider that arrived in recipients' inboxes.</p>\"\
-        },\
-        \"SpamRawCount\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The total number of messages that were sent from the selected domain to the specified email provider that arrived in recipients' spam or junk mail folders.</p>\"\
-        },\
-        \"InboxPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of messages that were sent from the selected domain to the specified email provider that arrived in recipients' inboxes.</p>\"\
-        },\
-        \"SpamPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of messages that were sent from the selected domain to the specified email provider that arrived in recipients' spam or junk mail folders.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains inbox placement data for email sent from one of your email domains to a specific email provider.</p>\"\
-    },\
-    \"DomainIspPlacements\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"DomainIspPlacement\"}\
-    },\
-    \"EmailAddress\":{\"type\":\"string\"},\
-    \"EmailAddressList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"EmailAddress\"}\
-    },\
-    \"EmailContent\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"Simple\":{\
-          \"shape\":\"Message\",\
-          \"documentation\":\"<p>The simple email message. The message consists of a subject and a message body.</p>\"\
-        },\
-        \"Raw\":{\
-          \"shape\":\"RawMessage\",\
-          \"documentation\":\"<p>The raw email message. The message has to meet the following criteria:</p> <ul> <li> <p>The message has to contain a header and a body, separated by one blank line.</p> </li> <li> <p>All of the required header fields must be present in the message.</p> </li> <li> <p>Each part of a multipart MIME message must be formatted properly.</p> </li> <li> <p>If you include attachments, they must be in a file format that the Amazon SES API v2 supports. </p> </li> <li> <p>The entire message must be Base64 encoded.</p> </li> <li> <p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, you should encode that content to ensure that recipients' email clients render the message properly.</p> </li> <li> <p>The length of any single line of text in the message can't exceed 1,000 characters. This restriction is defined in <a href=\\\"https://tools.ietf.org/html/rfc5321\\\">RFC 5321</a>.</p> </li> </ul>\"\
-        },\
-        \"Template\":{\
-          \"shape\":\"Template\",\
-          \"documentation\":\"<p>The template to use for the email message.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that defines the entire content of the email, including the message headers and the body content. You can create a simple email message, in which you specify the subject and the text and HTML versions of the message body. You can also create raw messages, in which you specify a complete MIME-formatted message. Raw messages can include attachments and custom headers.</p>\"\
-    },\
-    \"EmailTemplateContent\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"Subject\":{\
-          \"shape\":\"EmailTemplateSubject\",\
-          \"documentation\":\"<p>The subject line of the email.</p>\"\
-        },\
-        \"Text\":{\
-          \"shape\":\"EmailTemplateText\",\
-          \"documentation\":\"<p>The email body that will be visible to recipients whose email clients do not display HTML.</p>\"\
-        },\
-        \"Html\":{\
-          \"shape\":\"EmailTemplateHtml\",\
-          \"documentation\":\"<p>The HTML body of the email.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>\"\
-    },\
-    \"EmailTemplateData\":{\
+    \"DsnAction\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>An object that defines the values to use for message variables in the template. This object is a set of key-value pairs. Each key defines a message variable in the template. The corresponding value defines the value to use for that variable.</p>\",\
-      \"max\":262144\
+      \"enum\":[\
+        \"failed\",\
+        \"delayed\",\
+        \"delivered\",\
+        \"relayed\",\
+        \"expanded\"\
+      ]\
     },\
-    \"EmailTemplateHtml\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The HTML body of the email.</p>\"\
-    },\
-    \"EmailTemplateMetadata\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template.</p>\"\
-        },\
-        \"CreatedTimestamp\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The time and date the template was created.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Contains information about an email template.</p>\"\
-    },\
-    \"EmailTemplateMetadataList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"EmailTemplateMetadata\"},\
-      \"documentation\":\"<p>A list of the EmailTemplateMetadata object.</p>\"\
-    },\
-    \"EmailTemplateName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of the template. You will refer to this name when you send email using the <code>SendTemplatedEmail</code> or <code>SendBulkTemplatedEmail</code> operations.</p>\",\
-      \"min\":1\
-    },\
-    \"EmailTemplateSubject\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The subject line of the email.</p>\"\
-    },\
-    \"EmailTemplateText\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The email body that will be visible to recipients whose email clients do not display HTML.</p>\"\
-    },\
+    \"DsnStatus\":{\"type\":\"string\"},\
     \"Enabled\":{\"type\":\"boolean\"},\
-    \"EnabledWrapper\":{\"type\":\"boolean\"},\
-    \"ErrorMessage\":{\"type\":\"string\"},\
-    \"Esp\":{\"type\":\"string\"},\
-    \"Esps\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"Esp\"}\
-    },\
+    \"Error\":{\"type\":\"string\"},\
     \"EventDestination\":{\
       \"type\":\"structure\",\
       \"required\":[\
@@ -2400,257 +2157,153 @@
       \"members\":{\
         \"Name\":{\
           \"shape\":\"EventDestinationName\",\
-          \"documentation\":\"<p>A name that identifies the event destination.</p>\"\
+          \"documentation\":\"<p>The name of the event destination. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>\"\
         },\
         \"Enabled\":{\
           \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If <code>true</code>, the event destination is enabled. When the event destination is enabled, the specified event types are sent to the destinations in this <code>EventDestinationDefinition</code>.</p> <p>If <code>false</code>, the event destination is disabled. When the event destination is disabled, events aren't sent to the specified destinations.</p>\"\
+          \"documentation\":\"<p>Sets whether Amazon SES publishes events to this destination when you send an email with the associated configuration set. Set to <code>true</code> to enable publishing to this destination; set to <code>false</code> to prevent publishing to this destination. The default value is <code>false</code>.</p>\"\
         },\
         \"MatchingEventTypes\":{\
           \"shape\":\"EventTypes\",\
-          \"documentation\":\"<p>The types of events that Amazon SES sends to the specified event destinations.</p>\"\
+          \"documentation\":\"<p>The type of email sending events to publish to the event destination.</p>\"\
         },\
         \"KinesisFirehoseDestination\":{\
           \"shape\":\"KinesisFirehoseDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to stream data to other services, such as Amazon S3 and Amazon Redshift.</p>\"\
+          \"documentation\":\"<p>An object that contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p>\"\
         },\
         \"CloudWatchDestination\":{\
           \"shape\":\"CloudWatchDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to monitor and gain insights on your email sending metrics.</p>\"\
+          \"documentation\":\"<p>An object that contains the names, default values, and sources of the dimensions associated with an Amazon CloudWatch event destination.</p>\"\
         },\
-        \"SnsDestination\":{\
-          \"shape\":\"SnsDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to send notification when certain email events occur.</p>\"\
-        },\
-        \"PinpointDestination\":{\
-          \"shape\":\"PinpointDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon Pinpoint project destination for email events. You can send email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging dashboards that are built in to Amazon Pinpoint. For more information, see <a href=\\\"https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html\\\">Transactional Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>\"\
+        \"SNSDestination\":{\
+          \"shape\":\"SNSDestination\",\
+          \"documentation\":\"<p>An object that contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>In the Amazon SES API v2, <i>events</i> include message sends, deliveries, opens, clicks, bounces, complaints and delivery delays. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>\"\
+      \"documentation\":\"<p>Contains information about the event destination that the specified email sending events will be published to.</p> <note> <p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose or Amazon Simple Notification Service (Amazon SNS).</p> </note> <p>Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"EventDestinationDefinition\":{\
+    \"EventDestinationAlreadyExistsException\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"Enabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If <code>true</code>, the event destination is enabled. When the event destination is enabled, the specified event types are sent to the destinations in this <code>EventDestinationDefinition</code>.</p> <p>If <code>false</code>, the event destination is disabled. When the event destination is disabled, events aren't sent to the specified destinations.</p>\"\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
         },\
-        \"MatchingEventTypes\":{\
-          \"shape\":\"EventTypes\",\
-          \"documentation\":\"<p>An array that specifies which events the Amazon SES API v2 should send to the destinations in this <code>EventDestinationDefinition</code>.</p>\"\
-        },\
-        \"KinesisFirehoseDestination\":{\
-          \"shape\":\"KinesisFirehoseDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to stream data to other services, such as Amazon S3 and Amazon Redshift.</p>\"\
-        },\
-        \"CloudWatchDestination\":{\
-          \"shape\":\"CloudWatchDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon CloudWatch destination for email events. You can use Amazon CloudWatch to monitor and gain insights on your email sending metrics.</p>\"\
-        },\
-        \"SnsDestination\":{\
-          \"shape\":\"SnsDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to send notification when certain email events occur.</p>\"\
-        },\
-        \"PinpointDestination\":{\
-          \"shape\":\"PinpointDestination\",\
-          \"documentation\":\"<p>An object that defines an Amazon Pinpoint project destination for email events. You can send email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging dashboards that are built in to Amazon Pinpoint. For more information, see <a href=\\\"https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html\\\">Transactional Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>\"\
+        \"EventDestinationName\":{\
+          \"shape\":\"EventDestinationName\",\
+          \"documentation\":\"<p>Indicates that the event destination does not exist.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that defines the event destination. Specifically, it defines which services receive events from emails sent using the configuration set that the event destination is associated with. Also defines the types of events that are sent to the event destination.</p>\"\
+      \"documentation\":\"<p>Indicates that the event destination could not be created because of a naming conflict.</p>\",\
+      \"error\":{\
+        \"code\":\"EventDestinationAlreadyExists\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"EventDestinationName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of an event destination.</p> <p> <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>\"\
+    \"EventDestinationDoesNotExistException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
+        },\
+        \"EventDestinationName\":{\
+          \"shape\":\"EventDestinationName\",\
+          \"documentation\":\"<p>Indicates that the event destination does not exist.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the event destination does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"EventDestinationDoesNotExist\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
+    \"EventDestinationName\":{\"type\":\"string\"},\
     \"EventDestinations\":{\
       \"type\":\"list\",\
       \"member\":{\"shape\":\"EventDestination\"}\
     },\
     \"EventType\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>An email sending event type. For example, email sends, opens, and bounces are all email events.</p>\",\
       \"enum\":[\
-        \"SEND\",\
-        \"REJECT\",\
-        \"BOUNCE\",\
-        \"COMPLAINT\",\
-        \"DELIVERY\",\
-        \"OPEN\",\
-        \"CLICK\",\
-        \"RENDERING_FAILURE\",\
-        \"DELIVERY_DELAY\"\
+        \"send\",\
+        \"reject\",\
+        \"bounce\",\
+        \"complaint\",\
+        \"delivery\",\
+        \"open\",\
+        \"click\",\
+        \"renderingFailure\"\
       ]\
     },\
     \"EventTypes\":{\
       \"type\":\"list\",\
       \"member\":{\"shape\":\"EventType\"}\
     },\
-    \"FailedRecordsCount\":{\"type\":\"integer\"},\
-    \"FailedRecordsS3Url\":{\"type\":\"string\"},\
-    \"FailureInfo\":{\
+    \"Explanation\":{\"type\":\"string\"},\
+    \"ExtensionField\":{\
       \"type\":\"structure\",\
+      \"required\":[\
+        \"Name\",\
+        \"Value\"\
+      ],\
       \"members\":{\
-        \"FailedRecordsS3Url\":{\
-          \"shape\":\"FailedRecordsS3Url\",\
-          \"documentation\":\"<p>An Amazon S3 presigned URL that contains all the failed records and related information.</p>\"\
+        \"Name\":{\
+          \"shape\":\"ExtensionFieldName\",\
+          \"documentation\":\"<p>The name of the header to add. Must be between 1 and 50 characters, inclusive, and consist of alphanumeric (a-z, A-Z, 0-9) characters and dashes only.</p>\"\
         },\
-        \"ErrorMessage\":{\
-          \"shape\":\"ErrorMessage\",\
-          \"documentation\":\"<p>A message about why the import job failed.</p>\"\
+        \"Value\":{\
+          \"shape\":\"ExtensionFieldValue\",\
+          \"documentation\":\"<p>The value of the header to add. Must be less than 2048 characters, and must not contain newline characters (\\\"\\\\r\\\" or \\\"\\\\n\\\").</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that contains the failure details about an import job.</p>\"\
+      \"documentation\":\"<p>Additional X-headers to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"FailureRedirectionURL\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The URL that the recipient of the verification email is sent to if his or her address is not successfully verified.</p>\"\
+    \"ExtensionFieldList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ExtensionField\"}\
     },\
-    \"FeedbackId\":{\"type\":\"string\"},\
-    \"GeneralEnforcementStatus\":{\"type\":\"string\"},\
-    \"GetAccountRequest\":{\
+    \"ExtensionFieldName\":{\"type\":\"string\"},\
+    \"ExtensionFieldValue\":{\"type\":\"string\"},\
+    \"FailureRedirectionURL\":{\"type\":\"string\"},\
+    \"FromAddress\":{\"type\":\"string\"},\
+    \"FromEmailAddressNotVerifiedException\":{\
       \"type\":\"structure\",\
       \"members\":{\
+        \"FromEmailAddress\":{\
+          \"shape\":\"FromAddress\",\
+          \"documentation\":\"<p>Indicates that the from email address associated with the custom verification email template is not verified.</p>\"\
+        }\
       },\
-      \"documentation\":\"<p>A request to obtain information about the email-sending capabilities of your Amazon SES account.</p>\"\
+      \"documentation\":\"<p>Indicates that the sender address specified for a custom verification email is not verified, and is therefore not eligible to send the custom verification email. </p>\",\
+      \"error\":{\
+        \"code\":\"FromEmailAddressNotVerified\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"GetAccountResponse\":{\
+    \"GetAccountSendingEnabledResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"DedicatedIpAutoWarmupEnabled\":{\
+        \"Enabled\":{\
           \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Indicates whether or not the automatic warm-up feature is enabled for dedicated IP addresses that are associated with your account.</p>\"\
-        },\
-        \"EnforcementStatus\":{\
-          \"shape\":\"GeneralEnforcementStatus\",\
-          \"documentation\":\"<p>The reputation status of your Amazon SES account. The status can be one of the following:</p> <ul> <li> <p> <code>HEALTHY</code> â There are no reputation-related issues that currently impact your account.</p> </li> <li> <p> <code>PROBATION</code> â We've identified potential issues with your Amazon SES account. We're placing your account under review while you work on correcting these issues.</p> </li> <li> <p> <code>SHUTDOWN</code> â Your account's ability to send email is currently paused because of an issue with the email sent from your account. When you correct the issue, you can contact us and request that your account's ability to send email is resumed.</p> </li> </ul>\"\
-        },\
-        \"ProductionAccessEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Indicates whether or not your account has production access in the current AWS Region.</p> <p>If the value is <code>false</code>, then your account is in the <i>sandbox</i>. When your account is in the sandbox, you can only send email to verified identities. Additionally, the maximum number of emails you can send in a 24-hour period (your sending quota) is 200, and the maximum number of emails you can send per second (your maximum sending rate) is 1.</p> <p>If the value is <code>true</code>, then your account has production access. When your account has production access, you can send email to any address. The sending quota and maximum sending rate for your account vary based on your specific use case.</p>\"\
-        },\
-        \"SendQuota\":{\
-          \"shape\":\"SendQuota\",\
-          \"documentation\":\"<p>An object that contains information about the per-day and per-second sending limits for your Amazon SES account in the current AWS Region.</p>\"\
-        },\
-        \"SendingEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Indicates whether or not email sending is enabled for your Amazon SES account in the current AWS Region.</p>\"\
-        },\
-        \"SuppressionAttributes\":{\
-          \"shape\":\"SuppressionAttributes\",\
-          \"documentation\":\"<p>An object that contains information about the email address suppression preferences for your account in the current AWS Region.</p>\"\
-        },\
-        \"Details\":{\
-          \"shape\":\"AccountDetails\",\
-          \"documentation\":\"<p>An object that defines your account details.</p>\"\
+          \"documentation\":\"<p>Describes whether email sending is enabled or disabled for your Amazon SES account in the current AWS Region.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A list of details about the email-sending capabilities of your Amazon SES account in the current AWS Region.</p>\"\
-    },\
-    \"GetBlacklistReportsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"BlacklistItemNames\"],\
-      \"members\":{\
-        \"BlacklistItemNames\":{\
-          \"shape\":\"BlacklistItemNames\",\
-          \"documentation\":\"<p>A list of IP addresses that you want to retrieve blacklist information about. You can only specify the dedicated IP addresses that you use to send email using Amazon SES or Amazon Pinpoint.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"BlacklistItemNames\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to retrieve a list of the blacklists that your dedicated IP addresses appear on.</p>\"\
-    },\
-    \"GetBlacklistReportsResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"BlacklistReport\"],\
-      \"members\":{\
-        \"BlacklistReport\":{\
-          \"shape\":\"BlacklistReport\",\
-          \"documentation\":\"<p>An object that contains information about a blacklist that one of your dedicated IP addresses appears on.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about blacklist events.</p>\"\
-    },\
-    \"GetConfigurationSetEventDestinationsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that contains the event destination.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to obtain information about the event destinations for a configuration set.</p>\"\
-    },\
-    \"GetConfigurationSetEventDestinationsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"EventDestinations\":{\
-          \"shape\":\"EventDestinations\",\
-          \"documentation\":\"<p>An array that includes all of the events destinations that have been configured for the configuration set.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Information about an event destination for a configuration set.</p>\"\
-    },\
-    \"GetConfigurationSetRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to obtain more information about.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to obtain information about a configuration set.</p>\"\
-    },\
-    \"GetConfigurationSetResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set.</p>\"\
-        },\
-        \"TrackingOptions\":{\
-          \"shape\":\"TrackingOptions\",\
-          \"documentation\":\"<p>An object that defines the open and click tracking options for emails that you send using the configuration set.</p>\"\
-        },\
-        \"DeliveryOptions\":{\
-          \"shape\":\"DeliveryOptions\",\
-          \"documentation\":\"<p>An object that defines the dedicated IP pool that is used to send emails that you send using the configuration set.</p>\"\
-        },\
-        \"ReputationOptions\":{\
-          \"shape\":\"ReputationOptions\",\
-          \"documentation\":\"<p>An object that defines whether or not Amazon SES collects reputation metrics for the emails that you send that use the configuration set.</p>\"\
-        },\
-        \"SendingOptions\":{\
-          \"shape\":\"SendingOptions\",\
-          \"documentation\":\"<p>An object that defines whether or not Amazon SES can send email that you send using the configuration set.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array of objects that define the tags (keys and values) that are associated with the configuration set.</p>\"\
-        },\
-        \"SuppressionOptions\":{\
-          \"shape\":\"SuppressionOptions\",\
-          \"documentation\":\"<p>An object that contains information about the suppression list preferences for your account.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Information about a configuration set.</p>\"\
+      \"documentation\":\"<p>Represents a request to return the email sending status for your Amazon SES account in the current AWS Region.</p>\"\
     },\
     \"GetCustomVerificationEmailTemplateRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\"TemplateName\"],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the custom verification email template that you want to retrieve.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the custom verification email template that you want to retrieve.</p>\"\
         }\
       },\
       \"documentation\":\"<p>Represents a request to retrieve an existing custom verification email template.</p>\"\
@@ -2659,15 +2312,15 @@
       \"type\":\"structure\",\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
+          \"shape\":\"TemplateName\",\
           \"documentation\":\"<p>The name of the custom verification email template.</p>\"\
         },\
         \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
+          \"shape\":\"FromAddress\",\
           \"documentation\":\"<p>The email address that the custom verification email is sent from.</p>\"\
         },\
         \"TemplateSubject\":{\
-          \"shape\":\"EmailTemplateSubject\",\
+          \"shape\":\"Subject\",\
           \"documentation\":\"<p>The subject line of the custom verification email.</p>\"\
         },\
         \"TemplateContent\":{\
@@ -2683,581 +2336,522 @@
           \"documentation\":\"<p>The URL that the recipient of the verification email is sent to if his or her address is not successfully verified.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>The following elements are returned by the service.</p>\"\
+      \"documentation\":\"<p>The content of the custom verification email template.</p>\"\
     },\
-    \"GetDedicatedIpRequest\":{\
+    \"GetIdentityDkimAttributesRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\"Ip\"],\
+      \"required\":[\"Identities\"],\
       \"members\":{\
-        \"Ip\":{\
-          \"shape\":\"Ip\",\
-          \"documentation\":\"<p>The IP address that you want to obtain more information about. The value you specify has to be a dedicated IP address that's assocaited with your AWS account.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"IP\"\
+        \"Identities\":{\
+          \"shape\":\"IdentityList\",\
+          \"documentation\":\"<p>A list of one or more verified identities - email addresses, domains, or both.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to obtain more information about a dedicated IP address.</p>\"\
+      \"documentation\":\"<p>Represents a request for the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this request also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published. For more information about Easy DKIM, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"GetDedicatedIpResponse\":{\
+    \"GetIdentityDkimAttributesResponse\":{\
       \"type\":\"structure\",\
+      \"required\":[\"DkimAttributes\"],\
       \"members\":{\
-        \"DedicatedIp\":{\
-          \"shape\":\"DedicatedIp\",\
-          \"documentation\":\"<p>An object that contains information about a dedicated IP address.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Information about a dedicated IP address.</p>\"\
-    },\
-    \"GetDedicatedIpsRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"PoolName\":{\
-          \"shape\":\"PoolName\",\
-          \"documentation\":\"<p>The name of the IP pool that the dedicated IP address is associated with.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PoolName\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>GetDedicatedIps</code> to indicate the position of the dedicated IP pool in the list of IP pools.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
-        },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>GetDedicatedIpsRequest</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to obtain more information about dedicated IP pools.</p>\"\
-    },\
-    \"GetDedicatedIpsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"DedicatedIps\":{\
-          \"shape\":\"DedicatedIpList\",\
-          \"documentation\":\"<p>A list of dedicated IP addresses that are associated with your AWS account.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token that indicates that there are additional dedicated IP addresses to list. To view additional addresses, issue another request to <code>GetDedicatedIps</code>, passing this token in the <code>NextToken</code> parameter.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Information about the dedicated IP addresses that are associated with your AWS account.</p>\"\
-    },\
-    \"GetDeliverabilityDashboardOptionsRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>Retrieve information about the status of the Deliverability dashboard for your AWS account. When the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and other metrics for your domains. You also gain the ability to perform predictive inbox placement tests.</p> <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href=\\\"http://aws.amazon.com/pinpoint/pricing/\\\">Amazon Pinpoint Pricing</a>.</p>\"\
-    },\
-    \"GetDeliverabilityDashboardOptionsResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"DashboardEnabled\"],\
-      \"members\":{\
-        \"DashboardEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Specifies whether the Deliverability dashboard is enabled. If this value is <code>true</code>, the dashboard is enabled.</p>\"\
-        },\
-        \"SubscriptionExpiryDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The date, in Unix time format, when your current subscription to the Deliverability dashboard is scheduled to expire, if your subscription is scheduled to expire at the end of the current calendar month. This value is null if you have an active subscription that isnât due to expire at the end of the month.</p>\"\
-        },\
-        \"AccountStatus\":{\
-          \"shape\":\"DeliverabilityDashboardAccountStatus\",\
-          \"documentation\":\"<p>The current status of your Deliverability dashboard subscription. If this value is <code>PENDING_EXPIRATION</code>, your subscription is scheduled to expire at the end of the current calendar month.</p>\"\
-        },\
-        \"ActiveSubscribedDomains\":{\
-          \"shape\":\"DomainDeliverabilityTrackingOptions\",\
-          \"documentation\":\"<p>An array of objects, one for each verified domain that you use to send email and currently has an active Deliverability dashboard subscription that isnât scheduled to expire at the end of the current calendar month.</p>\"\
-        },\
-        \"PendingExpirationSubscribedDomains\":{\
-          \"shape\":\"DomainDeliverabilityTrackingOptions\",\
-          \"documentation\":\"<p>An array of objects, one for each verified domain that you use to send email and currently has an active Deliverability dashboard subscription that's scheduled to expire at the end of the current calendar month.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that shows the status of the Deliverability dashboard.</p>\"\
-    },\
-    \"GetDeliverabilityTestReportRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ReportId\"],\
-      \"members\":{\
-        \"ReportId\":{\
-          \"shape\":\"ReportId\",\
-          \"documentation\":\"<p>A unique string that identifies the predictive inbox placement test.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ReportId\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to retrieve the results of a predictive inbox placement test.</p>\"\
-    },\
-    \"GetDeliverabilityTestReportResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"DeliverabilityTestReport\",\
-        \"OverallPlacement\",\
-        \"IspPlacements\"\
-      ],\
-      \"members\":{\
-        \"DeliverabilityTestReport\":{\
-          \"shape\":\"DeliverabilityTestReport\",\
-          \"documentation\":\"<p>An object that contains the results of the predictive inbox placement test.</p>\"\
-        },\
-        \"OverallPlacement\":{\
-          \"shape\":\"PlacementStatistics\",\
-          \"documentation\":\"<p>An object that specifies how many test messages that were sent during the predictive inbox placement test were delivered to recipients' inboxes, how many were sent to recipients' spam folders, and how many weren't delivered.</p>\"\
-        },\
-        \"IspPlacements\":{\
-          \"shape\":\"IspPlacements\",\
-          \"documentation\":\"<p>An object that describes how the test email was handled by several email providers, including Gmail, Hotmail, Yahoo, AOL, and others.</p>\"\
-        },\
-        \"Message\":{\
-          \"shape\":\"MessageContent\",\
-          \"documentation\":\"<p>An object that contains the message that you sent when you performed this predictive inbox placement test.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array of objects that define the tags (keys and values) that are associated with the predictive inbox placement test.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>The results of the predictive inbox placement test.</p>\"\
-    },\
-    \"GetDomainDeliverabilityCampaignRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"CampaignId\"],\
-      \"members\":{\
-        \"CampaignId\":{\
-          \"shape\":\"CampaignId\",\
-          \"documentation\":\"<p>The unique identifier for the campaign. The Deliverability dashboard automatically generates and assigns this identifier to a campaign.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"CampaignId\"\
-        }\
-      },\
-      \"documentation\":\"<p>Retrieve all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for (<code>PutDeliverabilityDashboardOption</code> operation).</p>\"\
-    },\
-    \"GetDomainDeliverabilityCampaignResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"DomainDeliverabilityCampaign\"],\
-      \"members\":{\
-        \"DomainDeliverabilityCampaign\":{\
-          \"shape\":\"DomainDeliverabilityCampaign\",\
-          \"documentation\":\"<p>An object that contains the deliverability data for the campaign.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for.</p>\"\
-    },\
-    \"GetDomainStatisticsReportRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"Domain\",\
-        \"StartDate\",\
-        \"EndDate\"\
-      ],\
-      \"members\":{\
-        \"Domain\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The domain that you want to obtain deliverability metrics for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"Domain\"\
-        },\
-        \"StartDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The first day (in Unix time) that you want to obtain domain deliverability metrics for.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"StartDate\"\
-        },\
-        \"EndDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The last day (in Unix time) that you want to obtain domain deliverability metrics for. The <code>EndDate</code> that you specify has to be less than or equal to 30 days after the <code>StartDate</code>.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"EndDate\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to obtain deliverability metrics for a domain.</p>\"\
-    },\
-    \"GetDomainStatisticsReportResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"OverallVolume\",\
-        \"DailyVolumes\"\
-      ],\
-      \"members\":{\
-        \"OverallVolume\":{\
-          \"shape\":\"OverallVolume\",\
-          \"documentation\":\"<p>An object that contains deliverability metrics for the domain that you specified. The data in this object is a summary of all of the data that was collected from the <code>StartDate</code> to the <code>EndDate</code>.</p>\"\
-        },\
-        \"DailyVolumes\":{\
-          \"shape\":\"DailyVolumes\",\
-          \"documentation\":\"<p>An object that contains deliverability metrics for the domain that you specified. This object contains data for each day, starting on the <code>StartDate</code> and ending on the <code>EndDate</code>.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that includes statistics that are related to the domain that you specified.</p>\"\
-    },\
-    \"GetEmailIdentityPoliciesRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
-      \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity that you want to retrieve policies for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to return the policies of an email identity.</p>\"\
-    },\
-    \"GetEmailIdentityPoliciesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"Policies\":{\
-          \"shape\":\"PolicyMap\",\
-          \"documentation\":\"<p>A map of policy names to policies.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Identity policies associated with email identity.</p>\"\
-    },\
-    \"GetEmailIdentityRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
-      \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity that you want to retrieve details for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to return details about an email identity.</p>\"\
-    },\
-    \"GetEmailIdentityResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"IdentityType\":{\
-          \"shape\":\"IdentityType\",\
-          \"documentation\":\"<p>The email identity type.</p>\"\
-        },\
-        \"FeedbackForwardingStatus\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>The feedback forwarding configuration for the identity.</p> <p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p> <p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>\"\
-        },\
-        \"VerifiedForSendingStatus\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Specifies whether or not the identity is verified. You can only send email from verified email addresses or domains. For more information about verifying identities, see the <a href=\\\"https://docs.aws.amazon.com/pinpoint/latest/userguide/channels-email-manage-verify.html\\\">Amazon Pinpoint User Guide</a>.</p>\"\
-        },\
         \"DkimAttributes\":{\
           \"shape\":\"DkimAttributes\",\
-          \"documentation\":\"<p>An object that contains information about the DKIM attributes for the identity.</p>\"\
+          \"documentation\":\"<p>The DKIM attributes for an email address or a domain.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the status of Amazon SES Easy DKIM signing for an identity. For domain identities, this response also contains the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES successfully verified that these tokens were published.</p>\"\
+    },\
+    \"GetIdentityMailFromDomainAttributesRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Identities\"],\
+      \"members\":{\
+        \"Identities\":{\
+          \"shape\":\"IdentityList\",\
+          \"documentation\":\"<p>A list of one or more identities.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the Amazon SES custom MAIL FROM attributes for a list of identities. For information about using a custom MAIL FROM domain, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"GetIdentityMailFromDomainAttributesResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"MailFromDomainAttributes\"],\
+      \"members\":{\
+        \"MailFromDomainAttributes\":{\
+          \"shape\":\"MailFromDomainAttributes\",\
+          \"documentation\":\"<p>A map of identities to custom MAIL FROM attributes.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the custom MAIL FROM attributes for a list of identities.</p>\"\
+    },\
+    \"GetIdentityNotificationAttributesRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Identities\"],\
+      \"members\":{\
+        \"Identities\":{\
+          \"shape\":\"IdentityList\",\
+          \"documentation\":\"<p>A list of one or more identities. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the notification attributes for a list of identities you verified with Amazon SES. For information about Amazon SES notifications, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"GetIdentityNotificationAttributesResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"NotificationAttributes\"],\
+      \"members\":{\
+        \"NotificationAttributes\":{\
+          \"shape\":\"NotificationAttributes\",\
+          \"documentation\":\"<p>A map of Identity to IdentityNotificationAttributes.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the notification attributes for a list of identities.</p>\"\
+    },\
+    \"GetIdentityPoliciesRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Identity\",\
+        \"PolicyNames\"\
+      ],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The identity for which the policies will be retrieved. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>\"\
         },\
-        \"MailFromAttributes\":{\
-          \"shape\":\"MailFromAttributes\",\
-          \"documentation\":\"<p>An object that contains information about the Mail-From attributes for the email identity.</p>\"\
-        },\
+        \"PolicyNames\":{\
+          \"shape\":\"PolicyNameList\",\
+          \"documentation\":\"<p>A list of the names of policies to be retrieved. You can retrieve a maximum of 20 policies at a time. If you do not know the names of the policies that are attached to the identity, you can use <code>ListIdentityPolicies</code>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the requested sending authorization policies for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"GetIdentityPoliciesResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Policies\"],\
+      \"members\":{\
         \"Policies\":{\
           \"shape\":\"PolicyMap\",\
           \"documentation\":\"<p>A map of policy names to policies.</p>\"\
-        },\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array of objects that define the tags (keys and values) that are associated with the email identity.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Details about an email identity.</p>\"\
+      \"documentation\":\"<p>Represents the requested sending authorization policies.</p>\"\
     },\
-    \"GetEmailTemplateRequest\":{\
+    \"GetIdentityVerificationAttributesRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Identities\"],\
+      \"members\":{\
+        \"Identities\":{\
+          \"shape\":\"IdentityList\",\
+          \"documentation\":\"<p>A list of identities.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return the Amazon SES verification status of a list of identities. For domain identities, this request also returns the verification token. For information about verifying identities with Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"GetIdentityVerificationAttributesResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"VerificationAttributes\"],\
+      \"members\":{\
+        \"VerificationAttributes\":{\
+          \"shape\":\"VerificationAttributes\",\
+          \"documentation\":\"<p>A map of Identities to IdentityVerificationAttributes objects.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>The Amazon SES verification status of a list of identities. For domain identities, this response also contains the verification token.</p>\"\
+    },\
+    \"GetSendQuotaResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Max24HourSend\":{\
+          \"shape\":\"Max24HourSend\",\
+          \"documentation\":\"<p>The maximum number of emails the user is allowed to send in a 24-hour interval. A value of -1 signifies an unlimited quota.</p>\"\
+        },\
+        \"MaxSendRate\":{\
+          \"shape\":\"MaxSendRate\",\
+          \"documentation\":\"<p>The maximum number of emails that Amazon SES can accept from the user's account per second.</p> <note> <p>The rate at which Amazon SES accepts the user's messages might be less than the maximum send rate.</p> </note>\"\
+        },\
+        \"SentLast24Hours\":{\
+          \"shape\":\"SentLast24Hours\",\
+          \"documentation\":\"<p>The number of emails sent during the previous 24 hours.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents your Amazon SES daily sending quota, maximum send rate, and the number of emails you have sent in the last 24 hours.</p>\"\
+    },\
+    \"GetSendStatisticsResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"SendDataPoints\":{\
+          \"shape\":\"SendDataPointList\",\
+          \"documentation\":\"<p>A list of data points, each of which represents 15 minutes of activity.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a list of data points. This list contains aggregated data from the previous two weeks of your sending activity with Amazon SES.</p>\"\
+    },\
+    \"GetTemplateRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\"TemplateName\"],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template you want to retrieve.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the template you want to retrieve.</p>\"\
         }\
-      },\
-      \"documentation\":\"<p>Represents a request to display the template object (which includes the subject line, HTML part and text part) for the template you specify.</p>\"\
+      }\
     },\
-    \"GetEmailTemplateResponse\":{\
+    \"GetTemplateResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Template\":{\"shape\":\"Template\"}\
+      }\
+    },\
+    \"HeaderName\":{\"type\":\"string\"},\
+    \"HeaderValue\":{\"type\":\"string\"},\
+    \"HtmlPart\":{\"type\":\"string\"},\
+    \"Identity\":{\"type\":\"string\"},\
+    \"IdentityDkimAttributes\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"TemplateName\",\
-        \"TemplateContent\"\
+        \"DkimEnabled\",\
+        \"DkimVerificationStatus\"\
       ],\
       \"members\":{\
-        \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template you want to retrieve.</p>\"\
-        },\
-        \"TemplateContent\":{\
-          \"shape\":\"EmailTemplateContent\",\
-          \"documentation\":\"<p>The content of the email template, composed of a subject line, an HTML part, and a text-only part.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>The following element is returned by the service.</p>\"\
-    },\
-    \"GetImportJobRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"JobId\"],\
-      \"members\":{\
-        \"JobId\":{\
-          \"shape\":\"JobId\",\
-          \"documentation\":\"<p>The ID of the import job.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"JobId\"\
-        }\
-      },\
-      \"documentation\":\"<p>Represents a request for information about an import job using the import job ID.</p>\"\
-    },\
-    \"GetImportJobResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"JobId\":{\
-          \"shape\":\"JobId\",\
-          \"documentation\":\"<p>A string that represents the import job ID.</p>\"\
-        },\
-        \"ImportDestination\":{\
-          \"shape\":\"ImportDestination\",\
-          \"documentation\":\"<p>The destination of the import job.</p>\"\
-        },\
-        \"ImportDataSource\":{\
-          \"shape\":\"ImportDataSource\",\
-          \"documentation\":\"<p>The data source of the import job.</p>\"\
-        },\
-        \"FailureInfo\":{\
-          \"shape\":\"FailureInfo\",\
-          \"documentation\":\"<p>The failure details about an import job.</p>\"\
-        },\
-        \"JobStatus\":{\
-          \"shape\":\"JobStatus\",\
-          \"documentation\":\"<p>The status of the import job.</p>\"\
-        },\
-        \"CreatedTimestamp\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The time stamp of when the import job was created.</p>\"\
-        },\
-        \"CompletedTimestamp\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The time stamp of when the import job was completed.</p>\"\
-        },\
-        \"ProcessedRecordsCount\":{\
-          \"shape\":\"ProcessedRecordsCount\",\
-          \"documentation\":\"<p>The current number of records processed.</p>\"\
-        },\
-        \"FailedRecordsCount\":{\
-          \"shape\":\"FailedRecordsCount\",\
-          \"documentation\":\"<p>The number of records that failed processing because of invalid input or other reasons.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"GetSuppressedDestinationRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"EmailAddress\"],\
-      \"members\":{\
-        \"EmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that's on the account suppression list.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailAddress\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to retrieve information about an email address that's on the suppression list for your account.</p>\"\
-    },\
-    \"GetSuppressedDestinationResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"SuppressedDestination\"],\
-      \"members\":{\
-        \"SuppressedDestination\":{\
-          \"shape\":\"SuppressedDestination\",\
-          \"documentation\":\"<p>An object containing information about the suppressed email address.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Information about the suppressed email address.</p>\"\
-    },\
-    \"Identity\":{\
-      \"type\":\"string\",\
-      \"min\":1\
-    },\
-    \"IdentityInfo\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"IdentityType\":{\
-          \"shape\":\"IdentityType\",\
-          \"documentation\":\"<p>The email identity type. The identity type can be one of the following:</p> <ul> <li> <p> <code>EMAIL_ADDRESS</code> â The identity is an email address.</p> </li> <li> <p> <code>DOMAIN</code> â The identity is a domain.</p> </li> <li> <p> <code>MANAGED_DOMAIN</code> â The identity is a domain that is managed by AWS.</p> </li> </ul>\"\
-        },\
-        \"IdentityName\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The address or domain of the identity.</p>\"\
-        },\
-        \"SendingEnabled\":{\
+        \"DkimEnabled\":{\
           \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Indicates whether or not you can send email from the identity.</p> <p>An <i>identity</i> is an email address or domain that you send email from. Before you can send email from an identity, you have to demostrate that you own the identity, and that you authorize Amazon SES to send email from that identity.</p>\"\
+          \"documentation\":\"<p>Is true if DKIM signing is enabled for email sent from the identity. It's false otherwise. The default value is true.</p>\"\
+        },\
+        \"DkimVerificationStatus\":{\
+          \"shape\":\"VerificationStatus\",\
+          \"documentation\":\"<p>Describes whether Amazon SES has successfully verified the DKIM DNS records (tokens) published in the domain name's DNS. (This only applies to domain identities, not email address identities.)</p>\"\
+        },\
+        \"DkimTokens\":{\
+          \"shape\":\"VerificationTokenList\",\
+          \"documentation\":\"<p>A set of character strings that represent the domain's identity. Using these tokens, you need to create DNS CNAME records that point to DKIM public keys that are hosted by Amazon SES. Amazon Web Services eventually detects that you've updated your DNS records. This detection process might take up to 72 hours. After successful detection, Amazon SES is able to DKIM-sign email originating from that domain. (This only applies to domain identities, not email address identities.)</p> <p>For more information about creating DNS records using DKIM tokens, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Amazon SES Developer Guide</a>.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Information about an email identity.</p>\"\
+      \"documentation\":\"<p>Represents the DKIM attributes of a verified email address or a domain.</p>\"\
     },\
-    \"IdentityInfoList\":{\
+    \"IdentityList\":{\
       \"type\":\"list\",\
-      \"member\":{\"shape\":\"IdentityInfo\"}\
+      \"member\":{\"shape\":\"Identity\"}\
+    },\
+    \"IdentityMailFromDomainAttributes\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"MailFromDomain\",\
+        \"MailFromDomainStatus\",\
+        \"BehaviorOnMXFailure\"\
+      ],\
+      \"members\":{\
+        \"MailFromDomain\":{\
+          \"shape\":\"MailFromDomainName\",\
+          \"documentation\":\"<p>The custom MAIL FROM domain that the identity is configured to use.</p>\"\
+        },\
+        \"MailFromDomainStatus\":{\
+          \"shape\":\"CustomMailFromStatus\",\
+          \"documentation\":\"<p>The state that indicates whether Amazon SES has successfully read the MX record required for custom MAIL FROM domain setup. If the state is <code>Success</code>, Amazon SES uses the specified custom MAIL FROM domain when the verified identity sends an email. All other states indicate that Amazon SES takes the action described by <code>BehaviorOnMXFailure</code>.</p>\"\
+        },\
+        \"BehaviorOnMXFailure\":{\
+          \"shape\":\"BehaviorOnMXFailure\",\
+          \"documentation\":\"<p>The action that Amazon SES takes if it cannot successfully read the required MX record when you send an email. A value of <code>UseDefaultValue</code> indicates that if Amazon SES cannot read the required MX record, it uses amazonses.com (or a subdomain of that) as the MAIL FROM domain. A value of <code>RejectMessage</code> indicates that if Amazon SES cannot read the required MX record, Amazon SES returns a <code>MailFromDomainNotVerified</code> error and does not send the email.</p> <p>The custom MAIL FROM setup states that result in this behavior are <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the custom MAIL FROM domain attributes of a verified identity (email address or domain).</p>\"\
+    },\
+    \"IdentityNotificationAttributes\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"BounceTopic\",\
+        \"ComplaintTopic\",\
+        \"DeliveryTopic\",\
+        \"ForwardingEnabled\"\
+      ],\
+      \"members\":{\
+        \"BounceTopic\":{\
+          \"shape\":\"NotificationTopic\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish bounce notifications.</p>\"\
+        },\
+        \"ComplaintTopic\":{\
+          \"shape\":\"NotificationTopic\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish complaint notifications.</p>\"\
+        },\
+        \"DeliveryTopic\":{\
+          \"shape\":\"NotificationTopic\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic where Amazon SES will publish delivery notifications.</p>\"\
+        },\
+        \"ForwardingEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> indicates that Amazon SES will forward bounce and complaint notifications as email, while <code>false</code> indicates that bounce and complaint notifications will be published only to the specified bounce and complaint Amazon SNS topics.</p>\"\
+        },\
+        \"HeadersInBounceNotificationsEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Bounce</code>. A value of <code>true</code> specifies that Amazon SES will include headers in bounce notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in bounce notifications.</p>\"\
+        },\
+        \"HeadersInComplaintNotificationsEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Complaint</code>. A value of <code>true</code> specifies that Amazon SES will include headers in complaint notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in complaint notifications.</p>\"\
+        },\
+        \"HeadersInDeliveryNotificationsEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether Amazon SES includes the original email headers in Amazon SNS notifications of type <code>Delivery</code>. A value of <code>true</code> specifies that Amazon SES will include headers in delivery notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in delivery notifications.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents the notification attributes of an identity, including whether an identity has Amazon Simple Notification Service (Amazon SNS) topics set for bounce, complaint, and/or delivery notifications, and whether feedback forwarding is enabled for bounce and complaint notifications.</p>\"\
     },\
     \"IdentityType\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The email identity type. The identity type can be one of the following:</p> <ul> <li> <p> <code>EMAIL_ADDRESS</code> â The identity is an email address.</p> </li> <li> <p> <code>DOMAIN</code> â The identity is a domain.</p> </li> </ul>\",\
       \"enum\":[\
-        \"EMAIL_ADDRESS\",\
-        \"DOMAIN\",\
-        \"MANAGED_DOMAIN\"\
+        \"EmailAddress\",\
+        \"Domain\"\
       ]\
     },\
-    \"ImageUrl\":{\"type\":\"string\"},\
-    \"ImportDataSource\":{\
+    \"IdentityVerificationAttributes\":{\
       \"type\":\"structure\",\
-      \"required\":[\
-        \"S3Url\",\
-        \"DataFormat\"\
-      ],\
+      \"required\":[\"VerificationStatus\"],\
       \"members\":{\
-        \"S3Url\":{\
-          \"shape\":\"S3Url\",\
-          \"documentation\":\"<p>An Amazon S3 URL in the format s3://<i>&lt;bucket_name&gt;</i>/<i>&lt;object&gt;</i>.</p>\"\
+        \"VerificationStatus\":{\
+          \"shape\":\"VerificationStatus\",\
+          \"documentation\":\"<p>The verification status of the identity: \\\"Pending\\\", \\\"Success\\\", \\\"Failed\\\", or \\\"TemporaryFailure\\\".</p>\"\
         },\
-        \"DataFormat\":{\
-          \"shape\":\"DataFormat\",\
-          \"documentation\":\"<p>The data format of the import job's data source.</p>\"\
+        \"VerificationToken\":{\
+          \"shape\":\"VerificationToken\",\
+          \"documentation\":\"<p>The verification token for a domain identity. Null for email address identities.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that contains details about the data source of the import job.</p>\"\
+      \"documentation\":\"<p>Represents the verification attributes of a single identity.</p>\"\
     },\
-    \"ImportDestination\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"SuppressionListDestination\"],\
-      \"members\":{\
-        \"SuppressionListDestination\":{\
-          \"shape\":\"SuppressionListDestination\",\
-          \"documentation\":\"<p>An object that contains the action of the import job towards suppression list.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains details about the resource destination the import job is going to target.</p>\"\
-    },\
-    \"ImportDestinationType\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The destination of the import job, which can be used to list import jobs that have a certain <code>ImportDestinationType</code>.</p>\",\
-      \"enum\":[\"SUPPRESSION_LIST\"]\
-    },\
-    \"ImportJobSummary\":{\
+    \"InvalidCloudWatchDestinationException\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"JobId\":{\"shape\":\"JobId\"},\
-        \"ImportDestination\":{\"shape\":\"ImportDestination\"},\
-        \"JobStatus\":{\"shape\":\"JobStatus\"},\
-        \"CreatedTimestamp\":{\"shape\":\"Timestamp\"}\
-      },\
-      \"documentation\":\"<p>A summary of the import job.</p>\"\
-    },\
-    \"ImportJobSummaryList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"ImportJobSummary\"},\
-      \"documentation\":\"<p>A list of the import job summaries.</p>\"\
-    },\
-    \"InboxPlacementTrackingOption\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"Global\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Specifies whether inbox placement data is being tracked for the domain.</p>\"\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
         },\
-        \"TrackedIsps\":{\
-          \"shape\":\"IspNameList\",\
-          \"documentation\":\"<p>An array of strings, one for each major email provider that the inbox placement data applies to.</p>\"\
+        \"EventDestinationName\":{\
+          \"shape\":\"EventDestinationName\",\
+          \"documentation\":\"<p>Indicates that the event destination does not exist.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that contains information about the inbox placement data settings for a verified domain thatâs associated with your AWS account. This data is available only if you enabled the Deliverability dashboard for the domain.</p>\"\
-    },\
-    \"InvalidNextTokenException\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
+      \"documentation\":\"<p>Indicates that the Amazon CloudWatch destination is invalid. See the error message for details.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidCloudWatchDestination\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
       },\
-      \"documentation\":\"<p>The specified request includes an invalid or expired token.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
       \"exception\":true\
     },\
-    \"Ip\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>An IPv4 address.</p>\"\
-    },\
-    \"IpList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"Ip\"}\
-    },\
-    \"IspName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of an email provider.</p>\"\
-    },\
-    \"IspNameList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"IspName\"}\
-    },\
-    \"IspPlacement\":{\
+    \"InvalidConfigurationSetException\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"IspName\":{\
-          \"shape\":\"IspName\",\
-          \"documentation\":\"<p>The name of the email provider that the inbox placement data applies to.</p>\"\
+      },\
+      \"documentation\":\"<p>Indicates that the configuration set is invalid. See the error message for details.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidConfigurationSet\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidDeliveryOptionsException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>Indicates that provided delivery option is invalid.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidDeliveryOptions\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidFirehoseDestinationException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
         },\
-        \"PlacementStatistics\":{\
-          \"shape\":\"PlacementStatistics\",\
-          \"documentation\":\"<p>An object that contains inbox placement metrics for a specific email provider.</p>\"\
+        \"EventDestinationName\":{\
+          \"shape\":\"EventDestinationName\",\
+          \"documentation\":\"<p>Indicates that the event destination does not exist.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that describes how email sent during the predictive inbox placement test was handled by a certain email provider.</p>\"\
+      \"documentation\":\"<p>Indicates that the Amazon Kinesis Firehose destination is invalid. See the error message for details.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidFirehoseDestination\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"IspPlacements\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"IspPlacement\"}\
+    \"InvalidLambdaFunctionException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"FunctionArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>Indicates that the ARN of the function was not found.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the provided AWS Lambda function is invalid, or that Amazon SES could not execute the provided function, possibly due to permissions issues. For information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidLambdaFunction\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"JobId\":{\
+    \"InvalidPolicyException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>Indicates that the provided policy is invalid. Check the error stack for more information about what caused the error.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidPolicy\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidRenderingParameterException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"TemplateName\":{\"shape\":\"TemplateName\"}\
+      },\
+      \"documentation\":\"<p>Indicates that one or more of the replacement values you provided is invalid. This error may occur when the TemplateData object contains invalid JSON.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidRenderingParameter\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidS3ConfigurationException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Bucket\":{\
+          \"shape\":\"S3BucketName\",\
+          \"documentation\":\"<p>Indicated that the S3 Bucket was not found.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the provided Amazon S3 bucket or AWS KMS encryption key is invalid, or that Amazon SES could not publish to the bucket, possibly due to permissions issues. For information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidS3Configuration\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidSNSDestinationException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that the configuration set does not exist.</p>\"\
+        },\
+        \"EventDestinationName\":{\
+          \"shape\":\"EventDestinationName\",\
+          \"documentation\":\"<p>Indicates that the event destination does not exist.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the Amazon Simple Notification Service (Amazon SNS) destination is invalid. See the error message for details.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidSNSDestination\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidSnsTopicException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Topic\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>Indicates that the topic does not exist.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the provided Amazon SNS topic is invalid, or that Amazon SES could not publish to the topic, possibly due to permissions issues. For information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidSnsTopic\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidTemplateException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"TemplateName\":{\"shape\":\"TemplateName\"}\
+      },\
+      \"documentation\":\"<p>Indicates that the template that you specified could not be rendered. This issue may occur when a template refers to a partial that does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"InvalidTemplate\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvalidTrackingOptionsException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>Indicates that the custom domain to be used for open and click tracking redirects is invalid. This error appears most often in the following situations:</p> <ul> <li> <p>When the tracking domain you specified is not verified in Amazon SES.</p> </li> <li> <p>When the tracking domain you specified is not a valid domain or subdomain.</p> </li> </ul>\",\
+      \"error\":{\
+        \"code\":\"InvalidTrackingOptions\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"InvocationType\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>A string that represents the import job ID.</p>\",\
-      \"min\":1\
-    },\
-    \"JobStatus\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The status of the import job.</p>\",\
       \"enum\":[\
-        \"CREATED\",\
-        \"PROCESSING\",\
-        \"COMPLETED\",\
-        \"FAILED\"\
+        \"Event\",\
+        \"RequestResponse\"\
       ]\
     },\
     \"KinesisFirehoseDestination\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"IamRoleArn\",\
-        \"DeliveryStreamArn\"\
+        \"IAMRoleARN\",\
+        \"DeliveryStreamARN\"\
       ],\
       \"members\":{\
-        \"IamRoleArn\":{\
+        \"IAMRoleARN\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the IAM role that the Amazon SES API v2 uses to send email events to the Amazon Kinesis Data Firehose stream.</p>\"\
+          \"documentation\":\"<p>The ARN of the IAM role under which Amazon SES publishes email sending events to the Amazon Kinesis Firehose stream.</p>\"\
         },\
-        \"DeliveryStreamArn\":{\
+        \"DeliveryStreamARN\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon Kinesis Data Firehose stream that the Amazon SES API v2 sends email events to.</p>\"\
+          \"documentation\":\"<p>The ARN of the Amazon Kinesis Firehose stream that email sending events should be published to.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that defines an Amazon Kinesis Data Firehose destination for email events. You can use Amazon Kinesis Data Firehose to stream data to other services, such as Amazon S3 and Amazon Redshift.</p>\"\
+      \"documentation\":\"<p>Contains the delivery stream ARN and the IAM role ARN associated with an Amazon Kinesis Firehose event destination.</p> <p>Event destinations, such as Amazon Kinesis Firehose, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"LastFreshStart\":{\
-      \"type\":\"timestamp\",\
-      \"documentation\":\"<p>The date and time (in Unix time) when the reputation metrics were last given a fresh start. When your account is given a fresh start, your reputation metrics are calculated starting from the date of the fresh start.</p>\"\
+    \"LambdaAction\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"FunctionArn\"],\
+      \"members\":{\
+        \"TopicArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the Lambda action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        },\
+        \"FunctionArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the AWS Lambda function. An example of an AWS Lambda function ARN is <code>arn:aws:lambda:us-west-2:account-id:function:MyFunction</code>. For more information about AWS Lambda, see the <a href=\\\"https://docs.aws.amazon.com/lambda/latest/dg/welcome.html\\\">AWS Lambda Developer Guide</a>.</p>\"\
+        },\
+        \"InvocationType\":{\
+          \"shape\":\"InvocationType\",\
+          \"documentation\":\"<p>The invocation type of the AWS Lambda function. An invocation type of <code>RequestResponse</code> means that the execution of the function will immediately result in a response, and a value of <code>Event</code> means that the function will be invoked asynchronously. The default value is <code>Event</code>. For information about AWS Lambda invocation types, see the <a href=\\\"https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html\\\">AWS Lambda Developer Guide</a>.</p> <important> <p>There is a 30-second timeout on <code>RequestResponse</code> invocations. You should use <code>Event</code> invocation in most cases. Use <code>RequestResponse</code> only when you want to make a mail flow decision, such as whether to stop the receipt rule or the receipt rule set.</p> </important>\"\
+        }\
+      },\
+      \"documentation\":\"<p>When included in a receipt rule, this action calls an AWS Lambda function and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>To enable Amazon SES to call your AWS Lambda function or to publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p> <p>For information about using AWS Lambda actions in receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-lambda.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
+    \"LastAttemptDate\":{\"type\":\"timestamp\"},\
+    \"LastFreshStart\":{\"type\":\"timestamp\"},\
     \"LimitExceededException\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>There are too many instances of the specified resource type.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
+      \"documentation\":\"<p>Indicates that a resource could not be created because of service limits. For a list of Amazon SES limits, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/limits.html\\\">Amazon SES Developer Guide</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"LimitExceeded\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
       \"exception\":true\
     },\
     \"ListConfigurationSetsRequest\":{\
@@ -3265,417 +2859,214 @@
       \"members\":{\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListConfigurationSets</code> to indicate the position in the list of configuration sets.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
+          \"documentation\":\"<p>A token returned from a previous call to <code>ListConfigurationSets</code> to indicate the position of the configuration set in the configuration set list.</p>\"\
         },\
-        \"PageSize\":{\
+        \"MaxItems\":{\
           \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListConfigurationSets</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
+          \"documentation\":\"<p>The number of configuration sets to return.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to obtain a list of configuration sets for your Amazon SES account in the current AWS Region.</p>\"\
+      \"documentation\":\"<p>Represents a request to list the configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"ListConfigurationSetsResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"ConfigurationSets\":{\
-          \"shape\":\"ConfigurationSetNameList\",\
-          \"documentation\":\"<p>An array that contains all of the configuration sets in your Amazon SES account in the current AWS Region.</p>\"\
+          \"shape\":\"ConfigurationSets\",\
+          \"documentation\":\"<p>A list of configuration sets.</p>\"\
         },\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token that indicates that there are additional configuration sets to list. To view additional configuration sets, issue another request to <code>ListConfigurationSets</code>, and pass this token in the <code>NextToken</code> parameter.</p>\"\
+          \"documentation\":\"<p>A token indicating that there are additional configuration sets available to be listed. Pass this token to successive calls of <code>ListConfigurationSets</code>. </p>\"\
         }\
       },\
-      \"documentation\":\"<p>A list of configuration sets in your Amazon SES account in the current AWS Region.</p>\"\
+      \"documentation\":\"<p>A list of configuration sets associated with your AWS account. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"ListCustomVerificationEmailTemplatesRequest\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListCustomVerificationEmailTemplates</code> to indicate the position in the list of custom verification email templates.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
+          \"documentation\":\"<p>An array the contains the name and creation time stamp for each template in your Amazon SES account.</p>\"\
         },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListCustomVerificationEmailTemplates</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p> <p>The value you specify has to be at least 1, and can be no more than 50.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
+        \"MaxResults\":{\
+          \"shape\":\"MaxResults\",\
+          \"documentation\":\"<p>The maximum number of custom verification email templates to return. This value must be at least 1 and less than or equal to 50. If you do not specify a value, or if you specify a value less than 1 or greater than 50, the operation will return up to 50 results.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents a request to list the existing custom verification email templates for your account.</p>\"\
+      \"documentation\":\"<p>Represents a request to list the existing custom verification email templates for your account.</p> <p>For more information about custom verification email templates, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html\\\">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
     },\
     \"ListCustomVerificationEmailTemplatesResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"CustomVerificationEmailTemplates\":{\
-          \"shape\":\"CustomVerificationEmailTemplatesList\",\
+          \"shape\":\"CustomVerificationEmailTemplates\",\
           \"documentation\":\"<p>A list of the custom verification email templates that exist in your account.</p>\"\
         },\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token indicating that there are additional custom verification email templates available to be listed. Pass this token to a subsequent call to <code>ListCustomVerificationEmailTemplates</code> to retrieve the next 50 custom verification email templates.</p>\"\
+          \"documentation\":\"<p>A token indicating that there are additional custom verification email templates available to be listed. Pass this token to a subsequent call to <code>ListTemplates</code> to retrieve the next 50 custom verification email templates.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>The following elements are returned by the service.</p>\"\
+      \"documentation\":\"<p>A paginated list of custom verification email templates.</p>\"\
     },\
-    \"ListDedicatedIpPoolsRequest\":{\
+    \"ListIdentitiesRequest\":{\
       \"type\":\"structure\",\
       \"members\":{\
+        \"IdentityType\":{\
+          \"shape\":\"IdentityType\",\
+          \"documentation\":\"<p>The type of the identities to list. Possible values are \\\"EmailAddress\\\" and \\\"Domain\\\". If this parameter is omitted, then all identities will be listed.</p>\"\
+        },\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListDedicatedIpPools</code> to indicate the position in the list of dedicated IP pools.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
+          \"documentation\":\"<p>The token to use for pagination.</p>\"\
         },\
-        \"PageSize\":{\
+        \"MaxItems\":{\
           \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListDedicatedIpPools</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
+          \"documentation\":\"<p>The maximum number of identities per page. Possible values are 1-1000 inclusive.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to obtain a list of dedicated IP pools.</p>\"\
+      \"documentation\":\"<p>Represents a request to return a list of all identities (email addresses and domains) that you have attempted to verify under your AWS account, regardless of verification status.</p>\"\
     },\
-    \"ListDedicatedIpPoolsResponse\":{\
+    \"ListIdentitiesResponse\":{\
       \"type\":\"structure\",\
+      \"required\":[\"Identities\"],\
       \"members\":{\
-        \"DedicatedIpPools\":{\
-          \"shape\":\"ListOfDedicatedIpPools\",\
-          \"documentation\":\"<p>A list of all of the dedicated IP pools that are associated with your AWS account in the current Region.</p>\"\
+        \"Identities\":{\
+          \"shape\":\"IdentityList\",\
+          \"documentation\":\"<p>A list of identities.</p>\"\
         },\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token that indicates that there are additional IP pools to list. To view additional IP pools, issue another request to <code>ListDedicatedIpPools</code>, passing this token in the <code>NextToken</code> parameter.</p>\"\
+          \"documentation\":\"<p>The token used for pagination.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A list of dedicated IP pools.</p>\"\
+      \"documentation\":\"<p>A list of all identities that you have attempted to verify under your AWS account, regardless of verification status.</p>\"\
     },\
-    \"ListDeliverabilityTestReportsRequest\":{\
+    \"ListIdentityPoliciesRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Identity\"],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The identity that is associated with the policy for which the policies will be listed. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to return a list of sending authorization policies that are attached to an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ListIdentityPoliciesResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"PolicyNames\"],\
+      \"members\":{\
+        \"PolicyNames\":{\
+          \"shape\":\"PolicyNameList\",\
+          \"documentation\":\"<p>A list of names of policies that apply to the specified identity.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>A list of names of sending authorization policies that apply to an identity.</p>\"\
+    },\
+    \"ListReceiptFiltersRequest\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>Represents a request to list the IP address filters that exist under your AWS account. You use IP address filters when you receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ListReceiptFiltersResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Filters\":{\
+          \"shape\":\"ReceiptFilterList\",\
+          \"documentation\":\"<p>A list of IP address filter data structures, which each consist of a name, an IP address range, and whether to allow or block mail from it.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>A list of IP address filters that exist under your AWS account.</p>\"\
+    },\
+    \"ListReceiptRuleSetsRequest\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListDeliverabilityTestReports</code> to indicate the position in the list of predictive inbox placement tests.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
+          \"documentation\":\"<p>A token returned from a previous call to <code>ListReceiptRuleSets</code> to indicate the position in the receipt rule set list.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to list the receipt rule sets that exist under your AWS account. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ListReceiptRuleSetsResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"RuleSets\":{\
+          \"shape\":\"ReceiptRuleSetsLists\",\
+          \"documentation\":\"<p>The metadata for the currently active receipt rule set. The metadata consists of the rule set name and the timestamp of when the rule set was created.</p>\"\
         },\
-        \"PageSize\":{\
+        \"NextToken\":{\
+          \"shape\":\"NextToken\",\
+          \"documentation\":\"<p>A token indicating that there are additional receipt rule sets available to be listed. Pass this token to successive calls of <code>ListReceiptRuleSets</code> to retrieve up to 100 receipt rule sets at a time.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>A list of receipt rule sets that exist under your AWS account.</p>\"\
+    },\
+    \"ListTemplatesRequest\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"NextToken\":{\
+          \"shape\":\"NextToken\",\
+          \"documentation\":\"<p>A token returned from a previous call to <code>ListTemplates</code> to indicate the position in the list of email templates.</p>\"\
+        },\
+        \"MaxItems\":{\
           \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListDeliverabilityTestReports</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p> <p>The value you specify has to be at least 0, and can be no more than 1000.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
+          \"documentation\":\"<p>The maximum number of templates to return. This value must be at least 1 and less than or equal to 10. If you do not specify a value, or if you specify a value less than 1 or greater than 10, the operation will return up to 10 results.</p>\"\
         }\
-      },\
-      \"documentation\":\"<p>A request to list all of the predictive inbox placement tests that you've performed.</p>\"\
+      }\
     },\
-    \"ListDeliverabilityTestReportsResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"DeliverabilityTestReports\"],\
-      \"members\":{\
-        \"DeliverabilityTestReports\":{\
-          \"shape\":\"DeliverabilityTestReports\",\
-          \"documentation\":\"<p>An object that contains a lists of predictive inbox placement tests that you've performed.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token that indicates that there are additional predictive inbox placement tests to list. To view additional predictive inbox placement tests, issue another request to <code>ListDeliverabilityTestReports</code>, and pass this token in the <code>NextToken</code> parameter.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A list of the predictive inbox placement test reports that are available for your account, regardless of whether or not those tests are complete.</p>\"\
-    },\
-    \"ListDomainDeliverabilityCampaignsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"StartDate\",\
-        \"EndDate\",\
-        \"SubscribedDomain\"\
-      ],\
-      \"members\":{\
-        \"StartDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The first day, in Unix time format, that you want to obtain deliverability data for.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"StartDate\"\
-        },\
-        \"EndDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The last day, in Unix time format, that you want to obtain deliverability data for. This value has to be less than or equal to 30 days after the value of the <code>StartDate</code> parameter.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"EndDate\"\
-        },\
-        \"SubscribedDomain\":{\
-          \"shape\":\"Domain\",\
-          \"documentation\":\"<p>The domain to obtain deliverability data for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"SubscribedDomain\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token thatâs returned from a previous call to the <code>ListDomainDeliverabilityCampaigns</code> operation. This token indicates the position of a campaign in the list of campaigns.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
-        },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The maximum number of results to include in response to a single call to the <code>ListDomainDeliverabilityCampaigns</code> operation. If the number of results is larger than the number that you specify in this parameter, the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
-        }\
-      },\
-      \"documentation\":\"<p>Retrieve deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard.</p>\"\
-    },\
-    \"ListDomainDeliverabilityCampaignsResponse\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"DomainDeliverabilityCampaigns\"],\
-      \"members\":{\
-        \"DomainDeliverabilityCampaigns\":{\
-          \"shape\":\"DomainDeliverabilityCampaignList\",\
-          \"documentation\":\"<p>An array of responses, one for each campaign that used the domain to send email during the specified time range.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token thatâs returned from a previous call to the <code>ListDomainDeliverabilityCampaigns</code> operation. This token indicates the position of the campaign in the list of campaigns.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An array of objects that provide deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard for the domain.</p>\"\
-    },\
-    \"ListEmailIdentitiesRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListEmailIdentities</code> to indicate the position in the list of identities.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
-        },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListEmailIdentities</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p> <p>The value you specify has to be at least 0, and can be no more than 1000.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to list all of the email identities associated with your AWS account. This list includes identities that you've already verified, identities that are unverified, and identities that were verified in the past, but are no longer verified.</p>\"\
-    },\
-    \"ListEmailIdentitiesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"EmailIdentities\":{\
-          \"shape\":\"IdentityInfoList\",\
-          \"documentation\":\"<p>An array that includes all of the email identities associated with your AWS account.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token that indicates that there are additional configuration sets to list. To view additional configuration sets, issue another request to <code>ListEmailIdentities</code>, and pass this token in the <code>NextToken</code> parameter.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A list of all of the identities that you've attempted to verify, regardless of whether or not those identities were successfully verified.</p>\"\
-    },\
-    \"ListEmailTemplatesRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListEmailTemplates</code> to indicate the position in the list of email templates.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
-        },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListEmailTemplates</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p> <p>The value you specify has to be at least 1, and can be no more than 10.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
-        }\
-      },\
-      \"documentation\":\"<p>Represents a request to list the email templates present in your Amazon SES account in the current AWS Region. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
-    },\
-    \"ListEmailTemplatesResponse\":{\
+    \"ListTemplatesResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
         \"TemplatesMetadata\":{\
-          \"shape\":\"EmailTemplateMetadataList\",\
+          \"shape\":\"TemplateMetadataList\",\
           \"documentation\":\"<p>An array the contains the name and creation time stamp for each template in your Amazon SES account.</p>\"\
         },\
         \"NextToken\":{\
           \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token indicating that there are additional email templates available to be listed. Pass this token to a subsequent <code>ListEmailTemplates</code> call to retrieve the next 10 email templates.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>The following elements are returned by the service.</p>\"\
-    },\
-    \"ListImportJobsRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"ImportDestinationType\":{\
-          \"shape\":\"ImportDestinationType\",\
-          \"documentation\":\"<p>The destination of the import job, which can be used to list import jobs that have a certain <code>ImportDestinationType</code>.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A string token indicating that there might be additional import jobs available to be listed. Copy this token to a subsequent call to <code>ListImportJobs</code> with the same parameters to retrieve the next page of import jobs.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
-        },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>Maximum number of import jobs to return at once. Use this parameter to paginate results. If additional import jobs exist beyond the specified limit, the <code>NextToken</code> element is sent in the response. Use the <code>NextToken</code> value in subsequent requests to retrieve additional addresses.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
-        }\
-      },\
-      \"documentation\":\"<p>Represents a request to list all of the import jobs for a data destination within the specified maximum number of import jobs.</p>\"\
-    },\
-    \"ListImportJobsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"ImportJobs\":{\
-          \"shape\":\"ImportJobSummaryList\",\
-          \"documentation\":\"<p>A list of the import job summaries.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A string token indicating that there might be additional import jobs available to be listed. Copy this token to a subsequent call to <code>ListImportJobs</code> with the same parameters to retrieve the next page of import jobs.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"ListOfDedicatedIpPools\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"PoolName\"},\
-      \"documentation\":\"<p>A list of dedicated IP pools that are associated with your AWS account.</p>\"\
-    },\
-    \"ListSuppressedDestinationsRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"Reasons\":{\
-          \"shape\":\"SuppressionListReasons\",\
-          \"documentation\":\"<p>The factors that caused the email address to be added to .</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"Reason\"\
-        },\
-        \"StartDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>Used to filter the list of suppressed email destinations so that it only includes addresses that were added to the list after a specific date. The date that you specify should be in Unix time format.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"StartDate\"\
-        },\
-        \"EndDate\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>Used to filter the list of suppressed email destinations so that it only includes addresses that were added to the list before a specific date. The date that you specify should be in Unix time format.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"EndDate\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token returned from a previous call to <code>ListSuppressedDestinations</code> to indicate the position in the list of suppressed email addresses.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"NextToken\"\
-        },\
-        \"PageSize\":{\
-          \"shape\":\"MaxItems\",\
-          \"documentation\":\"<p>The number of results to show in a single call to <code>ListSuppressedDestinations</code>. If the number of results is larger than the number you specified in this parameter, then the response includes a <code>NextToken</code> element, which you can use to obtain additional results.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"PageSize\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to obtain a list of email destinations that are on the suppression list for your account.</p>\"\
-    },\
-    \"ListSuppressedDestinationsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SuppressedDestinationSummaries\":{\
-          \"shape\":\"SuppressedDestinationSummaries\",\
-          \"documentation\":\"<p>A list of summaries, each containing a summary for a suppressed email destination.</p>\"\
-        },\
-        \"NextToken\":{\
-          \"shape\":\"NextToken\",\
-          \"documentation\":\"<p>A token that indicates that there are additional email addresses on the suppression list for your account. To view additional suppressed addresses, issue another request to <code>ListSuppressedDestinations</code>, and pass this token in the <code>NextToken</code> parameter.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A list of suppressed email addresses.</p>\"\
-    },\
-    \"ListTagsForResourceRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ResourceArn\"],\
-      \"members\":{\
-        \"ResourceArn\":{\
-          \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the resource that you want to retrieve tag information for.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"ResourceArn\"\
+          \"documentation\":\"<p>A token indicating that there are additional email templates available to be listed. Pass this token to a subsequent call to <code>ListTemplates</code> to retrieve the next 50 email templates.</p>\"\
         }\
       }\
     },\
-    \"ListTagsForResourceResponse\":{\
+    \"ListVerifiedEmailAddressesResponse\":{\
       \"type\":\"structure\",\
-      \"required\":[\"Tags\"],\
       \"members\":{\
-        \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>An array that lists all the tags that are associated with the resource. Each tag consists of a required tag key (<code>Key</code>) and an associated tag value (<code>Value</code>)</p>\"\
-        }\
-      }\
-    },\
-    \"MailFromAttributes\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"MailFromDomain\",\
-        \"MailFromDomainStatus\",\
-        \"BehaviorOnMxFailure\"\
-      ],\
-      \"members\":{\
-        \"MailFromDomain\":{\
-          \"shape\":\"MailFromDomainName\",\
-          \"documentation\":\"<p>The name of a domain that an email identity uses as a custom MAIL FROM domain.</p>\"\
-        },\
-        \"MailFromDomainStatus\":{\
-          \"shape\":\"MailFromDomainStatus\",\
-          \"documentation\":\"<p>The status of the MAIL FROM domain. This status can have the following values:</p> <ul> <li> <p> <code>PENDING</code> â Amazon SES hasn't started searching for the MX record yet.</p> </li> <li> <p> <code>SUCCESS</code> â Amazon SES detected the required MX record for the MAIL FROM domain.</p> </li> <li> <p> <code>FAILED</code> â Amazon SES can't find the required MX record, or the record no longer exists.</p> </li> <li> <p> <code>TEMPORARY_FAILURE</code> â A temporary issue occurred, which prevented Amazon SES from determining the status of the MAIL FROM domain.</p> </li> </ul>\"\
-        },\
-        \"BehaviorOnMxFailure\":{\
-          \"shape\":\"BehaviorOnMxFailure\",\
-          \"documentation\":\"<p>The action that you want to take if the required MX record can't be found when you send an email. When you set this value to <code>UseDefaultValue</code>, the mail is sent using <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, the Amazon SES API v2 returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.</p> <p>These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>\"\
+        \"VerifiedEmailAddresses\":{\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>A list of email addresses that have been verified.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A list of attributes that are associated with a MAIL FROM domain.</p>\"\
+      \"documentation\":\"<p>A list of email addresses that you have verified with Amazon SES under your AWS account.</p>\"\
     },\
-    \"MailFromDomainName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The domain that you want to use as a MAIL FROM domain.</p>\"\
+    \"MailFromDomainAttributes\":{\
+      \"type\":\"map\",\
+      \"key\":{\"shape\":\"Identity\"},\
+      \"value\":{\"shape\":\"IdentityMailFromDomainAttributes\"}\
     },\
+    \"MailFromDomainName\":{\"type\":\"string\"},\
     \"MailFromDomainNotVerifiedException\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>The message can't be sent because the sending domain isn't verified.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
+      \"documentation\":\"<p> Indicates that the message could not be sent because Amazon SES could not read the MX record required to use the specified MAIL FROM domain. For information about editing the custom MAIL FROM domain settings for an identity, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-edit.html\\\">Amazon SES Developer Guide</a>.</p>\",\
+      \"error\":{\
+        \"code\":\"MailFromDomainNotVerifiedException\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
       \"exception\":true\
-    },\
-    \"MailFromDomainStatus\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The status of the MAIL FROM domain. This status can have the following values:</p> <ul> <li> <p> <code>PENDING</code> â Amazon SES hasn't started searching for the MX record yet.</p> </li> <li> <p> <code>SUCCESS</code> â Amazon SES detected the required MX record for the MAIL FROM domain.</p> </li> <li> <p> <code>FAILED</code> â Amazon SES can't find the required MX record, or the record no longer exists.</p> </li> <li> <p> <code>TEMPORARY_FAILURE</code> â A temporary issue occurred, which prevented Amazon SES from determining the status of the MAIL FROM domain.</p> </li> </ul>\",\
-      \"enum\":[\
-        \"PENDING\",\
-        \"SUCCESS\",\
-        \"FAILED\",\
-        \"TEMPORARY_FAILURE\"\
-      ]\
-    },\
-    \"MailType\":{\
-      \"type\":\"string\",\
-      \"enum\":[\
-        \"MARKETING\",\
-        \"TRANSACTIONAL\"\
-      ]\
     },\
     \"Max24HourSend\":{\"type\":\"double\"},\
     \"MaxItems\":{\"type\":\"integer\"},\
+    \"MaxResults\":{\
+      \"type\":\"integer\",\
+      \"box\":true,\
+      \"max\":50,\
+      \"min\":1\
+    },\
     \"MaxSendRate\":{\"type\":\"double\"},\
     \"Message\":{\
       \"type\":\"structure\",\
@@ -3686,26 +3077,46 @@
       \"members\":{\
         \"Subject\":{\
           \"shape\":\"Content\",\
-          \"documentation\":\"<p>The subject line of the email. The subject line can only contain 7-bit ASCII characters. However, you can specify non-ASCII characters in the subject line by using encoded-word syntax, as described in <a href=\\\"https://tools.ietf.org/html/rfc2047\\\">RFC 2047</a>.</p>\"\
+          \"documentation\":\"<p>The subject of the message: A short summary of the content, which will appear in the recipient's inbox.</p>\"\
         },\
         \"Body\":{\
           \"shape\":\"Body\",\
-          \"documentation\":\"<p>The body of the message. You can specify an HTML version of the message, a text-only version of the message, or both.</p>\"\
+          \"documentation\":\"<p>The message body.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents the email message that you're sending. The <code>Message</code> object consists of a subject line and a message body.</p>\"\
-    },\
-    \"MessageContent\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The body of an email message.</p>\"\
+      \"documentation\":\"<p>Represents the message to be sent, composed of a subject and a body.</p>\"\
     },\
     \"MessageData\":{\"type\":\"string\"},\
+    \"MessageDsn\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"ReportingMta\"],\
+      \"members\":{\
+        \"ReportingMta\":{\
+          \"shape\":\"ReportingMta\",\
+          \"documentation\":\"<p>The reporting MTA that attempted to deliver the message, formatted as specified in <a href=\\\"https://tools.ietf.org/html/rfc3464\\\">RFC 3464</a> (<code>mta-name-type; mta-name</code>). The default value is <code>dns; inbound-smtp.[region].amazonaws.com</code>.</p>\"\
+        },\
+        \"ArrivalDate\":{\
+          \"shape\":\"ArrivalDate\",\
+          \"documentation\":\"<p>When the message was received by the reporting mail transfer agent (MTA), in <a href=\\\"https://www.ietf.org/rfc/rfc0822.txt\\\">RFC 822</a> date-time format.</p>\"\
+        },\
+        \"ExtensionFields\":{\
+          \"shape\":\"ExtensionFieldList\",\
+          \"documentation\":\"<p>Additional X-headers to include in the DSN.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Message-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"MessageId\":{\"type\":\"string\"},\
     \"MessageRejected\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>The message can't be sent because it contains invalid content.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
+      \"documentation\":\"<p>Indicates that the action failed, and the message could not be sent. Check the error stack for more information about what caused the error.</p>\",\
+      \"error\":{\
+        \"code\":\"MessageRejected\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
       \"exception\":true\
     },\
     \"MessageTag\":{\
@@ -3717,214 +3128,78 @@
       \"members\":{\
         \"Name\":{\
           \"shape\":\"MessageTagName\",\
-          \"documentation\":\"<p>The name of the message tag. The message tag name has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
+          \"documentation\":\"<p>The name of the tag. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>\"\
         },\
         \"Value\":{\
           \"shape\":\"MessageTagValue\",\
-          \"documentation\":\"<p>The value of the message tag. The message tag value has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
+          \"documentation\":\"<p>The value of the tag. The value must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Contain less than 256 characters.</p> </li> </ul>\"\
         }\
       },\
-      \"documentation\":\"<p>Contains the name and value of a tag that you apply to an email. You can use message tags when you publish email sending events. </p>\"\
+      \"documentation\":\"<p>Contains the name and value of a tag that you can provide to <code>SendEmail</code> or <code>SendRawEmail</code> to apply to an email.</p> <p>Message tags, which you use with configuration sets, enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"MessageTagList\":{\
       \"type\":\"list\",\
-      \"member\":{\"shape\":\"MessageTag\"},\
-      \"documentation\":\"<p>A list of message tags.</p>\"\
+      \"member\":{\"shape\":\"MessageTag\"}\
     },\
-    \"MessageTagName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of the message tag. The message tag name has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
-    },\
-    \"MessageTagValue\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The value of the message tag. The message tag value has to meet the following criteria:</p> <ul> <li> <p>It can only contain ASCII letters (aâz, AâZ), numbers (0â9), underscores (_), or dashes (-).</p> </li> <li> <p>It can contain no more than 256 characters.</p> </li> </ul>\"\
-    },\
-    \"NextToken\":{\"type\":\"string\"},\
-    \"NotFoundException\":{\
+    \"MessageTagName\":{\"type\":\"string\"},\
+    \"MessageTagValue\":{\"type\":\"string\"},\
+    \"MissingRenderingAttributeException\":{\
       \"type\":\"structure\",\
       \"members\":{\
+        \"TemplateName\":{\"shape\":\"TemplateName\"}\
       },\
-      \"documentation\":\"<p>The resource you attempted to access doesn't exist.</p>\",\
-      \"error\":{\"httpStatusCode\":404},\
+      \"documentation\":\"<p>Indicates that one or more of the replacement values for the specified template was not specified. Ensure that the TemplateData object contains references to all of the replacement tags in the specified template.</p>\",\
+      \"error\":{\
+        \"code\":\"MissingRenderingAttribute\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
       \"exception\":true\
     },\
-    \"OutboundMessageId\":{\"type\":\"string\"},\
-    \"OverallVolume\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"VolumeStatistics\":{\
-          \"shape\":\"VolumeStatistics\",\
-          \"documentation\":\"<p>An object that contains information about the numbers of messages that arrived in recipients' inboxes and junk mail folders.</p>\"\
-        },\
-        \"ReadRatePercent\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of emails that were sent from the domain that were read by their recipients.</p>\"\
-        },\
-        \"DomainIspPlacements\":{\
-          \"shape\":\"DomainIspPlacements\",\
-          \"documentation\":\"<p>An object that contains inbox and junk mail placement metrics for individual email providers.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about email that was sent from the selected domain.</p>\"\
+    \"NextToken\":{\"type\":\"string\"},\
+    \"NotificationAttributes\":{\
+      \"type\":\"map\",\
+      \"key\":{\"shape\":\"Identity\"},\
+      \"value\":{\"shape\":\"IdentityNotificationAttributes\"}\
     },\
-    \"Percentage\":{\
-      \"type\":\"double\",\
-      \"documentation\":\"<p>An object that contains information about inbox placement percentages.</p>\"\
-    },\
-    \"Percentage100Wrapper\":{\"type\":\"integer\"},\
-    \"PinpointDestination\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"ApplicationArn\":{\
-          \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon Pinpoint project that you want to send email events to.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that defines an Amazon Pinpoint project destination for email events. You can send email event data to a Amazon Pinpoint project to view metrics using the Transactional Messaging dashboards that are built in to Amazon Pinpoint. For more information, see <a href=\\\"https://docs.aws.amazon.com/pinpoint/latest/userguide/analytics-transactional-messages.html\\\">Transactional Messaging Charts</a> in the <i>Amazon Pinpoint User Guide</i>.</p>\"\
-    },\
-    \"PlacementStatistics\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"InboxPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of emails that arrived in recipients' inboxes during the predictive inbox placement test.</p>\"\
-        },\
-        \"SpamPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of emails that arrived in recipients' spam or junk mail folders during the predictive inbox placement test.</p>\"\
-        },\
-        \"MissingPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of emails that didn't arrive in recipients' inboxes at all during the predictive inbox placement test.</p>\"\
-        },\
-        \"SpfPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of emails that were authenticated by using Sender Policy Framework (SPF) during the predictive inbox placement test.</p>\"\
-        },\
-        \"DkimPercentage\":{\
-          \"shape\":\"Percentage\",\
-          \"documentation\":\"<p>The percentage of emails that were authenticated by using DomainKeys Identified Mail (DKIM) during the predictive inbox placement test.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains inbox placement data for an email provider.</p>\"\
+    \"NotificationTopic\":{\"type\":\"string\"},\
+    \"NotificationType\":{\
+      \"type\":\"string\",\
+      \"enum\":[\
+        \"Bounce\",\
+        \"Complaint\",\
+        \"Delivery\"\
+      ]\
     },\
     \"Policy\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p> <p>For information about the syntax of sending authorization policies, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\",\
       \"min\":1\
     },\
     \"PolicyMap\":{\
       \"type\":\"map\",\
       \"key\":{\"shape\":\"PolicyName\"},\
-      \"value\":{\"shape\":\"Policy\"},\
-      \"documentation\":\"<p>An object that contains mapping between <code>PolicyName</code> and <code>Policy</code> text.</p>\"\
+      \"value\":{\"shape\":\"Policy\"}\
     },\
     \"PolicyName\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The name of the policy.</p> <p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>\",\
       \"max\":64,\
       \"min\":1\
     },\
-    \"PoolName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of a dedicated IP pool.</p>\"\
+    \"PolicyNameList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"PolicyName\"}\
     },\
-    \"PrivateKey\":{\
-      \"type\":\"string\",\
-      \"max\":20480,\
-      \"min\":1,\
-      \"pattern\":\"^[a-zA-Z0-9+\\\\/]+={0,2}$\",\
-      \"sensitive\":true\
-    },\
-    \"ProcessedRecordsCount\":{\"type\":\"integer\"},\
-    \"PutAccountDedicatedIpWarmupAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"AutoWarmupEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Enables or disables the automatic warm-up feature for dedicated IP addresses that are associated with your Amazon SES account in the current AWS Region. Set to <code>true</code> to enable the automatic warm-up feature, or set to <code>false</code> to disable it.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to enable or disable the automatic IP address warm-up feature.</p>\"\
-    },\
-    \"PutAccountDedicatedIpWarmupAttributesResponse\":{\
+    \"ProductionAccessNotGrantedException\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutAccountDetailsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"MailType\",\
-        \"WebsiteURL\",\
-        \"UseCaseDescription\"\
-      ],\
-      \"members\":{\
-        \"MailType\":{\
-          \"shape\":\"MailType\",\
-          \"documentation\":\"<p>The type of email your account will send.</p>\"\
-        },\
-        \"WebsiteURL\":{\
-          \"shape\":\"WebsiteURL\",\
-          \"documentation\":\"<p>The URL of your website. This information helps us better understand the type of content that you plan to send.</p>\"\
-        },\
-        \"ContactLanguage\":{\
-          \"shape\":\"ContactLanguage\",\
-          \"documentation\":\"<p>The language you would prefer to be contacted with.</p>\"\
-        },\
-        \"UseCaseDescription\":{\
-          \"shape\":\"UseCaseDescription\",\
-          \"documentation\":\"<p>A description of the types of email that you plan to send.</p>\"\
-        },\
-        \"AdditionalContactEmailAddresses\":{\
-          \"shape\":\"AdditionalContactEmailAddresses\",\
-          \"documentation\":\"<p>Additional email addresses that you would like to be notified regarding Amazon SES matters.</p>\"\
-        },\
-        \"ProductionAccessEnabled\":{\
-          \"shape\":\"EnabledWrapper\",\
-          \"documentation\":\"<p>Indicates whether or not your account should have production access in the current AWS Region.</p> <p>If the value is <code>false</code>, then your account is in the <i>sandbox</i>. When your account is in the sandbox, you can only send email to verified identities. Additionally, the maximum number of emails you can send in a 24-hour period (your sending quota) is 200, and the maximum number of emails you can send per second (your maximum sending rate) is 1.</p> <p>If the value is <code>true</code>, then your account has production access. When your account has production access, you can send email to any address. The sending quota and maximum sending rate for your account vary based on your specific use case.</p>\"\
-        }\
+      \"documentation\":\"<p>Indicates that the account has not been granted production access.</p>\",\
+      \"error\":{\
+        \"code\":\"ProductionAccessNotGranted\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
       },\
-      \"documentation\":\"<p>A request to submit new account details.</p>\"\
-    },\
-    \"PutAccountDetailsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutAccountSendingAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SendingEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Enables or disables your account's ability to send email. Set to <code>true</code> to enable email sending, or set to <code>false</code> to disable email sending.</p> <note> <p>If AWS paused your account's ability to send email, you can't use this operation to resume your account's ability to send email.</p> </note>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to change the ability of your account to send email.</p>\"\
-    },\
-    \"PutAccountSendingAttributesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutAccountSuppressionAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SuppressedReasons\":{\
-          \"shape\":\"SuppressionListReasons\",\
-          \"documentation\":\"<p>A list that contains the reasons that email addresses will be automatically added to the suppression list for your account. This list can contain any or all of the following:</p> <ul> <li> <p> <code>COMPLAINT</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p> </li> <li> <p> <code>BOUNCE</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p> </li> </ul>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to change your account's suppression preferences.</p>\"\
-    },\
-    \"PutAccountSuppressionAttributesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"exception\":true\
     },\
     \"PutConfigurationSetDeliveryOptionsRequest\":{\
       \"type\":\"structure\",\
@@ -3932,20 +3207,14 @@
       \"members\":{\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to associate with a dedicated IP pool.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
+          \"documentation\":\"<p>The name of the configuration set that you want to specify the delivery options for.</p>\"\
         },\
-        \"TlsPolicy\":{\
-          \"shape\":\"TlsPolicy\",\
-          \"documentation\":\"<p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.</p>\"\
-        },\
-        \"SendingPoolName\":{\
-          \"shape\":\"SendingPoolName\",\
-          \"documentation\":\"<p>The name of the dedicated IP pool that you want to associate with the configuration set.</p>\"\
+        \"DeliveryOptions\":{\
+          \"shape\":\"DeliveryOptions\",\
+          \"documentation\":\"<p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS).</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to associate a configuration set with a dedicated IP pool.</p>\"\
+      \"documentation\":\"<p>A request to modify the delivery options for a configuration set.</p>\"\
     },\
     \"PutConfigurationSetDeliveryOptionsResponse\":{\
       \"type\":\"structure\",\
@@ -3953,305 +3222,34 @@
       },\
       \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
     },\
-    \"PutConfigurationSetReputationOptionsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to enable or disable reputation metric tracking for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        },\
-        \"ReputationMetricsEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If <code>true</code>, tracking of reputation metrics is enabled for the configuration set. If <code>false</code>, tracking of reputation metrics is disabled for the configuration set.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to enable or disable tracking of reputation metrics for a configuration set.</p>\"\
-    },\
-    \"PutConfigurationSetReputationOptionsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutConfigurationSetSendingOptionsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to enable or disable email sending for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        },\
-        \"SendingEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If <code>true</code>, email sending is enabled for the configuration set. If <code>false</code>, email sending is disabled for the configuration set.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to enable or disable the ability of Amazon SES to send emails that use a specific configuration set.</p>\"\
-    },\
-    \"PutConfigurationSetSendingOptionsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutConfigurationSetSuppressionOptionsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to change the suppression list preferences for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        },\
-        \"SuppressedReasons\":{\
-          \"shape\":\"SuppressionListReasons\",\
-          \"documentation\":\"<p>A list that contains the reasons that email addresses are automatically added to the suppression list for your account. This list can contain any or all of the following:</p> <ul> <li> <p> <code>COMPLAINT</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p> </li> <li> <p> <code>BOUNCE</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p> </li> </ul>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to change the account suppression list preferences for a specific configuration set.</p>\"\
-    },\
-    \"PutConfigurationSetSuppressionOptionsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutConfigurationSetTrackingOptionsRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"ConfigurationSetName\"],\
-      \"members\":{\
-        \"ConfigurationSetName\":{\
-          \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to add a custom tracking domain to.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        },\
-        \"CustomRedirectDomain\":{\
-          \"shape\":\"CustomRedirectDomain\",\
-          \"documentation\":\"<p>The domain that you want to use to track open and click events.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to add a custom domain for tracking open and click events to a configuration set.</p>\"\
-    },\
-    \"PutConfigurationSetTrackingOptionsResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutDedicatedIpInPoolRequest\":{\
+    \"PutIdentityPolicyRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"Ip\",\
-        \"DestinationPoolName\"\
+        \"Identity\",\
+        \"PolicyName\",\
+        \"Policy\"\
       ],\
       \"members\":{\
-        \"Ip\":{\
-          \"shape\":\"Ip\",\
-          \"documentation\":\"<p>The IP address that you want to move to the dedicated IP pool. The value you specify has to be a dedicated IP address that's associated with your AWS account.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"IP\"\
-        },\
-        \"DestinationPoolName\":{\
-          \"shape\":\"PoolName\",\
-          \"documentation\":\"<p>The name of the IP pool that you want to add the dedicated IP address to. You have to specify an IP pool that already exists.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to move a dedicated IP address to a dedicated IP pool.</p>\"\
-    },\
-    \"PutDedicatedIpInPoolResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutDedicatedIpWarmupAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"Ip\",\
-        \"WarmupPercentage\"\
-      ],\
-      \"members\":{\
-        \"Ip\":{\
-          \"shape\":\"Ip\",\
-          \"documentation\":\"<p>The dedicated IP address that you want to update the warm-up attributes for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"IP\"\
-        },\
-        \"WarmupPercentage\":{\
-          \"shape\":\"Percentage100Wrapper\",\
-          \"documentation\":\"<p>The warm-up percentage that you want to associate with the dedicated IP address.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to change the warm-up attributes for a dedicated IP address. This operation is useful when you want to resume the warm-up process for an existing IP address.</p>\"\
-    },\
-    \"PutDedicatedIpWarmupAttributesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutDeliverabilityDashboardOptionRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"DashboardEnabled\"],\
-      \"members\":{\
-        \"DashboardEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Specifies whether to enable the Deliverability dashboard. To enable the dashboard, set this value to <code>true</code>.</p>\"\
-        },\
-        \"SubscribedDomains\":{\
-          \"shape\":\"DomainDeliverabilityTrackingOptions\",\
-          \"documentation\":\"<p>An array of objects, one for each verified domain that you use to send email and enabled the Deliverability dashboard for.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email using Amazon SES API v2. You also gain the ability to perform predictive inbox placement tests.</p> <p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href=\\\"http://aws.amazon.com/pinpoint/pricing/\\\">Amazon Pinpoint Pricing</a>.</p>\"\
-    },\
-    \"PutDeliverabilityDashboardOptionResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>A response that indicates whether the Deliverability dashboard is enabled.</p>\"\
-    },\
-    \"PutEmailIdentityDkimAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
-      \"members\":{\
-        \"EmailIdentity\":{\
+        \"Identity\":{\
           \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity that you want to change the DKIM settings for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
+          \"documentation\":\"<p>The identity that the policy will apply to. You can specify an identity by using its name or by using its Amazon Resource Name (ARN). Examples: <code>user@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p> <p>To successfully call this API, you must own the identity.</p>\"\
         },\
-        \"SigningEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Sets the DKIM signing configuration for the identity.</p> <p>When you set this value <code>true</code>, then the messages that are sent from the identity are signed using DKIM. If you set this value to <code>false</code>, your messages are sent without DKIM signing.</p>\"\
+        \"PolicyName\":{\
+          \"shape\":\"PolicyName\",\
+          \"documentation\":\"<p>The name of the policy.</p> <p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>\"\
+        },\
+        \"Policy\":{\
+          \"shape\":\"Policy\",\
+          \"documentation\":\"<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p> <p>For information about the syntax of sending authorization policies, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html\\\">Amazon SES Developer Guide</a>. </p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to enable or disable DKIM signing of email that you send from an email identity.</p>\"\
+      \"documentation\":\"<p>Represents a request to add or update a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"PutEmailIdentityDkimAttributesResponse\":{\
+    \"PutIdentityPolicyResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutEmailIdentityDkimSigningAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"EmailIdentity\",\
-        \"SigningAttributesOrigin\"\
-      ],\
-      \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity that you want to configure DKIM for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
-        },\
-        \"SigningAttributesOrigin\":{\
-          \"shape\":\"DkimSigningAttributesOrigin\",\
-          \"documentation\":\"<p>The method that you want to use to configure DKIM for the identity. There are two possible values:</p> <ul> <li> <p> <code>AWS_SES</code> â Configure DKIM for the identity by using <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a>.</p> </li> <li> <p> <code>EXTERNAL</code> â Configure DKIM for the identity by using Bring Your Own DKIM (BYODKIM).</p> </li> </ul>\"\
-        },\
-        \"SigningAttributes\":{\
-          \"shape\":\"DkimSigningAttributes\",\
-          \"documentation\":\"<p>An object that contains information about the private key and selector that you want to use to configure DKIM for the identity. This object is only required if you want to configure Bring Your Own DKIM (BYODKIM) for the identity.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to change the DKIM attributes for an email identity.</p>\"\
-    },\
-    \"PutEmailIdentityDkimSigningAttributesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"DkimStatus\":{\
-          \"shape\":\"DkimStatus\",\
-          \"documentation\":\"<p>The DKIM authentication status of the identity. Amazon SES determines the authentication status by searching for specific records in the DNS configuration for your domain. If you used <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a> to set up DKIM authentication, Amazon SES tries to find three unique CNAME records in the DNS configuration for your domain.</p> <p>If you provided a public key to perform DKIM authentication, Amazon SES tries to find a TXT record that uses the selector that you specified. The value of the TXT record must be a public key that's paired with the private key that you specified in the process of creating the identity.</p> <p>The status can be one of the following:</p> <ul> <li> <p> <code>PENDING</code> â The verification process was initiated, but Amazon SES hasn't yet detected the DKIM records in the DNS configuration for the domain.</p> </li> <li> <p> <code>SUCCESS</code> â The verification process completed successfully.</p> </li> <li> <p> <code>FAILED</code> â The verification process failed. This typically occurs when Amazon SES fails to find the DKIM records in the DNS configuration of the domain.</p> </li> <li> <p> <code>TEMPORARY_FAILURE</code> â A temporary issue is preventing Amazon SES from determining the DKIM authentication status of the domain.</p> </li> <li> <p> <code>NOT_STARTED</code> â The DKIM verification process hasn't been initiated for the domain.</p> </li> </ul>\"\
-        },\
-        \"DkimTokens\":{\
-          \"shape\":\"DnsTokenList\",\
-          \"documentation\":\"<p>If you used <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Easy DKIM</a> to configure DKIM authentication for the domain, then this object contains a set of unique strings that you use to create a set of CNAME records that you add to the DNS configuration for your domain. When Amazon SES detects these records in the DNS configuration for your domain, the DKIM authentication process is complete.</p> <p>If you configured DKIM authentication for the domain by providing your own public-private key pair, then this object contains the selector that's associated with your public key.</p> <p>Regardless of the DKIM authentication method you use, Amazon SES searches for the appropriate records in the DNS configuration of the domain for up to 72 hours.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response.</p> <p>The following data is returned in JSON format by the service.</p>\"\
-    },\
-    \"PutEmailIdentityFeedbackAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
-      \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity that you want to configure bounce and complaint feedback forwarding for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
-        },\
-        \"EmailForwardingEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>Sets the feedback forwarding configuration for the identity.</p> <p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p> <p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to set the attributes that control how bounce and complaint events are processed.</p>\"\
-    },\
-    \"PutEmailIdentityFeedbackAttributesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutEmailIdentityMailFromAttributesRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"EmailIdentity\"],\
-      \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The verified email identity that you want to set up the custom MAIL FROM domain for.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
-        },\
-        \"MailFromDomain\":{\
-          \"shape\":\"MailFromDomainName\",\
-          \"documentation\":\"<p> The custom MAIL FROM domain that you want the verified identity to use. The MAIL FROM domain must meet the following criteria:</p> <ul> <li> <p>It has to be a subdomain of the verified identity.</p> </li> <li> <p>It can't be used to receive email.</p> </li> <li> <p>It can't be used in a \\\"From\\\" address if the MAIL FROM domain is a destination for feedback forwarding emails.</p> </li> </ul>\"\
-        },\
-        \"BehaviorOnMxFailure\":{\
-          \"shape\":\"BehaviorOnMxFailure\",\
-          \"documentation\":\"<p>The action that you want to take if the required MX record isn't found when you send an email. When you set this value to <code>UseDefaultValue</code>, the mail is sent using <i>amazonses.com</i> as the MAIL FROM domain. When you set this value to <code>RejectMessage</code>, the Amazon SES API v2 returns a <code>MailFromDomainNotVerified</code> error, and doesn't attempt to deliver the email.</p> <p>These behaviors are taken when the custom MAIL FROM domain configuration is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to configure the custom MAIL FROM domain for a verified identity.</p>\"\
-    },\
-    \"PutEmailIdentityMailFromAttributesResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
-    },\
-    \"PutSuppressedDestinationRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"EmailAddress\",\
-        \"Reason\"\
-      ],\
-      \"members\":{\
-        \"EmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that should be added to the suppression list for your account.</p>\"\
-        },\
-        \"Reason\":{\
-          \"shape\":\"SuppressionListReason\",\
-          \"documentation\":\"<p>The factors that should cause the email address to be added to the suppression list for your account.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A request to add an email destination to the suppression list for your account.</p>\"\
-    },\
-    \"PutSuppressedDestinationResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
     \"RawMessage\":{\
       \"type\":\"structure\",\
@@ -4259,152 +3257,445 @@
       \"members\":{\
         \"Data\":{\
           \"shape\":\"RawMessageData\",\
-          \"documentation\":\"<p>The raw email message. The message has to meet the following criteria:</p> <ul> <li> <p>The message has to contain a header and a body, separated by one blank line.</p> </li> <li> <p>All of the required header fields must be present in the message.</p> </li> <li> <p>Each part of a multipart MIME message must be formatted properly.</p> </li> <li> <p>Attachments must be in a file format that the Amazon SES supports.</p> </li> <li> <p>The entire message must be Base64 encoded.</p> </li> <li> <p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, you should encode that content to ensure that recipients' email clients render the message properly.</p> </li> <li> <p>The length of any single line of text in the message can't exceed 1,000 characters. This restriction is defined in <a href=\\\"https://tools.ietf.org/html/rfc5321\\\">RFC 5321</a>.</p> </li> </ul>\"\
+          \"documentation\":\"<p>The raw data of the message. This data needs to base64-encoded if you are accessing Amazon SES directly through the HTTPS interface. If you are accessing Amazon SES using an AWS SDK, the SDK takes care of the base 64-encoding for you. In all cases, the client must ensure that the message format complies with Internet email standards regarding email header fields, MIME types, and MIME encoding.</p> <p>The To:, CC:, and BCC: headers in the raw message can contain a group list.</p> <p>If you are using <code>SendRawEmail</code> with sending authorization, you can include X-headers in the raw message to specify the \\\"Source,\\\" \\\"From,\\\" and \\\"Return-Path\\\" addresses. For more information, see the documentation for <code>SendRawEmail</code>. </p> <important> <p>Do not include these X-headers in the DKIM signature, because they are removed by Amazon SES before sending the email.</p> </important> <p>For more information, go to the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html\\\">Amazon SES Developer Guide</a>.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents the raw content of an email message.</p>\"\
+      \"documentation\":\"<p>Represents the raw data of the message.</p>\"\
     },\
-    \"RawMessageData\":{\
-      \"type\":\"blob\",\
-      \"documentation\":\"<p>The raw email message. The message has to meet the following criteria:</p> <ul> <li> <p>The message has to contain a header and a body, separated by one blank line.</p> </li> <li> <p>All of the required header fields must be present in the message.</p> </li> <li> <p>Each part of a multipart MIME message must be formatted properly.</p> </li> <li> <p>Attachments must be in a file format that the Amazon SES API v2 supports. </p> </li> <li> <p>The entire message must be Base64 encoded.</p> </li> <li> <p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, you should encode that content to ensure that recipients' email clients render the message properly.</p> </li> <li> <p>The length of any single line of text in the message can't exceed 1,000 characters. This restriction is defined in <a href=\\\"https://tools.ietf.org/html/rfc5321\\\">RFC 5321</a>.</p> </li> </ul>\"\
-    },\
-    \"RblName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of a blacklist that an IP address was found on.</p>\"\
-    },\
-    \"RenderedEmailTemplate\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The complete MIME message rendered by applying the data in the TemplateData parameter to the template specified in the TemplateName parameter.</p>\"\
-    },\
-    \"ReplacementEmailContent\":{\
+    \"RawMessageData\":{\"type\":\"blob\"},\
+    \"ReceiptAction\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"ReplacementTemplate\":{\
-          \"shape\":\"ReplacementTemplate\",\
-          \"documentation\":\"<p>The <code>ReplacementTemplate</code> associated with <code>ReplacementEmailContent</code>.</p>\"\
+        \"S3Action\":{\
+          \"shape\":\"S3Action\",\
+          \"documentation\":\"<p>Saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon SNS.</p>\"\
+        },\
+        \"BounceAction\":{\
+          \"shape\":\"BounceAction\",\
+          \"documentation\":\"<p>Rejects the received email by returning a bounce response to the sender and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p>\"\
+        },\
+        \"WorkmailAction\":{\
+          \"shape\":\"WorkmailAction\",\
+          \"documentation\":\"<p>Calls Amazon WorkMail and, optionally, publishes a notification to Amazon Amazon SNS.</p>\"\
+        },\
+        \"LambdaAction\":{\
+          \"shape\":\"LambdaAction\",\
+          \"documentation\":\"<p>Calls an AWS Lambda function, and optionally, publishes a notification to Amazon SNS.</p>\"\
+        },\
+        \"StopAction\":{\
+          \"shape\":\"StopAction\",\
+          \"documentation\":\"<p>Terminates the evaluation of the receipt rule set and optionally publishes a notification to Amazon SNS.</p>\"\
+        },\
+        \"AddHeaderAction\":{\
+          \"shape\":\"AddHeaderAction\",\
+          \"documentation\":\"<p>Adds a header to the received email.</p>\"\
+        },\
+        \"SNSAction\":{\
+          \"shape\":\"SNSAction\",\
+          \"documentation\":\"<p>Publishes the email content within a notification to Amazon SNS.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>The <code>ReplaceEmailContent</code> object to be used for a specific <code>BulkEmailEntry</code>. The <code>ReplacementTemplate</code> can be specified within this object.</p>\"\
+      \"documentation\":\"<p>An action that Amazon SES can take when it receives an email on behalf of one or more email addresses or domains that you own. An instance of this data type can represent only one action.</p> <p>For information about setting up receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"ReplacementTemplate\":{\
+    \"ReceiptActionsList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ReceiptAction\"}\
+    },\
+    \"ReceiptFilter\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Name\",\
+        \"IpFilter\"\
+      ],\
+      \"members\":{\
+        \"Name\":{\
+          \"shape\":\"ReceiptFilterName\",\
+          \"documentation\":\"<p>The name of the IP address filter. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>\"\
+        },\
+        \"IpFilter\":{\
+          \"shape\":\"ReceiptIpFilter\",\
+          \"documentation\":\"<p>A structure that provides the IP addresses to block or allow, and whether to block or allow incoming mail from them.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p> <p>For information about setting up IP address filters, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ReceiptFilterList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ReceiptFilter\"}\
+    },\
+    \"ReceiptFilterName\":{\"type\":\"string\"},\
+    \"ReceiptFilterPolicy\":{\
+      \"type\":\"string\",\
+      \"enum\":[\
+        \"Block\",\
+        \"Allow\"\
+      ]\
+    },\
+    \"ReceiptIpFilter\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Policy\",\
+        \"Cidr\"\
+      ],\
+      \"members\":{\
+        \"Policy\":{\
+          \"shape\":\"ReceiptFilterPolicy\",\
+          \"documentation\":\"<p>Indicates whether to block or allow incoming mail from the specified IP addresses.</p>\"\
+        },\
+        \"Cidr\":{\
+          \"shape\":\"Cidr\",\
+          \"documentation\":\"<p>A single IP address or a range of IP addresses that you want to block or allow, specified in Classless Inter-Domain Routing (CIDR) notation. An example of a single email address is 10.0.0.1. An example of a range of IP addresses is 10.0.0.1/24. For more information about CIDR notation, see <a href=\\\"https://tools.ietf.org/html/rfc2317\\\">RFC 2317</a>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>A receipt IP address filter enables you to specify whether to accept or reject mail originating from an IP address or range of IP addresses.</p> <p>For information about setting up IP address filters, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ReceiptRule\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Name\"],\
+      \"members\":{\
+        \"Name\":{\
+          \"shape\":\"ReceiptRuleName\",\
+          \"documentation\":\"<p>The name of the receipt rule. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>\"\
+        },\
+        \"Enabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>If <code>true</code>, the receipt rule is active. The default value is <code>false</code>.</p>\"\
+        },\
+        \"TlsPolicy\":{\
+          \"shape\":\"TlsPolicy\",\
+          \"documentation\":\"<p>Specifies whether Amazon SES should require that incoming email is delivered over a connection encrypted with Transport Layer Security (TLS). If this parameter is set to <code>Require</code>, Amazon SES will bounce emails that are not received over TLS. The default is <code>Optional</code>.</p>\"\
+        },\
+        \"Recipients\":{\
+          \"shape\":\"RecipientsList\",\
+          \"documentation\":\"<p>The recipient domains and email addresses that the receipt rule applies to. If this field is not specified, this rule will match all recipients under all verified domains.</p>\"\
+        },\
+        \"Actions\":{\
+          \"shape\":\"ReceiptActionsList\",\
+          \"documentation\":\"<p>An ordered list of actions to perform on messages that match at least one of the recipient email addresses or domains specified in the receipt rule.</p>\"\
+        },\
+        \"ScanEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>If <code>true</code>, then messages that this receipt rule applies to are scanned for spam and viruses. The default value is <code>false</code>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Receipt rules enable you to specify which actions Amazon SES should take when it receives mail on behalf of one or more email addresses or domains that you own.</p> <p>Each receipt rule defines a set of email addresses or domains that it applies to. If the email addresses or domains match at least one recipient address of the message, Amazon SES executes all of the receipt rule's actions on the message.</p> <p>For information about setting up receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ReceiptRuleName\":{\"type\":\"string\"},\
+    \"ReceiptRuleNamesList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ReceiptRuleName\"}\
+    },\
+    \"ReceiptRuleSetMetadata\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"ReplacementTemplateData\":{\
-          \"shape\":\"EmailTemplateData\",\
-          \"documentation\":\"<p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>\"\
+        \"Name\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set. The name must:</p> <ul> <li> <p>This value can only contain ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).</p> </li> <li> <p>Start and end with a letter or number.</p> </li> <li> <p>Contain less than 64 characters.</p> </li> </ul>\"\
+        },\
+        \"CreatedTimestamp\":{\
+          \"shape\":\"Timestamp\",\
+          \"documentation\":\"<p>The date and time the receipt rule set was created.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object which contains <code>ReplacementTemplateData</code> to be used for a specific <code>BulkEmailEntry</code>.</p>\"\
+      \"documentation\":\"<p>Information about a receipt rule set.</p> <p>A receipt rule set is a collection of rules that specify what Amazon SES should do with mail it receives on behalf of your account's verified domains.</p> <p>For information about setting up receipt rule sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"ReportId\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>A unique string that identifies a Deliverability dashboard report.</p>\"\
+    \"ReceiptRuleSetName\":{\"type\":\"string\"},\
+    \"ReceiptRuleSetsLists\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ReceiptRuleSetMetadata\"}\
     },\
-    \"ReportName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>A name that helps you identify a report generated by the Deliverability dashboard.</p>\"\
+    \"ReceiptRulesList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"ReceiptRule\"}\
     },\
+    \"Recipient\":{\"type\":\"string\"},\
+    \"RecipientDsnFields\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Action\",\
+        \"Status\"\
+      ],\
+      \"members\":{\
+        \"FinalRecipient\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that the message was ultimately delivered to. This corresponds to the <code>Final-Recipient</code> in the DSN. If not specified, <code>FinalRecipient</code> will be set to the <code>Recipient</code> specified in the <code>BouncedRecipientInfo</code> structure. Either <code>FinalRecipient</code> or the recipient in <code>BouncedRecipientInfo</code> must be a recipient of the original bounced message.</p> <note> <p>Do not prepend the <code>FinalRecipient</code> email address with <code>rfc 822;</code>, as described in <a href=\\\"https://tools.ietf.org/html/rfc3798\\\">RFC 3798</a>.</p> </note>\"\
+        },\
+        \"Action\":{\
+          \"shape\":\"DsnAction\",\
+          \"documentation\":\"<p>The action performed by the reporting mail transfer agent (MTA) as a result of its attempt to deliver the message to the recipient address. This is required by <a href=\\\"https://tools.ietf.org/html/rfc3464\\\">RFC 3464</a>.</p>\"\
+        },\
+        \"RemoteMta\":{\
+          \"shape\":\"RemoteMta\",\
+          \"documentation\":\"<p>The MTA to which the remote MTA attempted to deliver the message, formatted as specified in <a href=\\\"https://tools.ietf.org/html/rfc3464\\\">RFC 3464</a> (<code>mta-name-type; mta-name</code>). This parameter typically applies only to propagating synchronous bounces.</p>\"\
+        },\
+        \"Status\":{\
+          \"shape\":\"DsnStatus\",\
+          \"documentation\":\"<p>The status code that indicates what went wrong. This is required by <a href=\\\"https://tools.ietf.org/html/rfc3464\\\">RFC 3464</a>.</p>\"\
+        },\
+        \"DiagnosticCode\":{\
+          \"shape\":\"DiagnosticCode\",\
+          \"documentation\":\"<p>An extended explanation of what went wrong; this is usually an SMTP response. See <a href=\\\"https://tools.ietf.org/html/rfc3463\\\">RFC 3463</a> for the correct formatting of this parameter.</p>\"\
+        },\
+        \"LastAttemptDate\":{\
+          \"shape\":\"LastAttemptDate\",\
+          \"documentation\":\"<p>The time the final delivery attempt was made, in <a href=\\\"https://www.ietf.org/rfc/rfc0822.txt\\\">RFC 822</a> date-time format.</p>\"\
+        },\
+        \"ExtensionFields\":{\
+          \"shape\":\"ExtensionFieldList\",\
+          \"documentation\":\"<p>Additional X-headers to include in the DSN.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Recipient-related information to include in the Delivery Status Notification (DSN) when an email that Amazon SES receives on your behalf bounces.</p> <p>For information about receiving email through Amazon SES, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"RecipientsList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"Recipient\"}\
+    },\
+    \"RemoteMta\":{\"type\":\"string\"},\
+    \"RenderedTemplate\":{\"type\":\"string\"},\
+    \"ReorderReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"RuleSetName\",\
+        \"RuleNames\"\
+      ],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set to reorder.</p>\"\
+        },\
+        \"RuleNames\":{\
+          \"shape\":\"ReceiptRuleNamesList\",\
+          \"documentation\":\"<p>A list of the specified receipt rule set's receipt rules in the order that you want to put them.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to reorder the receipt rules within a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"ReorderReceiptRuleSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"ReportingMta\":{\"type\":\"string\"},\
     \"ReputationOptions\":{\
       \"type\":\"structure\",\
       \"members\":{\
+        \"SendingEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether email sending is enabled or disabled for the configuration set. If the value is <code>true</code>, then Amazon SES will send emails that use the configuration set. If the value is <code>false</code>, Amazon SES will not send emails that use the configuration set. The default value is <code>true</code>. You can change this setting using <a>UpdateConfigurationSetSendingEnabled</a>.</p>\"\
+        },\
         \"ReputationMetricsEnabled\":{\
           \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If <code>true</code>, tracking of reputation metrics is enabled for the configuration set. If <code>false</code>, tracking of reputation metrics is disabled for the configuration set.</p>\"\
+          \"documentation\":\"<p>Describes whether or not Amazon SES publishes reputation metrics for the configuration set, such as bounce and complaint rates, to Amazon CloudWatch.</p> <p>If the value is <code>true</code>, reputation metrics are published. If the value is <code>false</code>, reputation metrics are not published. The default value is <code>false</code>.</p>\"\
         },\
         \"LastFreshStart\":{\
           \"shape\":\"LastFreshStart\",\
-          \"documentation\":\"<p>The date and time (in Unix time) when the reputation metrics were last given a fresh start. When your account is given a fresh start, your reputation metrics are calculated starting from the date of the fresh start.</p>\"\
+          \"documentation\":\"<p>The date and time at which the reputation metrics for the configuration set were last reset. Resetting these metrics is known as a <i>fresh start</i>.</p> <p>When you disable email sending for a configuration set using <a>UpdateConfigurationSetSendingEnabled</a> and later re-enable it, the reputation metrics for the configuration set (but not for the entire Amazon SES account) are reset.</p> <p>If email sending for the configuration set has never been disabled and later re-enabled, the value of this attribute is <code>null</code>.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Enable or disable collection of reputation metrics for emails that you send using this configuration set in the current AWS Region. </p>\"\
+      \"documentation\":\"<p>Contains information about the reputation settings for a configuration set.</p>\"\
     },\
-    \"ReviewDetails\":{\
+    \"RuleDoesNotExistException\":{\
       \"type\":\"structure\",\
       \"members\":{\
-        \"Status\":{\
-          \"shape\":\"ReviewStatus\",\
-          \"documentation\":\"<p>The status of the latest review of your account. The status can be one of the following:</p> <ul> <li> <p> <code>PENDING</code> â We have received your appeal and are in the process of reviewing it.</p> </li> <li> <p> <code>GRANTED</code> â Your appeal has been reviewed and your production access has been granted.</p> </li> <li> <p> <code>DENIED</code> â Your appeal has been reviewed and your production access has been denied.</p> </li> <li> <p> <code>FAILED</code> â An internal error occurred and we didn't receive your appeal. You can submit your appeal again.</p> </li> </ul>\"\
-        },\
-        \"CaseId\":{\
-          \"shape\":\"CaseId\",\
-          \"documentation\":\"<p>The associated support center case ID (if any).</p>\"\
+        \"Name\":{\
+          \"shape\":\"RuleOrRuleSetName\",\
+          \"documentation\":\"<p>Indicates that the named receipt rule does not exist.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that contains information about your account details review.</p>\"\
+      \"documentation\":\"<p>Indicates that the provided receipt rule does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"RuleDoesNotExist\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"ReviewStatus\":{\
+    \"RuleOrRuleSetName\":{\"type\":\"string\"},\
+    \"RuleSetDoesNotExistException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Name\":{\
+          \"shape\":\"RuleOrRuleSetName\",\
+          \"documentation\":\"<p>Indicates that the named receipt rule set does not exist.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the provided receipt rule set does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"RuleSetDoesNotExist\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"S3Action\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"BucketName\"],\
+      \"members\":{\
+        \"TopicArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The ARN of the Amazon SNS topic to notify when the message is saved to the Amazon S3 bucket. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        },\
+        \"BucketName\":{\
+          \"shape\":\"S3BucketName\",\
+          \"documentation\":\"<p>The name of the Amazon S3 bucket that incoming email will be saved to.</p>\"\
+        },\
+        \"ObjectKeyPrefix\":{\
+          \"shape\":\"S3KeyPrefix\",\
+          \"documentation\":\"<p>The key prefix of the Amazon S3 bucket. The key prefix is similar to a directory name that enables you to store similar data under the same directory in a bucket.</p>\"\
+        },\
+        \"KmsKeyArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The customer master key that Amazon SES should use to encrypt your emails before saving them to the Amazon S3 bucket. You can use the default master key or a custom master key you created in AWS KMS as follows:</p> <ul> <li> <p>To use the default master key, provide an ARN in the form of <code>arn:aws:kms:REGION:ACCOUNT-ID-WITHOUT-HYPHENS:alias/aws/ses</code>. For example, if your AWS account ID is 123456789012 and you want to use the default master key in the US West (Oregon) region, the ARN of the default master key would be <code>arn:aws:kms:us-west-2:123456789012:alias/aws/ses</code>. If you use the default master key, you don't need to perform any extra steps to give Amazon SES permission to use the key.</p> </li> <li> <p>To use a custom master key you created in AWS KMS, provide the ARN of the master key and ensure that you add a statement to your key's policy to give Amazon SES permission to use it. For more information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p> </li> </ul> <p>For more information about key policies, see the <a href=\\\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html\\\">AWS KMS Developer Guide</a>. If you do not specify a master key, Amazon SES will not encrypt your emails.</p> <important> <p>Your mail is encrypted by Amazon SES using the Amazon S3 encryption client before the mail is submitted to Amazon S3 for storage. It is not encrypted using Amazon S3 server-side encryption. This means that you must use the Amazon S3 encryption client to decrypt the email after retrieving it from Amazon S3, as the service has no access to use your AWS KMS keys for decryption. This encryption client is currently available with the <a href=\\\"http://aws.amazon.com/sdk-for-java/\\\">AWS SDK for Java</a> and <a href=\\\"http://aws.amazon.com/sdk-for-ruby/\\\">AWS SDK for Ruby</a> only. For more information about client-side encryption using AWS KMS master keys, see the <a href=\\\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\\\">Amazon S3 Developer Guide</a>.</p> </important>\"\
+        }\
+      },\
+      \"documentation\":\"<p>When included in a receipt rule, this action saves the received message to an Amazon Simple Storage Service (Amazon S3) bucket and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>To enable Amazon SES to write emails to your Amazon S3 bucket, use an AWS KMS key to encrypt your emails, or publish to an Amazon SNS topic of another account, Amazon SES must have permission to access those resources. For information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p> <note> <p>When you save your emails to an Amazon S3 bucket, the maximum email size (including headers) is 30 MB. Emails larger than that will bounce.</p> </note> <p>For information about specifying Amazon S3 actions in receipt rules, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-s3.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"S3BucketName\":{\"type\":\"string\"},\
+    \"S3KeyPrefix\":{\"type\":\"string\"},\
+    \"SNSAction\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"TopicArn\"],\
+      \"members\":{\
+        \"TopicArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        },\
+        \"Encoding\":{\
+          \"shape\":\"SNSActionEncoding\",\
+          \"documentation\":\"<p>The encoding to use for the email within the Amazon SNS notification. UTF-8 is easier to use, but may not preserve all special characters when a message was encoded with a different encoding format. Base64 preserves all special characters. The default value is UTF-8.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>When included in a receipt rule, this action publishes a notification to Amazon Simple Notification Service (Amazon SNS). This action includes a complete copy of the email content in the Amazon SNS notifications. Amazon SNS notifications for all other actions simply provide information about the email. They do not include the email content itself.</p> <p>If you own the Amazon SNS topic, you don't need to do anything to give Amazon SES permission to publish emails to it. However, if you don't own the Amazon SNS topic, you need to attach a policy to the topic to give Amazon SES permissions to access it. For information about giving permissions, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-permissions.html\\\">Amazon SES Developer Guide</a>.</p> <important> <p>You can only publish emails that are 150 KB or less (including the header) to Amazon SNS. Larger emails will bounce. If you anticipate emails larger than 150 KB, use the S3 action instead.</p> </important> <p>For information about using a receipt rule to publish an Amazon SNS notification, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-sns.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SNSActionEncoding\":{\
       \"type\":\"string\",\
       \"enum\":[\
-        \"PENDING\",\
-        \"FAILED\",\
-        \"GRANTED\",\
-        \"DENIED\"\
+        \"UTF-8\",\
+        \"Base64\"\
       ]\
     },\
-    \"S3Url\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>An Amazon S3 URL in the format s3://<i>&lt;bucket_name&gt;</i>/<i>&lt;object&gt;</i>.</p>\",\
-      \"pattern\":\"^s3:\\\\/\\\\/([^\\\\/]+)\\\\/(.*?([^\\\\/]+)\\\\/?)$\"\
+    \"SNSDestination\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"TopicARN\"],\
+      \"members\":{\
+        \"TopicARN\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The ARN of the Amazon SNS topic that email sending events will be published to. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Contains the topic ARN associated with an Amazon Simple Notification Service (Amazon SNS) event destination.</p> <p>Event destinations, such as Amazon SNS, are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"Selector\":{\
-      \"type\":\"string\",\
-      \"max\":63,\
-      \"min\":1,\
-      \"pattern\":\"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\\\-]*[a-zA-Z0-9]))$\"\
-    },\
-    \"SendBulkEmailRequest\":{\
+    \"SendBounceRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"DefaultContent\",\
-        \"BulkEmailEntries\"\
+        \"OriginalMessageId\",\
+        \"BounceSender\",\
+        \"BouncedRecipientInfoList\"\
       ],\
       \"members\":{\
-        \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that you want to use as the \\\"From\\\" address for the email. The address that you specify has to be verified.</p>\"\
+        \"OriginalMessageId\":{\
+          \"shape\":\"MessageId\",\
+          \"documentation\":\"<p>The message ID of the message to be bounced.</p>\"\
         },\
-        \"FromEmailAddressIdentityArn\":{\
+        \"BounceSender\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The address to use in the \\\"From\\\" header of the bounce message. This must be an identity that you have verified with Amazon SES.</p>\"\
+        },\
+        \"Explanation\":{\
+          \"shape\":\"Explanation\",\
+          \"documentation\":\"<p>Human-readable text for the bounce message to explain the failure. If not specified, the text will be auto-generated based on the bounced recipient information.</p>\"\
+        },\
+        \"MessageDsn\":{\
+          \"shape\":\"MessageDsn\",\
+          \"documentation\":\"<p>Message-related DSN fields. If not specified, Amazon SES will choose the values.</p>\"\
+        },\
+        \"BouncedRecipientInfoList\":{\
+          \"shape\":\"BouncedRecipientInfoList\",\
+          \"documentation\":\"<p>A list of recipients of the bounced message, including the information required to create the Delivery Status Notifications (DSNs) for the recipients. You must specify at least one <code>BouncedRecipientInfo</code> in the list.</p>\"\
+        },\
+        \"BounceSenderArn\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FromEmailAddress</code> parameter.</p> <p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use sender@example.com, then you would specify the <code>FromEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FromEmailAddress</code> to be sender@example.com.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the address in the \\\"From\\\" header of the bounce. For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to send a bounce message to the sender of an email you received through Amazon SES.</p>\"\
+    },\
+    \"SendBounceResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"MessageId\":{\
+          \"shape\":\"MessageId\",\
+          \"documentation\":\"<p>The message ID of the bounce message.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a unique message ID.</p>\"\
+    },\
+    \"SendBulkTemplatedEmailRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Source\",\
+        \"Template\",\
+        \"Destinations\"\
+      ],\
+      \"members\":{\
+        \"Source\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Amazon SES Developer Guide</a>.</p> <p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\\\"https://tools.ietf.org/html/rfc6531\\\">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href=\\\"https://en.wikipedia.org/wiki/Email_address#Local-part\\\">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href=\\\"https://tools.ietf.org/html/rfc3492.html\\\">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in <a href=\\\"https://tools.ietf.org/html/rfc2047\\\">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p> </note>\"\
+        },\
+        \"SourceArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
         },\
         \"ReplyToAddresses\":{\
-          \"shape\":\"EmailAddressList\",\
-          \"documentation\":\"<p>The \\\"Reply-to\\\" email addresses for the message. When the recipient replies to the message, each Reply-to address receives the reply.</p>\"\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>\"\
         },\
-        \"FeedbackForwardingEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The address that you want bounce and complaint notifications to be sent to.</p>\"\
+        \"ReturnPath\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that bounces and complaints will be forwarded to when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>\"\
         },\
-        \"FeedbackForwardingEmailAddressIdentityArn\":{\
+        \"ReturnPathArn\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FeedbackForwardingEmailAddress</code> parameter.</p> <p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use feedback@example.com, then you would specify the <code>FeedbackForwardingEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FeedbackForwardingEmailAddress</code> to be feedback@example.com.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
-        },\
-        \"DefaultEmailTags\":{\
-          \"shape\":\"MessageTagList\",\
-          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using the <code>SendEmail</code> operation. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>\"\
-        },\
-        \"DefaultContent\":{\
-          \"shape\":\"BulkEmailContent\",\
-          \"documentation\":\"<p>An object that contains the body of the message. You can specify a template message.</p>\"\
-        },\
-        \"BulkEmailEntries\":{\
-          \"shape\":\"BulkEmailEntryList\",\
-          \"documentation\":\"<p>The list of bulk email entry objects.</p>\"\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
         },\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to use when sending the email.</p>\"\
+          \"documentation\":\"<p>The name of the configuration set to use when you send an email using <code>SendBulkTemplatedEmail</code>.</p>\"\
+        },\
+        \"DefaultTags\":{\
+          \"shape\":\"MessageTagList\",\
+          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send to a destination using <code>SendBulkTemplatedEmail</code>.</p>\"\
+        },\
+        \"Template\":{\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The template to use when sending this email.</p>\"\
+        },\
+        \"TemplateArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The ARN of the template to use when sending this email.</p>\"\
+        },\
+        \"DefaultTemplateData\":{\
+          \"shape\":\"TemplateData\",\
+          \"documentation\":\"<p>A list of replacement values to apply to the template when replacement data is not specified in a Destination object. These values act as a default or fallback option when no other data is available.</p> <p>The template data is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>\"\
+        },\
+        \"Destinations\":{\
+          \"shape\":\"BulkEmailDestinationList\",\
+          \"documentation\":\"<p>One or more <code>Destination</code> objects. All of the recipients in a <code>Destination</code> will receive the same version of the email. You can specify up to 50 <code>Destination</code> objects within a <code>Destinations</code> array.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents a request to send email messages to multiple destinations using Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+      \"documentation\":\"<p>Represents a request to send a templated email to multiple destinations using Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"SendBulkEmailResponse\":{\
+    \"SendBulkTemplatedEmailResponse\":{\
       \"type\":\"structure\",\
-      \"required\":[\"BulkEmailEntryResults\"],\
+      \"required\":[\"Status\"],\
       \"members\":{\
-        \"BulkEmailEntryResults\":{\"shape\":\"BulkEmailEntryResultList\"}\
-      },\
-      \"documentation\":\"<p>The following data is returned in JSON format by the service.</p>\"\
+        \"Status\":{\
+          \"shape\":\"BulkEmailDestinationStatusList\",\
+          \"documentation\":\"<p>The unique message identifier returned from the <code>SendBulkTemplatedEmail</code> action.</p>\"\
+        }\
+      }\
     },\
     \"SendCustomVerificationEmailRequest\":{\
       \"type\":\"structure\",\
@@ -4414,11 +3705,11 @@
       ],\
       \"members\":{\
         \"EmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
+          \"shape\":\"Address\",\
           \"documentation\":\"<p>The email address to verify.</p>\"\
         },\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
+          \"shape\":\"TemplateName\",\
           \"documentation\":\"<p>The name of the custom verification email template to use when sending the verification email.</p>\"\
         },\
         \"ConfigurationSetName\":{\
@@ -4432,314 +3723,474 @@
       \"type\":\"structure\",\
       \"members\":{\
         \"MessageId\":{\
-          \"shape\":\"OutboundMessageId\",\
+          \"shape\":\"MessageId\",\
           \"documentation\":\"<p>The unique message identifier returned from the <code>SendCustomVerificationEmail</code> operation.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>The following element is returned by the service.</p>\"\
+      \"documentation\":\"<p>The response received when attempting to send the custom verification email.</p>\"\
+    },\
+    \"SendDataPoint\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Timestamp\":{\
+          \"shape\":\"Timestamp\",\
+          \"documentation\":\"<p>Time of the data point.</p>\"\
+        },\
+        \"DeliveryAttempts\":{\
+          \"shape\":\"Counter\",\
+          \"documentation\":\"<p>Number of emails that have been sent.</p>\"\
+        },\
+        \"Bounces\":{\
+          \"shape\":\"Counter\",\
+          \"documentation\":\"<p>Number of emails that have bounced.</p>\"\
+        },\
+        \"Complaints\":{\
+          \"shape\":\"Counter\",\
+          \"documentation\":\"<p>Number of unwanted emails that were rejected by recipients.</p>\"\
+        },\
+        \"Rejects\":{\
+          \"shape\":\"Counter\",\
+          \"documentation\":\"<p>Number of emails rejected by Amazon SES.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents sending statistics data. Each <code>SendDataPoint</code> contains statistics for a 15-minute period of sending activity. </p>\"\
+    },\
+    \"SendDataPointList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"SendDataPoint\"}\
     },\
     \"SendEmailRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\"Content\"],\
+      \"required\":[\
+        \"Source\",\
+        \"Destination\",\
+        \"Message\"\
+      ],\
       \"members\":{\
-        \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that you want to use as the \\\"From\\\" address for the email. The address that you specify has to be verified. </p>\"\
-        },\
-        \"FromEmailAddressIdentityArn\":{\
-          \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FromEmailAddress</code> parameter.</p> <p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use sender@example.com, then you would specify the <code>FromEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FromEmailAddress</code> to be sender@example.com.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <p>For Raw emails, the <code>FromEmailAddressIdentityArn</code> value overrides the X-SES-SOURCE-ARN and X-SES-FROM-ARN headers specified in raw email message content.</p>\"\
+        \"Source\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Amazon SES Developer Guide</a>.</p> <p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\\\"https://tools.ietf.org/html/rfc6531\\\">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href=\\\"https://en.wikipedia.org/wiki/Email_address#Local-part\\\">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href=\\\"https://tools.ietf.org/html/rfc3492.html\\\">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in <a href=\\\"https://tools.ietf.org/html/rfc2047\\\">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p> </note>\"\
         },\
         \"Destination\":{\
           \"shape\":\"Destination\",\
-          \"documentation\":\"<p>An object that contains the recipients of the email message.</p>\"\
+          \"documentation\":\"<p>The destination for this email, composed of To:, CC:, and BCC: fields.</p>\"\
+        },\
+        \"Message\":{\
+          \"shape\":\"Message\",\
+          \"documentation\":\"<p>The message to be sent.</p>\"\
         },\
         \"ReplyToAddresses\":{\
-          \"shape\":\"EmailAddressList\",\
-          \"documentation\":\"<p>The \\\"Reply-to\\\" email addresses for the message. When the recipient replies to the message, each Reply-to address receives the reply.</p>\"\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>\"\
         },\
-        \"FeedbackForwardingEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The address that you want bounce and complaint notifications to be sent to.</p>\"\
+        \"ReturnPath\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that bounces and complaints will be forwarded to when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>\"\
         },\
-        \"FeedbackForwardingEmailAddressIdentityArn\":{\
+        \"SourceArn\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>FeedbackForwardingEmailAddress</code> parameter.</p> <p>For example, if the owner of example.com (which has ARN arn:aws:ses:us-east-1:123456789012:identity/example.com) attaches a policy to it that authorizes you to use feedback@example.com, then you would specify the <code>FeedbackForwardingEmailAddressIdentityArn</code> to be arn:aws:ses:us-east-1:123456789012:identity/example.com, and the <code>FeedbackForwardingEmailAddress</code> to be feedback@example.com.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
         },\
-        \"Content\":{\
-          \"shape\":\"EmailContent\",\
-          \"documentation\":\"<p>An object that contains the body of the message. You can send either a Simple message Raw message or a template Message.</p>\"\
+        \"ReturnPathArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
         },\
-        \"EmailTags\":{\
+        \"Tags\":{\
           \"shape\":\"MessageTagList\",\
-          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using the <code>SendEmail</code> operation. Tags correspond to characteristics of the email that you define, so that you can publish email sending events. </p>\"\
+          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>\"\
         },\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that you want to use when sending the email.</p>\"\
+          \"documentation\":\"<p>The name of the configuration set to use when you send an email using <code>SendEmail</code>.</p>\"\
         }\
       },\
       \"documentation\":\"<p>Represents a request to send a single formatted email using Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-formatted.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"SendEmailResponse\":{\
       \"type\":\"structure\",\
+      \"required\":[\"MessageId\"],\
       \"members\":{\
         \"MessageId\":{\
-          \"shape\":\"OutboundMessageId\",\
-          \"documentation\":\"<p>A unique identifier for the message that is generated when the message is accepted.</p> <note> <p>It's possible for Amazon SES to accept a message without sending it. This can happen when the message that you're trying to send has an attachment contains a virus, or when you send a templated email that contains invalid personalization content, for example.</p> </note>\"\
+          \"shape\":\"MessageId\",\
+          \"documentation\":\"<p>The unique message identifier returned from the <code>SendEmail</code> action. </p>\"\
         }\
       },\
-      \"documentation\":\"<p>A unique message ID that you receive when an email is accepted for sending.</p>\"\
+      \"documentation\":\"<p>Represents a unique message ID.</p>\"\
     },\
-    \"SendQuota\":{\
+    \"SendRawEmailRequest\":{\
       \"type\":\"structure\",\
+      \"required\":[\"RawMessage\"],\
       \"members\":{\
-        \"Max24HourSend\":{\
-          \"shape\":\"Max24HourSend\",\
-          \"documentation\":\"<p>The maximum number of emails that you can send in the current AWS Region over a 24-hour period. This value is also called your <i>sending quota</i>.</p>\"\
+        \"Source\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The identity's email address. If you do not provide a value for this parameter, you must specify a \\\"From\\\" address in the raw text of the message. (You can also specify both.)</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in<a href=\\\"https://tools.ietf.org/html/rfc6531\\\">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href=\\\"https://en.wikipedia.org/wiki/Email_address#Local-part\\\">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href=\\\"https://tools.ietf.org/html/rfc3492.html\\\">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in <a href=\\\"https://tools.ietf.org/html/rfc2047\\\">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p> </note> <p>If you specify the <code>Source</code> parameter and have feedback forwarding enabled, then bounces and complaints will be sent to this email address. This takes precedence over any Return-Path header that you might include in the raw text of the message.</p>\"\
         },\
-        \"MaxSendRate\":{\
-          \"shape\":\"MaxSendRate\",\
-          \"documentation\":\"<p>The maximum number of emails that you can send per second in the current AWS Region. This value is also called your <i>maximum sending rate</i> or your <i>maximum TPS (transactions per second) rate</i>.</p>\"\
+        \"Destinations\":{\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>A list of destinations for the message, consisting of To:, CC:, and BCC: addresses.</p>\"\
         },\
-        \"SentLast24Hours\":{\
-          \"shape\":\"SentLast24Hours\",\
-          \"documentation\":\"<p>The number of emails sent from your Amazon SES account in the current AWS Region over the past 24 hours.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the per-day and per-second sending limits for your Amazon SES account in the current AWS Region.</p>\"\
-    },\
-    \"SendingOptions\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SendingEnabled\":{\
-          \"shape\":\"Enabled\",\
-          \"documentation\":\"<p>If <code>true</code>, email sending is enabled for the configuration set. If <code>false</code>, email sending is disabled for the configuration set.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Used to enable or disable email sending for messages that use this configuration set in the current AWS Region.</p>\"\
-    },\
-    \"SendingPausedException\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>The message can't be sent because the account's ability to send email is currently paused.</p>\",\
-      \"error\":{\"httpStatusCode\":400},\
-      \"exception\":true\
-    },\
-    \"SendingPoolName\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The name of the dedicated IP pool that you want to associate with the configuration set.</p>\"\
-    },\
-    \"SentLast24Hours\":{\"type\":\"double\"},\
-    \"SnsDestination\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"TopicArn\"],\
-      \"members\":{\
-        \"TopicArn\":{\
+        \"RawMessage\":{\
+          \"shape\":\"RawMessage\",\
+          \"documentation\":\"<p>The raw email message itself. The message has to meet the following criteria:</p> <ul> <li> <p>The message has to contain a header and a body, separated by a blank line.</p> </li> <li> <p>All of the required header fields must be present in the message.</p> </li> <li> <p>Each part of a multipart MIME message must be formatted properly.</p> </li> <li> <p>Attachments must be of a content type that Amazon SES supports. For a list on unsupported content types, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mime-types.html\\\">Unsupported Attachment Types</a> in the <i>Amazon SES Developer Guide</i>.</p> </li> <li> <p>The entire message must be base64-encoded.</p> </li> <li> <p>If any of the MIME parts in your message contain content that is outside of the 7-bit ASCII character range, we highly recommend that you encode that content. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html\\\">Sending Raw Email</a> in the <i>Amazon SES Developer Guide</i>.</p> </li> <li> <p>Per <a href=\\\"https://tools.ietf.org/html/rfc5321#section-4.5.3.1.6\\\">RFC 5321</a>, the maximum length of each line of text, including the &lt;CRLF&gt;, must not exceed 1,000 characters.</p> </li> </ul>\"\
+        },\
+        \"FromArn\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic that you want to publish email events to. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that defines an Amazon SNS destination for email events. You can use Amazon SNS to send notification when certain email events occur.</p>\"\
-    },\
-    \"Subject\":{\"type\":\"string\"},\
-    \"SuccessRedirectionURL\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The URL that the recipient of the verification email is sent to if his or her address is successfully verified.</p>\"\
-    },\
-    \"SuppressedDestination\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"EmailAddress\",\
-        \"Reason\",\
-        \"LastUpdateTime\"\
-      ],\
-      \"members\":{\
-        \"EmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that is on the suppression list for your account.</p>\"\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to specify a particular \\\"From\\\" address in the header of the raw email.</p> <p>Instead of using this parameter, you can use the X-header <code>X-SES-FROM-ARN</code> in the raw message of the email. If you use both the <code>FromArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>FromArn</code> parameter.</p> <note> <p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html\\\">Amazon SES Developer Guide</a>.</p> </note>\"\
         },\
-        \"Reason\":{\
-          \"shape\":\"SuppressionListReason\",\
-          \"documentation\":\"<p>The reason that the address was added to the suppression list for your account.</p>\"\
-        },\
-        \"LastUpdateTime\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The date and time when the suppressed destination was last updated, shown in Unix time format.</p>\"\
-        },\
-        \"Attributes\":{\
-          \"shape\":\"SuppressedDestinationAttributes\",\
-          \"documentation\":\"<p>An optional value that can contain additional information about the reasons that the address was added to the suppression list for your account.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about an email address that is on the suppression list for your account.</p>\"\
-    },\
-    \"SuppressedDestinationAttributes\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"MessageId\":{\
-          \"shape\":\"OutboundMessageId\",\
-          \"documentation\":\"<p>The unique identifier of the email message that caused the email address to be added to the suppression list for your account.</p>\"\
-        },\
-        \"FeedbackId\":{\
-          \"shape\":\"FeedbackId\",\
-          \"documentation\":\"<p>A unique identifier that's generated when an email address is added to the suppression list for your account.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains additional attributes that are related an email address that is on the suppression list for your account.</p>\"\
-    },\
-    \"SuppressedDestinationSummaries\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"SuppressedDestinationSummary\"}\
-    },\
-    \"SuppressedDestinationSummary\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"EmailAddress\",\
-        \"Reason\",\
-        \"LastUpdateTime\"\
-      ],\
-      \"members\":{\
-        \"EmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
-          \"documentation\":\"<p>The email address that's on the suppression list for your account.</p>\"\
-        },\
-        \"Reason\":{\
-          \"shape\":\"SuppressionListReason\",\
-          \"documentation\":\"<p>The reason that the address was added to the suppression list for your account.</p>\"\
-        },\
-        \"LastUpdateTime\":{\
-          \"shape\":\"Timestamp\",\
-          \"documentation\":\"<p>The date and time when the suppressed destination was last updated, shown in Unix time format.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>A summary that describes the suppressed email address.</p>\"\
-    },\
-    \"SuppressionAttributes\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SuppressedReasons\":{\
-          \"shape\":\"SuppressionListReasons\",\
-          \"documentation\":\"<p>A list that contains the reasons that email addresses will be automatically added to the suppression list for your account. This list can contain any or all of the following:</p> <ul> <li> <p> <code>COMPLAINT</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p> </li> <li> <p> <code>BOUNCE</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p> </li> </ul>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the email address suppression preferences for your account in the current AWS Region.</p>\"\
-    },\
-    \"SuppressionListDestination\":{\
-      \"type\":\"structure\",\
-      \"required\":[\"SuppressionListImportAction\"],\
-      \"members\":{\
-        \"SuppressionListImportAction\":{\
-          \"shape\":\"SuppressionListImportAction\",\
-          \"documentation\":\"<p>The type of action that you want to perform on the address. Acceptable values:</p> <ul> <li> <p>PUT: add the addresses to the suppression list. If the record already exists, it will override it with the new value.</p> </li> <li> <p>DELETE: remove the addresses from the suppression list.</p> </li> </ul>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains details about the action of suppression list.</p>\"\
-    },\
-    \"SuppressionListImportAction\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The type of action that you want to perform on the address. Acceptable values:</p> <ul> <li> <p>PUT: add the addresses to the suppression list.</p> </li> <li> <p>DELETE: remove the address from the suppression list.</p> </li> </ul>\",\
-      \"enum\":[\
-        \"DELETE\",\
-        \"PUT\"\
-      ]\
-    },\
-    \"SuppressionListReason\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The reason that the address was added to the suppression list for your account. The value can be one of the following:</p> <ul> <li> <p> <code>COMPLAINT</code> â Amazon SES added an email address to the suppression list for your account because a message sent to that address results in a complaint.</p> </li> <li> <p> <code>BOUNCE</code> â Amazon SES added an email address to the suppression list for your account because a message sent to that address results in a hard bounce.</p> </li> </ul>\",\
-      \"enum\":[\
-        \"BOUNCE\",\
-        \"COMPLAINT\"\
-      ]\
-    },\
-    \"SuppressionListReasons\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"SuppressionListReason\"}\
-    },\
-    \"SuppressionOptions\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"SuppressedReasons\":{\
-          \"shape\":\"SuppressionListReasons\",\
-          \"documentation\":\"<p>A list that contains the reasons that email addresses are automatically added to the suppression list for your account. This list can contain any or all of the following:</p> <ul> <li> <p> <code>COMPLAINT</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a complaint.</p> </li> <li> <p> <code>BOUNCE</code> â Amazon SES adds an email address to the suppression list for your account when a message sent to that address results in a hard bounce.</p> </li> </ul>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the suppression list preferences for your account.</p>\"\
-    },\
-    \"Tag\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"Key\",\
-        \"Value\"\
-      ],\
-      \"members\":{\
-        \"Key\":{\
-          \"shape\":\"TagKey\",\
-          \"documentation\":\"<p>One part of a key-value pair that defines a tag. The maximum length of a tag key is 128 characters. The minimum length is 1 character.</p>\"\
-        },\
-        \"Value\":{\
-          \"shape\":\"TagValue\",\
-          \"documentation\":\"<p>The optional part of a key-value pair that defines a tag. The maximum length of a tag value is 256 characters. The minimum length is 0 characters. If you don't want a resource to have a specific tag value, don't specify a value for thisÂ parameter. If you don't specify a value, Amazon SES sets the value to an empty string.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that defines the tags that are associated with a resource. AÂ <i>tag</i>Â is a label that you optionally define and associate with a resource. Tags can help you categorize and manage resources in different ways, such as by purpose, owner, environment, or other criteria. A resource can have as many as 50 tags.</p> <p>Each tag consists of a requiredÂ <i>tag key</i>Â and an associatedÂ <i>tag value</i>, both of which you define. A tag key is a general label that acts as a category for a more specific tag value. A tag value acts as a descriptor within a tag key. A tag key can contain as many as 128 characters. A tag value can contain as many as 256 characters. The characters can be Unicode letters, digits, white space, or one of the following symbols: _ . : / = + -. The following additional restrictions apply to tags:</p> <ul> <li> <p>Tag keys and values are case sensitive.</p> </li> <li> <p>For each associated resource, each tag key must be unique and it can have only one value.</p> </li> <li> <p>TheÂ <code>aws:</code>Â prefix is reserved for use by AWS; you canât use it in any tag keys or values that you define. In addition, you can't edit or remove tag keys or values that use this prefix. Tags that use this prefix donât count against the limit of 50 tags per resource.</p> </li> <li> <p>You can associate tags with public or shared resources, but the tags are available only for your AWS account, not any other accounts that share the resource. In addition, the tags are available only for resources that are located in the specified AWS Region for your AWS account.</p> </li> </ul>\"\
-    },\
-    \"TagKey\":{\"type\":\"string\"},\
-    \"TagKeyList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"TagKey\"}\
-    },\
-    \"TagList\":{\
-      \"type\":\"list\",\
-      \"member\":{\"shape\":\"Tag\"}\
-    },\
-    \"TagResourceRequest\":{\
-      \"type\":\"structure\",\
-      \"required\":[\
-        \"ResourceArn\",\
-        \"Tags\"\
-      ],\
-      \"members\":{\
-        \"ResourceArn\":{\
+        \"SourceArn\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the resource that you want to add one or more tags to.</p>\"\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p> <p>Instead of using this parameter, you can use the X-header <code>X-SES-SOURCE-ARN</code> in the raw message of the email. If you use both the <code>SourceArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>SourceArn</code> parameter.</p> <note> <p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html\\\">Amazon SES Developer Guide</a>.</p> </note>\"\
+        },\
+        \"ReturnPathArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p> <p>Instead of using this parameter, you can use the X-header <code>X-SES-RETURN-PATH-ARN</code> in the raw message of the email. If you use both the <code>ReturnPathArn</code> parameter and the corresponding X-header, Amazon SES uses the value of the <code>ReturnPathArn</code> parameter.</p> <note> <p>For information about when to use this parameter, see the description of <code>SendRawEmail</code> in this guide, or see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html\\\">Amazon SES Developer Guide</a>.</p> </note>\"\
         },\
         \"Tags\":{\
-          \"shape\":\"TagList\",\
-          \"documentation\":\"<p>A list of the tags that you want to add to the resource. A tag consists of a required tag key (<code>Key</code>) and an associated tag value (<code>Value</code>). The maximum length of a tag key is 128 characters. The maximum length of a tag value is 256 characters.</p>\"\
+          \"shape\":\"MessageTagList\",\
+          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendRawEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>\"\
+        },\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set to use when you send an email using <code>SendRawEmail</code>.</p>\"\
         }\
-      }\
+      },\
+      \"documentation\":\"<p>Represents a request to send a single raw email using Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"TagResourceResponse\":{\
+    \"SendRawEmailResponse\":{\
       \"type\":\"structure\",\
+      \"required\":[\"MessageId\"],\
       \"members\":{\
-      }\
+        \"MessageId\":{\
+          \"shape\":\"MessageId\",\
+          \"documentation\":\"<p>The unique message identifier returned from the <code>SendRawEmail</code> action. </p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a unique message ID.</p>\"\
     },\
-    \"TagValue\":{\"type\":\"string\"},\
-    \"Template\":{\
+    \"SendTemplatedEmailRequest\":{\
       \"type\":\"structure\",\
+      \"required\":[\
+        \"Source\",\
+        \"Destination\",\
+        \"Template\",\
+        \"TemplateData\"\
+      ],\
       \"members\":{\
-        \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template. You will refer to this name when you send email using the <code>SendTemplatedEmail</code> or <code>SendBulkTemplatedEmail</code> operations. </p>\"\
+        \"Source\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that is sending the email. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. For information about verifying identities, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html\\\">Amazon SES Developer Guide</a>.</p> <p>If you are sending on behalf of another user and have been permitted to do so by a sending authorization policy, then you must also specify the <code>SourceArn</code> parameter. For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p> <note> <p>Amazon SES does not support the SMTPUTF8 extension, as described in <a href=\\\"https://tools.ietf.org/html/rfc6531\\\">RFC6531</a>. For this reason, the <i>local part</i> of a source email address (the part of the email address that precedes the @ sign) may only contain <a href=\\\"https://en.wikipedia.org/wiki/Email_address#Local-part\\\">7-bit ASCII characters</a>. If the <i>domain part</i> of an address (the part after the @ sign) contains non-ASCII characters, they must be encoded using Punycode, as described in <a href=\\\"https://tools.ietf.org/html/rfc3492.html\\\">RFC3492</a>. The sender name (also known as the <i>friendly name</i>) may contain non-ASCII characters. These characters must be encoded using MIME encoded-word syntax, as described in<a href=\\\"https://tools.ietf.org/html/rfc2047\\\">RFC 2047</a>. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>.</p> </note>\"\
+        },\
+        \"Destination\":{\
+          \"shape\":\"Destination\",\
+          \"documentation\":\"<p>The destination for this email, composed of To:, CC:, and BCC: fields. A Destination can include up to 50 recipients across these three fields.</p>\"\
+        },\
+        \"ReplyToAddresses\":{\
+          \"shape\":\"AddressList\",\
+          \"documentation\":\"<p>The reply-to email address(es) for the message. If the recipient replies to the message, each reply-to address will receive the reply.</p>\"\
+        },\
+        \"ReturnPath\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address that bounces and complaints will be forwarded to when feedback forwarding is enabled. If the message cannot be delivered to the recipient, then an error message will be returned from the recipient's ISP; this message will then be forwarded to the email address specified by the <code>ReturnPath</code> parameter. The <code>ReturnPath</code> parameter is never overwritten. This email address must be either individually verified with Amazon SES, or from a domain that has been verified with Amazon SES. </p>\"\
+        },\
+        \"SourceArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to send for the email address specified in the <code>Source</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to send from <code>user@example.com</code>, then you would specify the <code>SourceArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>Source</code> to be <code>user@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        },\
+        \"ReturnPathArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>This parameter is used only for sending authorization. It is the ARN of the identity that is associated with the sending authorization policy that permits you to use the email address specified in the <code>ReturnPath</code> parameter.</p> <p>For example, if the owner of <code>example.com</code> (which has ARN <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>) attaches a policy to it that authorizes you to use <code>feedback@example.com</code>, then you would specify the <code>ReturnPathArn</code> to be <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>, and the <code>ReturnPath</code> to be <code>feedback@example.com</code>.</p> <p>For more information about sending authorization, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        },\
+        \"Tags\":{\
+          \"shape\":\"MessageTagList\",\
+          \"documentation\":\"<p>A list of tags, in the form of name/value pairs, to apply to an email that you send using <code>SendTemplatedEmail</code>. Tags correspond to characteristics of the email that you define, so that you can publish email sending events.</p>\"\
+        },\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set to use when you send an email using <code>SendTemplatedEmail</code>.</p>\"\
+        },\
+        \"Template\":{\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The template to use when sending this email.</p>\"\
         },\
         \"TemplateArn\":{\
           \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the template.</p>\"\
+          \"documentation\":\"<p>The ARN of the template to use when sending this email.</p>\"\
         },\
         \"TemplateData\":{\
-          \"shape\":\"EmailTemplateData\",\
-          \"documentation\":\"<p>An object that defines the values to use for message variables in the template. This object is a set of key-value pairs. Each key defines a message variable in the template. The corresponding value defines the value to use for that variable.</p>\"\
+          \"shape\":\"TemplateData\",\
+          \"documentation\":\"<p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that defines the email template to use for an email message, and the values to use for any message variables in that template. An <i>email template</i> is a type of message template that contains content that you want to define, save, and reuse in email messages that you send.</p>\"\
+      \"documentation\":\"<p>Represents a request to send a templated email using Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"TemplateContent\":{\
+    \"SendTemplatedEmailResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"MessageId\"],\
+      \"members\":{\
+        \"MessageId\":{\
+          \"shape\":\"MessageId\",\
+          \"documentation\":\"<p>The unique message identifier returned from the <code>SendTemplatedEmail</code> action. </p>\"\
+        }\
+      }\
+    },\
+    \"SentLast24Hours\":{\"type\":\"double\"},\
+    \"SetActiveReceiptRuleSetRequest\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set to make active. Setting this value to null disables all email receiving.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to set a receipt rule set as the active receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetActiveReceiptRuleSetResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"SetIdentityDkimEnabledRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Identity\",\
+        \"DkimEnabled\"\
+      ],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The identity for which DKIM signing should be enabled or disabled.</p>\"\
+        },\
+        \"DkimEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Sets whether DKIM signing is enabled for an identity. Set to <code>true</code> to enable DKIM signing for this identity; <code>false</code> to disable it. </p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to enable or disable Amazon SES Easy DKIM signing for an identity. For more information about setting up Easy DKIM, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityDkimEnabledResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"SetIdentityFeedbackForwardingEnabledRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Identity\",\
+        \"ForwardingEnabled\"\
+      ],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The identity for which to set bounce and complaint notification forwarding. Examples: <code>user@example.com</code>, <code>example.com</code>.</p>\"\
+        },\
+        \"ForwardingEnabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Sets whether Amazon SES will forward bounce and complaint notifications as email. <code>true</code> specifies that Amazon SES will forward bounce and complaint notifications as email, in addition to any Amazon SNS topic publishing otherwise specified. <code>false</code> specifies that Amazon SES will publish bounce and complaint notifications only through Amazon SNS. This value can only be set to <code>false</code> when Amazon SNS topics are set for both <code>Bounce</code> and <code>Complaint</code> notification types.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to enable or disable whether Amazon SES forwards you bounce and complaint notifications through email. For information about email feedback forwarding, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-email.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityFeedbackForwardingEnabledResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"SetIdentityHeadersInNotificationsEnabledRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Identity\",\
+        \"NotificationType\",\
+        \"Enabled\"\
+      ],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The identity for which to enable or disable headers in notifications. Examples: <code>user@example.com</code>, <code>example.com</code>.</p>\"\
+        },\
+        \"NotificationType\":{\
+          \"shape\":\"NotificationType\",\
+          \"documentation\":\"<p>The notification type for which to enable or disable headers in notifications. </p>\"\
+        },\
+        \"Enabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Sets whether Amazon SES includes the original email headers in Amazon SNS notifications of the specified notification type. A value of <code>true</code> specifies that Amazon SES will include headers in notifications, and a value of <code>false</code> specifies that Amazon SES will not include headers in notifications.</p> <p>This value can only be set when <code>NotificationType</code> is already set to use a particular Amazon SNS topic.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to set whether Amazon SES includes the original email headers in the Amazon SNS notifications of a specified type. For information about notifications, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityHeadersInNotificationsEnabledResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"SetIdentityMailFromDomainRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Identity\"],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The verified identity for which you want to enable or disable the specified custom MAIL FROM domain.</p>\"\
+        },\
+        \"MailFromDomain\":{\
+          \"shape\":\"MailFromDomainName\",\
+          \"documentation\":\"<p>The custom MAIL FROM domain that you want the verified identity to use. The MAIL FROM domain must 1) be a subdomain of the verified identity, 2) not be used in a \\\"From\\\" address if the MAIL FROM domain is the destination of email feedback forwarding (for more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html\\\">Amazon SES Developer Guide</a>), and 3) not be used to receive emails. A value of <code>null</code> disables the custom MAIL FROM setting for the identity.</p>\"\
+        },\
+        \"BehaviorOnMXFailure\":{\
+          \"shape\":\"BehaviorOnMXFailure\",\
+          \"documentation\":\"<p>The action that you want Amazon SES to take if it cannot successfully read the required MX record when you send an email. If you choose <code>UseDefaultValue</code>, Amazon SES will use amazonses.com (or a subdomain of that) as the MAIL FROM domain. If you choose <code>RejectMessage</code>, Amazon SES will return a <code>MailFromDomainNotVerified</code> error and not send the email.</p> <p>The action specified in <code>BehaviorOnMXFailure</code> is taken when the custom MAIL FROM domain setup is in the <code>Pending</code>, <code>Failed</code>, and <code>TemporaryFailure</code> states.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to enable or disable the Amazon SES custom MAIL FROM domain setup for a verified identity. For information about using a custom MAIL FROM domain, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityMailFromDomainResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"SetIdentityNotificationTopicRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"Identity\",\
+        \"NotificationType\"\
+      ],\
+      \"members\":{\
+        \"Identity\":{\
+          \"shape\":\"Identity\",\
+          \"documentation\":\"<p>The identity (email address or domain) that you want to set the Amazon SNS topic for.</p> <important> <p>You can only specify a verified identity for this parameter.</p> </important> <p>You can specify an identity by using its name or by using its Amazon Resource Name (ARN). The following examples are all valid identities: <code>sender@example.com</code>, <code>example.com</code>, <code>arn:aws:ses:us-east-1:123456789012:identity/example.com</code>.</p>\"\
+        },\
+        \"NotificationType\":{\
+          \"shape\":\"NotificationType\",\
+          \"documentation\":\"<p>The type of notifications that will be published to the specified Amazon SNS topic.</p>\"\
+        },\
+        \"SnsTopic\":{\
+          \"shape\":\"NotificationTopic\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic. If the parameter is omitted from the request or a null value is passed, <code>SnsTopic</code> is cleared and publishing is disabled.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to specify the Amazon SNS topic to which Amazon SES will publish bounce, complaint, or delivery notifications for emails sent with that identity as the Source. For information about Amazon SES notifications, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications-via-sns.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetIdentityNotificationTopicResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"SetReceiptRulePositionRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"RuleSetName\",\
+        \"RuleName\"\
+      ],\
+      \"members\":{\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set that contains the receipt rule to reposition.</p>\"\
+        },\
+        \"RuleName\":{\
+          \"shape\":\"ReceiptRuleName\",\
+          \"documentation\":\"<p>The name of the receipt rule to reposition.</p>\"\
+        },\
+        \"After\":{\
+          \"shape\":\"ReceiptRuleName\",\
+          \"documentation\":\"<p>The name of the receipt rule after which to place the specified receipt rule.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to set the position of a receipt rule in a receipt rule set. You use receipt rule sets to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"SetReceiptRulePositionResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"StopAction\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Scope\"],\
+      \"members\":{\
+        \"Scope\":{\
+          \"shape\":\"StopScope\",\
+          \"documentation\":\"<p>The scope of the StopAction. The only acceptable value is <code>RuleSet</code>.</p>\"\
+        },\
+        \"TopicArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the stop action is taken. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>When included in a receipt rule, this action terminates the evaluation of the receipt rule set and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS).</p> <p>For information about setting a stop action in a receipt rule, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-stop.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"StopScope\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>The content of the custom verification email template.</p>\"\
+      \"enum\":[\"RuleSet\"]\
     },\
-    \"TestRenderEmailTemplateRequest\":{\
+    \"Subject\":{\"type\":\"string\"},\
+    \"SubjectPart\":{\"type\":\"string\"},\
+    \"SuccessRedirectionURL\":{\"type\":\"string\"},\
+    \"Template\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"TemplateName\"],\
+      \"members\":{\
+        \"TemplateName\":{\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the template. You will refer to this name when you send email using the <code>SendTemplatedEmail</code> or <code>SendBulkTemplatedEmail</code> operations.</p>\"\
+        },\
+        \"SubjectPart\":{\
+          \"shape\":\"SubjectPart\",\
+          \"documentation\":\"<p>The subject line of the email.</p>\"\
+        },\
+        \"TextPart\":{\
+          \"shape\":\"TextPart\",\
+          \"documentation\":\"<p>The email body that will be visible to recipients whose email clients do not display HTML.</p>\"\
+        },\
+        \"HtmlPart\":{\
+          \"shape\":\"HtmlPart\",\
+          \"documentation\":\"<p>The HTML body of the email.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>The content of the email, composed of a subject line, an HTML part, and a text-only part.</p>\"\
+    },\
+    \"TemplateContent\":{\"type\":\"string\"},\
+    \"TemplateData\":{\
+      \"type\":\"string\",\
+      \"max\":262144\
+    },\
+    \"TemplateDoesNotExistException\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"TemplateName\":{\"shape\":\"TemplateName\"}\
+      },\
+      \"documentation\":\"<p>Indicates that the Template object you specified does not exist in your Amazon SES account.</p>\",\
+      \"error\":{\
+        \"code\":\"TemplateDoesNotExist\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"TemplateMetadata\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Name\":{\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the template.</p>\"\
+        },\
+        \"CreatedTimestamp\":{\
+          \"shape\":\"Timestamp\",\
+          \"documentation\":\"<p>The time and date the template was created.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Contains information about an email template.</p>\"\
+    },\
+    \"TemplateMetadataList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"TemplateMetadata\"}\
+    },\
+    \"TemplateName\":{\"type\":\"string\"},\
+    \"TestRenderTemplateRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
         \"TemplateName\",\
@@ -4747,144 +4198,185 @@
       ],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template that you want to render.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the template that you want to render.</p>\"\
         },\
         \"TemplateData\":{\
-          \"shape\":\"EmailTemplateData\",\
+          \"shape\":\"TemplateData\",\
           \"documentation\":\"<p>A list of replacement values to apply to the template. This parameter is a JSON object, typically consisting of key-value pairs in which the keys correspond to replacement tags in the email template.</p>\"\
         }\
-      },\
-      \"documentation\":\"<p>&gt;Represents a request to create a preview of the MIME content of an email when provided with a template and a set of replacement data.</p>\"\
+      }\
     },\
-    \"TestRenderEmailTemplateResponse\":{\
+    \"TestRenderTemplateResponse\":{\
       \"type\":\"structure\",\
-      \"required\":[\"RenderedTemplate\"],\
       \"members\":{\
         \"RenderedTemplate\":{\
-          \"shape\":\"RenderedEmailTemplate\",\
-          \"documentation\":\"<p>The complete MIME message rendered by applying the data in the <code>TemplateData</code> parameter to the template specified in the TemplateName parameter.</p>\"\
+          \"shape\":\"RenderedTemplate\",\
+          \"documentation\":\"<p>The complete MIME message rendered by applying the data in the TemplateData parameter to the template specified in the TemplateName parameter.</p>\"\
         }\
-      },\
-      \"documentation\":\"<p>The following element is returned by the service.</p>\"\
+      }\
     },\
+    \"TextPart\":{\"type\":\"string\"},\
     \"Timestamp\":{\"type\":\"timestamp\"},\
     \"TlsPolicy\":{\
       \"type\":\"string\",\
-      \"documentation\":\"<p>Specifies whether messages that use the configuration set are required to use Transport Layer Security (TLS). If the value is <code>Require</code>, messages are only delivered if a TLS connection can be established. If the value is <code>Optional</code>, messages can be delivered in plain text if a TLS connection can't be established.</p>\",\
       \"enum\":[\
-        \"REQUIRE\",\
-        \"OPTIONAL\"\
+        \"Require\",\
+        \"Optional\"\
       ]\
-    },\
-    \"TooManyRequestsException\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>Too many requests have been made to the operation.</p>\",\
-      \"error\":{\"httpStatusCode\":429},\
-      \"exception\":true\
     },\
     \"TrackingOptions\":{\
       \"type\":\"structure\",\
-      \"required\":[\"CustomRedirectDomain\"],\
       \"members\":{\
         \"CustomRedirectDomain\":{\
           \"shape\":\"CustomRedirectDomain\",\
-          \"documentation\":\"<p>The domain that you want to use for tracking open and click events.</p>\"\
+          \"documentation\":\"<p>The custom subdomain that will be used to redirect email recipients to the Amazon SES event tracking domain.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>An object that defines the tracking options for a configuration set. When you use the Amazon SES API v2 to send an email, it contains an invisible image that's used to track when recipients open your email. If your email contains links, those links are changed slightly in order to track when recipients click them.</p> <p>These images and links include references to a domain operated by AWS. You can optionally configure the Amazon SES to use a domain that you operate for these images and links.</p>\"\
+      \"documentation\":\"<p>A domain that is used to redirect email recipients to an Amazon SES-operated domain. This domain captures open and click events generated by Amazon SES emails.</p> <p>For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html\\\">Configuring Custom Domains to Handle Open and Click Tracking</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
     },\
-    \"UntagResourceRequest\":{\
+    \"TrackingOptionsAlreadyExistsException\":{\
       \"type\":\"structure\",\
-      \"required\":[\
-        \"ResourceArn\",\
-        \"TagKeys\"\
-      ],\
       \"members\":{\
-        \"ResourceArn\":{\
-          \"shape\":\"AmazonResourceName\",\
-          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the resource that you want to remove one or more tags from.</p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"ResourceArn\"\
-        },\
-        \"TagKeys\":{\
-          \"shape\":\"TagKeyList\",\
-          \"documentation\":\"<p>The tags (tag keys) that you want to remove from the resource. When you specify a tag key, the action removes both that key and its associated tag value.</p> <p>To remove more than one tag from the resource, append the <code>TagKeys</code> parameter and argument for each additional tag to remove, separated by an ampersand. For example: <code>/v2/email/tags?ResourceArn=ResourceArn&amp;TagKeys=Key1&amp;TagKeys=Key2</code> </p>\",\
-          \"location\":\"querystring\",\
-          \"locationName\":\"TagKeys\"\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that a TrackingOptions object already exists in the specified configuration set.</p>\"\
         }\
-      }\
+      },\
+      \"documentation\":\"<p>Indicates that the configuration set you specified already contains a TrackingOptions object.</p>\",\
+      \"error\":{\
+        \"code\":\"TrackingOptionsAlreadyExistsException\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
     },\
-    \"UntagResourceResponse\":{\
+    \"TrackingOptionsDoesNotExistException\":{\
       \"type\":\"structure\",\
       \"members\":{\
-      }\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>Indicates that a TrackingOptions object does not exist in the specified configuration set.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Indicates that the TrackingOptions object you specified does not exist.</p>\",\
+      \"error\":{\
+        \"code\":\"TrackingOptionsDoesNotExistException\",\
+        \"httpStatusCode\":400,\
+        \"senderFault\":true\
+      },\
+      \"exception\":true\
+    },\
+    \"UpdateAccountSendingEnabledRequest\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+        \"Enabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether email sending is enabled or disabled for your Amazon SES account in the current AWS Region.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to enable or disable the email sending capabilities for your entire Amazon SES account.</p>\"\
     },\
     \"UpdateConfigurationSetEventDestinationRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
         \"ConfigurationSetName\",\
-        \"EventDestinationName\",\
         \"EventDestination\"\
       ],\
       \"members\":{\
         \"ConfigurationSetName\":{\
           \"shape\":\"ConfigurationSetName\",\
-          \"documentation\":\"<p>The name of the configuration set that contains the event destination that you want to modify.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"ConfigurationSetName\"\
-        },\
-        \"EventDestinationName\":{\
-          \"shape\":\"EventDestinationName\",\
-          \"documentation\":\"<p>The name of the event destination that you want to modify.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EventDestinationName\"\
+          \"documentation\":\"<p>The name of the configuration set that contains the event destination that you want to update.</p>\"\
         },\
         \"EventDestination\":{\
-          \"shape\":\"EventDestinationDefinition\",\
-          \"documentation\":\"<p>An object that defines the event destination.</p>\"\
+          \"shape\":\"EventDestination\",\
+          \"documentation\":\"<p>The event destination object that you want to apply to the specified configuration set.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>A request to change the settings for an event destination for a configuration set.</p>\"\
+      \"documentation\":\"<p>Represents a request to update the event destination of a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
     \"UpdateConfigurationSetEventDestinationResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"UpdateConfigurationSetReputationMetricsEnabledRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"ConfigurationSetName\",\
+        \"Enabled\"\
+      ],\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set that you want to update.</p>\"\
+        },\
+        \"Enabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether or not Amazon SES will publish reputation metrics for the configuration set, such as bounce and complaint rates, to Amazon CloudWatch.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to modify the reputation metric publishing settings for a configuration set.</p>\"\
+    },\
+    \"UpdateConfigurationSetSendingEnabledRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"ConfigurationSetName\",\
+        \"Enabled\"\
+      ],\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set that you want to update.</p>\"\
+        },\
+        \"Enabled\":{\
+          \"shape\":\"Enabled\",\
+          \"documentation\":\"<p>Describes whether email sending is enabled or disabled for the configuration set. </p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to enable or disable the email sending capabilities for a specific configuration set.</p>\"\
+    },\
+    \"UpdateConfigurationSetTrackingOptionsRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\
+        \"ConfigurationSetName\",\
+        \"TrackingOptions\"\
+      ],\
+      \"members\":{\
+        \"ConfigurationSetName\":{\
+          \"shape\":\"ConfigurationSetName\",\
+          \"documentation\":\"<p>The name of the configuration set for which you want to update the custom tracking domain.</p>\"\
+        },\
+        \"TrackingOptions\":{\"shape\":\"TrackingOptions\"}\
+      },\
+      \"documentation\":\"<p>Represents a request to update the tracking options for a configuration set. </p>\"\
+    },\
+    \"UpdateConfigurationSetTrackingOptionsResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
     \"UpdateCustomVerificationEmailTemplateRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\
-        \"TemplateName\",\
-        \"FromEmailAddress\",\
-        \"TemplateSubject\",\
-        \"TemplateContent\",\
-        \"SuccessRedirectionURL\",\
-        \"FailureRedirectionURL\"\
-      ],\
+      \"required\":[\"TemplateName\"],\
       \"members\":{\
         \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the custom verification email template that you want to update.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
+          \"shape\":\"TemplateName\",\
+          \"documentation\":\"<p>The name of the custom verification email template that you want to update.</p>\"\
         },\
         \"FromEmailAddress\":{\
-          \"shape\":\"EmailAddress\",\
+          \"shape\":\"FromAddress\",\
           \"documentation\":\"<p>The email address that the custom verification email is sent from.</p>\"\
         },\
         \"TemplateSubject\":{\
-          \"shape\":\"EmailTemplateSubject\",\
+          \"shape\":\"Subject\",\
           \"documentation\":\"<p>The subject line of the custom verification email.</p>\"\
         },\
         \"TemplateContent\":{\
           \"shape\":\"TemplateContent\",\
-          \"documentation\":\"<p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html#custom-verification-emails-faq\\\">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
+          \"documentation\":\"<p>The content of the custom verification email. The total size of the email must be less than 10 MB. The message body may contain HTML, with some limitations. For more information, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html#custom-verification-emails-faq\\\">Custom Verification Email Frequently Asked Questions</a> in the <i>Amazon SES Developer Guide</i>.</p>\"\
         },\
         \"SuccessRedirectionURL\":{\
           \"shape\":\"SuccessRedirectionURL\",\
@@ -4897,120 +4389,151 @@
       },\
       \"documentation\":\"<p>Represents a request to update an existing custom verification email template.</p>\"\
     },\
-    \"UpdateCustomVerificationEmailTemplateResponse\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>\"\
-    },\
-    \"UpdateEmailIdentityPolicyRequest\":{\
+    \"UpdateReceiptRuleRequest\":{\
       \"type\":\"structure\",\
       \"required\":[\
-        \"EmailIdentity\",\
-        \"PolicyName\",\
-        \"Policy\"\
+        \"RuleSetName\",\
+        \"Rule\"\
       ],\
       \"members\":{\
-        \"EmailIdentity\":{\
-          \"shape\":\"Identity\",\
-          \"documentation\":\"<p>The email identity for which you want to update policy.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"EmailIdentity\"\
+        \"RuleSetName\":{\
+          \"shape\":\"ReceiptRuleSetName\",\
+          \"documentation\":\"<p>The name of the receipt rule set that the receipt rule belongs to.</p>\"\
         },\
-        \"PolicyName\":{\
-          \"shape\":\"PolicyName\",\
-          \"documentation\":\"<p>The name of the policy.</p> <p>The policy name cannot exceed 64 characters and can only include alphanumeric characters, dashes, and underscores.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"PolicyName\"\
-        },\
-        \"Policy\":{\
-          \"shape\":\"Policy\",\
-          \"documentation\":\"<p>The text of the policy in JSON format. The policy cannot exceed 4 KB.</p> <p> For information about the syntax of sending authorization policies, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        \"Rule\":{\
+          \"shape\":\"ReceiptRule\",\
+          \"documentation\":\"<p>A data structure that contains the updated receipt rule information.</p>\"\
         }\
       },\
-      \"documentation\":\"<p>Represents a request to update a sending authorization policy for an identity. Sending authorization is an Amazon SES feature that enables you to authorize other senders to use your identities. For information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-identity-owner-tasks-management.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+      \"documentation\":\"<p>Represents a request to update a receipt rule. You use receipt rules to receive email with Amazon SES. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-concepts.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     },\
-    \"UpdateEmailIdentityPolicyResponse\":{\
+    \"UpdateReceiptRuleResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
       },\
-      \"documentation\":\"<p>An HTTP 200 response if the request succeeds, or an error message if the request fails.</p>\"\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
     },\
-    \"UpdateEmailTemplateRequest\":{\
+    \"UpdateTemplateRequest\":{\
       \"type\":\"structure\",\
-      \"required\":[\
-        \"TemplateName\",\
-        \"TemplateContent\"\
-      ],\
+      \"required\":[\"Template\"],\
       \"members\":{\
-        \"TemplateName\":{\
-          \"shape\":\"EmailTemplateName\",\
-          \"documentation\":\"<p>The name of the template you want to update.</p>\",\
-          \"location\":\"uri\",\
-          \"locationName\":\"TemplateName\"\
-        },\
-        \"TemplateContent\":{\
-          \"shape\":\"EmailTemplateContent\",\
-          \"documentation\":\"<p>The content of the email template, composed of a subject line, an HTML part, and a text-only part.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>Represents a request to update an email template. For more information, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        \"Template\":{\"shape\":\"Template\"}\
+      }\
     },\
-    \"UpdateEmailTemplateResponse\":{\
+    \"UpdateTemplateResponse\":{\
       \"type\":\"structure\",\
       \"members\":{\
-      },\
-      \"documentation\":\"<p>If the action is successful, the service sends back an HTTP 200 response with an empty HTTP body.</p>\"\
+      }\
     },\
-    \"UseCaseDescription\":{\
+    \"VerificationAttributes\":{\
+      \"type\":\"map\",\
+      \"key\":{\"shape\":\"Identity\"},\
+      \"value\":{\"shape\":\"IdentityVerificationAttributes\"}\
+    },\
+    \"VerificationStatus\":{\
       \"type\":\"string\",\
-      \"max\":5000,\
-      \"min\":1,\
-      \"sensitive\":true\
-    },\
-    \"Volume\":{\
-      \"type\":\"long\",\
-      \"documentation\":\"<p>An object that contains information about inbox placement volume.</p>\"\
-    },\
-    \"VolumeStatistics\":{\
-      \"type\":\"structure\",\
-      \"members\":{\
-        \"InboxRawCount\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The total number of emails that arrived in recipients' inboxes.</p>\"\
-        },\
-        \"SpamRawCount\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>The total number of emails that arrived in recipients' spam or junk mail folders.</p>\"\
-        },\
-        \"ProjectedInbox\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>An estimate of the percentage of emails sent from the current domain that will arrive in recipients' inboxes.</p>\"\
-        },\
-        \"ProjectedSpam\":{\
-          \"shape\":\"Volume\",\
-          \"documentation\":\"<p>An estimate of the percentage of emails sent from the current domain that will arrive in recipients' spam or junk mail folders.</p>\"\
-        }\
-      },\
-      \"documentation\":\"<p>An object that contains information about the amount of email that was delivered to recipients.</p>\"\
-    },\
-    \"WarmupStatus\":{\
-      \"type\":\"string\",\
-      \"documentation\":\"<p>The warmup status of a dedicated IP.</p>\",\
       \"enum\":[\
-        \"IN_PROGRESS\",\
-        \"DONE\"\
+        \"Pending\",\
+        \"Success\",\
+        \"Failed\",\
+        \"TemporaryFailure\",\
+        \"NotStarted\"\
       ]\
     },\
-    \"WebsiteURL\":{\
-      \"type\":\"string\",\
-      \"max\":1000,\
-      \"min\":1,\
-      \"pattern\":\"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\\\?([^#]*))?(#(.*))?\",\
-      \"sensitive\":true\
+    \"VerificationToken\":{\"type\":\"string\"},\
+    \"VerificationTokenList\":{\
+      \"type\":\"list\",\
+      \"member\":{\"shape\":\"VerificationToken\"}\
+    },\
+    \"VerifyDomainDkimRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Domain\"],\
+      \"members\":{\
+        \"Domain\":{\
+          \"shape\":\"Domain\",\
+          \"documentation\":\"<p>The name of the domain to be verified for Easy DKIM signing.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to generate the CNAME records needed to set up Easy DKIM with Amazon SES. For more information about setting up Easy DKIM, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"VerifyDomainDkimResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"DkimTokens\"],\
+      \"members\":{\
+        \"DkimTokens\":{\
+          \"shape\":\"VerificationTokenList\",\
+          \"documentation\":\"<p>A set of character strings that represent the domain's identity. If the identity is an email address, the tokens represent the domain of that address.</p> <p>Using these tokens, you need to create DNS CNAME records that point to DKIM public keys that are hosted by Amazon SES. Amazon Web Services eventually detects that you've updated your DNS records. This detection process might take up to 72 hours. After successful detection, Amazon SES is able to DKIM-sign email originating from that domain. (This only applies to domain identities, not email address identities.)</p> <p>For more information about creating DNS records using DKIM tokens, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Returns CNAME records that you must publish to the DNS server of your domain to set up Easy DKIM with Amazon SES.</p>\"\
+    },\
+    \"VerifyDomainIdentityRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"Domain\"],\
+      \"members\":{\
+        \"Domain\":{\
+          \"shape\":\"Domain\",\
+          \"documentation\":\"<p>The domain to be verified.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to begin Amazon SES domain verification and to generate the TXT records that you must publish to the DNS server of your domain to complete the verification. For information about domain verification, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"VerifyDomainIdentityResponse\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"VerificationToken\"],\
+      \"members\":{\
+        \"VerificationToken\":{\
+          \"shape\":\"VerificationToken\",\
+          \"documentation\":\"<p>A TXT record that you must place in the DNS settings of the domain to complete domain verification with Amazon SES.</p> <p>As Amazon SES searches for the TXT record, the domain's verification status is \\\"Pending\\\". When Amazon SES detects the record, the domain's verification status changes to \\\"Success\\\". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to \\\"Failed.\\\" In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Returns a TXT record that you must publish to the DNS server of your domain to complete domain verification with Amazon SES.</p>\"\
+    },\
+    \"VerifyEmailAddressRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"EmailAddress\"],\
+      \"members\":{\
+        \"EmailAddress\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address to be verified.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"VerifyEmailIdentityRequest\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"EmailAddress\"],\
+      \"members\":{\
+        \"EmailAddress\":{\
+          \"shape\":\"Address\",\
+          \"documentation\":\"<p>The email address to be verified.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>Represents a request to begin email address verification with Amazon SES. For information about email address verification, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html\\\">Amazon SES Developer Guide</a>.</p>\"\
+    },\
+    \"VerifyEmailIdentityResponse\":{\
+      \"type\":\"structure\",\
+      \"members\":{\
+      },\
+      \"documentation\":\"<p>An empty element returned on a successful request.</p>\"\
+    },\
+    \"WorkmailAction\":{\
+      \"type\":\"structure\",\
+      \"required\":[\"OrganizationArn\"],\
+      \"members\":{\
+        \"TopicArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The Amazon Resource Name (ARN) of the Amazon SNS topic to notify when the WorkMail action is called. An example of an Amazon SNS topic ARN is <code>arn:aws:sns:us-west-2:123456789012:MyTopic</code>. For more information about Amazon SNS topics, see the <a href=\\\"https://docs.aws.amazon.com/sns/latest/dg/CreateTopic.html\\\">Amazon SNS Developer Guide</a>.</p>\"\
+        },\
+        \"OrganizationArn\":{\
+          \"shape\":\"AmazonResourceName\",\
+          \"documentation\":\"<p>The ARN of the Amazon WorkMail organization. An example of an Amazon WorkMail organization ARN is <code>arn:aws:workmail:us-west-2:123456789012:organization/m-68755160c4cb4e29a2b2f8fb58f359d7</code>. For information about Amazon WorkMail organizations, see the <a href=\\\"https://docs.aws.amazon.com/workmail/latest/adminguide/organizations_overview.html\\\">Amazon WorkMail Administrator Guide</a>.</p>\"\
+        }\
+      },\
+      \"documentation\":\"<p>When included in a receipt rule, this action calls Amazon WorkMail and, optionally, publishes a notification to Amazon Simple Notification Service (Amazon SNS). You will typically not use this action directly because Amazon WorkMail adds the rule automatically during its setup procedure.</p> <p>For information using a receipt rule to call Amazon WorkMail, see the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-action-workmail.html\\\">Amazon SES Developer Guide</a>.</p>\"\
     }\
   },\
-  \"documentation\":\"<fullname>Amazon SES API v2</fullname> <p>Welcome to the Amazon SES API v2 Reference. This guide provides information about the Amazon SES API v2, including supported operations, data types, parameters, and schemas.</p> <p> <a href=\\\"https://aws.amazon.com/pinpoint\\\">Amazon SES</a> is an AWS service that you can use to send email messages to your customers.</p> <p>If you're new to Amazon SES API v2, you might find it helpful to also review the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/\\\">Amazon Simple Email Service Developer Guide</a>. The <i>Amazon SES Developer Guide</i> provides information and code samples that demonstrate how to use Amazon SES API v2 features programmatically.</p> <p>The Amazon SES API v2 is available in several AWS Regions and it provides an endpoint for each of these Regions. For a list of all the Regions and endpoints where the API is currently available, see <a href=\\\"https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region\\\">AWS Service Endpoints</a> in the <i>Amazon Web Services General Reference</i>. To learn more about AWS Regions, see <a href=\\\"https://docs.aws.amazon.com/general/latest/gr/rande-manage.html\\\">Managing AWS Regions</a> in the <i>Amazon Web Services General Reference</i>.</p> <p>In each Region, AWS maintains multiple Availability Zones. These Availability Zones are physically isolated from each other, but are united by private, low-latency, high-throughput, and highly redundant network connections. These Availability Zones enable us to provide very high levels of availability and redundancy, while also minimizing latency. To learn more about the number of Availability Zones that are available in each Region, see <a href=\\\"http://aws.amazon.com/about-aws/global-infrastructure/\\\">AWS Global Infrastructure</a>.</p>\"\
+  \"documentation\":\"<fullname>Amazon Simple Email Service</fullname> <p> This document contains reference information for the <a href=\\\"https://aws.amazon.com/ses/\\\">Amazon Simple Email Service</a> (Amazon SES) API, version 2010-12-01. This document is best used in conjunction with the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html\\\">Amazon SES Developer Guide</a>. </p> <note> <p> For a list of Amazon SES endpoints to use in service requests, see <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html\\\">Regions and Amazon SES</a> in the <a href=\\\"https://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html\\\">Amazon SES Developer Guide</a>.</p> </note>\"\
 }\
 ";
 }

--- a/AWSSES/AWSSESService.h
+++ b/AWSSES/AWSSESService.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 
 /**
- <fullname>Amazon SES API v2</fullname><p>Welcome to the Amazon SES API v2 Reference. This guide provides information about the Amazon SES API v2, including supported operations, data types, parameters, and schemas.</p><p><a href="https://aws.amazon.com/pinpoint">Amazon SES</a> is an AWS service that you can use to send email messages to your customers.</p><p>If you're new to Amazon SES API v2, you might find it helpful to also review the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/">Amazon Simple Email Service Developer Guide</a>. The <i>Amazon SES Developer Guide</i> provides information and code samples that demonstrate how to use Amazon SES API v2 features programmatically.</p><p>The Amazon SES API v2 is available in several AWS Regions and it provides an endpoint for each of these Regions. For a list of all the Regions and endpoints where the API is currently available, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#ses_region">AWS Service Endpoints</a> in the <i>Amazon Web Services General Reference</i>. To learn more about AWS Regions, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande-manage.html">Managing AWS Regions</a> in the <i>Amazon Web Services General Reference</i>.</p><p>In each Region, AWS maintains multiple Availability Zones. These Availability Zones are physically isolated from each other, but are united by private, low-latency, high-throughput, and highly redundant network connections. These Availability Zones enable us to provide very high levels of availability and redundancy, while also minimizing latency. To learn more about the number of Availability Zones that are available in each Region, see <a href="http://aws.amazon.com/about-aws/global-infrastructure/">AWS Global Infrastructure</a>.</p>
+ <fullname>Amazon Simple Email Service</fullname><p> This document contains reference information for the <a href="https://aws.amazon.com/ses/">Amazon Simple Email Service</a> (Amazon SES) API, version 2010-12-01. This document is best used in conjunction with the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html">Amazon SES Developer Guide</a>. </p><note><p> For a list of Amazon SES endpoints to use in service requests, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html">Regions and Amazon SES</a> in the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/Welcome.html">Amazon SES Developer Guide</a>.</p></note>
  */
 @interface AWSSES : AWSService
 
@@ -175,11 +175,36 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 + (void)removeSESForKey:(NSString *)key;
 
 /**
- <p>Create a configuration set. <i>Configuration sets</i> are groups of rules that you can apply to the emails that you send. You apply a configuration set to an email by specifying the name of the configuration set when you call the Amazon SES API v2. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email. </p>
+ <p>Creates a receipt rule set by cloning an existing one. All receipt rules and configurations are copied to the new receipt rule set and are completely independent of the source rule set.</p><p>For information about setting up rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the CloneReceiptRuleSet service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCloneReceiptRuleSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`.
+ 
+ @see AWSSESCloneReceiptRuleSetRequest
+ @see AWSSESCloneReceiptRuleSetResponse
+ */
+- (AWSTask<AWSSESCloneReceiptRuleSetResponse *> *)cloneReceiptRuleSet:(AWSSESCloneReceiptRuleSetRequest *)request;
+
+/**
+ <p>Creates a receipt rule set by cloning an existing one. All receipt rules and configurations are copied to the new receipt rule set and are completely independent of the source rule set.</p><p>For information about setting up rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the CloneReceiptRuleSet service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`.
+ 
+ @see AWSSESCloneReceiptRuleSetRequest
+ @see AWSSESCloneReceiptRuleSetResponse
+ */
+- (void)cloneReceiptRuleSet:(AWSSESCloneReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCloneReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Creates a configuration set.</p><p>Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the CreateConfigurationSet service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateConfigurationSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateConfigurationSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetAlreadyExists`, `AWSSESErrorInvalidConfigurationSet`, `AWSSESErrorLimitExceeded`.
  
  @see AWSSESCreateConfigurationSetRequest
  @see AWSSESCreateConfigurationSetResponse
@@ -187,12 +212,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESCreateConfigurationSetResponse *> *)createConfigurationSet:(AWSSESCreateConfigurationSetRequest *)request;
 
 /**
- <p>Create a configuration set. <i>Configuration sets</i> are groups of rules that you can apply to the emails that you send. You apply a configuration set to an email by specifying the name of the configuration set when you call the Amazon SES API v2. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email. </p>
+ <p>Creates a configuration set.</p><p>Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the CreateConfigurationSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetAlreadyExists`, `AWSSESErrorInvalidConfigurationSet`, `AWSSESErrorLimitExceeded`.
  
  @see AWSSESCreateConfigurationSetRequest
  @see AWSSESCreateConfigurationSetResponse
@@ -200,11 +225,11 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)createConfigurationSet:(AWSSESCreateConfigurationSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateConfigurationSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Create an event destination. <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p><p>A single configuration set can include more than one event destination.</p>
+ <p>Creates a configuration set event destination.</p><note><p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS).</p></note><p>An event destination is the AWS service to which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the CreateConfigurationSetEventDestination service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateConfigurationSetEventDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateConfigurationSetEventDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorEventDestinationAlreadyExists`, `AWSSESErrorInvalidCloudWatchDestination`, `AWSSESErrorInvalidFirehoseDestination`, `AWSSESErrorInvalidSNSDestination`, `AWSSESErrorLimitExceeded`.
  
  @see AWSSESCreateConfigurationSetEventDestinationRequest
  @see AWSSESCreateConfigurationSetEventDestinationResponse
@@ -212,12 +237,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESCreateConfigurationSetEventDestinationResponse *> *)createConfigurationSetEventDestination:(AWSSESCreateConfigurationSetEventDestinationRequest *)request;
 
 /**
- <p>Create an event destination. <i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p><p>A single configuration set can include more than one event destination.</p>
+ <p>Creates a configuration set event destination.</p><note><p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS).</p></note><p>An event destination is the AWS service to which Amazon SES publishes the email sending events associated with a configuration set. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the CreateConfigurationSetEventDestination service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorEventDestinationAlreadyExists`, `AWSSESErrorInvalidCloudWatchDestination`, `AWSSESErrorInvalidFirehoseDestination`, `AWSSESErrorInvalidSNSDestination`, `AWSSESErrorLimitExceeded`.
  
  @see AWSSESCreateConfigurationSetEventDestinationRequest
  @see AWSSESCreateConfigurationSetEventDestinationResponse
@@ -225,186 +250,158 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)createConfigurationSetEventDestination:(AWSSESCreateConfigurationSetEventDestinationRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateConfigurationSetEventDestinationResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Creates a new custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Creates an association between a configuration set and a custom domain for open and click event tracking. </p><p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the CreateConfigurationSetTrackingOptions service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateConfigurationSetTrackingOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTrackingOptionsAlreadyExists`, `AWSSESErrorInvalidTrackingOptions`.
+ 
+ @see AWSSESCreateConfigurationSetTrackingOptionsRequest
+ @see AWSSESCreateConfigurationSetTrackingOptionsResponse
+ */
+- (AWSTask<AWSSESCreateConfigurationSetTrackingOptionsResponse *> *)createConfigurationSetTrackingOptions:(AWSSESCreateConfigurationSetTrackingOptionsRequest *)request;
+
+/**
+ <p>Creates an association between a configuration set and a custom domain for open and click event tracking. </p><p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the CreateConfigurationSetTrackingOptions service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTrackingOptionsAlreadyExists`, `AWSSESErrorInvalidTrackingOptions`.
+ 
+ @see AWSSESCreateConfigurationSetTrackingOptionsRequest
+ @see AWSSESCreateConfigurationSetTrackingOptionsResponse
+ */
+- (void)createConfigurationSetTrackingOptions:(AWSSESCreateConfigurationSetTrackingOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateConfigurationSetTrackingOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Creates a new custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the CreateCustomVerificationEmailTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateCustomVerificationEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorAlreadyExists`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCustomVerificationEmailTemplateAlreadyExists`, `AWSSESErrorFromEmailAddressNotVerified`, `AWSSESErrorCustomVerificationEmailInvalidContent`, `AWSSESErrorLimitExceeded`.
  
  @see AWSSESCreateCustomVerificationEmailTemplateRequest
- @see AWSSESCreateCustomVerificationEmailTemplateResponse
  */
-- (AWSTask<AWSSESCreateCustomVerificationEmailTemplateResponse *> *)createCustomVerificationEmailTemplate:(AWSSESCreateCustomVerificationEmailTemplateRequest *)request;
+- (AWSTask *)createCustomVerificationEmailTemplate:(AWSSESCreateCustomVerificationEmailTemplateRequest *)request;
 
 /**
- <p>Creates a new custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Creates a new custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the CreateCustomVerificationEmailTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorAlreadyExists`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCustomVerificationEmailTemplateAlreadyExists`, `AWSSESErrorFromEmailAddressNotVerified`, `AWSSESErrorCustomVerificationEmailInvalidContent`, `AWSSESErrorLimitExceeded`.
  
  @see AWSSESCreateCustomVerificationEmailTemplateRequest
- @see AWSSESCreateCustomVerificationEmailTemplateResponse
  */
-- (void)createCustomVerificationEmailTemplate:(AWSSESCreateCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateCustomVerificationEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)createCustomVerificationEmailTemplate:(AWSSESCreateCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
 
 /**
- <p>Create a new pool of dedicated IP addresses. A pool can include one or more dedicated IP addresses that are associated with your AWS account. You can associate a pool with a configuration set. When you send an email that uses that configuration set, the message is sent from one of the addresses in the associated pool.</p>
+ <p>Creates a new IP address filter.</p><p>For information about setting up IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateDedicatedIpPool service method.
+ @param request A container for the necessary parameters to execute the CreateReceiptFilter service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateDedicatedIpPoolResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateReceiptFilterResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorLimitExceeded`, `AWSSESErrorAlreadyExists`.
  
- @see AWSSESCreateDedicatedIpPoolRequest
- @see AWSSESCreateDedicatedIpPoolResponse
+ @see AWSSESCreateReceiptFilterRequest
+ @see AWSSESCreateReceiptFilterResponse
  */
-- (AWSTask<AWSSESCreateDedicatedIpPoolResponse *> *)createDedicatedIpPool:(AWSSESCreateDedicatedIpPoolRequest *)request;
+- (AWSTask<AWSSESCreateReceiptFilterResponse *> *)createReceiptFilter:(AWSSESCreateReceiptFilterRequest *)request;
 
 /**
- <p>Create a new pool of dedicated IP addresses. A pool can include one or more dedicated IP addresses that are associated with your AWS account. You can associate a pool with a configuration set. When you send an email that uses that configuration set, the message is sent from one of the addresses in the associated pool.</p>
+ <p>Creates a new IP address filter.</p><p>For information about setting up IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-ip-filters.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateDedicatedIpPool service method.
+ @param request A container for the necessary parameters to execute the CreateReceiptFilter service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorLimitExceeded`, `AWSSESErrorAlreadyExists`.
  
- @see AWSSESCreateDedicatedIpPoolRequest
- @see AWSSESCreateDedicatedIpPoolResponse
+ @see AWSSESCreateReceiptFilterRequest
+ @see AWSSESCreateReceiptFilterResponse
  */
-- (void)createDedicatedIpPool:(AWSSESCreateDedicatedIpPoolRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateDedicatedIpPoolResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)createReceiptFilter:(AWSSESCreateReceiptFilterRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateReceiptFilterResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Create a new predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will be handled by various email providers around the world. When you perform a predictive inbox placement test, you provide a sample message that contains the content that you plan to send to your customers. Amazon SES then sends that message to special email addresses spread across several major email providers. After about 24 hours, the test is complete, and you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.</p>
+ <p>Creates a receipt rule.</p><p>For information about setting up receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateDeliverabilityTestReport service method.
+ @param request A container for the necessary parameters to execute the CreateReceiptRule service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateDeliverabilityTestReportResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAccountSuspended`, `AWSSESErrorSendingPaused`, `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateReceiptRuleResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorInvalidSnsTopic`, `AWSSESErrorInvalidS3Configuration`, `AWSSESErrorInvalidLambdaFunction`, `AWSSESErrorAlreadyExists`, `AWSSESErrorRuleDoesNotExist`, `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESCreateDeliverabilityTestReportRequest
- @see AWSSESCreateDeliverabilityTestReportResponse
+ @see AWSSESCreateReceiptRuleRequest
+ @see AWSSESCreateReceiptRuleResponse
  */
-- (AWSTask<AWSSESCreateDeliverabilityTestReportResponse *> *)createDeliverabilityTestReport:(AWSSESCreateDeliverabilityTestReportRequest *)request;
+- (AWSTask<AWSSESCreateReceiptRuleResponse *> *)createReceiptRule:(AWSSESCreateReceiptRuleRequest *)request;
 
 /**
- <p>Create a new predictive inbox placement test. Predictive inbox placement tests can help you predict how your messages will be handled by various email providers around the world. When you perform a predictive inbox placement test, you provide a sample message that contains the content that you plan to send to your customers. Amazon SES then sends that message to special email addresses spread across several major email providers. After about 24 hours, the test is complete, and you can use the <code>GetDeliverabilityTestReport</code> operation to view the results of the test.</p>
+ <p>Creates a receipt rule.</p><p>For information about setting up receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateDeliverabilityTestReport service method.
+ @param request A container for the necessary parameters to execute the CreateReceiptRule service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAccountSuspended`, `AWSSESErrorSendingPaused`, `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorInvalidSnsTopic`, `AWSSESErrorInvalidS3Configuration`, `AWSSESErrorInvalidLambdaFunction`, `AWSSESErrorAlreadyExists`, `AWSSESErrorRuleDoesNotExist`, `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESCreateDeliverabilityTestReportRequest
- @see AWSSESCreateDeliverabilityTestReportResponse
+ @see AWSSESCreateReceiptRuleRequest
+ @see AWSSESCreateReceiptRuleResponse
  */
-- (void)createDeliverabilityTestReport:(AWSSESCreateDeliverabilityTestReportRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateDeliverabilityTestReportResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)createReceiptRule:(AWSSESCreateReceiptRuleRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateReceiptRuleResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Starts the process of verifying an email identity. An <i>identity</i> is an email address or domain that you use when you send email. Before you can use an identity to send email, you first have to verify it. By verifying an identity, you demonstrate that you're the owner of the identity, and that you've given Amazon SES API v2 permission to send email from the identity.</p><p>When you verify an email address, Amazon SES sends an email to the address. Your email address is verified as soon as you follow the link in the verification email. </p><p>When you verify a domain without specifying the <code>DkimSigningAttributes</code> object, this operation provides a set of DKIM tokens. You can convert these tokens into CNAME records, which you then add to the DNS configuration for your domain. Your domain is verified when Amazon SES detects these records in the DNS configuration for your domain. This verification method is known as <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a>.</p><p>Alternatively, you can perform the verification process by providing your own public-private key pair. This verification method is known as Bring Your Own DKIM (BYODKIM). To use BYODKIM, your call to the <code>CreateEmailIdentity</code> operation has to include the <code>DkimSigningAttributes</code> object. When you specify this object, you provide a selector (a component of the DNS record name that identifies the public key that you want to use for DKIM authentication) and a private key.</p>
+ <p>Creates an empty receipt rule set.</p><p>For information about setting up receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateEmailIdentity service method.
+ @param request A container for the necessary parameters to execute the CreateReceiptRuleSet service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateEmailIdentityResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateReceiptRuleSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESCreateEmailIdentityRequest
- @see AWSSESCreateEmailIdentityResponse
+ @see AWSSESCreateReceiptRuleSetRequest
+ @see AWSSESCreateReceiptRuleSetResponse
  */
-- (AWSTask<AWSSESCreateEmailIdentityResponse *> *)createEmailIdentity:(AWSSESCreateEmailIdentityRequest *)request;
+- (AWSTask<AWSSESCreateReceiptRuleSetResponse *> *)createReceiptRuleSet:(AWSSESCreateReceiptRuleSetRequest *)request;
 
 /**
- <p>Starts the process of verifying an email identity. An <i>identity</i> is an email address or domain that you use when you send email. Before you can use an identity to send email, you first have to verify it. By verifying an identity, you demonstrate that you're the owner of the identity, and that you've given Amazon SES API v2 permission to send email from the identity.</p><p>When you verify an email address, Amazon SES sends an email to the address. Your email address is verified as soon as you follow the link in the verification email. </p><p>When you verify a domain without specifying the <code>DkimSigningAttributes</code> object, this operation provides a set of DKIM tokens. You can convert these tokens into CNAME records, which you then add to the DNS configuration for your domain. Your domain is verified when Amazon SES detects these records in the DNS configuration for your domain. This verification method is known as <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Easy DKIM</a>.</p><p>Alternatively, you can perform the verification process by providing your own public-private key pair. This verification method is known as Bring Your Own DKIM (BYODKIM). To use BYODKIM, your call to the <code>CreateEmailIdentity</code> operation has to include the <code>DkimSigningAttributes</code> object. When you specify this object, you provide a selector (a component of the DNS record name that identifies the public key that you want to use for DKIM authentication) and a private key.</p>
+ <p>Creates an empty receipt rule set.</p><p>For information about setting up receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateEmailIdentity service method.
+ @param request A container for the necessary parameters to execute the CreateReceiptRuleSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESCreateEmailIdentityRequest
- @see AWSSESCreateEmailIdentityResponse
+ @see AWSSESCreateReceiptRuleSetRequest
+ @see AWSSESCreateReceiptRuleSetResponse
  */
-- (void)createEmailIdentity:(AWSSESCreateEmailIdentityRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateEmailIdentityResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Creates the specified sending authorization policy for the given identity (an email address or a domain).</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
- 
- @param request A container for the necessary parameters to execute the CreateEmailIdentityPolicy service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateEmailIdentityPolicyResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorAlreadyExists`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESCreateEmailIdentityPolicyRequest
- @see AWSSESCreateEmailIdentityPolicyResponse
- */
-- (AWSTask<AWSSESCreateEmailIdentityPolicyResponse *> *)createEmailIdentityPolicy:(AWSSESCreateEmailIdentityPolicyRequest *)request;
-
-/**
- <p>Creates the specified sending authorization policy for the given identity (an email address or a domain).</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
- 
- @param request A container for the necessary parameters to execute the CreateEmailIdentityPolicy service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorAlreadyExists`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESCreateEmailIdentityPolicyRequest
- @see AWSSESCreateEmailIdentityPolicyResponse
- */
-- (void)createEmailIdentityPolicy:(AWSSESCreateEmailIdentityPolicyRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateEmailIdentityPolicyResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)createReceiptRuleSet:(AWSSESCreateReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Creates an email template. Email templates enable you to send personalized email to one or more destinations in a single API operation. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the CreateTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorLimitExceeded`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorInvalidTemplate`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESCreateEmailTemplateRequest
- @see AWSSESCreateEmailTemplateResponse
+ @see AWSSESCreateTemplateRequest
+ @see AWSSESCreateTemplateResponse
  */
-- (AWSTask<AWSSESCreateEmailTemplateResponse *> *)createEmailTemplate:(AWSSESCreateEmailTemplateRequest *)request;
+- (AWSTask<AWSSESCreateTemplateResponse *> *)createTemplate:(AWSSESCreateTemplateRequest *)request;
 
 /**
  <p>Creates an email template. Email templates enable you to send personalized email to one or more destinations in a single API operation. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the CreateEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the CreateTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorLimitExceeded`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorInvalidTemplate`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESCreateEmailTemplateRequest
- @see AWSSESCreateEmailTemplateResponse
+ @see AWSSESCreateTemplateRequest
+ @see AWSSESCreateTemplateResponse
  */
-- (void)createEmailTemplate:(AWSSESCreateEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)createTemplate:(AWSSESCreateTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Creates an import job for a data destination.</p>
- 
- @param request A container for the necessary parameters to execute the CreateImportJob service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESCreateImportJobResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`.
- 
- @see AWSSESCreateImportJobRequest
- @see AWSSESCreateImportJobResponse
- */
-- (AWSTask<AWSSESCreateImportJobResponse *> *)createImportJob:(AWSSESCreateImportJobRequest *)request;
-
-/**
- <p>Creates an import job for a data destination.</p>
- 
- @param request A container for the necessary parameters to execute the CreateImportJob service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorLimitExceeded`, `AWSSESErrorTooManyRequests`.
- 
- @see AWSSESCreateImportJobRequest
- @see AWSSESCreateImportJobResponse
- */
-- (void)createImportJob:(AWSSESCreateImportJobRequest *)request completionHandler:(void (^ _Nullable)(AWSSESCreateImportJobResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Delete an existing configuration set.</p><p><i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>
+ <p>Deletes a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the DeleteConfigurationSet service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteConfigurationSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteConfigurationSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
  
  @see AWSSESDeleteConfigurationSetRequest
  @see AWSSESDeleteConfigurationSetResponse
@@ -412,12 +409,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESDeleteConfigurationSetResponse *> *)deleteConfigurationSet:(AWSSESDeleteConfigurationSetRequest *)request;
 
 /**
- <p>Delete an existing configuration set.</p><p><i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>
+ <p>Deletes a configuration set. Configuration sets enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the DeleteConfigurationSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
  
  @see AWSSESDeleteConfigurationSetRequest
  @see AWSSESDeleteConfigurationSetResponse
@@ -425,11 +422,11 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)deleteConfigurationSet:(AWSSESDeleteConfigurationSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteConfigurationSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Delete an event destination.</p><p><i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Deletes a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the DeleteConfigurationSetEventDestination service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteConfigurationSetEventDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteConfigurationSetEventDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorEventDestinationDoesNotExist`.
  
  @see AWSSESDeleteConfigurationSetEventDestinationRequest
  @see AWSSESDeleteConfigurationSetEventDestinationResponse
@@ -437,12 +434,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESDeleteConfigurationSetEventDestinationResponse *> *)deleteConfigurationSetEventDestination:(AWSSESDeleteConfigurationSetEventDestinationRequest *)request;
 
 /**
- <p>Delete an event destination.</p><p><i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Deletes a configuration set event destination. Configuration set event destinations are associated with configuration sets, which enable you to publish email sending events. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the DeleteConfigurationSetEventDestination service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorEventDestinationDoesNotExist`.
  
  @see AWSSESDeleteConfigurationSetEventDestinationRequest
  @see AWSSESDeleteConfigurationSetEventDestinationResponse
@@ -450,261 +447,355 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)deleteConfigurationSetEventDestination:(AWSSESDeleteConfigurationSetEventDestinationRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteConfigurationSetEventDestinationResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Deletes an existing custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/es/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Deletes an association between a configuration set and a custom domain for open and click event tracking.</p><p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Amazon SES Developer Guide</a>.</p><note><p>Deleting this kind of association will result in emails sent using the specified configuration set to capture open and click events using the standard, Amazon SES-operated domains.</p></note>
+ 
+ @param request A container for the necessary parameters to execute the DeleteConfigurationSetTrackingOptions service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteConfigurationSetTrackingOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTrackingOptionsDoesNotExist`.
+ 
+ @see AWSSESDeleteConfigurationSetTrackingOptionsRequest
+ @see AWSSESDeleteConfigurationSetTrackingOptionsResponse
+ */
+- (AWSTask<AWSSESDeleteConfigurationSetTrackingOptionsResponse *> *)deleteConfigurationSetTrackingOptions:(AWSSESDeleteConfigurationSetTrackingOptionsRequest *)request;
+
+/**
+ <p>Deletes an association between a configuration set and a custom domain for open and click event tracking.</p><p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Amazon SES Developer Guide</a>.</p><note><p>Deleting this kind of association will result in emails sent using the specified configuration set to capture open and click events using the standard, Amazon SES-operated domains.</p></note>
+ 
+ @param request A container for the necessary parameters to execute the DeleteConfigurationSetTrackingOptions service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTrackingOptionsDoesNotExist`.
+ 
+ @see AWSSESDeleteConfigurationSetTrackingOptionsRequest
+ @see AWSSESDeleteConfigurationSetTrackingOptionsResponse
+ */
+- (void)deleteConfigurationSetTrackingOptions:(AWSSESDeleteConfigurationSetTrackingOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteConfigurationSetTrackingOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Deletes an existing custom verification email template. </p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the DeleteCustomVerificationEmailTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteCustomVerificationEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`.
  
  @see AWSSESDeleteCustomVerificationEmailTemplateRequest
- @see AWSSESDeleteCustomVerificationEmailTemplateResponse
  */
-- (AWSTask<AWSSESDeleteCustomVerificationEmailTemplateResponse *> *)deleteCustomVerificationEmailTemplate:(AWSSESDeleteCustomVerificationEmailTemplateRequest *)request;
+- (AWSTask *)deleteCustomVerificationEmailTemplate:(AWSSESDeleteCustomVerificationEmailTemplateRequest *)request;
 
 /**
- <p>Deletes an existing custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/es/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Deletes an existing custom verification email template. </p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the DeleteCustomVerificationEmailTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
  @see AWSSESDeleteCustomVerificationEmailTemplateRequest
- @see AWSSESDeleteCustomVerificationEmailTemplateResponse
  */
-- (void)deleteCustomVerificationEmailTemplate:(AWSSESDeleteCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteCustomVerificationEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)deleteCustomVerificationEmailTemplate:(AWSSESDeleteCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
 
 /**
- <p>Delete a dedicated IP pool.</p>
+ <p>Deletes the specified identity (an email address or a domain) from the list of verified identities.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the DeleteDedicatedIpPool service method.
+ @param request A container for the necessary parameters to execute the DeleteIdentity service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteDedicatedIpPoolResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteIdentityResponse`.
  
- @see AWSSESDeleteDedicatedIpPoolRequest
- @see AWSSESDeleteDedicatedIpPoolResponse
+ @see AWSSESDeleteIdentityRequest
+ @see AWSSESDeleteIdentityResponse
  */
-- (AWSTask<AWSSESDeleteDedicatedIpPoolResponse *> *)deleteDedicatedIpPool:(AWSSESDeleteDedicatedIpPoolRequest *)request;
+- (AWSTask<AWSSESDeleteIdentityResponse *> *)deleteIdentity:(AWSSESDeleteIdentityRequest *)request;
 
 /**
- <p>Delete a dedicated IP pool.</p>
+ <p>Deletes the specified identity (an email address or a domain) from the list of verified identities.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the DeleteDedicatedIpPool service method.
+ @param request A container for the necessary parameters to execute the DeleteIdentity service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESDeleteDedicatedIpPoolRequest
- @see AWSSESDeleteDedicatedIpPoolResponse
+ @see AWSSESDeleteIdentityRequest
+ @see AWSSESDeleteIdentityResponse
  */
-- (void)deleteDedicatedIpPool:(AWSSESDeleteDedicatedIpPoolRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteDedicatedIpPoolResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Deletes an email identity. An identity can be either an email address or a domain name.</p>
- 
- @param request A container for the necessary parameters to execute the DeleteEmailIdentity service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteEmailIdentityResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
- 
- @see AWSSESDeleteEmailIdentityRequest
- @see AWSSESDeleteEmailIdentityResponse
- */
-- (AWSTask<AWSSESDeleteEmailIdentityResponse *> *)deleteEmailIdentity:(AWSSESDeleteEmailIdentityRequest *)request;
-
-/**
- <p>Deletes an email identity. An identity can be either an email address or a domain name.</p>
- 
- @param request A container for the necessary parameters to execute the DeleteEmailIdentity service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`.
- 
- @see AWSSESDeleteEmailIdentityRequest
- @see AWSSESDeleteEmailIdentityResponse
- */
-- (void)deleteEmailIdentity:(AWSSESDeleteEmailIdentityRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteEmailIdentityResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)deleteIdentity:(AWSSESDeleteIdentityRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteIdentityResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Deletes the specified sending authorization policy for the given identity (an email address or a domain). This API returns successfully even if a policy with the specified name does not exist.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the DeleteEmailIdentityPolicy service method.
+ @param request A container for the necessary parameters to execute the DeleteIdentityPolicy service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteEmailIdentityPolicyResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteIdentityPolicyResponse`.
  
- @see AWSSESDeleteEmailIdentityPolicyRequest
- @see AWSSESDeleteEmailIdentityPolicyResponse
+ @see AWSSESDeleteIdentityPolicyRequest
+ @see AWSSESDeleteIdentityPolicyResponse
  */
-- (AWSTask<AWSSESDeleteEmailIdentityPolicyResponse *> *)deleteEmailIdentityPolicy:(AWSSESDeleteEmailIdentityPolicyRequest *)request;
+- (AWSTask<AWSSESDeleteIdentityPolicyResponse *> *)deleteIdentityPolicy:(AWSSESDeleteIdentityPolicyRequest *)request;
 
 /**
  <p>Deletes the specified sending authorization policy for the given identity (an email address or a domain). This API returns successfully even if a policy with the specified name does not exist.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the DeleteEmailIdentityPolicy service method.
+ @param request A container for the necessary parameters to execute the DeleteIdentityPolicy service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESDeleteEmailIdentityPolicyRequest
- @see AWSSESDeleteEmailIdentityPolicyResponse
+ @see AWSSESDeleteIdentityPolicyRequest
+ @see AWSSESDeleteIdentityPolicyResponse
  */
-- (void)deleteEmailIdentityPolicy:(AWSSESDeleteEmailIdentityPolicyRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteEmailIdentityPolicyResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)deleteIdentityPolicy:(AWSSESDeleteIdentityPolicyRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteIdentityPolicyResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Deletes the specified IP address filter.</p><p>For information about managing IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DeleteReceiptFilter service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteReceiptFilterResponse`.
+ 
+ @see AWSSESDeleteReceiptFilterRequest
+ @see AWSSESDeleteReceiptFilterResponse
+ */
+- (AWSTask<AWSSESDeleteReceiptFilterResponse *> *)deleteReceiptFilter:(AWSSESDeleteReceiptFilterRequest *)request;
+
+/**
+ <p>Deletes the specified IP address filter.</p><p>For information about managing IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DeleteReceiptFilter service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESDeleteReceiptFilterRequest
+ @see AWSSESDeleteReceiptFilterResponse
+ */
+- (void)deleteReceiptFilter:(AWSSESDeleteReceiptFilterRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteReceiptFilterResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Deletes the specified receipt rule.</p><p>For information about managing receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DeleteReceiptRule service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteReceiptRuleResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`.
+ 
+ @see AWSSESDeleteReceiptRuleRequest
+ @see AWSSESDeleteReceiptRuleResponse
+ */
+- (AWSTask<AWSSESDeleteReceiptRuleResponse *> *)deleteReceiptRule:(AWSSESDeleteReceiptRuleRequest *)request;
+
+/**
+ <p>Deletes the specified receipt rule.</p><p>For information about managing receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DeleteReceiptRule service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`.
+ 
+ @see AWSSESDeleteReceiptRuleRequest
+ @see AWSSESDeleteReceiptRuleResponse
+ */
+- (void)deleteReceiptRule:(AWSSESDeleteReceiptRuleRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteReceiptRuleResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Deletes the specified receipt rule set and all of the receipt rules it contains.</p><note><p>The currently active rule set cannot be deleted.</p></note><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DeleteReceiptRuleSet service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteReceiptRuleSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCannotDelete`.
+ 
+ @see AWSSESDeleteReceiptRuleSetRequest
+ @see AWSSESDeleteReceiptRuleSetResponse
+ */
+- (AWSTask<AWSSESDeleteReceiptRuleSetResponse *> *)deleteReceiptRuleSet:(AWSSESDeleteReceiptRuleSetRequest *)request;
+
+/**
+ <p>Deletes the specified receipt rule set and all of the receipt rules it contains.</p><note><p>The currently active rule set cannot be deleted.</p></note><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DeleteReceiptRuleSet service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCannotDelete`.
+ 
+ @see AWSSESDeleteReceiptRuleSetRequest
+ @see AWSSESDeleteReceiptRuleSetResponse
+ */
+- (void)deleteReceiptRuleSet:(AWSSESDeleteReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Deletes an email template.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the DeleteEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the DeleteTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteTemplateResponse`.
  
- @see AWSSESDeleteEmailTemplateRequest
- @see AWSSESDeleteEmailTemplateResponse
+ @see AWSSESDeleteTemplateRequest
+ @see AWSSESDeleteTemplateResponse
  */
-- (AWSTask<AWSSESDeleteEmailTemplateResponse *> *)deleteEmailTemplate:(AWSSESDeleteEmailTemplateRequest *)request;
+- (AWSTask<AWSSESDeleteTemplateResponse *> *)deleteTemplate:(AWSSESDeleteTemplateRequest *)request;
 
 /**
  <p>Deletes an email template.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the DeleteEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the DeleteTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESDeleteEmailTemplateRequest
- @see AWSSESDeleteEmailTemplateResponse
+ @see AWSSESDeleteTemplateRequest
+ @see AWSSESDeleteTemplateResponse
  */
-- (void)deleteEmailTemplate:(AWSSESDeleteEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)deleteTemplate:(AWSSESDeleteTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Removes an email address from the suppression list for your account.</p>
+ <p>Deprecated. Use the <code>DeleteIdentity</code> operation to delete email addresses and domains.</p>
  
- @param request A container for the necessary parameters to execute the DeleteSuppressedDestination service method.
+ @param request A container for the necessary parameters to execute the DeleteVerifiedEmailAddress service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDeleteSuppressedDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`.
  
- @see AWSSESDeleteSuppressedDestinationRequest
- @see AWSSESDeleteSuppressedDestinationResponse
+ @see AWSSESDeleteVerifiedEmailAddressRequest
  */
-- (AWSTask<AWSSESDeleteSuppressedDestinationResponse *> *)deleteSuppressedDestination:(AWSSESDeleteSuppressedDestinationRequest *)request;
+- (AWSTask *)deleteVerifiedEmailAddress:(AWSSESDeleteVerifiedEmailAddressRequest *)request;
 
 /**
- <p>Removes an email address from the suppression list for your account.</p>
+ <p>Deprecated. Use the <code>DeleteIdentity</code> operation to delete email addresses and domains.</p>
  
- @param request A container for the necessary parameters to execute the DeleteSuppressedDestination service method.
+ @param request A container for the necessary parameters to execute the DeleteVerifiedEmailAddress service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESDeleteVerifiedEmailAddressRequest
+ */
+- (void)deleteVerifiedEmailAddress:(AWSSESDeleteVerifiedEmailAddressRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Returns the metadata and receipt rules for the receipt rule set that is currently active.</p><p>For information about setting up receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DescribeActiveReceiptRuleSet service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDescribeActiveReceiptRuleSetResponse`.
+ 
+ @see AWSSESDescribeActiveReceiptRuleSetRequest
+ @see AWSSESDescribeActiveReceiptRuleSetResponse
+ */
+- (AWSTask<AWSSESDescribeActiveReceiptRuleSetResponse *> *)describeActiveReceiptRuleSet:(AWSSESDescribeActiveReceiptRuleSetRequest *)request;
+
+/**
+ <p>Returns the metadata and receipt rules for the receipt rule set that is currently active.</p><p>For information about setting up receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rule-set.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the DescribeActiveReceiptRuleSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESDeleteSuppressedDestinationRequest
- @see AWSSESDeleteSuppressedDestinationResponse
+ @see AWSSESDescribeActiveReceiptRuleSetRequest
+ @see AWSSESDescribeActiveReceiptRuleSetResponse
  */
-- (void)deleteSuppressedDestination:(AWSSESDeleteSuppressedDestinationRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDeleteSuppressedDestinationResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)describeActiveReceiptRuleSet:(AWSSESDescribeActiveReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDescribeActiveReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Obtain information about the email-sending status and capabilities of your Amazon SES account in the current AWS Region.</p>
+ <p>Returns the details of the specified configuration set. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetAccount service method.
+ @param request A container for the necessary parameters to execute the DescribeConfigurationSet service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetAccountResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDescribeConfigurationSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
  
- @see AWSSESGetAccountRequest
- @see AWSSESGetAccountResponse
+ @see AWSSESDescribeConfigurationSetRequest
+ @see AWSSESDescribeConfigurationSetResponse
  */
-- (AWSTask<AWSSESGetAccountResponse *> *)getAccount:(AWSSESGetAccountRequest *)request;
+- (AWSTask<AWSSESDescribeConfigurationSetResponse *> *)describeConfigurationSet:(AWSSESDescribeConfigurationSetRequest *)request;
 
 /**
- <p>Obtain information about the email-sending status and capabilities of your Amazon SES account in the current AWS Region.</p>
+ <p>Returns the details of the specified configuration set. For information about using configuration sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetAccount service method.
+ @param request A container for the necessary parameters to execute the DescribeConfigurationSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
  
- @see AWSSESGetAccountRequest
- @see AWSSESGetAccountResponse
+ @see AWSSESDescribeConfigurationSetRequest
+ @see AWSSESDescribeConfigurationSetResponse
  */
-- (void)getAccount:(AWSSESGetAccountRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetAccountResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)describeConfigurationSet:(AWSSESDescribeConfigurationSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDescribeConfigurationSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Retrieve a list of the blacklists that your dedicated IP addresses appear on.</p>
+ <p>Returns the details of the specified receipt rule.</p><p>For information about setting up receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetBlacklistReports service method.
+ @param request A container for the necessary parameters to execute the DescribeReceiptRule service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetBlacklistReportsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDescribeReceiptRuleResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleDoesNotExist`, `AWSSESErrorRuleSetDoesNotExist`.
  
- @see AWSSESGetBlacklistReportsRequest
- @see AWSSESGetBlacklistReportsResponse
+ @see AWSSESDescribeReceiptRuleRequest
+ @see AWSSESDescribeReceiptRuleResponse
  */
-- (AWSTask<AWSSESGetBlacklistReportsResponse *> *)getBlacklistReports:(AWSSESGetBlacklistReportsRequest *)request;
+- (AWSTask<AWSSESDescribeReceiptRuleResponse *> *)describeReceiptRule:(AWSSESDescribeReceiptRuleRequest *)request;
 
 /**
- <p>Retrieve a list of the blacklists that your dedicated IP addresses appear on.</p>
+ <p>Returns the details of the specified receipt rule.</p><p>For information about setting up receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetBlacklistReports service method.
+ @param request A container for the necessary parameters to execute the DescribeReceiptRule service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleDoesNotExist`, `AWSSESErrorRuleSetDoesNotExist`.
  
- @see AWSSESGetBlacklistReportsRequest
- @see AWSSESGetBlacklistReportsResponse
+ @see AWSSESDescribeReceiptRuleRequest
+ @see AWSSESDescribeReceiptRuleResponse
  */
-- (void)getBlacklistReports:(AWSSESGetBlacklistReportsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetBlacklistReportsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)describeReceiptRule:(AWSSESDescribeReceiptRuleRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDescribeReceiptRuleResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Get information about an existing configuration set, including the dedicated IP pool that it's associated with, whether or not it's enabled for sending email, and more.</p><p><i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>
+ <p>Returns the details of the specified receipt rule set.</p><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetConfigurationSet service method.
+ @param request A container for the necessary parameters to execute the DescribeReceiptRuleSet service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetConfigurationSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESDescribeReceiptRuleSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`.
  
- @see AWSSESGetConfigurationSetRequest
- @see AWSSESGetConfigurationSetResponse
+ @see AWSSESDescribeReceiptRuleSetRequest
+ @see AWSSESDescribeReceiptRuleSetResponse
  */
-- (AWSTask<AWSSESGetConfigurationSetResponse *> *)getConfigurationSet:(AWSSESGetConfigurationSetRequest *)request;
+- (AWSTask<AWSSESDescribeReceiptRuleSetResponse *> *)describeReceiptRuleSet:(AWSSESDescribeReceiptRuleSetRequest *)request;
 
 /**
- <p>Get information about an existing configuration set, including the dedicated IP pool that it's associated with, whether or not it's enabled for sending email, and more.</p><p><i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>
+ <p>Returns the details of the specified receipt rule set.</p><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetConfigurationSet service method.
+ @param request A container for the necessary parameters to execute the DescribeReceiptRuleSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`.
  
- @see AWSSESGetConfigurationSetRequest
- @see AWSSESGetConfigurationSetResponse
+ @see AWSSESDescribeReceiptRuleSetRequest
+ @see AWSSESDescribeReceiptRuleSetResponse
  */
-- (void)getConfigurationSet:(AWSSESGetConfigurationSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetConfigurationSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)describeReceiptRuleSet:(AWSSESDescribeReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESDescribeReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Retrieve a list of event destinations that are associated with a configuration set.</p><p><i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Returns the email sending status of the Amazon SES account for the current region.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetConfigurationSetEventDestinations service method.
+ @param request A container for the necessary parameters to execute the GetAccountSendingEnabled service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetConfigurationSetEventDestinationsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetAccountSendingEnabledResponse`.
  
- @see AWSSESGetConfigurationSetEventDestinationsRequest
- @see AWSSESGetConfigurationSetEventDestinationsResponse
+ @see AWSRequest
+ @see AWSSESGetAccountSendingEnabledResponse
  */
-- (AWSTask<AWSSESGetConfigurationSetEventDestinationsResponse *> *)getConfigurationSetEventDestinations:(AWSSESGetConfigurationSetEventDestinationsRequest *)request;
+- (AWSTask<AWSSESGetAccountSendingEnabledResponse *> *)getAccountSendingEnabled:(AWSRequest *)request;
 
 /**
- <p>Retrieve a list of event destinations that are associated with a configuration set.</p><p><i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Returns the email sending status of the Amazon SES account for the current region.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetConfigurationSetEventDestinations service method.
+ @param request A container for the necessary parameters to execute the GetAccountSendingEnabled service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetConfigurationSetEventDestinationsRequest
- @see AWSSESGetConfigurationSetEventDestinationsResponse
+ @see AWSRequest
+ @see AWSSESGetAccountSendingEnabledResponse
  */
-- (void)getConfigurationSetEventDestinations:(AWSSESGetConfigurationSetEventDestinationsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetConfigurationSetEventDestinationsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getAccountSendingEnabled:(AWSRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetAccountSendingEnabledResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Returns the custom email verification template for the template name you specify.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Returns the custom email verification template for the template name you specify.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the GetCustomVerificationEmailTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetCustomVerificationEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetCustomVerificationEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCustomVerificationEmailTemplateDoesNotExist`.
  
  @see AWSSESGetCustomVerificationEmailTemplateRequest
  @see AWSSESGetCustomVerificationEmailTemplateResponse
@@ -712,12 +803,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESGetCustomVerificationEmailTemplateResponse *> *)getCustomVerificationEmailTemplate:(AWSSESGetCustomVerificationEmailTemplateRequest *)request;
 
 /**
- <p>Returns the custom email verification template for the template name you specify.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Returns the custom email verification template for the template name you specify.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the GetCustomVerificationEmailTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCustomVerificationEmailTemplateDoesNotExist`.
  
  @see AWSSESGetCustomVerificationEmailTemplateRequest
  @see AWSSESGetCustomVerificationEmailTemplateResponse
@@ -725,286 +816,211 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)getCustomVerificationEmailTemplate:(AWSSESGetCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetCustomVerificationEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Get information about a dedicated IP address, including the name of the dedicated IP pool that it's associated with, as well information about the automatic warm-up process for the address.</p>
+ <p>Returns the current status of Easy DKIM signing for an entity. For domain name identities, this operation also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES has successfully verified that these tokens have been published.</p><p>This operation takes a list of identities as input and returns the following information for each:</p><ul><li><p>Whether Easy DKIM signing is enabled or disabled.</p></li><li><p>A set of DKIM tokens that represent the identity. If the identity is an email address, the tokens represent the domain of that address.</p></li><li><p>Whether Amazon SES has successfully verified the DKIM tokens published in the domain's DNS. This information is only returned for domain name identities, not for email addresses.</p></li></ul><p>This operation is throttled at one request per second and can only get DKIM attributes for up to 100 identities at a time.</p><p>For more information about creating DNS records using DKIM tokens, go to the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html">Amazon SES Developer Guide</a>.</p>
  
- @param request A container for the necessary parameters to execute the GetDedicatedIp service method.
+ @param request A container for the necessary parameters to execute the GetIdentityDkimAttributes service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetDedicatedIpResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetIdentityDkimAttributesResponse`.
  
- @see AWSSESGetDedicatedIpRequest
- @see AWSSESGetDedicatedIpResponse
+ @see AWSSESGetIdentityDkimAttributesRequest
+ @see AWSSESGetIdentityDkimAttributesResponse
  */
-- (AWSTask<AWSSESGetDedicatedIpResponse *> *)getDedicatedIp:(AWSSESGetDedicatedIpRequest *)request;
+- (AWSTask<AWSSESGetIdentityDkimAttributesResponse *> *)getIdentityDkimAttributes:(AWSSESGetIdentityDkimAttributesRequest *)request;
 
 /**
- <p>Get information about a dedicated IP address, including the name of the dedicated IP pool that it's associated with, as well information about the automatic warm-up process for the address.</p>
+ <p>Returns the current status of Easy DKIM signing for an entity. For domain name identities, this operation also returns the DKIM tokens that are required for Easy DKIM signing, and whether Amazon SES has successfully verified that these tokens have been published.</p><p>This operation takes a list of identities as input and returns the following information for each:</p><ul><li><p>Whether Easy DKIM signing is enabled or disabled.</p></li><li><p>A set of DKIM tokens that represent the identity. If the identity is an email address, the tokens represent the domain of that address.</p></li><li><p>Whether Amazon SES has successfully verified the DKIM tokens published in the domain's DNS. This information is only returned for domain name identities, not for email addresses.</p></li></ul><p>This operation is throttled at one request per second and can only get DKIM attributes for up to 100 identities at a time.</p><p>For more information about creating DNS records using DKIM tokens, go to the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim-dns-records.html">Amazon SES Developer Guide</a>.</p>
  
- @param request A container for the necessary parameters to execute the GetDedicatedIp service method.
+ @param request A container for the necessary parameters to execute the GetIdentityDkimAttributes service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetDedicatedIpRequest
- @see AWSSESGetDedicatedIpResponse
+ @see AWSSESGetIdentityDkimAttributesRequest
+ @see AWSSESGetIdentityDkimAttributesResponse
  */
-- (void)getDedicatedIp:(AWSSESGetDedicatedIpRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetDedicatedIpResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getIdentityDkimAttributes:(AWSSESGetIdentityDkimAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetIdentityDkimAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>List the dedicated IP addresses that are associated with your AWS account.</p>
+ <p>Returns the custom MAIL FROM attributes for a list of identities (email addresses : domains).</p><p>This operation is throttled at one request per second and can only get custom MAIL FROM attributes for up to 100 identities at a time.</p>
  
- @param request A container for the necessary parameters to execute the GetDedicatedIps service method.
+ @param request A container for the necessary parameters to execute the GetIdentityMailFromDomainAttributes service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetDedicatedIpsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetIdentityMailFromDomainAttributesResponse`.
  
- @see AWSSESGetDedicatedIpsRequest
- @see AWSSESGetDedicatedIpsResponse
+ @see AWSSESGetIdentityMailFromDomainAttributesRequest
+ @see AWSSESGetIdentityMailFromDomainAttributesResponse
  */
-- (AWSTask<AWSSESGetDedicatedIpsResponse *> *)getDedicatedIps:(AWSSESGetDedicatedIpsRequest *)request;
+- (AWSTask<AWSSESGetIdentityMailFromDomainAttributesResponse *> *)getIdentityMailFromDomainAttributes:(AWSSESGetIdentityMailFromDomainAttributesRequest *)request;
 
 /**
- <p>List the dedicated IP addresses that are associated with your AWS account.</p>
+ <p>Returns the custom MAIL FROM attributes for a list of identities (email addresses : domains).</p><p>This operation is throttled at one request per second and can only get custom MAIL FROM attributes for up to 100 identities at a time.</p>
  
- @param request A container for the necessary parameters to execute the GetDedicatedIps service method.
+ @param request A container for the necessary parameters to execute the GetIdentityMailFromDomainAttributes service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetDedicatedIpsRequest
- @see AWSSESGetDedicatedIpsResponse
+ @see AWSSESGetIdentityMailFromDomainAttributesRequest
+ @see AWSSESGetIdentityMailFromDomainAttributesResponse
  */
-- (void)getDedicatedIps:(AWSSESGetDedicatedIpsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetDedicatedIpsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getIdentityMailFromDomainAttributes:(AWSSESGetIdentityMailFromDomainAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetIdentityMailFromDomainAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Retrieve information about the status of the Deliverability dashboard for your account. When the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email. You also gain the ability to perform predictive inbox placement tests.</p><p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href="http://aws.amazon.com/ses/pricing/">Amazon SES Pricing</a>.</p>
+ <p>Given a list of verified identities (email addresses and/or domains), returns a structure describing identity notification attributes.</p><p>This operation is throttled at one request per second and can only get notification attributes for up to 100 identities at a time.</p><p>For more information about using notifications with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
  
- @param request A container for the necessary parameters to execute the GetDeliverabilityDashboardOptions service method.
+ @param request A container for the necessary parameters to execute the GetIdentityNotificationAttributes service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetDeliverabilityDashboardOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetIdentityNotificationAttributesResponse`.
  
- @see AWSSESGetDeliverabilityDashboardOptionsRequest
- @see AWSSESGetDeliverabilityDashboardOptionsResponse
+ @see AWSSESGetIdentityNotificationAttributesRequest
+ @see AWSSESGetIdentityNotificationAttributesResponse
  */
-- (AWSTask<AWSSESGetDeliverabilityDashboardOptionsResponse *> *)getDeliverabilityDashboardOptions:(AWSSESGetDeliverabilityDashboardOptionsRequest *)request;
+- (AWSTask<AWSSESGetIdentityNotificationAttributesResponse *> *)getIdentityNotificationAttributes:(AWSSESGetIdentityNotificationAttributesRequest *)request;
 
 /**
- <p>Retrieve information about the status of the Deliverability dashboard for your account. When the Deliverability dashboard is enabled, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email. You also gain the ability to perform predictive inbox placement tests.</p><p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href="http://aws.amazon.com/ses/pricing/">Amazon SES Pricing</a>.</p>
+ <p>Given a list of verified identities (email addresses and/or domains), returns a structure describing identity notification attributes.</p><p>This operation is throttled at one request per second and can only get notification attributes for up to 100 identities at a time.</p><p>For more information about using notifications with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
  
- @param request A container for the necessary parameters to execute the GetDeliverabilityDashboardOptions service method.
+ @param request A container for the necessary parameters to execute the GetIdentityNotificationAttributes service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetDeliverabilityDashboardOptionsRequest
- @see AWSSESGetDeliverabilityDashboardOptionsResponse
+ @see AWSSESGetIdentityNotificationAttributesRequest
+ @see AWSSESGetIdentityNotificationAttributesResponse
  */
-- (void)getDeliverabilityDashboardOptions:(AWSSESGetDeliverabilityDashboardOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetDeliverabilityDashboardOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Retrieve the results of a predictive inbox placement test.</p>
- 
- @param request A container for the necessary parameters to execute the GetDeliverabilityTestReport service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetDeliverabilityTestReportResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESGetDeliverabilityTestReportRequest
- @see AWSSESGetDeliverabilityTestReportResponse
- */
-- (AWSTask<AWSSESGetDeliverabilityTestReportResponse *> *)getDeliverabilityTestReport:(AWSSESGetDeliverabilityTestReportRequest *)request;
-
-/**
- <p>Retrieve the results of a predictive inbox placement test.</p>
- 
- @param request A container for the necessary parameters to execute the GetDeliverabilityTestReport service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESGetDeliverabilityTestReportRequest
- @see AWSSESGetDeliverabilityTestReportResponse
- */
-- (void)getDeliverabilityTestReport:(AWSSESGetDeliverabilityTestReportRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetDeliverabilityTestReportResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Retrieve all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for.</p>
- 
- @param request A container for the necessary parameters to execute the GetDomainDeliverabilityCampaign service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetDomainDeliverabilityCampaignResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`.
- 
- @see AWSSESGetDomainDeliverabilityCampaignRequest
- @see AWSSESGetDomainDeliverabilityCampaignResponse
- */
-- (AWSTask<AWSSESGetDomainDeliverabilityCampaignResponse *> *)getDomainDeliverabilityCampaign:(AWSSESGetDomainDeliverabilityCampaignRequest *)request;
-
-/**
- <p>Retrieve all the deliverability data for a specific campaign. This data is available for a campaign only if the campaign sent email by using a domain that the Deliverability dashboard is enabled for.</p>
- 
- @param request A container for the necessary parameters to execute the GetDomainDeliverabilityCampaign service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`.
- 
- @see AWSSESGetDomainDeliverabilityCampaignRequest
- @see AWSSESGetDomainDeliverabilityCampaignResponse
- */
-- (void)getDomainDeliverabilityCampaign:(AWSSESGetDomainDeliverabilityCampaignRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetDomainDeliverabilityCampaignResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Retrieve inbox placement and engagement rates for the domains that you use to send email.</p>
- 
- @param request A container for the necessary parameters to execute the GetDomainStatisticsReport service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetDomainStatisticsReportResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESGetDomainStatisticsReportRequest
- @see AWSSESGetDomainStatisticsReportResponse
- */
-- (AWSTask<AWSSESGetDomainStatisticsReportResponse *> *)getDomainStatisticsReport:(AWSSESGetDomainStatisticsReportRequest *)request;
-
-/**
- <p>Retrieve inbox placement and engagement rates for the domains that you use to send email.</p>
- 
- @param request A container for the necessary parameters to execute the GetDomainStatisticsReport service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESGetDomainStatisticsReportRequest
- @see AWSSESGetDomainStatisticsReportResponse
- */
-- (void)getDomainStatisticsReport:(AWSSESGetDomainStatisticsReportRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetDomainStatisticsReportResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Provides information about a specific identity, including the identity's verification status, sending authorization policies, its DKIM authentication status, and its custom Mail-From settings.</p>
- 
- @param request A container for the necessary parameters to execute the GetEmailIdentity service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetEmailIdentityResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESGetEmailIdentityRequest
- @see AWSSESGetEmailIdentityResponse
- */
-- (AWSTask<AWSSESGetEmailIdentityResponse *> *)getEmailIdentity:(AWSSESGetEmailIdentityRequest *)request;
-
-/**
- <p>Provides information about a specific identity, including the identity's verification status, sending authorization policies, its DKIM authentication status, and its custom Mail-From settings.</p>
- 
- @param request A container for the necessary parameters to execute the GetEmailIdentity service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESGetEmailIdentityRequest
- @see AWSSESGetEmailIdentityResponse
- */
-- (void)getEmailIdentity:(AWSSESGetEmailIdentityRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetEmailIdentityResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getIdentityNotificationAttributes:(AWSSESGetIdentityNotificationAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetIdentityNotificationAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Returns the requested sending authorization policies for the given identity (an email address or a domain). The policies are returned as a map of policy names to policy contents. You can retrieve a maximum of 20 policies at a time.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetEmailIdentityPolicies service method.
+ @param request A container for the necessary parameters to execute the GetIdentityPolicies service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetEmailIdentityPoliciesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetIdentityPoliciesResponse`.
  
- @see AWSSESGetEmailIdentityPoliciesRequest
- @see AWSSESGetEmailIdentityPoliciesResponse
+ @see AWSSESGetIdentityPoliciesRequest
+ @see AWSSESGetIdentityPoliciesResponse
  */
-- (AWSTask<AWSSESGetEmailIdentityPoliciesResponse *> *)getEmailIdentityPolicies:(AWSSESGetEmailIdentityPoliciesRequest *)request;
+- (AWSTask<AWSSESGetIdentityPoliciesResponse *> *)getIdentityPolicies:(AWSSESGetIdentityPoliciesRequest *)request;
 
 /**
  <p>Returns the requested sending authorization policies for the given identity (an email address or a domain). The policies are returned as a map of policy names to policy contents. You can retrieve a maximum of 20 policies at a time.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetEmailIdentityPolicies service method.
+ @param request A container for the necessary parameters to execute the GetIdentityPolicies service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetEmailIdentityPoliciesRequest
- @see AWSSESGetEmailIdentityPoliciesResponse
+ @see AWSSESGetIdentityPoliciesRequest
+ @see AWSSESGetIdentityPoliciesResponse
  */
-- (void)getEmailIdentityPolicies:(AWSSESGetEmailIdentityPoliciesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetEmailIdentityPoliciesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getIdentityPolicies:(AWSSESGetIdentityPoliciesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetIdentityPoliciesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Displays the template object (which includes the subject line, HTML part and text part) for the template you specify.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Given a list of identities (email addresses and/or domains), returns the verification status and (for domain identities) the verification token for each identity.</p><p>The verification status of an email address is "Pending" until the email address owner clicks the link within the verification email that Amazon SES sent to that address. If the email address owner clicks the link within 24 hours, the verification status of the email address changes to "Success". If the link is not clicked within 24 hours, the verification status changes to "Failed." In that case, if you still want to verify the email address, you must restart the verification process from the beginning.</p><p>For domain identities, the domain's verification status is "Pending" as Amazon SES searches for the required TXT record in the DNS settings of the domain. When Amazon SES detects the record, the domain's verification status changes to "Success". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to "Failed." In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p><p>This operation is throttled at one request per second and can only get verification attributes for up to 100 identities at a time.</p>
  
- @param request A container for the necessary parameters to execute the GetEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the GetIdentityVerificationAttributes service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetIdentityVerificationAttributesResponse`.
  
- @see AWSSESGetEmailTemplateRequest
- @see AWSSESGetEmailTemplateResponse
+ @see AWSSESGetIdentityVerificationAttributesRequest
+ @see AWSSESGetIdentityVerificationAttributesResponse
  */
-- (AWSTask<AWSSESGetEmailTemplateResponse *> *)getEmailTemplate:(AWSSESGetEmailTemplateRequest *)request;
+- (AWSTask<AWSSESGetIdentityVerificationAttributesResponse *> *)getIdentityVerificationAttributes:(AWSSESGetIdentityVerificationAttributesRequest *)request;
 
 /**
- <p>Displays the template object (which includes the subject line, HTML part and text part) for the template you specify.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Given a list of identities (email addresses and/or domains), returns the verification status and (for domain identities) the verification token for each identity.</p><p>The verification status of an email address is "Pending" until the email address owner clicks the link within the verification email that Amazon SES sent to that address. If the email address owner clicks the link within 24 hours, the verification status of the email address changes to "Success". If the link is not clicked within 24 hours, the verification status changes to "Failed." In that case, if you still want to verify the email address, you must restart the verification process from the beginning.</p><p>For domain identities, the domain's verification status is "Pending" as Amazon SES searches for the required TXT record in the DNS settings of the domain. When Amazon SES detects the record, the domain's verification status changes to "Success". If Amazon SES is unable to detect the record within 72 hours, the domain's verification status changes to "Failed." In that case, if you still want to verify the domain, you must restart the verification process from the beginning.</p><p>This operation is throttled at one request per second and can only get verification attributes for up to 100 identities at a time.</p>
  
- @param request A container for the necessary parameters to execute the GetEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the GetIdentityVerificationAttributes service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetEmailTemplateRequest
- @see AWSSESGetEmailTemplateResponse
+ @see AWSSESGetIdentityVerificationAttributesRequest
+ @see AWSSESGetIdentityVerificationAttributesResponse
  */
-- (void)getEmailTemplate:(AWSSESGetEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getIdentityVerificationAttributes:(AWSSESGetIdentityVerificationAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetIdentityVerificationAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Provides information about an import job.</p>
+ <p>Provides the sending limits for the Amazon SES account. </p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetImportJob service method.
+ @param request A container for the necessary parameters to execute the GetSendQuota service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetImportJobResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetSendQuotaResponse`.
  
- @see AWSSESGetImportJobRequest
- @see AWSSESGetImportJobResponse
+ @see AWSRequest
+ @see AWSSESGetSendQuotaResponse
  */
-- (AWSTask<AWSSESGetImportJobResponse *> *)getImportJob:(AWSSESGetImportJobRequest *)request;
+- (AWSTask<AWSSESGetSendQuotaResponse *> *)getSendQuota:(AWSRequest *)request;
 
 /**
- <p>Provides information about an import job.</p>
+ <p>Provides the sending limits for the Amazon SES account. </p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetImportJob service method.
+ @param request A container for the necessary parameters to execute the GetSendQuota service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetImportJobRequest
- @see AWSSESGetImportJobResponse
+ @see AWSRequest
+ @see AWSSESGetSendQuotaResponse
  */
-- (void)getImportJob:(AWSSESGetImportJobRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetImportJobResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getSendQuota:(AWSRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetSendQuotaResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Retrieves information about a specific email address that's on the suppression list for your account.</p>
+ <p>Provides sending statistics for the current AWS Region. The result is a list of data points, representing the last two weeks of sending activity. Each data point in the list contains statistics for a 15-minute period of time.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetSuppressedDestination service method.
+ @param request A container for the necessary parameters to execute the GetSendStatistics service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetSuppressedDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetSendStatisticsResponse`.
  
- @see AWSSESGetSuppressedDestinationRequest
- @see AWSSESGetSuppressedDestinationResponse
+ @see AWSRequest
+ @see AWSSESGetSendStatisticsResponse
  */
-- (AWSTask<AWSSESGetSuppressedDestinationResponse *> *)getSuppressedDestination:(AWSSESGetSuppressedDestinationRequest *)request;
+- (AWSTask<AWSSESGetSendStatisticsResponse *> *)getSendStatistics:(AWSRequest *)request;
 
 /**
- <p>Retrieves information about a specific email address that's on the suppression list for your account.</p>
+ <p>Provides sending statistics for the current AWS Region. The result is a list of data points, representing the last two weeks of sending activity. Each data point in the list contains statistics for a 15-minute period of time.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the GetSuppressedDestination service method.
+ @param request A container for the necessary parameters to execute the GetSendStatistics service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESGetSuppressedDestinationRequest
- @see AWSSESGetSuppressedDestinationResponse
+ @see AWSRequest
+ @see AWSSESGetSendStatisticsResponse
  */
-- (void)getSuppressedDestination:(AWSSESGetSuppressedDestinationRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetSuppressedDestinationResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)getSendStatistics:(AWSRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetSendStatisticsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>List all of the configuration sets associated with your account in the current region.</p><p><i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>
+ <p>Displays the template object (which includes the Subject line, HTML part and text part) for the template you specify.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the GetTemplate service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESGetTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTemplateDoesNotExist`.
+ 
+ @see AWSSESGetTemplateRequest
+ @see AWSSESGetTemplateResponse
+ */
+- (AWSTask<AWSSESGetTemplateResponse *> *)getTemplate:(AWSSESGetTemplateRequest *)request;
+
+/**
+ <p>Displays the template object (which includes the Subject line, HTML part and text part) for the template you specify.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the GetTemplate service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTemplateDoesNotExist`.
+ 
+ @see AWSSESGetTemplateRequest
+ @see AWSSESGetTemplateResponse
+ */
+- (void)getTemplate:(AWSSESGetTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESGetTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Provides a list of the configuration sets associated with your Amazon SES account in the current AWS Region. For information about using configuration sets, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Monitoring Your Amazon SES Sending Activity</a> in the <i>Amazon SES Developer Guide.</i></p><p>You can execute this operation no more than once per second. This operation will return up to 1,000 configuration sets each time it is run. If your Amazon SES account has more than 1,000 configuration sets, this operation will also return a NextToken element. You can then execute the <code>ListConfigurationSets</code> operation again, passing the <code>NextToken</code> parameter and the value of the NextToken element to retrieve additional results.</p>
  
  @param request A container for the necessary parameters to execute the ListConfigurationSets service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListConfigurationSetsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListConfigurationSetsResponse`.
  
  @see AWSSESListConfigurationSetsRequest
  @see AWSSESListConfigurationSetsResponse
@@ -1012,12 +1028,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESListConfigurationSetsResponse *> *)listConfigurationSets:(AWSSESListConfigurationSetsRequest *)request;
 
 /**
- <p>List all of the configuration sets associated with your account in the current region.</p><p><i>Configuration sets</i> are groups of rules that you can apply to the emails you send. You apply a configuration set to an email by including a reference to the configuration set in the headers of the email. When you apply a configuration set to an email, all of the rules in that configuration set are applied to the email.</p>
+ <p>Provides a list of the configuration sets associated with your Amazon SES account in the current AWS Region. For information about using configuration sets, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Monitoring Your Amazon SES Sending Activity</a> in the <i>Amazon SES Developer Guide.</i></p><p>You can execute this operation no more than once per second. This operation will return up to 1,000 configuration sets each time it is run. If your Amazon SES account has more than 1,000 configuration sets, this operation will also return a NextToken element. You can then execute the <code>ListConfigurationSets</code> operation again, passing the <code>NextToken</code> parameter and the value of the NextToken element to retrieve additional results.</p>
  
  @param request A container for the necessary parameters to execute the ListConfigurationSets service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
  @see AWSSESListConfigurationSetsRequest
  @see AWSSESListConfigurationSetsResponse
@@ -1025,11 +1041,11 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)listConfigurationSets:(AWSSESListConfigurationSetsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListConfigurationSetsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Lists the existing custom verification email templates for your account in the current AWS Region.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Lists the existing custom verification email templates for your account in the current AWS Region.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the ListCustomVerificationEmailTemplates service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListCustomVerificationEmailTemplatesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListCustomVerificationEmailTemplatesResponse`.
  
  @see AWSSESListCustomVerificationEmailTemplatesRequest
  @see AWSSESListCustomVerificationEmailTemplatesResponse
@@ -1037,12 +1053,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESListCustomVerificationEmailTemplatesResponse *> *)listCustomVerificationEmailTemplates:(AWSSESListCustomVerificationEmailTemplatesRequest *)request;
 
 /**
- <p>Lists the existing custom verification email templates for your account in the current AWS Region.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Lists the existing custom verification email templates for your account in the current AWS Region.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the ListCustomVerificationEmailTemplates service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
  @see AWSSESListCustomVerificationEmailTemplatesRequest
  @see AWSSESListCustomVerificationEmailTemplatesResponse
@@ -1050,311 +1066,161 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)listCustomVerificationEmailTemplates:(AWSSESListCustomVerificationEmailTemplatesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListCustomVerificationEmailTemplatesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>List all of the dedicated IP pools that exist in your AWS account in the current Region.</p>
+ <p>Returns a list containing all of the identities (email addresses and domains) for your AWS account in the current AWS Region, regardless of verification status.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListDedicatedIpPools service method.
+ @param request A container for the necessary parameters to execute the ListIdentities service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListDedicatedIpPoolsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListIdentitiesResponse`.
  
- @see AWSSESListDedicatedIpPoolsRequest
- @see AWSSESListDedicatedIpPoolsResponse
+ @see AWSSESListIdentitiesRequest
+ @see AWSSESListIdentitiesResponse
  */
-- (AWSTask<AWSSESListDedicatedIpPoolsResponse *> *)listDedicatedIpPools:(AWSSESListDedicatedIpPoolsRequest *)request;
+- (AWSTask<AWSSESListIdentitiesResponse *> *)listIdentities:(AWSSESListIdentitiesRequest *)request;
 
 /**
- <p>List all of the dedicated IP pools that exist in your AWS account in the current Region.</p>
+ <p>Returns a list containing all of the identities (email addresses and domains) for your AWS account in the current AWS Region, regardless of verification status.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListDedicatedIpPools service method.
+ @param request A container for the necessary parameters to execute the ListIdentities service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESListDedicatedIpPoolsRequest
- @see AWSSESListDedicatedIpPoolsResponse
+ @see AWSSESListIdentitiesRequest
+ @see AWSSESListIdentitiesResponse
  */
-- (void)listDedicatedIpPools:(AWSSESListDedicatedIpPoolsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListDedicatedIpPoolsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)listIdentities:(AWSSESListIdentitiesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListIdentitiesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Show a list of the predictive inbox placement tests that you've performed, regardless of their statuses. For predictive inbox placement tests that are complete, you can use the <code>GetDeliverabilityTestReport</code> operation to view the results.</p>
+ <p>Returns a list of sending authorization policies that are attached to the given identity (an email address or a domain). This API returns only a list. If you want the actual policy content, you can use <code>GetIdentityPolicies</code>.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListDeliverabilityTestReports service method.
+ @param request A container for the necessary parameters to execute the ListIdentityPolicies service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListDeliverabilityTestReportsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListIdentityPoliciesResponse`.
  
- @see AWSSESListDeliverabilityTestReportsRequest
- @see AWSSESListDeliverabilityTestReportsResponse
+ @see AWSSESListIdentityPoliciesRequest
+ @see AWSSESListIdentityPoliciesResponse
  */
-- (AWSTask<AWSSESListDeliverabilityTestReportsResponse *> *)listDeliverabilityTestReports:(AWSSESListDeliverabilityTestReportsRequest *)request;
+- (AWSTask<AWSSESListIdentityPoliciesResponse *> *)listIdentityPolicies:(AWSSESListIdentityPoliciesRequest *)request;
 
 /**
- <p>Show a list of the predictive inbox placement tests that you've performed, regardless of their statuses. For predictive inbox placement tests that are complete, you can use the <code>GetDeliverabilityTestReport</code> operation to view the results.</p>
+ <p>Returns a list of sending authorization policies that are attached to the given identity (an email address or a domain). This API returns only a list. If you want the actual policy content, you can use <code>GetIdentityPolicies</code>.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListDeliverabilityTestReports service method.
+ @param request A container for the necessary parameters to execute the ListIdentityPolicies service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESListDeliverabilityTestReportsRequest
- @see AWSSESListDeliverabilityTestReportsResponse
+ @see AWSSESListIdentityPoliciesRequest
+ @see AWSSESListIdentityPoliciesResponse
  */
-- (void)listDeliverabilityTestReports:(AWSSESListDeliverabilityTestReportsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListDeliverabilityTestReportsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)listIdentityPolicies:(AWSSESListIdentityPoliciesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListIdentityPoliciesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Retrieve deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard for the domain.</p>
+ <p>Lists the IP address filters associated with your AWS account in the current AWS Region.</p><p>For information about managing IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListDomainDeliverabilityCampaigns service method.
+ @param request A container for the necessary parameters to execute the ListReceiptFilters service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListDomainDeliverabilityCampaignsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListReceiptFiltersResponse`.
  
- @see AWSSESListDomainDeliverabilityCampaignsRequest
- @see AWSSESListDomainDeliverabilityCampaignsResponse
+ @see AWSSESListReceiptFiltersRequest
+ @see AWSSESListReceiptFiltersResponse
  */
-- (AWSTask<AWSSESListDomainDeliverabilityCampaignsResponse *> *)listDomainDeliverabilityCampaigns:(AWSSESListDomainDeliverabilityCampaignsRequest *)request;
+- (AWSTask<AWSSESListReceiptFiltersResponse *> *)listReceiptFilters:(AWSSESListReceiptFiltersRequest *)request;
 
 /**
- <p>Retrieve deliverability data for all the campaigns that used a specific domain to send email during a specified time range. This data is available for a domain only if you enabled the Deliverability dashboard for the domain.</p>
+ <p>Lists the IP address filters associated with your AWS account in the current AWS Region.</p><p>For information about managing IP address filters, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-ip-filters.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListDomainDeliverabilityCampaigns service method.
+ @param request A container for the necessary parameters to execute the ListReceiptFilters service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESListDomainDeliverabilityCampaignsRequest
- @see AWSSESListDomainDeliverabilityCampaignsResponse
+ @see AWSSESListReceiptFiltersRequest
+ @see AWSSESListReceiptFiltersResponse
  */
-- (void)listDomainDeliverabilityCampaigns:(AWSSESListDomainDeliverabilityCampaignsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListDomainDeliverabilityCampaignsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)listReceiptFilters:(AWSSESListReceiptFiltersRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListReceiptFiltersResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Returns a list of all of the email identities that are associated with your AWS account. An identity can be either an email address or a domain. This operation returns identities that are verified as well as those that aren't. This operation returns identities that are associated with Amazon SES and Amazon Pinpoint.</p>
+ <p>Lists the receipt rule sets that exist under your AWS account in the current AWS Region. If there are additional receipt rule sets to be retrieved, you will receive a <code>NextToken</code> that you can provide to the next call to <code>ListReceiptRuleSets</code> to retrieve the additional entries.</p><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListEmailIdentities service method.
+ @param request A container for the necessary parameters to execute the ListReceiptRuleSets service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListEmailIdentitiesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListReceiptRuleSetsResponse`.
  
- @see AWSSESListEmailIdentitiesRequest
- @see AWSSESListEmailIdentitiesResponse
+ @see AWSSESListReceiptRuleSetsRequest
+ @see AWSSESListReceiptRuleSetsResponse
  */
-- (AWSTask<AWSSESListEmailIdentitiesResponse *> *)listEmailIdentities:(AWSSESListEmailIdentitiesRequest *)request;
+- (AWSTask<AWSSESListReceiptRuleSetsResponse *> *)listReceiptRuleSets:(AWSSESListReceiptRuleSetsRequest *)request;
 
 /**
- <p>Returns a list of all of the email identities that are associated with your AWS account. An identity can be either an email address or a domain. This operation returns identities that are verified as well as those that aren't. This operation returns identities that are associated with Amazon SES and Amazon Pinpoint.</p>
+ <p>Lists the receipt rule sets that exist under your AWS account in the current AWS Region. If there are additional receipt rule sets to be retrieved, you will receive a <code>NextToken</code> that you can provide to the next call to <code>ListReceiptRuleSets</code> to retrieve the additional entries.</p><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListEmailIdentities service method.
+ @param request A container for the necessary parameters to execute the ListReceiptRuleSets service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESListEmailIdentitiesRequest
- @see AWSSESListEmailIdentitiesResponse
+ @see AWSSESListReceiptRuleSetsRequest
+ @see AWSSESListReceiptRuleSetsResponse
  */
-- (void)listEmailIdentities:(AWSSESListEmailIdentitiesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListEmailIdentitiesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)listReceiptRuleSets:(AWSSESListReceiptRuleSetsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListReceiptRuleSetsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Lists the email templates present in your Amazon SES account in the current AWS Region.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListEmailTemplates service method.
+ @param request A container for the necessary parameters to execute the ListTemplates service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListEmailTemplatesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListTemplatesResponse`.
  
- @see AWSSESListEmailTemplatesRequest
- @see AWSSESListEmailTemplatesResponse
+ @see AWSSESListTemplatesRequest
+ @see AWSSESListTemplatesResponse
  */
-- (AWSTask<AWSSESListEmailTemplatesResponse *> *)listEmailTemplates:(AWSSESListEmailTemplatesRequest *)request;
+- (AWSTask<AWSSESListTemplatesResponse *> *)listTemplates:(AWSSESListTemplatesRequest *)request;
 
 /**
  <p>Lists the email templates present in your Amazon SES account in the current AWS Region.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the ListEmailTemplates service method.
+ @param request A container for the necessary parameters to execute the ListTemplates service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESListEmailTemplatesRequest
- @see AWSSESListEmailTemplatesResponse
+ @see AWSSESListTemplatesRequest
+ @see AWSSESListTemplatesResponse
  */
-- (void)listEmailTemplates:(AWSSESListEmailTemplatesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListEmailTemplatesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)listTemplates:(AWSSESListTemplatesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListTemplatesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Lists all of the import jobs.</p>
+ <p>Deprecated. Use the <code>ListIdentities</code> operation to list the email addresses and domains associated with your account.</p>
  
- @param request A container for the necessary parameters to execute the ListImportJobs service method.
+ @param request A container for the necessary parameters to execute the ListVerifiedEmailAddresses service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListImportJobsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListVerifiedEmailAddressesResponse`.
  
- @see AWSSESListImportJobsRequest
- @see AWSSESListImportJobsResponse
+ @see AWSRequest
+ @see AWSSESListVerifiedEmailAddressesResponse
  */
-- (AWSTask<AWSSESListImportJobsResponse *> *)listImportJobs:(AWSSESListImportJobsRequest *)request;
+- (AWSTask<AWSSESListVerifiedEmailAddressesResponse *> *)listVerifiedEmailAddresses:(AWSRequest *)request;
 
 /**
- <p>Lists all of the import jobs.</p>
+ <p>Deprecated. Use the <code>ListIdentities</code> operation to list the email addresses and domains associated with your account.</p>
  
- @param request A container for the necessary parameters to execute the ListImportJobs service method.
+ @param request A container for the necessary parameters to execute the ListVerifiedEmailAddresses service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESListImportJobsRequest
- @see AWSSESListImportJobsResponse
+ @see AWSRequest
+ @see AWSSESListVerifiedEmailAddressesResponse
  */
-- (void)listImportJobs:(AWSSESListImportJobsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListImportJobsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)listVerifiedEmailAddresses:(AWSRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListVerifiedEmailAddressesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Retrieves a list of email addresses that are on the suppression list for your account.</p>
- 
- @param request A container for the necessary parameters to execute the ListSuppressedDestinations service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListSuppressedDestinationsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`, `AWSSESErrorInvalidNextToken`.
- 
- @see AWSSESListSuppressedDestinationsRequest
- @see AWSSESListSuppressedDestinationsResponse
- */
-- (AWSTask<AWSSESListSuppressedDestinationsResponse *> *)listSuppressedDestinations:(AWSSESListSuppressedDestinationsRequest *)request;
-
-/**
- <p>Retrieves a list of email addresses that are on the suppression list for your account.</p>
- 
- @param request A container for the necessary parameters to execute the ListSuppressedDestinations service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`, `AWSSESErrorInvalidNextToken`.
- 
- @see AWSSESListSuppressedDestinationsRequest
- @see AWSSESListSuppressedDestinationsResponse
- */
-- (void)listSuppressedDestinations:(AWSSESListSuppressedDestinationsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListSuppressedDestinationsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Retrieve a list of the tags (keys and values) that are associated with a specified resource. A <i>tag</i> is a label that you optionally define and associate with a resource. Each tag consists of a required <i>tag key</i> and an optional associated <i>tag value</i>. A tag key is a general label that acts as a category for more specific tag values. A tag value acts as a descriptor within a tag key.</p>
- 
- @param request A container for the necessary parameters to execute the ListTagsForResource service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESListTagsForResourceResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
- 
- @see AWSSESListTagsForResourceRequest
- @see AWSSESListTagsForResourceResponse
- */
-- (AWSTask<AWSSESListTagsForResourceResponse *> *)listTagsForResource:(AWSSESListTagsForResourceRequest *)request;
-
-/**
- <p>Retrieve a list of the tags (keys and values) that are associated with a specified resource. A <i>tag</i> is a label that you optionally define and associate with a resource. Each tag consists of a required <i>tag key</i> and an optional associated <i>tag value</i>. A tag key is a general label that acts as a category for more specific tag values. A tag value acts as a descriptor within a tag key.</p>
- 
- @param request A container for the necessary parameters to execute the ListTagsForResource service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
- 
- @see AWSSESListTagsForResourceRequest
- @see AWSSESListTagsForResourceResponse
- */
-- (void)listTagsForResource:(AWSSESListTagsForResourceRequest *)request completionHandler:(void (^ _Nullable)(AWSSESListTagsForResourceResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Enable or disable the automatic warm-up feature for dedicated IP addresses.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountDedicatedIpWarmupAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutAccountDedicatedIpWarmupAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutAccountDedicatedIpWarmupAttributesRequest
- @see AWSSESPutAccountDedicatedIpWarmupAttributesResponse
- */
-- (AWSTask<AWSSESPutAccountDedicatedIpWarmupAttributesResponse *> *)putAccountDedicatedIpWarmupAttributes:(AWSSESPutAccountDedicatedIpWarmupAttributesRequest *)request;
-
-/**
- <p>Enable or disable the automatic warm-up feature for dedicated IP addresses.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountDedicatedIpWarmupAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutAccountDedicatedIpWarmupAttributesRequest
- @see AWSSESPutAccountDedicatedIpWarmupAttributesResponse
- */
-- (void)putAccountDedicatedIpWarmupAttributes:(AWSSESPutAccountDedicatedIpWarmupAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutAccountDedicatedIpWarmupAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Update your Amazon SES account details.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountDetails service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutAccountDetailsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConflict`.
- 
- @see AWSSESPutAccountDetailsRequest
- @see AWSSESPutAccountDetailsResponse
- */
-- (AWSTask<AWSSESPutAccountDetailsResponse *> *)putAccountDetails:(AWSSESPutAccountDetailsRequest *)request;
-
-/**
- <p>Update your Amazon SES account details.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountDetails service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`, `AWSSESErrorConflict`.
- 
- @see AWSSESPutAccountDetailsRequest
- @see AWSSESPutAccountDetailsResponse
- */
-- (void)putAccountDetails:(AWSSESPutAccountDetailsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutAccountDetailsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Enable or disable the ability of your account to send email.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountSendingAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutAccountSendingAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutAccountSendingAttributesRequest
- @see AWSSESPutAccountSendingAttributesResponse
- */
-- (AWSTask<AWSSESPutAccountSendingAttributesResponse *> *)putAccountSendingAttributes:(AWSSESPutAccountSendingAttributesRequest *)request;
-
-/**
- <p>Enable or disable the ability of your account to send email.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountSendingAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutAccountSendingAttributesRequest
- @see AWSSESPutAccountSendingAttributesResponse
- */
-- (void)putAccountSendingAttributes:(AWSSESPutAccountSendingAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutAccountSendingAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Change the settings for the account-level suppression list.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountSuppressionAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutAccountSuppressionAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutAccountSuppressionAttributesRequest
- @see AWSSESPutAccountSuppressionAttributesResponse
- */
-- (AWSTask<AWSSESPutAccountSuppressionAttributesResponse *> *)putAccountSuppressionAttributes:(AWSSESPutAccountSuppressionAttributesRequest *)request;
-
-/**
- <p>Change the settings for the account-level suppression list.</p>
- 
- @param request A container for the necessary parameters to execute the PutAccountSuppressionAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutAccountSuppressionAttributesRequest
- @see AWSSESPutAccountSuppressionAttributesResponse
- */
-- (void)putAccountSuppressionAttributes:(AWSSESPutAccountSuppressionAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutAccountSuppressionAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Associate a configuration set with a dedicated IP pool. You can use dedicated IP pools to create groups of dedicated IP addresses for sending specific types of email.</p>
+ <p>Adds or updates the delivery options for a configuration set.</p>
  
  @param request A container for the necessary parameters to execute the PutConfigurationSetDeliveryOptions service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutConfigurationSetDeliveryOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutConfigurationSetDeliveryOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorInvalidDeliveryOptions`.
  
  @see AWSSESPutConfigurationSetDeliveryOptionsRequest
  @see AWSSESPutConfigurationSetDeliveryOptionsResponse
@@ -1362,12 +1228,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESPutConfigurationSetDeliveryOptionsResponse *> *)putConfigurationSetDeliveryOptions:(AWSSESPutConfigurationSetDeliveryOptionsRequest *)request;
 
 /**
- <p>Associate a configuration set with a dedicated IP pool. You can use dedicated IP pools to create groups of dedicated IP addresses for sending specific types of email.</p>
+ <p>Adds or updates the delivery options for a configuration set.</p>
  
  @param request A container for the necessary parameters to execute the PutConfigurationSetDeliveryOptions service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorInvalidDeliveryOptions`.
  
  @see AWSSESPutConfigurationSetDeliveryOptionsRequest
  @see AWSSESPutConfigurationSetDeliveryOptionsResponse
@@ -1375,336 +1241,111 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)putConfigurationSetDeliveryOptions:(AWSSESPutConfigurationSetDeliveryOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutConfigurationSetDeliveryOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Enable or disable collection of reputation metrics for emails that you send using a particular configuration set in a specific AWS Region.</p>
+ <p>Adds or updates a sending authorization policy for the specified identity (an email address or a domain).</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetReputationOptions service method.
+ @param request A container for the necessary parameters to execute the PutIdentityPolicy service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutConfigurationSetReputationOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutIdentityPolicyResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorInvalidPolicy`.
  
- @see AWSSESPutConfigurationSetReputationOptionsRequest
- @see AWSSESPutConfigurationSetReputationOptionsResponse
+ @see AWSSESPutIdentityPolicyRequest
+ @see AWSSESPutIdentityPolicyResponse
  */
-- (AWSTask<AWSSESPutConfigurationSetReputationOptionsResponse *> *)putConfigurationSetReputationOptions:(AWSSESPutConfigurationSetReputationOptionsRequest *)request;
+- (AWSTask<AWSSESPutIdentityPolicyResponse *> *)putIdentityPolicy:(AWSSESPutIdentityPolicyRequest *)request;
 
 /**
- <p>Enable or disable collection of reputation metrics for emails that you send using a particular configuration set in a specific AWS Region.</p>
+ <p>Adds or updates a sending authorization policy for the specified identity (an email address or a domain).</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetReputationOptions service method.
+ @param request A container for the necessary parameters to execute the PutIdentityPolicy service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorInvalidPolicy`.
  
- @see AWSSESPutConfigurationSetReputationOptionsRequest
- @see AWSSESPutConfigurationSetReputationOptionsResponse
+ @see AWSSESPutIdentityPolicyRequest
+ @see AWSSESPutIdentityPolicyResponse
  */
-- (void)putConfigurationSetReputationOptions:(AWSSESPutConfigurationSetReputationOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutConfigurationSetReputationOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)putIdentityPolicy:(AWSSESPutIdentityPolicyRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutIdentityPolicyResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Enable or disable email sending for messages that use a particular configuration set in a specific AWS Region.</p>
+ <p>Reorders the receipt rules within a receipt rule set.</p><note><p>All of the rules in the rule set must be represented in this request. That is, this API will return an error if the reorder request doesn't explicitly position all of the rules.</p></note><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetSendingOptions service method.
+ @param request A container for the necessary parameters to execute the ReorderReceiptRuleSet service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutConfigurationSetSendingOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESReorderReceiptRuleSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorRuleDoesNotExist`.
  
- @see AWSSESPutConfigurationSetSendingOptionsRequest
- @see AWSSESPutConfigurationSetSendingOptionsResponse
+ @see AWSSESReorderReceiptRuleSetRequest
+ @see AWSSESReorderReceiptRuleSetResponse
  */
-- (AWSTask<AWSSESPutConfigurationSetSendingOptionsResponse *> *)putConfigurationSetSendingOptions:(AWSSESPutConfigurationSetSendingOptionsRequest *)request;
+- (AWSTask<AWSSESReorderReceiptRuleSetResponse *> *)reorderReceiptRuleSet:(AWSSESReorderReceiptRuleSetRequest *)request;
 
 /**
- <p>Enable or disable email sending for messages that use a particular configuration set in a specific AWS Region.</p>
+ <p>Reorders the receipt rules within a receipt rule set.</p><note><p>All of the rules in the rule set must be represented in this request. That is, this API will return an error if the reorder request doesn't explicitly position all of the rules.</p></note><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetSendingOptions service method.
+ @param request A container for the necessary parameters to execute the ReorderReceiptRuleSet service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorRuleDoesNotExist`.
  
- @see AWSSESPutConfigurationSetSendingOptionsRequest
- @see AWSSESPutConfigurationSetSendingOptionsResponse
+ @see AWSSESReorderReceiptRuleSetRequest
+ @see AWSSESReorderReceiptRuleSetResponse
  */
-- (void)putConfigurationSetSendingOptions:(AWSSESPutConfigurationSetSendingOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutConfigurationSetSendingOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)reorderReceiptRuleSet:(AWSSESReorderReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESReorderReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Specify the account suppression list preferences for a configuration set.</p>
+ <p>Generates and sends a bounce message to the sender of an email you received through Amazon SES. You can only use this API on an email up to 24 hours after you receive it.</p><note><p>You cannot use this API to send generic bounces for mail that was not received by Amazon SES.</p></note><p>For information about receiving email through Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetSuppressionOptions service method.
+ @param request A container for the necessary parameters to execute the SendBounce service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutConfigurationSetSuppressionOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendBounceResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`.
  
- @see AWSSESPutConfigurationSetSuppressionOptionsRequest
- @see AWSSESPutConfigurationSetSuppressionOptionsResponse
+ @see AWSSESSendBounceRequest
+ @see AWSSESSendBounceResponse
  */
-- (AWSTask<AWSSESPutConfigurationSetSuppressionOptionsResponse *> *)putConfigurationSetSuppressionOptions:(AWSSESPutConfigurationSetSuppressionOptionsRequest *)request;
+- (AWSTask<AWSSESSendBounceResponse *> *)sendBounce:(AWSSESSendBounceRequest *)request;
 
 /**
- <p>Specify the account suppression list preferences for a configuration set.</p>
+ <p>Generates and sends a bounce message to the sender of an email you received through Amazon SES. You can only use this API on an email up to 24 hours after you receive it.</p><note><p>You cannot use this API to send generic bounces for mail that was not received by Amazon SES.</p></note><p>For information about receiving email through Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetSuppressionOptions service method.
+ @param request A container for the necessary parameters to execute the SendBounce service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`.
  
- @see AWSSESPutConfigurationSetSuppressionOptionsRequest
- @see AWSSESPutConfigurationSetSuppressionOptionsResponse
+ @see AWSSESSendBounceRequest
+ @see AWSSESSendBounceResponse
  */
-- (void)putConfigurationSetSuppressionOptions:(AWSSESPutConfigurationSetSuppressionOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutConfigurationSetSuppressionOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)sendBounce:(AWSSESSendBounceRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendBounceResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Specify a custom domain to use for open and click tracking elements in email that you send.</p>
+ <p>Composes an email message to multiple destinations. The message body is created using an email template.</p><p>In order to send email using the <code>SendBulkTemplatedEmail</code> operation, your call to the API must meet the following requirements:</p><ul><li><p>The call must refer to an existing email template. You can create email templates using the <a>CreateTemplate</a> operation.</p></li><li><p>The message must be sent from a verified email address or domain.</p></li><li><p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>The maximum message size is 10 MB.</p></li><li><p>Each <code>Destination</code> parameter must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p></li><li><p>The message may not include more than 50 recipients, across the To:, CC: and BCC: fields. If you need to send an email message to a larger audience, you can divide your recipient list into groups of 50 or fewer, and then call the <code>SendBulkTemplatedEmail</code> operation several times to send the message to each group.</p></li><li><p>The number of destinations you can contact in a single call to the API may be limited by your account's maximum sending rate.</p></li></ul>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetTrackingOptions service method.
+ @param request A container for the necessary parameters to execute the SendBulkTemplatedEmail service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutConfigurationSetTrackingOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendBulkTemplatedEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
  
- @see AWSSESPutConfigurationSetTrackingOptionsRequest
- @see AWSSESPutConfigurationSetTrackingOptionsResponse
+ @see AWSSESSendBulkTemplatedEmailRequest
+ @see AWSSESSendBulkTemplatedEmailResponse
  */
-- (AWSTask<AWSSESPutConfigurationSetTrackingOptionsResponse *> *)putConfigurationSetTrackingOptions:(AWSSESPutConfigurationSetTrackingOptionsRequest *)request;
+- (AWSTask<AWSSESSendBulkTemplatedEmailResponse *> *)sendBulkTemplatedEmail:(AWSSESSendBulkTemplatedEmailRequest *)request;
 
 /**
- <p>Specify a custom domain to use for open and click tracking elements in email that you send.</p>
+ <p>Composes an email message to multiple destinations. The message body is created using an email template.</p><p>In order to send email using the <code>SendBulkTemplatedEmail</code> operation, your call to the API must meet the following requirements:</p><ul><li><p>The call must refer to an existing email template. You can create email templates using the <a>CreateTemplate</a> operation.</p></li><li><p>The message must be sent from a verified email address or domain.</p></li><li><p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>The maximum message size is 10 MB.</p></li><li><p>Each <code>Destination</code> parameter must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p></li><li><p>The message may not include more than 50 recipients, across the To:, CC: and BCC: fields. If you need to send an email message to a larger audience, you can divide your recipient list into groups of 50 or fewer, and then call the <code>SendBulkTemplatedEmail</code> operation several times to send the message to each group.</p></li><li><p>The number of destinations you can contact in a single call to the API may be limited by your account's maximum sending rate.</p></li></ul>
  
- @param request A container for the necessary parameters to execute the PutConfigurationSetTrackingOptions service method.
+ @param request A container for the necessary parameters to execute the SendBulkTemplatedEmail service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
  
- @see AWSSESPutConfigurationSetTrackingOptionsRequest
- @see AWSSESPutConfigurationSetTrackingOptionsResponse
+ @see AWSSESSendBulkTemplatedEmailRequest
+ @see AWSSESSendBulkTemplatedEmailResponse
  */
-- (void)putConfigurationSetTrackingOptions:(AWSSESPutConfigurationSetTrackingOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutConfigurationSetTrackingOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)sendBulkTemplatedEmail:(AWSSESSendBulkTemplatedEmailRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendBulkTemplatedEmailResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Move a dedicated IP address to an existing dedicated IP pool.</p><note><p>The dedicated IP address that you specify must already exist, and must be associated with your AWS account. </p><p>The dedicated IP pool you specify must already exist. You can create a new pool by using the <code>CreateDedicatedIpPool</code> operation.</p></note>
- 
- @param request A container for the necessary parameters to execute the PutDedicatedIpInPool service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutDedicatedIpInPoolResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutDedicatedIpInPoolRequest
- @see AWSSESPutDedicatedIpInPoolResponse
- */
-- (AWSTask<AWSSESPutDedicatedIpInPoolResponse *> *)putDedicatedIpInPool:(AWSSESPutDedicatedIpInPoolRequest *)request;
-
-/**
- <p>Move a dedicated IP address to an existing dedicated IP pool.</p><note><p>The dedicated IP address that you specify must already exist, and must be associated with your AWS account. </p><p>The dedicated IP pool you specify must already exist. You can create a new pool by using the <code>CreateDedicatedIpPool</code> operation.</p></note>
- 
- @param request A container for the necessary parameters to execute the PutDedicatedIpInPool service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutDedicatedIpInPoolRequest
- @see AWSSESPutDedicatedIpInPoolResponse
- */
-- (void)putDedicatedIpInPool:(AWSSESPutDedicatedIpInPoolRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutDedicatedIpInPoolResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p/>
- 
- @param request A container for the necessary parameters to execute the PutDedicatedIpWarmupAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutDedicatedIpWarmupAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutDedicatedIpWarmupAttributesRequest
- @see AWSSESPutDedicatedIpWarmupAttributesResponse
- */
-- (AWSTask<AWSSESPutDedicatedIpWarmupAttributesResponse *> *)putDedicatedIpWarmupAttributes:(AWSSESPutDedicatedIpWarmupAttributesRequest *)request;
-
-/**
- <p/>
- 
- @param request A container for the necessary parameters to execute the PutDedicatedIpWarmupAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutDedicatedIpWarmupAttributesRequest
- @see AWSSESPutDedicatedIpWarmupAttributesResponse
- */
-- (void)putDedicatedIpWarmupAttributes:(AWSSESPutDedicatedIpWarmupAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutDedicatedIpWarmupAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email. You also gain the ability to perform predictive inbox placement tests.</p><p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href="http://aws.amazon.com/ses/pricing/">Amazon SES Pricing</a>.</p>
- 
- @param request A container for the necessary parameters to execute the PutDeliverabilityDashboardOption service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutDeliverabilityDashboardOptionResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutDeliverabilityDashboardOptionRequest
- @see AWSSESPutDeliverabilityDashboardOptionResponse
- */
-- (AWSTask<AWSSESPutDeliverabilityDashboardOptionResponse *> *)putDeliverabilityDashboardOption:(AWSSESPutDeliverabilityDashboardOptionRequest *)request;
-
-/**
- <p>Enable or disable the Deliverability dashboard. When you enable the Deliverability dashboard, you gain access to reputation, deliverability, and other metrics for the domains that you use to send email. You also gain the ability to perform predictive inbox placement tests.</p><p>When you use the Deliverability dashboard, you pay a monthly subscription charge, in addition to any other fees that you accrue by using Amazon SES and other AWS services. For more information about the features and cost of a Deliverability dashboard subscription, see <a href="http://aws.amazon.com/ses/pricing/">Amazon SES Pricing</a>.</p>
- 
- @param request A container for the necessary parameters to execute the PutDeliverabilityDashboardOption service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorAlreadyExists`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutDeliverabilityDashboardOptionRequest
- @see AWSSESPutDeliverabilityDashboardOptionResponse
- */
-- (void)putDeliverabilityDashboardOption:(AWSSESPutDeliverabilityDashboardOptionRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutDeliverabilityDashboardOptionResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Used to enable or disable DKIM authentication for an email identity.</p>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityDkimAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutEmailIdentityDkimAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityDkimAttributesRequest
- @see AWSSESPutEmailIdentityDkimAttributesResponse
- */
-- (AWSTask<AWSSESPutEmailIdentityDkimAttributesResponse *> *)putEmailIdentityDkimAttributes:(AWSSESPutEmailIdentityDkimAttributesRequest *)request;
-
-/**
- <p>Used to enable or disable DKIM authentication for an email identity.</p>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityDkimAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityDkimAttributesRequest
- @see AWSSESPutEmailIdentityDkimAttributesResponse
- */
-- (void)putEmailIdentityDkimAttributes:(AWSSESPutEmailIdentityDkimAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutEmailIdentityDkimAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Used to configure or change the DKIM authentication settings for an email domain identity. You can use this operation to do any of the following:</p><ul><li><p>Update the signing attributes for an identity that uses Bring Your Own DKIM (BYODKIM).</p></li><li><p>Change from using no DKIM authentication to using Easy DKIM.</p></li><li><p>Change from using no DKIM authentication to using BYODKIM.</p></li><li><p>Change from using Easy DKIM to using BYODKIM.</p></li><li><p>Change from using BYODKIM to using Easy DKIM.</p></li></ul>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityDkimSigningAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutEmailIdentityDkimSigningAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityDkimSigningAttributesRequest
- @see AWSSESPutEmailIdentityDkimSigningAttributesResponse
- */
-- (AWSTask<AWSSESPutEmailIdentityDkimSigningAttributesResponse *> *)putEmailIdentityDkimSigningAttributes:(AWSSESPutEmailIdentityDkimSigningAttributesRequest *)request;
-
-/**
- <p>Used to configure or change the DKIM authentication settings for an email domain identity. You can use this operation to do any of the following:</p><ul><li><p>Update the signing attributes for an identity that uses Bring Your Own DKIM (BYODKIM).</p></li><li><p>Change from using no DKIM authentication to using Easy DKIM.</p></li><li><p>Change from using no DKIM authentication to using BYODKIM.</p></li><li><p>Change from using Easy DKIM to using BYODKIM.</p></li><li><p>Change from using BYODKIM to using Easy DKIM.</p></li></ul>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityDkimSigningAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityDkimSigningAttributesRequest
- @see AWSSESPutEmailIdentityDkimSigningAttributesResponse
- */
-- (void)putEmailIdentityDkimSigningAttributes:(AWSSESPutEmailIdentityDkimSigningAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutEmailIdentityDkimSigningAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Used to enable or disable feedback forwarding for an identity. This setting determines what happens when an identity is used to send an email that results in a bounce or complaint event.</p><p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p><p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityFeedbackAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutEmailIdentityFeedbackAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityFeedbackAttributesRequest
- @see AWSSESPutEmailIdentityFeedbackAttributesResponse
- */
-- (AWSTask<AWSSESPutEmailIdentityFeedbackAttributesResponse *> *)putEmailIdentityFeedbackAttributes:(AWSSESPutEmailIdentityFeedbackAttributesRequest *)request;
-
-/**
- <p>Used to enable or disable feedback forwarding for an identity. This setting determines what happens when an identity is used to send an email that results in a bounce or complaint event.</p><p>If the value is <code>true</code>, you receive email notifications when bounce or complaint events occur. These notifications are sent to the address that you specified in the <code>Return-Path</code> header of the original email.</p><p>You're required to have a method of tracking bounces and complaints. If you haven't set up another mechanism for receiving bounce or complaint notifications (for example, by setting up an event destination), you receive an email notification when these events occur (even if this setting is disabled).</p>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityFeedbackAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityFeedbackAttributesRequest
- @see AWSSESPutEmailIdentityFeedbackAttributesResponse
- */
-- (void)putEmailIdentityFeedbackAttributes:(AWSSESPutEmailIdentityFeedbackAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutEmailIdentityFeedbackAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Used to enable or disable the custom Mail-From domain configuration for an email identity.</p>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityMailFromAttributes service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutEmailIdentityMailFromAttributesResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityMailFromAttributesRequest
- @see AWSSESPutEmailIdentityMailFromAttributesResponse
- */
-- (AWSTask<AWSSESPutEmailIdentityMailFromAttributesResponse *> *)putEmailIdentityMailFromAttributes:(AWSSESPutEmailIdentityMailFromAttributesRequest *)request;
-
-/**
- <p>Used to enable or disable the custom Mail-From domain configuration for an email identity.</p>
- 
- @param request A container for the necessary parameters to execute the PutEmailIdentityMailFromAttributes service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESPutEmailIdentityMailFromAttributesRequest
- @see AWSSESPutEmailIdentityMailFromAttributesResponse
- */
-- (void)putEmailIdentityMailFromAttributes:(AWSSESPutEmailIdentityMailFromAttributesRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutEmailIdentityMailFromAttributesResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Adds an email address to the suppression list for your account.</p>
- 
- @param request A container for the necessary parameters to execute the PutSuppressedDestination service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESPutSuppressedDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`.
- 
- @see AWSSESPutSuppressedDestinationRequest
- @see AWSSESPutSuppressedDestinationResponse
- */
-- (AWSTask<AWSSESPutSuppressedDestinationResponse *> *)putSuppressedDestination:(AWSSESPutSuppressedDestinationRequest *)request;
-
-/**
- <p>Adds an email address to the suppression list for your account.</p>
- 
- @param request A container for the necessary parameters to execute the PutSuppressedDestination service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`.
- 
- @see AWSSESPutSuppressedDestinationRequest
- @see AWSSESPutSuppressedDestinationResponse
- */
-- (void)putSuppressedDestination:(AWSSESPutSuppressedDestinationRequest *)request completionHandler:(void (^ _Nullable)(AWSSESPutSuppressedDestinationResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Composes an email message to multiple destinations.</p>
- 
- @param request A container for the necessary parameters to execute the SendBulkEmail service method.
-
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendBulkEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorAccountSuspended`, `AWSSESErrorSendingPaused`, `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESSendBulkEmailRequest
- @see AWSSESSendBulkEmailResponse
- */
-- (AWSTask<AWSSESSendBulkEmailResponse *> *)sendBulkEmail:(AWSSESSendBulkEmailRequest *)request;
-
-/**
- <p>Composes an email message to multiple destinations.</p>
- 
- @param request A container for the necessary parameters to execute the SendBulkEmail service method.
- @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorAccountSuspended`, `AWSSESErrorSendingPaused`, `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
- 
- @see AWSSESSendBulkEmailRequest
- @see AWSSESSendBulkEmailResponse
- */
-- (void)sendBulkEmail:(AWSSESSendBulkEmailRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendBulkEmailResponse * _Nullable response, NSError * _Nullable error))completionHandler;
-
-/**
- <p>Adds an email address to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. As a result of executing this operation, a customized verification email is sent to the specified address.</p><p>To use this operation, you must first create a custom verification email template. For more information about creating and using custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Adds an email address to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. As a result of executing this operation, a customized verification email is sent to the specified address.</p><p>To use this operation, you must first create a custom verification email template. For more information about creating and using custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the SendCustomVerificationEmail service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendCustomVerificationEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorMessageRejected`, `AWSSESErrorSendingPaused`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendCustomVerificationEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorCustomVerificationEmailTemplateDoesNotExist`, `AWSSESErrorFromEmailAddressNotVerified`, `AWSSESErrorProductionAccessNotGranted`.
  
  @see AWSSESSendCustomVerificationEmailRequest
  @see AWSSESSendCustomVerificationEmailResponse
@@ -1712,12 +1353,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESSendCustomVerificationEmailResponse *> *)sendCustomVerificationEmail:(AWSSESSendCustomVerificationEmailRequest *)request;
 
 /**
- <p>Adds an email address to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. As a result of executing this operation, a customized verification email is sent to the specified address.</p><p>To use this operation, you must first create a custom verification email template. For more information about creating and using custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Adds an email address to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. As a result of executing this operation, a customized verification email is sent to the specified address.</p><p>To use this operation, you must first create a custom verification email template. For more information about creating and using custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the SendCustomVerificationEmail service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorMessageRejected`, `AWSSESErrorSendingPaused`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorCustomVerificationEmailTemplateDoesNotExist`, `AWSSESErrorFromEmailAddressNotVerified`, `AWSSESErrorProductionAccessNotGranted`.
  
  @see AWSSESSendCustomVerificationEmailRequest
  @see AWSSESSendCustomVerificationEmailResponse
@@ -1725,11 +1366,11 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)sendCustomVerificationEmail:(AWSSESSendCustomVerificationEmailRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendCustomVerificationEmailResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Sends an email message. You can use the Amazon SES API v2 to send two types of messages:</p><ul><li><p><b>Simple</b> – A standard email message. When you create this type of message, you specify the sender, the recipient, and the message body, and Amazon SES assembles the message for you.</p></li><li><p><b>Raw</b> – A raw, MIME-formatted email message. When you send this type of email, you have to specify all of the message headers, as well as the message body. You can use this message type to send messages that contain attachments. The message that you specify has to be a valid MIME message.</p></li><li><p><b>Templated</b> – A message that contains personalization tags. When you send this type of email, Amazon SES API v2 automatically replaces the tags with values that you specify.</p></li></ul>
+ <p>Composes an email message and immediately queues it for sending. In order to send email using the <code>SendEmail</code> operation, your message must meet the following requirements:</p><ul><li><p>The message must be sent from a verified email address or domain. If you attempt to send email using a non-verified address or domain, the operation will result in an "Email address not verified" error. </p></li><li><p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>The maximum message size is 10 MB.</p></li><li><p>The message must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p></li><li><p>The message may not include more than 50 recipients, across the To:, CC: and BCC: fields. If you need to send an email message to a larger audience, you can divide your recipient list into groups of 50 or fewer, and then call the <code>SendEmail</code> operation several times to send the message to each group.</p></li></ul><important><p>For every message that you send, the total number of recipients (including each recipient in the To:, CC: and BCC: fields) is counted against the maximum number of emails you can send in a 24-hour period (your <i>sending quota</i>). For more information about sending quotas in Amazon SES, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html">Managing Your Amazon SES Sending Limits</a> in the <i>Amazon SES Developer Guide.</i></p></important>
  
  @param request A container for the necessary parameters to execute the SendEmail service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorAccountSuspended`, `AWSSESErrorSendingPaused`, `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
  
  @see AWSSESSendEmailRequest
  @see AWSSESSendEmailResponse
@@ -1737,12 +1378,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESSendEmailResponse *> *)sendEmail:(AWSSESSendEmailRequest *)request;
 
 /**
- <p>Sends an email message. You can use the Amazon SES API v2 to send two types of messages:</p><ul><li><p><b>Simple</b> – A standard email message. When you create this type of message, you specify the sender, the recipient, and the message body, and Amazon SES assembles the message for you.</p></li><li><p><b>Raw</b> – A raw, MIME-formatted email message. When you send this type of email, you have to specify all of the message headers, as well as the message body. You can use this message type to send messages that contain attachments. The message that you specify has to be a valid MIME message.</p></li><li><p><b>Templated</b> – A message that contains personalization tags. When you send this type of email, Amazon SES API v2 automatically replaces the tags with values that you specify.</p></li></ul>
+ <p>Composes an email message and immediately queues it for sending. In order to send email using the <code>SendEmail</code> operation, your message must meet the following requirements:</p><ul><li><p>The message must be sent from a verified email address or domain. If you attempt to send email using a non-verified address or domain, the operation will result in an "Email address not verified" error. </p></li><li><p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>The maximum message size is 10 MB.</p></li><li><p>The message must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p></li><li><p>The message may not include more than 50 recipients, across the To:, CC: and BCC: fields. If you need to send an email message to a larger audience, you can divide your recipient list into groups of 50 or fewer, and then call the <code>SendEmail</code> operation several times to send the message to each group.</p></li></ul><important><p>For every message that you send, the total number of recipients (including each recipient in the To:, CC: and BCC: fields) is counted against the maximum number of emails you can send in a 24-hour period (your <i>sending quota</i>). For more information about sending quotas in Amazon SES, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html">Managing Your Amazon SES Sending Limits</a> in the <i>Amazon SES Developer Guide.</i></p></important>
  
  @param request A container for the necessary parameters to execute the SendEmail service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTooManyRequests`, `AWSSESErrorLimitExceeded`, `AWSSESErrorAccountSuspended`, `AWSSESErrorSendingPaused`, `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
  
  @see AWSSESSendEmailRequest
  @see AWSSESSendEmailResponse
@@ -1750,86 +1391,283 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)sendEmail:(AWSSESSendEmailRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendEmailResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Add one or more tags (keys and values) to a specified resource. A <i>tag</i> is a label that you optionally define and associate with a resource. Tags can help you categorize and manage resources in different ways, such as by purpose, owner, environment, or other criteria. A resource can have as many as 50 tags.</p><p>Each tag consists of a required <i>tag key</i> and an associated <i>tag value</i>, both of which you define. A tag key is a general label that acts as a category for more specific tag values. A tag value acts as a descriptor within a tag key.</p>
+ <p>Composes an email message and immediately queues it for sending.</p><p>This operation is more flexible than the <code>SendEmail</code> API operation. When you use the <code>SendRawEmail</code> operation, you can specify the headers of the message as well as its content. This flexibility is useful, for example, when you want to send a multipart MIME email (such a message that contains both a text and an HTML version). You can also use this operation to send messages that include attachments.</p><p>The <code>SendRawEmail</code> operation has the following requirements:</p><ul><li><p>You can only send email from <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">verified email addresses or domains</a>. If you try to send email from an address that isn't verified, the operation results in an "Email address not verified" error.</p></li><li><p>If your account is still in the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Amazon SES sandbox</a>, you can only send email to other verified addresses in your account, or to addresses that are associated with the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html">Amazon SES mailbox simulator</a>.</p></li><li><p>The maximum message size, including attachments, is 10 MB.</p></li><li><p>Each message has to include at least one recipient address. A recipient address includes any address on the To:, CC:, or BCC: lines.</p></li><li><p>If you send a single message to more than one recipient address, and one of the recipient addresses isn't in a valid format (that is, it's not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), Amazon SES rejects the entire message, even if the other addresses are valid.</p></li><li><p>Each message can include up to 50 recipient addresses across the To:, CC:, or BCC: lines. If you need to send a single message to more than 50 recipients, you have to split the list of recipient addresses into groups of less than 50 recipients, and send separate messages to each group.</p></li><li><p>Amazon SES allows you to specify 8-bit Content-Transfer-Encoding for MIME message parts. However, if Amazon SES has to modify the contents of your message (for example, if you use open and click tracking), 8-bit content isn't preserved. For this reason, we highly recommend that you encode all content that isn't 7-bit ASCII. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html#send-email-mime-encoding">MIME Encoding</a> in the <i>Amazon SES Developer Guide</i>.</p></li></ul><p>Additionally, keep the following considerations in mind when using the <code>SendRawEmail</code> operation:</p><ul><li><p>Although you can customize the message headers when using the <code>SendRawEmail</code> operation, Amazon SES will automatically apply its own <code>Message-ID</code> and <code>Date</code> headers; if you passed these headers when creating the message, they will be overwritten by the values that Amazon SES provides.</p></li><li><p>If you are using sending authorization to send on behalf of another user, <code>SendRawEmail</code> enables you to specify the cross-account identity for the email's Source, From, and Return-Path parameters in one of two ways: you can pass optional parameters <code>SourceArn</code>, <code>FromArn</code>, and/or <code>ReturnPathArn</code> to the API, or you can include the following X-headers in the header of your raw email:</p><ul><li><p><code>X-SES-SOURCE-ARN</code></p></li><li><p><code>X-SES-FROM-ARN</code></p></li><li><p><code>X-SES-RETURN-PATH-ARN</code></p></li></ul><important><p>Don't include these X-headers in the DKIM signature. Amazon SES removes these before it sends the email.</p></important><p>If you only specify the <code>SourceIdentityArn</code> parameter, Amazon SES sets the From and Return-Path addresses to the same identity that you specified.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Using Sending Authorization with Amazon SES</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>For every message that you send, the total number of recipients (including each recipient in the To:, CC: and BCC: fields) is counted against the maximum number of emails you can send in a 24-hour period (your <i>sending quota</i>). For more information about sending quotas in Amazon SES, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html">Managing Your Amazon SES Sending Limits</a> in the <i>Amazon SES Developer Guide.</i></p></li></ul>
  
- @param request A container for the necessary parameters to execute the TagResource service method.
+ @param request A container for the necessary parameters to execute the SendRawEmail service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESTagResourceResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendRawEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
  
- @see AWSSESTagResourceRequest
- @see AWSSESTagResourceResponse
+ @see AWSSESSendRawEmailRequest
+ @see AWSSESSendRawEmailResponse
  */
-- (AWSTask<AWSSESTagResourceResponse *> *)tagResource:(AWSSESTagResourceRequest *)request;
+- (AWSTask<AWSSESSendRawEmailResponse *> *)sendRawEmail:(AWSSESSendRawEmailRequest *)request;
 
 /**
- <p>Add one or more tags (keys and values) to a specified resource. A <i>tag</i> is a label that you optionally define and associate with a resource. Tags can help you categorize and manage resources in different ways, such as by purpose, owner, environment, or other criteria. A resource can have as many as 50 tags.</p><p>Each tag consists of a required <i>tag key</i> and an associated <i>tag value</i>, both of which you define. A tag key is a general label that acts as a category for more specific tag values. A tag value acts as a descriptor within a tag key.</p>
+ <p>Composes an email message and immediately queues it for sending.</p><p>This operation is more flexible than the <code>SendEmail</code> API operation. When you use the <code>SendRawEmail</code> operation, you can specify the headers of the message as well as its content. This flexibility is useful, for example, when you want to send a multipart MIME email (such a message that contains both a text and an HTML version). You can also use this operation to send messages that include attachments.</p><p>The <code>SendRawEmail</code> operation has the following requirements:</p><ul><li><p>You can only send email from <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">verified email addresses or domains</a>. If you try to send email from an address that isn't verified, the operation results in an "Email address not verified" error.</p></li><li><p>If your account is still in the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html">Amazon SES sandbox</a>, you can only send email to other verified addresses in your account, or to addresses that are associated with the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html">Amazon SES mailbox simulator</a>.</p></li><li><p>The maximum message size, including attachments, is 10 MB.</p></li><li><p>Each message has to include at least one recipient address. A recipient address includes any address on the To:, CC:, or BCC: lines.</p></li><li><p>If you send a single message to more than one recipient address, and one of the recipient addresses isn't in a valid format (that is, it's not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), Amazon SES rejects the entire message, even if the other addresses are valid.</p></li><li><p>Each message can include up to 50 recipient addresses across the To:, CC:, or BCC: lines. If you need to send a single message to more than 50 recipients, you have to split the list of recipient addresses into groups of less than 50 recipients, and send separate messages to each group.</p></li><li><p>Amazon SES allows you to specify 8-bit Content-Transfer-Encoding for MIME message parts. However, if Amazon SES has to modify the contents of your message (for example, if you use open and click tracking), 8-bit content isn't preserved. For this reason, we highly recommend that you encode all content that isn't 7-bit ASCII. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html#send-email-mime-encoding">MIME Encoding</a> in the <i>Amazon SES Developer Guide</i>.</p></li></ul><p>Additionally, keep the following considerations in mind when using the <code>SendRawEmail</code> operation:</p><ul><li><p>Although you can customize the message headers when using the <code>SendRawEmail</code> operation, Amazon SES will automatically apply its own <code>Message-ID</code> and <code>Date</code> headers; if you passed these headers when creating the message, they will be overwritten by the values that Amazon SES provides.</p></li><li><p>If you are using sending authorization to send on behalf of another user, <code>SendRawEmail</code> enables you to specify the cross-account identity for the email's Source, From, and Return-Path parameters in one of two ways: you can pass optional parameters <code>SourceArn</code>, <code>FromArn</code>, and/or <code>ReturnPathArn</code> to the API, or you can include the following X-headers in the header of your raw email:</p><ul><li><p><code>X-SES-SOURCE-ARN</code></p></li><li><p><code>X-SES-FROM-ARN</code></p></li><li><p><code>X-SES-RETURN-PATH-ARN</code></p></li></ul><important><p>Don't include these X-headers in the DKIM signature. Amazon SES removes these before it sends the email.</p></important><p>If you only specify the <code>SourceIdentityArn</code> parameter, Amazon SES sets the From and Return-Path addresses to the same identity that you specified.</p><p>For more information about sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Using Sending Authorization with Amazon SES</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>For every message that you send, the total number of recipients (including each recipient in the To:, CC: and BCC: fields) is counted against the maximum number of emails you can send in a 24-hour period (your <i>sending quota</i>). For more information about sending quotas in Amazon SES, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/manage-sending-limits.html">Managing Your Amazon SES Sending Limits</a> in the <i>Amazon SES Developer Guide.</i></p></li></ul>
  
- @param request A container for the necessary parameters to execute the TagResource service method.
+ @param request A container for the necessary parameters to execute the SendRawEmail service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
  
- @see AWSSESTagResourceRequest
- @see AWSSESTagResourceResponse
+ @see AWSSESSendRawEmailRequest
+ @see AWSSESSendRawEmailResponse
  */
-- (void)tagResource:(AWSSESTagResourceRequest *)request completionHandler:(void (^ _Nullable)(AWSSESTagResourceResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)sendRawEmail:(AWSSESSendRawEmailRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendRawEmailResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Composes an email message using an email template and immediately queues it for sending.</p><p>In order to send email using the <code>SendTemplatedEmail</code> operation, your call to the API must meet the following requirements:</p><ul><li><p>The call must refer to an existing email template. You can create email templates using the <a>CreateTemplate</a> operation.</p></li><li><p>The message must be sent from a verified email address or domain.</p></li><li><p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>The maximum message size is 10 MB.</p></li><li><p>Calls to the <code>SendTemplatedEmail</code> operation may only include one <code>Destination</code> parameter. A destination is a set of recipients who will receive the same version of the email. The <code>Destination</code> parameter can include up to 50 recipients, across the To:, CC: and BCC: fields.</p></li><li><p>The <code>Destination</code> parameter must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p></li></ul><important><p>If your call to the <code>SendTemplatedEmail</code> operation includes all of the required parameters, Amazon SES accepts it and returns a Message ID. However, if Amazon SES can't render the email because the template contains errors, it doesn't send the email. Additionally, because it already accepted the message, Amazon SES doesn't return a message stating that it was unable to send the email.</p><p>For these reasons, we highly recommend that you set up Amazon SES to send you notifications when Rendering Failure events occur. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Sending Personalized Email Using the Amazon SES API</a> in the <i>Amazon Simple Email Service Developer Guide</i>.</p></important>
+ 
+ @param request A container for the necessary parameters to execute the SendTemplatedEmail service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSendTemplatedEmailResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
+ 
+ @see AWSSESSendTemplatedEmailRequest
+ @see AWSSESSendTemplatedEmailResponse
+ */
+- (AWSTask<AWSSESSendTemplatedEmailResponse *> *)sendTemplatedEmail:(AWSSESSendTemplatedEmailRequest *)request;
+
+/**
+ <p>Composes an email message using an email template and immediately queues it for sending.</p><p>In order to send email using the <code>SendTemplatedEmail</code> operation, your call to the API must meet the following requirements:</p><ul><li><p>The call must refer to an existing email template. You can create email templates using the <a>CreateTemplate</a> operation.</p></li><li><p>The message must be sent from a verified email address or domain.</p></li><li><p>If your account is still in the Amazon SES sandbox, you may only send to verified addresses or domains, or to email addresses associated with the Amazon SES Mailbox Simulator. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p></li><li><p>The maximum message size is 10 MB.</p></li><li><p>Calls to the <code>SendTemplatedEmail</code> operation may only include one <code>Destination</code> parameter. A destination is a set of recipients who will receive the same version of the email. The <code>Destination</code> parameter can include up to 50 recipients, across the To:, CC: and BCC: fields.</p></li><li><p>The <code>Destination</code> parameter must include at least one recipient email address. The recipient address can be a To: address, a CC: address, or a BCC: address. If a recipient email address is invalid (that is, it is not in the format <i>UserName@[SubDomain.]Domain.TopLevelDomain</i>), the entire message will be rejected, even if the message contains other recipients that are valid.</p></li></ul><important><p>If your call to the <code>SendTemplatedEmail</code> operation includes all of the required parameters, Amazon SES accepts it and returns a Message ID. However, if Amazon SES can't render the email because the template contains errors, it doesn't send the email. Additionally, because it already accepted the message, Amazon SES doesn't return a message stating that it was unable to send the email.</p><p>For these reasons, we highly recommend that you set up Amazon SES to send you notifications when Rendering Failure events occur. For more information, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Sending Personalized Email Using the Amazon SES API</a> in the <i>Amazon Simple Email Service Developer Guide</i>.</p></important>
+ 
+ @param request A container for the necessary parameters to execute the SendTemplatedEmail service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorMessageRejected`, `AWSSESErrorMailFromDomainNotVerified`, `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorConfigurationSetSendingPaused`, `AWSSESErrorAccountSendingPaused`.
+ 
+ @see AWSSESSendTemplatedEmailRequest
+ @see AWSSESSendTemplatedEmailResponse
+ */
+- (void)sendTemplatedEmail:(AWSSESSendTemplatedEmailRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSendTemplatedEmailResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Sets the specified receipt rule set as the active receipt rule set.</p><note><p>To disable your email-receiving through Amazon SES completely, you can call this API with RuleSetName set to null.</p></note><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetActiveReceiptRuleSet service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetActiveReceiptRuleSetResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`.
+ 
+ @see AWSSESSetActiveReceiptRuleSetRequest
+ @see AWSSESSetActiveReceiptRuleSetResponse
+ */
+- (AWSTask<AWSSESSetActiveReceiptRuleSetResponse *> *)setActiveReceiptRuleSet:(AWSSESSetActiveReceiptRuleSetRequest *)request;
+
+/**
+ <p>Sets the specified receipt rule set as the active receipt rule set.</p><note><p>To disable your email-receiving through Amazon SES completely, you can call this API with RuleSetName set to null.</p></note><p>For information about managing receipt rule sets, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rule-sets.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetActiveReceiptRuleSet service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`.
+ 
+ @see AWSSESSetActiveReceiptRuleSetRequest
+ @see AWSSESSetActiveReceiptRuleSetResponse
+ */
+- (void)setActiveReceiptRuleSet:(AWSSESSetActiveReceiptRuleSetRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetActiveReceiptRuleSetResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Enables or disables Easy DKIM signing of email sent from an identity. If Easy DKIM signing is enabled for a domain, then Amazon SES uses DKIM to sign all email that it sends from addresses on that domain. If Easy DKIM signing is enabled for an email address, then Amazon SES uses DKIM to sign all email it sends from that address.</p><note><p>For email addresses (for example, <code>user@example.com</code>), you can only enable DKIM signing if the corresponding domain (in this case, <code>example.com</code>) has been set up to use Easy DKIM.</p></note><p>You can enable DKIM signing for an identity at any time after you start the verification process for the identity, even if the verification process isn't complete. </p><p>You can execute this operation no more than once per second.</p><p>For more information about Easy DKIM signing, go to the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityDkimEnabled service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetIdentityDkimEnabledResponse`.
+ 
+ @see AWSSESSetIdentityDkimEnabledRequest
+ @see AWSSESSetIdentityDkimEnabledResponse
+ */
+- (AWSTask<AWSSESSetIdentityDkimEnabledResponse *> *)setIdentityDkimEnabled:(AWSSESSetIdentityDkimEnabledRequest *)request;
+
+/**
+ <p>Enables or disables Easy DKIM signing of email sent from an identity. If Easy DKIM signing is enabled for a domain, then Amazon SES uses DKIM to sign all email that it sends from addresses on that domain. If Easy DKIM signing is enabled for an email address, then Amazon SES uses DKIM to sign all email it sends from that address.</p><note><p>For email addresses (for example, <code>user@example.com</code>), you can only enable DKIM signing if the corresponding domain (in this case, <code>example.com</code>) has been set up to use Easy DKIM.</p></note><p>You can enable DKIM signing for an identity at any time after you start the verification process for the identity, even if the verification process isn't complete. </p><p>You can execute this operation no more than once per second.</p><p>For more information about Easy DKIM signing, go to the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityDkimEnabled service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESSetIdentityDkimEnabledRequest
+ @see AWSSESSetIdentityDkimEnabledResponse
+ */
+- (void)setIdentityDkimEnabled:(AWSSESSetIdentityDkimEnabledRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetIdentityDkimEnabledResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Given an identity (an email address or a domain), enables or disables whether Amazon SES forwards bounce and complaint notifications as email. Feedback forwarding can only be disabled when Amazon Simple Notification Service (Amazon SNS) topics are specified for both bounces and complaints.</p><note><p>Feedback forwarding does not apply to delivery notifications. Delivery notifications are only available through Amazon SNS.</p></note><p>You can execute this operation no more than once per second.</p><p>For more information about using notifications with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityFeedbackForwardingEnabled service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetIdentityFeedbackForwardingEnabledResponse`.
+ 
+ @see AWSSESSetIdentityFeedbackForwardingEnabledRequest
+ @see AWSSESSetIdentityFeedbackForwardingEnabledResponse
+ */
+- (AWSTask<AWSSESSetIdentityFeedbackForwardingEnabledResponse *> *)setIdentityFeedbackForwardingEnabled:(AWSSESSetIdentityFeedbackForwardingEnabledRequest *)request;
+
+/**
+ <p>Given an identity (an email address or a domain), enables or disables whether Amazon SES forwards bounce and complaint notifications as email. Feedback forwarding can only be disabled when Amazon Simple Notification Service (Amazon SNS) topics are specified for both bounces and complaints.</p><note><p>Feedback forwarding does not apply to delivery notifications. Delivery notifications are only available through Amazon SNS.</p></note><p>You can execute this operation no more than once per second.</p><p>For more information about using notifications with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityFeedbackForwardingEnabled service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESSetIdentityFeedbackForwardingEnabledRequest
+ @see AWSSESSetIdentityFeedbackForwardingEnabledResponse
+ */
+- (void)setIdentityFeedbackForwardingEnabled:(AWSSESSetIdentityFeedbackForwardingEnabledRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetIdentityFeedbackForwardingEnabledResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Given an identity (an email address or a domain), sets whether Amazon SES includes the original email headers in the Amazon Simple Notification Service (Amazon SNS) notifications of a specified type.</p><p>You can execute this operation no more than once per second.</p><p>For more information about using notifications with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityHeadersInNotificationsEnabled service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetIdentityHeadersInNotificationsEnabledResponse`.
+ 
+ @see AWSSESSetIdentityHeadersInNotificationsEnabledRequest
+ @see AWSSESSetIdentityHeadersInNotificationsEnabledResponse
+ */
+- (AWSTask<AWSSESSetIdentityHeadersInNotificationsEnabledResponse *> *)setIdentityHeadersInNotificationsEnabled:(AWSSESSetIdentityHeadersInNotificationsEnabledRequest *)request;
+
+/**
+ <p>Given an identity (an email address or a domain), sets whether Amazon SES includes the original email headers in the Amazon Simple Notification Service (Amazon SNS) notifications of a specified type.</p><p>You can execute this operation no more than once per second.</p><p>For more information about using notifications with Amazon SES, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityHeadersInNotificationsEnabled service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESSetIdentityHeadersInNotificationsEnabledRequest
+ @see AWSSESSetIdentityHeadersInNotificationsEnabledResponse
+ */
+- (void)setIdentityHeadersInNotificationsEnabled:(AWSSESSetIdentityHeadersInNotificationsEnabledRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetIdentityHeadersInNotificationsEnabledResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Enables or disables the custom MAIL FROM domain setup for a verified identity (an email address or a domain).</p><important><p>To send emails using the specified MAIL FROM domain, you must add an MX record to your MAIL FROM domain's DNS settings. If you want your emails to pass Sender Policy Framework (SPF) checks, you must also add or update an SPF record. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-set.html">Amazon SES Developer Guide</a>.</p></important><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityMailFromDomain service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetIdentityMailFromDomainResponse`.
+ 
+ @see AWSSESSetIdentityMailFromDomainRequest
+ @see AWSSESSetIdentityMailFromDomainResponse
+ */
+- (AWSTask<AWSSESSetIdentityMailFromDomainResponse *> *)setIdentityMailFromDomain:(AWSSESSetIdentityMailFromDomainRequest *)request;
+
+/**
+ <p>Enables or disables the custom MAIL FROM domain setup for a verified identity (an email address or a domain).</p><important><p>To send emails using the specified MAIL FROM domain, you must add an MX record to your MAIL FROM domain's DNS settings. If you want your emails to pass Sender Policy Framework (SPF) checks, you must also add or update an SPF record. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from-set.html">Amazon SES Developer Guide</a>.</p></important><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityMailFromDomain service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESSetIdentityMailFromDomainRequest
+ @see AWSSESSetIdentityMailFromDomainResponse
+ */
+- (void)setIdentityMailFromDomain:(AWSSESSetIdentityMailFromDomainRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetIdentityMailFromDomainResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Sets an Amazon Simple Notification Service (Amazon SNS) topic to use when delivering notifications. When you use this operation, you specify a verified identity, such as an email address or domain. When you send an email that uses the chosen identity in the Source field, Amazon SES sends notifications to the topic you specified. You can send bounce, complaint, or delivery notifications (or any combination of the three) to the Amazon SNS topic that you specify.</p><p>You can execute this operation no more than once per second.</p><p>For more information about feedback notification, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityNotificationTopic service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetIdentityNotificationTopicResponse`.
+ 
+ @see AWSSESSetIdentityNotificationTopicRequest
+ @see AWSSESSetIdentityNotificationTopicResponse
+ */
+- (AWSTask<AWSSESSetIdentityNotificationTopicResponse *> *)setIdentityNotificationTopic:(AWSSESSetIdentityNotificationTopicRequest *)request;
+
+/**
+ <p>Sets an Amazon Simple Notification Service (Amazon SNS) topic to use when delivering notifications. When you use this operation, you specify a verified identity, such as an email address or domain. When you send an email that uses the chosen identity in the Source field, Amazon SES sends notifications to the topic you specified. You can send bounce, complaint, or delivery notifications (or any combination of the three) to the Amazon SNS topic that you specify.</p><p>You can execute this operation no more than once per second.</p><p>For more information about feedback notification, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notifications.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetIdentityNotificationTopic service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESSetIdentityNotificationTopicRequest
+ @see AWSSESSetIdentityNotificationTopicResponse
+ */
+- (void)setIdentityNotificationTopic:(AWSSESSetIdentityNotificationTopicRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetIdentityNotificationTopicResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Sets the position of the specified receipt rule in the receipt rule set.</p><p>For information about managing receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetReceiptRulePosition service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESSetReceiptRulePositionResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorRuleDoesNotExist`.
+ 
+ @see AWSSESSetReceiptRulePositionRequest
+ @see AWSSESSetReceiptRulePositionResponse
+ */
+- (AWSTask<AWSSESSetReceiptRulePositionResponse *> *)setReceiptRulePosition:(AWSSESSetReceiptRulePositionRequest *)request;
+
+/**
+ <p>Sets the position of the specified receipt rule in the receipt rule set.</p><p>For information about managing receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the SetReceiptRulePosition service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorRuleDoesNotExist`.
+ 
+ @see AWSSESSetReceiptRulePositionRequest
+ @see AWSSESSetReceiptRulePositionResponse
+ */
+- (void)setReceiptRulePosition:(AWSSESSetReceiptRulePositionRequest *)request completionHandler:(void (^ _Nullable)(AWSSESSetReceiptRulePositionResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Creates a preview of the MIME content of an email when provided with a template and a set of replacement data.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the TestRenderEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the TestRenderTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESTestRenderEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESTestRenderTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorInvalidRenderingParameter`, `AWSSESErrorMissingRenderingAttribute`.
  
- @see AWSSESTestRenderEmailTemplateRequest
- @see AWSSESTestRenderEmailTemplateResponse
+ @see AWSSESTestRenderTemplateRequest
+ @see AWSSESTestRenderTemplateResponse
  */
-- (AWSTask<AWSSESTestRenderEmailTemplateResponse *> *)testRenderEmailTemplate:(AWSSESTestRenderEmailTemplateRequest *)request;
+- (AWSTask<AWSSESTestRenderTemplateResponse *> *)testRenderTemplate:(AWSSESTestRenderTemplateRequest *)request;
 
 /**
  <p>Creates a preview of the MIME content of an email when provided with a template and a set of replacement data.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the TestRenderEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the TestRenderTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorInvalidRenderingParameter`, `AWSSESErrorMissingRenderingAttribute`.
  
- @see AWSSESTestRenderEmailTemplateRequest
- @see AWSSESTestRenderEmailTemplateResponse
+ @see AWSSESTestRenderTemplateRequest
+ @see AWSSESTestRenderTemplateResponse
  */
-- (void)testRenderEmailTemplate:(AWSSESTestRenderEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESTestRenderEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)testRenderTemplate:(AWSSESTestRenderTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESTestRenderTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Remove one or more tags (keys and values) from a specified resource.</p>
+ <p>Enables or disables email sending across your entire Amazon SES account in the current AWS Region. You can use this operation in conjunction with Amazon CloudWatch alarms to temporarily pause email sending across your Amazon SES account in a given AWS Region when reputation metrics (such as your bounce or complaint rates) reach certain thresholds.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the UntagResource service method.
+ @param request A container for the necessary parameters to execute the UpdateAccountSendingEnabled service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUntagResourceResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`.
  
- @see AWSSESUntagResourceRequest
- @see AWSSESUntagResourceResponse
+ @see AWSSESUpdateAccountSendingEnabledRequest
  */
-- (AWSTask<AWSSESUntagResourceResponse *> *)untagResource:(AWSSESUntagResourceRequest *)request;
+- (AWSTask *)updateAccountSendingEnabled:(AWSSESUpdateAccountSendingEnabledRequest *)request;
 
 /**
- <p>Remove one or more tags (keys and values) from a specified resource.</p>
+ <p>Enables or disables email sending across your entire Amazon SES account in the current AWS Region. You can use this operation in conjunction with Amazon CloudWatch alarms to temporarily pause email sending across your Amazon SES account in a given AWS Region when reputation metrics (such as your bounce or complaint rates) reach certain thresholds.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the UntagResource service method.
+ @param request A container for the necessary parameters to execute the UpdateAccountSendingEnabled service method.
  @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorBadRequest`, `AWSSESErrorConcurrentModification`, `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
  
- @see AWSSESUntagResourceRequest
- @see AWSSESUntagResourceResponse
+ @see AWSSESUpdateAccountSendingEnabledRequest
  */
-- (void)untagResource:(AWSSESUntagResourceRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUntagResourceResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)updateAccountSendingEnabled:(AWSSESUpdateAccountSendingEnabledRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
 
 /**
- <p>Update the configuration of an event destination for a configuration set.</p><p><i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Updates the event destination of a configuration set. Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Monitoring Your Amazon SES Sending Activity</a> in the <i>Amazon SES Developer Guide.</i></p><note><p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS).</p></note><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the UpdateConfigurationSetEventDestination service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateConfigurationSetEventDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateConfigurationSetEventDestinationResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorEventDestinationDoesNotExist`, `AWSSESErrorInvalidCloudWatchDestination`, `AWSSESErrorInvalidFirehoseDestination`, `AWSSESErrorInvalidSNSDestination`.
  
  @see AWSSESUpdateConfigurationSetEventDestinationRequest
  @see AWSSESUpdateConfigurationSetEventDestinationResponse
@@ -1837,12 +1675,12 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (AWSTask<AWSSESUpdateConfigurationSetEventDestinationResponse *> *)updateConfigurationSetEventDestination:(AWSSESUpdateConfigurationSetEventDestinationRequest *)request;
 
 /**
- <p>Update the configuration of an event destination for a configuration set.</p><p><i>Events</i> include message sends, deliveries, opens, clicks, bounces, and complaints. <i>Event destinations</i> are places that you can send information about these events to. For example, you can send event data to Amazon SNS to receive notifications when you receive bounces or complaints, or you can use Amazon Kinesis Data Firehose to stream data to Amazon S3 for long-term storage.</p>
+ <p>Updates the event destination of a configuration set. Event destinations are associated with configuration sets, which enable you to publish email sending events to Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS). For information about using configuration sets, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html">Monitoring Your Amazon SES Sending Activity</a> in the <i>Amazon SES Developer Guide.</i></p><note><p>When you create or update an event destination, you must provide one, and only one, destination. The destination can be Amazon CloudWatch, Amazon Kinesis Firehose, or Amazon Simple Notification Service (Amazon SNS).</p></note><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the UpdateConfigurationSetEventDestination service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorEventDestinationDoesNotExist`, `AWSSESErrorInvalidCloudWatchDestination`, `AWSSESErrorInvalidFirehoseDestination`, `AWSSESErrorInvalidSNSDestination`.
  
  @see AWSSESUpdateConfigurationSetEventDestinationRequest
  @see AWSSESUpdateConfigurationSetEventDestinationResponse
@@ -1850,79 +1688,242 @@ FOUNDATION_EXPORT NSString *const AWSSESSDKVersion;
 - (void)updateConfigurationSetEventDestination:(AWSSESUpdateConfigurationSetEventDestinationRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateConfigurationSetEventDestinationResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
- <p>Updates an existing custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Enables or disables the publishing of reputation metrics for emails sent using a specific configuration set in a given AWS Region. Reputation metrics include bounce and complaint rates. These metrics are published to Amazon CloudWatch. By using CloudWatch, you can create alarms when bounce or complaint rates exceed certain thresholds.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the UpdateConfigurationSetReputationMetricsEnabled service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
+ 
+ @see AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest
+ */
+- (AWSTask *)updateConfigurationSetReputationMetricsEnabled:(AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest *)request;
+
+/**
+ <p>Enables or disables the publishing of reputation metrics for emails sent using a specific configuration set in a given AWS Region. Reputation metrics include bounce and complaint rates. These metrics are published to Amazon CloudWatch. By using CloudWatch, you can create alarms when bounce or complaint rates exceed certain thresholds.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the UpdateConfigurationSetReputationMetricsEnabled service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
+ 
+ @see AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest
+ */
+- (void)updateConfigurationSetReputationMetricsEnabled:(AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Enables or disables email sending for messages sent using a specific configuration set in a given AWS Region. You can use this operation in conjunction with Amazon CloudWatch alarms to temporarily pause email sending for a configuration set when the reputation metrics for that configuration set (such as your bounce on complaint rate) exceed certain thresholds.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the UpdateConfigurationSetSendingEnabled service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
+ 
+ @see AWSSESUpdateConfigurationSetSendingEnabledRequest
+ */
+- (AWSTask *)updateConfigurationSetSendingEnabled:(AWSSESUpdateConfigurationSetSendingEnabledRequest *)request;
+
+/**
+ <p>Enables or disables email sending for messages sent using a specific configuration set in a given AWS Region. You can use this operation in conjunction with Amazon CloudWatch alarms to temporarily pause email sending for a configuration set when the reputation metrics for that configuration set (such as your bounce on complaint rate) exceed certain thresholds.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the UpdateConfigurationSetSendingEnabled service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`.
+ 
+ @see AWSSESUpdateConfigurationSetSendingEnabledRequest
+ */
+- (void)updateConfigurationSetSendingEnabled:(AWSSESUpdateConfigurationSetSendingEnabledRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Modifies an association between a configuration set and a custom domain for open and click event tracking. </p><p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the UpdateConfigurationSetTrackingOptions service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateConfigurationSetTrackingOptionsResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTrackingOptionsDoesNotExist`, `AWSSESErrorInvalidTrackingOptions`.
+ 
+ @see AWSSESUpdateConfigurationSetTrackingOptionsRequest
+ @see AWSSESUpdateConfigurationSetTrackingOptionsResponse
+ */
+- (AWSTask<AWSSESUpdateConfigurationSetTrackingOptionsResponse *> *)updateConfigurationSetTrackingOptions:(AWSSESUpdateConfigurationSetTrackingOptionsRequest *)request;
+
+/**
+ <p>Modifies an association between a configuration set and a custom domain for open and click event tracking. </p><p>By default, images and links used for tracking open and click events are hosted on domains operated by Amazon SES. You can configure a subdomain of your own to handle these events. For information about using custom domains, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/configure-custom-open-click-domains.html">Amazon SES Developer Guide</a>.</p>
+ 
+ @param request A container for the necessary parameters to execute the UpdateConfigurationSetTrackingOptions service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorConfigurationSetDoesNotExist`, `AWSSESErrorTrackingOptionsDoesNotExist`, `AWSSESErrorInvalidTrackingOptions`.
+ 
+ @see AWSSESUpdateConfigurationSetTrackingOptionsRequest
+ @see AWSSESUpdateConfigurationSetTrackingOptionsResponse
+ */
+- (void)updateConfigurationSetTrackingOptions:(AWSSESUpdateConfigurationSetTrackingOptionsRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateConfigurationSetTrackingOptionsResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Updates an existing custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the UpdateCustomVerificationEmailTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateCustomVerificationEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCustomVerificationEmailTemplateDoesNotExist`, `AWSSESErrorFromEmailAddressNotVerified`, `AWSSESErrorCustomVerificationEmailInvalidContent`.
  
  @see AWSSESUpdateCustomVerificationEmailTemplateRequest
- @see AWSSESUpdateCustomVerificationEmailTemplateResponse
  */
-- (AWSTask<AWSSESUpdateCustomVerificationEmailTemplateResponse *> *)updateCustomVerificationEmailTemplate:(AWSSESUpdateCustomVerificationEmailTemplateRequest *)request;
+- (AWSTask *)updateCustomVerificationEmailTemplate:(AWSSESUpdateCustomVerificationEmailTemplateRequest *)request;
 
 /**
- <p>Updates an existing custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-verify-address-custom.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Updates an existing custom verification email template.</p><p>For more information about custom verification email templates, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/custom-verification-emails.html">Using Custom Verification Email Templates</a> in the <i>Amazon SES Developer Guide</i>.</p><p>You can execute this operation no more than once per second.</p>
  
  @param request A container for the necessary parameters to execute the UpdateCustomVerificationEmailTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
-                          `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorBadRequest`, `AWSSESErrorTooManyRequests`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorCustomVerificationEmailTemplateDoesNotExist`, `AWSSESErrorFromEmailAddressNotVerified`, `AWSSESErrorCustomVerificationEmailInvalidContent`.
  
  @see AWSSESUpdateCustomVerificationEmailTemplateRequest
- @see AWSSESUpdateCustomVerificationEmailTemplateResponse
  */
-- (void)updateCustomVerificationEmailTemplate:(AWSSESUpdateCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateCustomVerificationEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)updateCustomVerificationEmailTemplate:(AWSSESUpdateCustomVerificationEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
 
 /**
- <p>Updates the specified sending authorization policy for the given identity (an email address or a domain). This API returns successfully even if a policy with the specified name does not exist.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Updates a receipt rule.</p><p>For information about managing receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the UpdateEmailIdentityPolicy service method.
+ @param request A container for the necessary parameters to execute the UpdateReceiptRule service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateEmailIdentityPolicyResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateReceiptRuleResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorInvalidSnsTopic`, `AWSSESErrorInvalidS3Configuration`, `AWSSESErrorInvalidLambdaFunction`, `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorRuleDoesNotExist`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESUpdateEmailIdentityPolicyRequest
- @see AWSSESUpdateEmailIdentityPolicyResponse
+ @see AWSSESUpdateReceiptRuleRequest
+ @see AWSSESUpdateReceiptRuleResponse
  */
-- (AWSTask<AWSSESUpdateEmailIdentityPolicyResponse *> *)updateEmailIdentityPolicy:(AWSSESUpdateEmailIdentityPolicyRequest *)request;
+- (AWSTask<AWSSESUpdateReceiptRuleResponse *> *)updateReceiptRule:(AWSSESUpdateReceiptRuleRequest *)request;
 
 /**
- <p>Updates the specified sending authorization policy for the given identity (an email address or a domain). This API returns successfully even if a policy with the specified name does not exist.</p><note><p>This API is for the identity owner only. If you have not verified the identity, this API will return an error.</p></note><p>Sending authorization is a feature that enables an identity owner to authorize other senders to use its identities. For information about using sending authorization, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
+ <p>Updates a receipt rule.</p><p>For information about managing receipt rules, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-managing-receipt-rules.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the UpdateEmailIdentityPolicy service method.
+ @param request A container for the necessary parameters to execute the UpdateReceiptRule service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorInvalidSnsTopic`, `AWSSESErrorInvalidS3Configuration`, `AWSSESErrorInvalidLambdaFunction`, `AWSSESErrorRuleSetDoesNotExist`, `AWSSESErrorRuleDoesNotExist`, `AWSSESErrorLimitExceeded`.
  
- @see AWSSESUpdateEmailIdentityPolicyRequest
- @see AWSSESUpdateEmailIdentityPolicyResponse
+ @see AWSSESUpdateReceiptRuleRequest
+ @see AWSSESUpdateReceiptRuleResponse
  */
-- (void)updateEmailIdentityPolicy:(AWSSESUpdateEmailIdentityPolicyRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateEmailIdentityPolicyResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)updateReceiptRule:(AWSSESUpdateReceiptRuleRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateReceiptRuleResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 /**
  <p>Updates an email template. Email templates enable you to send personalized email to one or more destinations in a single API operation. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the UpdateEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the UpdateTemplate service method.
 
- @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateEmailTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESUpdateTemplateResponse`. On failed execution, `task.error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorInvalidTemplate`.
  
- @see AWSSESUpdateEmailTemplateRequest
- @see AWSSESUpdateEmailTemplateResponse
+ @see AWSSESUpdateTemplateRequest
+ @see AWSSESUpdateTemplateResponse
  */
-- (AWSTask<AWSSESUpdateEmailTemplateResponse *> *)updateEmailTemplate:(AWSSESUpdateEmailTemplateRequest *)request;
+- (AWSTask<AWSSESUpdateTemplateResponse *> *)updateTemplate:(AWSSESUpdateTemplateRequest *)request;
 
 /**
  <p>Updates an email template. Email templates enable you to send personalized email to one or more destinations in a single API operation. For more information, see the <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-personalized-email-api.html">Amazon SES Developer Guide</a>.</p><p>You can execute this operation no more than once per second.</p>
  
- @param request A container for the necessary parameters to execute the UpdateEmailTemplate service method.
+ @param request A container for the necessary parameters to execute the UpdateTemplate service method.
  @param completionHandler The completion handler to call when the load request is complete.
                           `response` - A response object, or `nil` if the request failed.
-                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorNotFound`, `AWSSESErrorTooManyRequests`, `AWSSESErrorBadRequest`.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful. On failed execution, `error` may contain an `NSError` with `AWSSESErrorDomain` domain and the following error code: `AWSSESErrorTemplateDoesNotExist`, `AWSSESErrorInvalidTemplate`.
  
- @see AWSSESUpdateEmailTemplateRequest
- @see AWSSESUpdateEmailTemplateResponse
+ @see AWSSESUpdateTemplateRequest
+ @see AWSSESUpdateTemplateResponse
  */
-- (void)updateEmailTemplate:(AWSSESUpdateEmailTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateEmailTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+- (void)updateTemplate:(AWSSESUpdateTemplateRequest *)request completionHandler:(void (^ _Nullable)(AWSSESUpdateTemplateResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Returns a set of DKIM tokens for a domain identity.</p><important><p>When you execute the <code>VerifyDomainDkim</code> operation, the domain that you specify is added to the list of identities that are associated with your account. This is true even if you haven't already associated the domain with your account by using the <code>VerifyDomainIdentity</code> operation. However, you can't send email from the domain until you either successfully <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html">verify it</a> or you successfully <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">set up DKIM for it</a>.</p></important><p>You use the tokens that are generated by this operation to create CNAME records. When Amazon SES detects that you've added these records to the DNS configuration for a domain, you can start sending email from that domain. You can start sending email even if you haven't added the TXT record provided by the VerifyDomainIdentity operation to the DNS configuration for your domain. All email that you send from the domain is authenticated using DKIM.</p><p>To create the CNAME records for DKIM authentication, use the following values:</p><ul><li><p><b>Name</b>: <i>token</i>._domainkey.<i>example.com</i></p></li><li><p><b>Type</b>: CNAME</p></li><li><p><b>Value</b>: <i>token</i>.dkim.amazonses.com</p></li></ul><p>In the preceding example, replace <i>token</i> with one of the tokens that are generated when you execute this operation. Replace <i>example.com</i> with your domain. Repeat this process for each token that's generated by this operation.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyDomainDkim service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESVerifyDomainDkimResponse`.
+ 
+ @see AWSSESVerifyDomainDkimRequest
+ @see AWSSESVerifyDomainDkimResponse
+ */
+- (AWSTask<AWSSESVerifyDomainDkimResponse *> *)verifyDomainDkim:(AWSSESVerifyDomainDkimRequest *)request;
+
+/**
+ <p>Returns a set of DKIM tokens for a domain identity.</p><important><p>When you execute the <code>VerifyDomainDkim</code> operation, the domain that you specify is added to the list of identities that are associated with your account. This is true even if you haven't already associated the domain with your account by using the <code>VerifyDomainIdentity</code> operation. However, you can't send email from the domain until you either successfully <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html">verify it</a> or you successfully <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/easy-dkim.html">set up DKIM for it</a>.</p></important><p>You use the tokens that are generated by this operation to create CNAME records. When Amazon SES detects that you've added these records to the DNS configuration for a domain, you can start sending email from that domain. You can start sending email even if you haven't added the TXT record provided by the VerifyDomainIdentity operation to the DNS configuration for your domain. All email that you send from the domain is authenticated using DKIM.</p><p>To create the CNAME records for DKIM authentication, use the following values:</p><ul><li><p><b>Name</b>: <i>token</i>._domainkey.<i>example.com</i></p></li><li><p><b>Type</b>: CNAME</p></li><li><p><b>Value</b>: <i>token</i>.dkim.amazonses.com</p></li></ul><p>In the preceding example, replace <i>token</i> with one of the tokens that are generated when you execute this operation. Replace <i>example.com</i> with your domain. Repeat this process for each token that's generated by this operation.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyDomainDkim service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESVerifyDomainDkimRequest
+ @see AWSSESVerifyDomainDkimResponse
+ */
+- (void)verifyDomainDkim:(AWSSESVerifyDomainDkimRequest *)request completionHandler:(void (^ _Nullable)(AWSSESVerifyDomainDkimResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Adds a domain to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. For more information about verifying domains, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyDomainIdentity service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESVerifyDomainIdentityResponse`.
+ 
+ @see AWSSESVerifyDomainIdentityRequest
+ @see AWSSESVerifyDomainIdentityResponse
+ */
+- (AWSTask<AWSSESVerifyDomainIdentityResponse *> *)verifyDomainIdentity:(AWSSESVerifyDomainIdentityRequest *)request;
+
+/**
+ <p>Adds a domain to the list of identities for your Amazon SES account in the current AWS Region and attempts to verify it. For more information about verifying domains, see <a href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-addresses-and-domains.html">Verifying Email Addresses and Domains</a> in the <i>Amazon SES Developer Guide.</i></p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyDomainIdentity service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESVerifyDomainIdentityRequest
+ @see AWSSESVerifyDomainIdentityResponse
+ */
+- (void)verifyDomainIdentity:(AWSSESVerifyDomainIdentityRequest *)request completionHandler:(void (^ _Nullable)(AWSSESVerifyDomainIdentityResponse * _Nullable response, NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Deprecated. Use the <code>VerifyEmailIdentity</code> operation to verify a new email address.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyEmailAddress service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will be `nil`.
+ 
+ @see AWSSESVerifyEmailAddressRequest
+ */
+- (AWSTask *)verifyEmailAddress:(AWSSESVerifyEmailAddressRequest *)request;
+
+/**
+ <p>Deprecated. Use the <code>VerifyEmailIdentity</code> operation to verify a new email address.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyEmailAddress service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESVerifyEmailAddressRequest
+ */
+- (void)verifyEmailAddress:(AWSSESVerifyEmailAddressRequest *)request completionHandler:(void (^ _Nullable)(NSError * _Nullable error))completionHandler;
+
+/**
+ <p>Adds an email address to the list of identities for your Amazon SES account in the current AWS region and attempts to verify it. As a result of executing this operation, a verification email is sent to the specified address.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyEmailIdentity service method.
+
+ @return An instance of `AWSTask`. On successful execution, `task.result` will contain an instance of `AWSSESVerifyEmailIdentityResponse`.
+ 
+ @see AWSSESVerifyEmailIdentityRequest
+ @see AWSSESVerifyEmailIdentityResponse
+ */
+- (AWSTask<AWSSESVerifyEmailIdentityResponse *> *)verifyEmailIdentity:(AWSSESVerifyEmailIdentityRequest *)request;
+
+/**
+ <p>Adds an email address to the list of identities for your Amazon SES account in the current AWS region and attempts to verify it. As a result of executing this operation, a verification email is sent to the specified address.</p><p>You can execute this operation no more than once per second.</p>
+ 
+ @param request A container for the necessary parameters to execute the VerifyEmailIdentity service method.
+ @param completionHandler The completion handler to call when the load request is complete.
+                          `response` - A response object, or `nil` if the request failed.
+                          `error` - An error object that indicates why the request failed, or `nil` if the request was successful.
+ 
+ @see AWSSESVerifyEmailIdentityRequest
+ @see AWSSESVerifyEmailIdentityResponse
+ */
+- (void)verifyEmailIdentity:(AWSSESVerifyEmailIdentityRequest *)request completionHandler:(void (^ _Nullable)(AWSSESVerifyEmailIdentityResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 
 @end
 

--- a/AWSSESUnitTests/AWSGeneralSESTests.m
+++ b/AWSSESUnitTests/AWSGeneralSESTests.m
@@ -57,6 +57,54 @@ static id mockNetworking = nil;
 
 }
 
+- (void)testCloneReceiptRuleSet {
+    NSString *key = @"testCloneReceiptRuleSet";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] cloneReceiptRuleSet:[AWSSESCloneReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testCloneReceiptRuleSetCompletionHandler {
+    NSString *key = @"testCloneReceiptRuleSet";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] cloneReceiptRuleSet:[AWSSESCloneReceiptRuleSetRequest new] completionHandler:^(AWSSESCloneReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
 - (void)testCreateConfigurationSet {
     NSString *key = @"testCreateConfigurationSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
@@ -153,6 +201,54 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
+- (void)testCreateConfigurationSetTrackingOptions {
+    NSString *key = @"testCreateConfigurationSetTrackingOptions";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] createConfigurationSetTrackingOptions:[AWSSESCreateConfigurationSetTrackingOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testCreateConfigurationSetTrackingOptionsCompletionHandler {
+    NSString *key = @"testCreateConfigurationSetTrackingOptions";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] createConfigurationSetTrackingOptions:[AWSSESCreateConfigurationSetTrackingOptionsRequest new] completionHandler:^(AWSSESCreateConfigurationSetTrackingOptionsResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
 - (void)testCreateCustomVerificationEmailTemplate {
     NSString *key = @"testCreateCustomVerificationEmailTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
@@ -187,7 +283,54 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] createCustomVerificationEmailTemplate:[AWSSESCreateCustomVerificationEmailTemplateRequest new] completionHandler:^(AWSSESCreateCustomVerificationEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] createCustomVerificationEmailTemplate:[AWSSESCreateCustomVerificationEmailTemplateRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testCreateReceiptFilter {
+    NSString *key = @"testCreateReceiptFilter";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] createReceiptFilter:[AWSSESCreateReceiptFilterRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testCreateReceiptFilterCompletionHandler {
+    NSString *key = @"testCreateReceiptFilter";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] createReceiptFilter:[AWSSESCreateReceiptFilterRequest new] completionHandler:^(AWSSESCreateReceiptFilterResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -201,8 +344,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testCreateDedicatedIpPool {
-    NSString *key = @"testCreateDedicatedIpPool";
+- (void)testCreateReceiptRule {
+    NSString *key = @"testCreateReceiptRule";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -210,7 +353,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] createDedicatedIpPool:[AWSSESCreateDedicatedIpPoolRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] createReceiptRule:[AWSSESCreateReceiptRuleRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -223,8 +366,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testCreateDedicatedIpPoolCompletionHandler {
-    NSString *key = @"testCreateDedicatedIpPool";
+- (void)testCreateReceiptRuleCompletionHandler {
+    NSString *key = @"testCreateReceiptRule";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -235,7 +378,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] createDedicatedIpPool:[AWSSESCreateDedicatedIpPoolRequest new] completionHandler:^(AWSSESCreateDedicatedIpPoolResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] createReceiptRule:[AWSSESCreateReceiptRuleRequest new] completionHandler:^(AWSSESCreateReceiptRuleResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -249,8 +392,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testCreateDeliverabilityTestReport {
-    NSString *key = @"testCreateDeliverabilityTestReport";
+- (void)testCreateReceiptRuleSet {
+    NSString *key = @"testCreateReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -258,7 +401,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] createDeliverabilityTestReport:[AWSSESCreateDeliverabilityTestReportRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] createReceiptRuleSet:[AWSSESCreateReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -271,8 +414,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testCreateDeliverabilityTestReportCompletionHandler {
-    NSString *key = @"testCreateDeliverabilityTestReport";
+- (void)testCreateReceiptRuleSetCompletionHandler {
+    NSString *key = @"testCreateReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -283,7 +426,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] createDeliverabilityTestReport:[AWSSESCreateDeliverabilityTestReportRequest new] completionHandler:^(AWSSESCreateDeliverabilityTestReportResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] createReceiptRuleSet:[AWSSESCreateReceiptRuleSetRequest new] completionHandler:^(AWSSESCreateReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -297,8 +440,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testCreateEmailIdentity {
-    NSString *key = @"testCreateEmailIdentity";
+- (void)testCreateTemplate {
+    NSString *key = @"testCreateTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -306,7 +449,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] createEmailIdentity:[AWSSESCreateEmailIdentityRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] createTemplate:[AWSSESCreateTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -319,8 +462,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testCreateEmailIdentityCompletionHandler {
-    NSString *key = @"testCreateEmailIdentity";
+- (void)testCreateTemplateCompletionHandler {
+    NSString *key = @"testCreateTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -331,151 +474,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] createEmailIdentity:[AWSSESCreateEmailIdentityRequest new] completionHandler:^(AWSSESCreateEmailIdentityResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testCreateEmailIdentityPolicy {
-    NSString *key = @"testCreateEmailIdentityPolicy";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] createEmailIdentityPolicy:[AWSSESCreateEmailIdentityPolicyRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testCreateEmailIdentityPolicyCompletionHandler {
-    NSString *key = @"testCreateEmailIdentityPolicy";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] createEmailIdentityPolicy:[AWSSESCreateEmailIdentityPolicyRequest new] completionHandler:^(AWSSESCreateEmailIdentityPolicyResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testCreateEmailTemplate {
-    NSString *key = @"testCreateEmailTemplate";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] createEmailTemplate:[AWSSESCreateEmailTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testCreateEmailTemplateCompletionHandler {
-    NSString *key = @"testCreateEmailTemplate";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] createEmailTemplate:[AWSSESCreateEmailTemplateRequest new] completionHandler:^(AWSSESCreateEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testCreateImportJob {
-    NSString *key = @"testCreateImportJob";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] createImportJob:[AWSSESCreateImportJobRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testCreateImportJobCompletionHandler {
-    NSString *key = @"testCreateImportJob";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] createImportJob:[AWSSESCreateImportJobRequest new] completionHandler:^(AWSSESCreateImportJobResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] createTemplate:[AWSSESCreateTemplateRequest new] completionHandler:^(AWSSESCreateTemplateResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -585,6 +584,54 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
+- (void)testDeleteConfigurationSetTrackingOptions {
+    NSString *key = @"testDeleteConfigurationSetTrackingOptions";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] deleteConfigurationSetTrackingOptions:[AWSSESDeleteConfigurationSetTrackingOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testDeleteConfigurationSetTrackingOptionsCompletionHandler {
+    NSString *key = @"testDeleteConfigurationSetTrackingOptions";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] deleteConfigurationSetTrackingOptions:[AWSSESDeleteConfigurationSetTrackingOptionsRequest new] completionHandler:^(AWSSESDeleteConfigurationSetTrackingOptionsResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
 - (void)testDeleteCustomVerificationEmailTemplate {
     NSString *key = @"testDeleteCustomVerificationEmailTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
@@ -619,7 +666,54 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] deleteCustomVerificationEmailTemplate:[AWSSESDeleteCustomVerificationEmailTemplateRequest new] completionHandler:^(AWSSESDeleteCustomVerificationEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteCustomVerificationEmailTemplate:[AWSSESDeleteCustomVerificationEmailTemplateRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testDeleteIdentity {
+    NSString *key = @"testDeleteIdentity";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] deleteIdentity:[AWSSESDeleteIdentityRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testDeleteIdentityCompletionHandler {
+    NSString *key = @"testDeleteIdentity";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] deleteIdentity:[AWSSESDeleteIdentityRequest new] completionHandler:^(AWSSESDeleteIdentityResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -633,8 +727,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteDedicatedIpPool {
-    NSString *key = @"testDeleteDedicatedIpPool";
+- (void)testDeleteIdentityPolicy {
+    NSString *key = @"testDeleteIdentityPolicy";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -642,7 +736,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] deleteDedicatedIpPool:[AWSSESDeleteDedicatedIpPoolRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] deleteIdentityPolicy:[AWSSESDeleteIdentityPolicyRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -655,8 +749,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteDedicatedIpPoolCompletionHandler {
-    NSString *key = @"testDeleteDedicatedIpPool";
+- (void)testDeleteIdentityPolicyCompletionHandler {
+    NSString *key = @"testDeleteIdentityPolicy";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -667,7 +761,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] deleteDedicatedIpPool:[AWSSESDeleteDedicatedIpPoolRequest new] completionHandler:^(AWSSESDeleteDedicatedIpPoolResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteIdentityPolicy:[AWSSESDeleteIdentityPolicyRequest new] completionHandler:^(AWSSESDeleteIdentityPolicyResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -681,8 +775,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteEmailIdentity {
-    NSString *key = @"testDeleteEmailIdentity";
+- (void)testDeleteReceiptFilter {
+    NSString *key = @"testDeleteReceiptFilter";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -690,7 +784,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] deleteEmailIdentity:[AWSSESDeleteEmailIdentityRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] deleteReceiptFilter:[AWSSESDeleteReceiptFilterRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -703,8 +797,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteEmailIdentityCompletionHandler {
-    NSString *key = @"testDeleteEmailIdentity";
+- (void)testDeleteReceiptFilterCompletionHandler {
+    NSString *key = @"testDeleteReceiptFilter";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -715,7 +809,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] deleteEmailIdentity:[AWSSESDeleteEmailIdentityRequest new] completionHandler:^(AWSSESDeleteEmailIdentityResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteReceiptFilter:[AWSSESDeleteReceiptFilterRequest new] completionHandler:^(AWSSESDeleteReceiptFilterResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -729,8 +823,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteEmailIdentityPolicy {
-    NSString *key = @"testDeleteEmailIdentityPolicy";
+- (void)testDeleteReceiptRule {
+    NSString *key = @"testDeleteReceiptRule";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -738,7 +832,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] deleteEmailIdentityPolicy:[AWSSESDeleteEmailIdentityPolicyRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] deleteReceiptRule:[AWSSESDeleteReceiptRuleRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -751,8 +845,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteEmailIdentityPolicyCompletionHandler {
-    NSString *key = @"testDeleteEmailIdentityPolicy";
+- (void)testDeleteReceiptRuleCompletionHandler {
+    NSString *key = @"testDeleteReceiptRule";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -763,7 +857,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] deleteEmailIdentityPolicy:[AWSSESDeleteEmailIdentityPolicyRequest new] completionHandler:^(AWSSESDeleteEmailIdentityPolicyResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteReceiptRule:[AWSSESDeleteReceiptRuleRequest new] completionHandler:^(AWSSESDeleteReceiptRuleResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -777,8 +871,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteEmailTemplate {
-    NSString *key = @"testDeleteEmailTemplate";
+- (void)testDeleteReceiptRuleSet {
+    NSString *key = @"testDeleteReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -786,7 +880,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] deleteEmailTemplate:[AWSSESDeleteEmailTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] deleteReceiptRuleSet:[AWSSESDeleteReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -799,8 +893,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteEmailTemplateCompletionHandler {
-    NSString *key = @"testDeleteEmailTemplate";
+- (void)testDeleteReceiptRuleSetCompletionHandler {
+    NSString *key = @"testDeleteReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -811,7 +905,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] deleteEmailTemplate:[AWSSESDeleteEmailTemplateRequest new] completionHandler:^(AWSSESDeleteEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteReceiptRuleSet:[AWSSESDeleteReceiptRuleSetRequest new] completionHandler:^(AWSSESDeleteReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -825,8 +919,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteSuppressedDestination {
-    NSString *key = @"testDeleteSuppressedDestination";
+- (void)testDeleteTemplate {
+    NSString *key = @"testDeleteTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -834,7 +928,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] deleteSuppressedDestination:[AWSSESDeleteSuppressedDestinationRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] deleteTemplate:[AWSSESDeleteTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -847,8 +941,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testDeleteSuppressedDestinationCompletionHandler {
-    NSString *key = @"testDeleteSuppressedDestination";
+- (void)testDeleteTemplateCompletionHandler {
+    NSString *key = @"testDeleteTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -859,7 +953,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] deleteSuppressedDestination:[AWSSESDeleteSuppressedDestinationRequest new] completionHandler:^(AWSSESDeleteSuppressedDestinationResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteTemplate:[AWSSESDeleteTemplateRequest new] completionHandler:^(AWSSESDeleteTemplateResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -873,8 +967,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetAccount {
-    NSString *key = @"testGetAccount";
+- (void)testDeleteVerifiedEmailAddress {
+    NSString *key = @"testDeleteVerifiedEmailAddress";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -882,7 +976,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getAccount:[AWSSESGetAccountRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] deleteVerifiedEmailAddress:[AWSSESDeleteVerifiedEmailAddressRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -895,8 +989,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetAccountCompletionHandler {
-    NSString *key = @"testGetAccount";
+- (void)testDeleteVerifiedEmailAddressCompletionHandler {
+    NSString *key = @"testDeleteVerifiedEmailAddress";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -907,7 +1001,54 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getAccount:[AWSSESGetAccountRequest new] completionHandler:^(AWSSESGetAccountResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] deleteVerifiedEmailAddress:[AWSSESDeleteVerifiedEmailAddressRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testDescribeActiveReceiptRuleSet {
+    NSString *key = @"testDescribeActiveReceiptRuleSet";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] describeActiveReceiptRuleSet:[AWSSESDescribeActiveReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testDescribeActiveReceiptRuleSetCompletionHandler {
+    NSString *key = @"testDescribeActiveReceiptRuleSet";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] describeActiveReceiptRuleSet:[AWSSESDescribeActiveReceiptRuleSetRequest new] completionHandler:^(AWSSESDescribeActiveReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -921,8 +1062,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetBlacklistReports {
-    NSString *key = @"testGetBlacklistReports";
+- (void)testDescribeConfigurationSet {
+    NSString *key = @"testDescribeConfigurationSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -930,7 +1071,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getBlacklistReports:[AWSSESGetBlacklistReportsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] describeConfigurationSet:[AWSSESDescribeConfigurationSetRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -943,8 +1084,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetBlacklistReportsCompletionHandler {
-    NSString *key = @"testGetBlacklistReports";
+- (void)testDescribeConfigurationSetCompletionHandler {
+    NSString *key = @"testDescribeConfigurationSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -955,7 +1096,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getBlacklistReports:[AWSSESGetBlacklistReportsRequest new] completionHandler:^(AWSSESGetBlacklistReportsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] describeConfigurationSet:[AWSSESDescribeConfigurationSetRequest new] completionHandler:^(AWSSESDescribeConfigurationSetResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -969,8 +1110,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetConfigurationSet {
-    NSString *key = @"testGetConfigurationSet";
+- (void)testDescribeReceiptRule {
+    NSString *key = @"testDescribeReceiptRule";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -978,7 +1119,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getConfigurationSet:[AWSSESGetConfigurationSetRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] describeReceiptRule:[AWSSESDescribeReceiptRuleRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -991,8 +1132,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetConfigurationSetCompletionHandler {
-    NSString *key = @"testGetConfigurationSet";
+- (void)testDescribeReceiptRuleCompletionHandler {
+    NSString *key = @"testDescribeReceiptRule";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1003,7 +1144,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getConfigurationSet:[AWSSESGetConfigurationSetRequest new] completionHandler:^(AWSSESGetConfigurationSetResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] describeReceiptRule:[AWSSESDescribeReceiptRuleRequest new] completionHandler:^(AWSSESDescribeReceiptRuleResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1017,8 +1158,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetConfigurationSetEventDestinations {
-    NSString *key = @"testGetConfigurationSetEventDestinations";
+- (void)testDescribeReceiptRuleSet {
+    NSString *key = @"testDescribeReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1026,7 +1167,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getConfigurationSetEventDestinations:[AWSSESGetConfigurationSetEventDestinationsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] describeReceiptRuleSet:[AWSSESDescribeReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1039,8 +1180,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetConfigurationSetEventDestinationsCompletionHandler {
-    NSString *key = @"testGetConfigurationSetEventDestinations";
+- (void)testDescribeReceiptRuleSetCompletionHandler {
+    NSString *key = @"testDescribeReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1051,7 +1192,55 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getConfigurationSetEventDestinations:[AWSSESGetConfigurationSetEventDestinationsRequest new] completionHandler:^(AWSSESGetConfigurationSetEventDestinationsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] describeReceiptRuleSet:[AWSSESDescribeReceiptRuleSetRequest new] completionHandler:^(AWSSESDescribeReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testGetAccountSendingEnabled {
+    NSString *key = @"testGetAccountSendingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] getAccountSendingEnabled:[AWSRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testGetAccountSendingEnabledCompletionHandler {
+    NSString *key = @"testGetAccountSendingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] getAccountSendingEnabled:[AWSRequest new] completionHandler:^(AWSSESGetAccountSendingEnabledResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1113,8 +1302,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDedicatedIp {
-    NSString *key = @"testGetDedicatedIp";
+- (void)testGetIdentityDkimAttributes {
+    NSString *key = @"testGetIdentityDkimAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1122,7 +1311,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getDedicatedIp:[AWSSESGetDedicatedIpRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getIdentityDkimAttributes:[AWSSESGetIdentityDkimAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1135,8 +1324,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDedicatedIpCompletionHandler {
-    NSString *key = @"testGetDedicatedIp";
+- (void)testGetIdentityDkimAttributesCompletionHandler {
+    NSString *key = @"testGetIdentityDkimAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1147,7 +1336,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getDedicatedIp:[AWSSESGetDedicatedIpRequest new] completionHandler:^(AWSSESGetDedicatedIpResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getIdentityDkimAttributes:[AWSSESGetIdentityDkimAttributesRequest new] completionHandler:^(AWSSESGetIdentityDkimAttributesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1161,8 +1350,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDedicatedIps {
-    NSString *key = @"testGetDedicatedIps";
+- (void)testGetIdentityMailFromDomainAttributes {
+    NSString *key = @"testGetIdentityMailFromDomainAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1170,7 +1359,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getDedicatedIps:[AWSSESGetDedicatedIpsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getIdentityMailFromDomainAttributes:[AWSSESGetIdentityMailFromDomainAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1183,8 +1372,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDedicatedIpsCompletionHandler {
-    NSString *key = @"testGetDedicatedIps";
+- (void)testGetIdentityMailFromDomainAttributesCompletionHandler {
+    NSString *key = @"testGetIdentityMailFromDomainAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1195,7 +1384,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getDedicatedIps:[AWSSESGetDedicatedIpsRequest new] completionHandler:^(AWSSESGetDedicatedIpsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getIdentityMailFromDomainAttributes:[AWSSESGetIdentityMailFromDomainAttributesRequest new] completionHandler:^(AWSSESGetIdentityMailFromDomainAttributesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1209,8 +1398,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDeliverabilityDashboardOptions {
-    NSString *key = @"testGetDeliverabilityDashboardOptions";
+- (void)testGetIdentityNotificationAttributes {
+    NSString *key = @"testGetIdentityNotificationAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1218,7 +1407,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getDeliverabilityDashboardOptions:[AWSSESGetDeliverabilityDashboardOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getIdentityNotificationAttributes:[AWSSESGetIdentityNotificationAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1231,8 +1420,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDeliverabilityDashboardOptionsCompletionHandler {
-    NSString *key = @"testGetDeliverabilityDashboardOptions";
+- (void)testGetIdentityNotificationAttributesCompletionHandler {
+    NSString *key = @"testGetIdentityNotificationAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1243,7 +1432,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getDeliverabilityDashboardOptions:[AWSSESGetDeliverabilityDashboardOptionsRequest new] completionHandler:^(AWSSESGetDeliverabilityDashboardOptionsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getIdentityNotificationAttributes:[AWSSESGetIdentityNotificationAttributesRequest new] completionHandler:^(AWSSESGetIdentityNotificationAttributesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1257,8 +1446,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDeliverabilityTestReport {
-    NSString *key = @"testGetDeliverabilityTestReport";
+- (void)testGetIdentityPolicies {
+    NSString *key = @"testGetIdentityPolicies";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1266,7 +1455,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getDeliverabilityTestReport:[AWSSESGetDeliverabilityTestReportRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getIdentityPolicies:[AWSSESGetIdentityPoliciesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1279,8 +1468,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDeliverabilityTestReportCompletionHandler {
-    NSString *key = @"testGetDeliverabilityTestReport";
+- (void)testGetIdentityPoliciesCompletionHandler {
+    NSString *key = @"testGetIdentityPolicies";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1291,7 +1480,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getDeliverabilityTestReport:[AWSSESGetDeliverabilityTestReportRequest new] completionHandler:^(AWSSESGetDeliverabilityTestReportResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getIdentityPolicies:[AWSSESGetIdentityPoliciesRequest new] completionHandler:^(AWSSESGetIdentityPoliciesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1305,8 +1494,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDomainDeliverabilityCampaign {
-    NSString *key = @"testGetDomainDeliverabilityCampaign";
+- (void)testGetIdentityVerificationAttributes {
+    NSString *key = @"testGetIdentityVerificationAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1314,7 +1503,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getDomainDeliverabilityCampaign:[AWSSESGetDomainDeliverabilityCampaignRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getIdentityVerificationAttributes:[AWSSESGetIdentityVerificationAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1327,8 +1516,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDomainDeliverabilityCampaignCompletionHandler {
-    NSString *key = @"testGetDomainDeliverabilityCampaign";
+- (void)testGetIdentityVerificationAttributesCompletionHandler {
+    NSString *key = @"testGetIdentityVerificationAttributes";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1339,7 +1528,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getDomainDeliverabilityCampaign:[AWSSESGetDomainDeliverabilityCampaignRequest new] completionHandler:^(AWSSESGetDomainDeliverabilityCampaignResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getIdentityVerificationAttributes:[AWSSESGetIdentityVerificationAttributesRequest new] completionHandler:^(AWSSESGetIdentityVerificationAttributesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1353,8 +1542,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDomainStatisticsReport {
-    NSString *key = @"testGetDomainStatisticsReport";
+- (void)testGetSendQuota {
+    NSString *key = @"testGetSendQuota";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1362,7 +1551,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getDomainStatisticsReport:[AWSSESGetDomainStatisticsReportRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getSendQuota:[AWSRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1375,8 +1564,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetDomainStatisticsReportCompletionHandler {
-    NSString *key = @"testGetDomainStatisticsReport";
+- (void)testGetSendQuotaCompletionHandler {
+    NSString *key = @"testGetSendQuota";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1387,7 +1576,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getDomainStatisticsReport:[AWSSESGetDomainStatisticsReportRequest new] completionHandler:^(AWSSESGetDomainStatisticsReportResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getSendQuota:[AWSRequest new] completionHandler:^(AWSSESGetSendQuotaResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1401,8 +1590,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetEmailIdentity {
-    NSString *key = @"testGetEmailIdentity";
+- (void)testGetSendStatistics {
+    NSString *key = @"testGetSendStatistics";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1410,7 +1599,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getEmailIdentity:[AWSSESGetEmailIdentityRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getSendStatistics:[AWSRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1423,8 +1612,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetEmailIdentityCompletionHandler {
-    NSString *key = @"testGetEmailIdentity";
+- (void)testGetSendStatisticsCompletionHandler {
+    NSString *key = @"testGetSendStatistics";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1435,7 +1624,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getEmailIdentity:[AWSSESGetEmailIdentityRequest new] completionHandler:^(AWSSESGetEmailIdentityResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getSendStatistics:[AWSRequest new] completionHandler:^(AWSSESGetSendStatisticsResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1449,8 +1638,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetEmailIdentityPolicies {
-    NSString *key = @"testGetEmailIdentityPolicies";
+- (void)testGetTemplate {
+    NSString *key = @"testGetTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1458,7 +1647,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getEmailIdentityPolicies:[AWSSESGetEmailIdentityPoliciesRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] getTemplate:[AWSSESGetTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1471,8 +1660,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testGetEmailIdentityPoliciesCompletionHandler {
-    NSString *key = @"testGetEmailIdentityPolicies";
+- (void)testGetTemplateCompletionHandler {
+    NSString *key = @"testGetTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1483,151 +1672,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] getEmailIdentityPolicies:[AWSSESGetEmailIdentityPoliciesRequest new] completionHandler:^(AWSSESGetEmailIdentityPoliciesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testGetEmailTemplate {
-    NSString *key = @"testGetEmailTemplate";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getEmailTemplate:[AWSSESGetEmailTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testGetEmailTemplateCompletionHandler {
-    NSString *key = @"testGetEmailTemplate";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] getEmailTemplate:[AWSSESGetEmailTemplateRequest new] completionHandler:^(AWSSESGetEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testGetImportJob {
-    NSString *key = @"testGetImportJob";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getImportJob:[AWSSESGetImportJobRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testGetImportJobCompletionHandler {
-    NSString *key = @"testGetImportJob";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] getImportJob:[AWSSESGetImportJobRequest new] completionHandler:^(AWSSESGetImportJobResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testGetSuppressedDestination {
-    NSString *key = @"testGetSuppressedDestination";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] getSuppressedDestination:[AWSSESGetSuppressedDestinationRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testGetSuppressedDestinationCompletionHandler {
-    NSString *key = @"testGetSuppressedDestination";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] getSuppressedDestination:[AWSSESGetSuppressedDestinationRequest new] completionHandler:^(AWSSESGetSuppressedDestinationResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] getTemplate:[AWSSESGetTemplateRequest new] completionHandler:^(AWSSESGetTemplateResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1737,8 +1782,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListDedicatedIpPools {
-    NSString *key = @"testListDedicatedIpPools";
+- (void)testListIdentities {
+    NSString *key = @"testListIdentities";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1746,7 +1791,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listDedicatedIpPools:[AWSSESListDedicatedIpPoolsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] listIdentities:[AWSSESListIdentitiesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1759,8 +1804,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListDedicatedIpPoolsCompletionHandler {
-    NSString *key = @"testListDedicatedIpPools";
+- (void)testListIdentitiesCompletionHandler {
+    NSString *key = @"testListIdentities";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1771,7 +1816,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] listDedicatedIpPools:[AWSSESListDedicatedIpPoolsRequest new] completionHandler:^(AWSSESListDedicatedIpPoolsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] listIdentities:[AWSSESListIdentitiesRequest new] completionHandler:^(AWSSESListIdentitiesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1785,8 +1830,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListDeliverabilityTestReports {
-    NSString *key = @"testListDeliverabilityTestReports";
+- (void)testListIdentityPolicies {
+    NSString *key = @"testListIdentityPolicies";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1794,7 +1839,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listDeliverabilityTestReports:[AWSSESListDeliverabilityTestReportsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] listIdentityPolicies:[AWSSESListIdentityPoliciesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1807,8 +1852,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListDeliverabilityTestReportsCompletionHandler {
-    NSString *key = @"testListDeliverabilityTestReports";
+- (void)testListIdentityPoliciesCompletionHandler {
+    NSString *key = @"testListIdentityPolicies";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1819,7 +1864,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] listDeliverabilityTestReports:[AWSSESListDeliverabilityTestReportsRequest new] completionHandler:^(AWSSESListDeliverabilityTestReportsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] listIdentityPolicies:[AWSSESListIdentityPoliciesRequest new] completionHandler:^(AWSSESListIdentityPoliciesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1833,8 +1878,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListDomainDeliverabilityCampaigns {
-    NSString *key = @"testListDomainDeliverabilityCampaigns";
+- (void)testListReceiptFilters {
+    NSString *key = @"testListReceiptFilters";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1842,7 +1887,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listDomainDeliverabilityCampaigns:[AWSSESListDomainDeliverabilityCampaignsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] listReceiptFilters:[AWSSESListReceiptFiltersRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1855,8 +1900,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListDomainDeliverabilityCampaignsCompletionHandler {
-    NSString *key = @"testListDomainDeliverabilityCampaigns";
+- (void)testListReceiptFiltersCompletionHandler {
+    NSString *key = @"testListReceiptFilters";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1867,7 +1912,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] listDomainDeliverabilityCampaigns:[AWSSESListDomainDeliverabilityCampaignsRequest new] completionHandler:^(AWSSESListDomainDeliverabilityCampaignsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] listReceiptFilters:[AWSSESListReceiptFiltersRequest new] completionHandler:^(AWSSESListReceiptFiltersResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1881,8 +1926,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListEmailIdentities {
-    NSString *key = @"testListEmailIdentities";
+- (void)testListReceiptRuleSets {
+    NSString *key = @"testListReceiptRuleSets";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1890,7 +1935,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listEmailIdentities:[AWSSESListEmailIdentitiesRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] listReceiptRuleSets:[AWSSESListReceiptRuleSetsRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1903,8 +1948,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListEmailIdentitiesCompletionHandler {
-    NSString *key = @"testListEmailIdentities";
+- (void)testListReceiptRuleSetsCompletionHandler {
+    NSString *key = @"testListReceiptRuleSets";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1915,7 +1960,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] listEmailIdentities:[AWSSESListEmailIdentitiesRequest new] completionHandler:^(AWSSESListEmailIdentitiesResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] listReceiptRuleSets:[AWSSESListReceiptRuleSetsRequest new] completionHandler:^(AWSSESListReceiptRuleSetsResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1929,8 +1974,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListEmailTemplates {
-    NSString *key = @"testListEmailTemplates";
+- (void)testListTemplates {
+    NSString *key = @"testListTemplates";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1938,7 +1983,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listEmailTemplates:[AWSSESListEmailTemplatesRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] listTemplates:[AWSSESListTemplatesRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1951,8 +1996,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListEmailTemplatesCompletionHandler {
-    NSString *key = @"testListEmailTemplates";
+- (void)testListTemplatesCompletionHandler {
+    NSString *key = @"testListTemplates";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1963,7 +2008,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] listEmailTemplates:[AWSSESListEmailTemplatesRequest new] completionHandler:^(AWSSESListEmailTemplatesResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] listTemplates:[AWSSESListTemplatesRequest new] completionHandler:^(AWSSESListTemplatesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -1977,8 +2022,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListImportJobs {
-    NSString *key = @"testListImportJobs";
+- (void)testListVerifiedEmailAddresses {
+    NSString *key = @"testListVerifiedEmailAddresses";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -1986,7 +2031,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listImportJobs:[AWSSESListImportJobsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] listVerifiedEmailAddresses:[AWSRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -1999,8 +2044,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testListImportJobsCompletionHandler {
-    NSString *key = @"testListImportJobs";
+- (void)testListVerifiedEmailAddressesCompletionHandler {
+    NSString *key = @"testListVerifiedEmailAddresses";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2011,295 +2056,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] listImportJobs:[AWSSESListImportJobsRequest new] completionHandler:^(AWSSESListImportJobsResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testListSuppressedDestinations {
-    NSString *key = @"testListSuppressedDestinations";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listSuppressedDestinations:[AWSSESListSuppressedDestinationsRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testListSuppressedDestinationsCompletionHandler {
-    NSString *key = @"testListSuppressedDestinations";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] listSuppressedDestinations:[AWSSESListSuppressedDestinationsRequest new] completionHandler:^(AWSSESListSuppressedDestinationsResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testListTagsForResource {
-    NSString *key = @"testListTagsForResource";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] listTagsForResource:[AWSSESListTagsForResourceRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testListTagsForResourceCompletionHandler {
-    NSString *key = @"testListTagsForResource";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] listTagsForResource:[AWSSESListTagsForResourceRequest new] completionHandler:^(AWSSESListTagsForResourceResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountDedicatedIpWarmupAttributes {
-    NSString *key = @"testPutAccountDedicatedIpWarmupAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putAccountDedicatedIpWarmupAttributes:[AWSSESPutAccountDedicatedIpWarmupAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountDedicatedIpWarmupAttributesCompletionHandler {
-    NSString *key = @"testPutAccountDedicatedIpWarmupAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putAccountDedicatedIpWarmupAttributes:[AWSSESPutAccountDedicatedIpWarmupAttributesRequest new] completionHandler:^(AWSSESPutAccountDedicatedIpWarmupAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountDetails {
-    NSString *key = @"testPutAccountDetails";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putAccountDetails:[AWSSESPutAccountDetailsRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountDetailsCompletionHandler {
-    NSString *key = @"testPutAccountDetails";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putAccountDetails:[AWSSESPutAccountDetailsRequest new] completionHandler:^(AWSSESPutAccountDetailsResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountSendingAttributes {
-    NSString *key = @"testPutAccountSendingAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putAccountSendingAttributes:[AWSSESPutAccountSendingAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountSendingAttributesCompletionHandler {
-    NSString *key = @"testPutAccountSendingAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putAccountSendingAttributes:[AWSSESPutAccountSendingAttributesRequest new] completionHandler:^(AWSSESPutAccountSendingAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountSuppressionAttributes {
-    NSString *key = @"testPutAccountSuppressionAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putAccountSuppressionAttributes:[AWSSESPutAccountSuppressionAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutAccountSuppressionAttributesCompletionHandler {
-    NSString *key = @"testPutAccountSuppressionAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putAccountSuppressionAttributes:[AWSSESPutAccountSuppressionAttributesRequest new] completionHandler:^(AWSSESPutAccountSuppressionAttributesResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] listVerifiedEmailAddresses:[AWSRequest new] completionHandler:^(AWSSESListVerifiedEmailAddressesResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -2361,8 +2118,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetReputationOptions {
-    NSString *key = @"testPutConfigurationSetReputationOptions";
+- (void)testPutIdentityPolicy {
+    NSString *key = @"testPutIdentityPolicy";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2370,7 +2127,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putConfigurationSetReputationOptions:[AWSSESPutConfigurationSetReputationOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] putIdentityPolicy:[AWSSESPutIdentityPolicyRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -2383,8 +2140,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetReputationOptionsCompletionHandler {
-    NSString *key = @"testPutConfigurationSetReputationOptions";
+- (void)testPutIdentityPolicyCompletionHandler {
+    NSString *key = @"testPutIdentityPolicy";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2395,7 +2152,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] putConfigurationSetReputationOptions:[AWSSESPutConfigurationSetReputationOptionsRequest new] completionHandler:^(AWSSESPutConfigurationSetReputationOptionsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] putIdentityPolicy:[AWSSESPutIdentityPolicyRequest new] completionHandler:^(AWSSESPutIdentityPolicyResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -2409,8 +2166,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetSendingOptions {
-    NSString *key = @"testPutConfigurationSetSendingOptions";
+- (void)testReorderReceiptRuleSet {
+    NSString *key = @"testReorderReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2418,7 +2175,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putConfigurationSetSendingOptions:[AWSSESPutConfigurationSetSendingOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] reorderReceiptRuleSet:[AWSSESReorderReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -2431,8 +2188,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetSendingOptionsCompletionHandler {
-    NSString *key = @"testPutConfigurationSetSendingOptions";
+- (void)testReorderReceiptRuleSetCompletionHandler {
+    NSString *key = @"testReorderReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2443,7 +2200,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] putConfigurationSetSendingOptions:[AWSSESPutConfigurationSetSendingOptionsRequest new] completionHandler:^(AWSSESPutConfigurationSetSendingOptionsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] reorderReceiptRuleSet:[AWSSESReorderReceiptRuleSetRequest new] completionHandler:^(AWSSESReorderReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -2457,8 +2214,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetSuppressionOptions {
-    NSString *key = @"testPutConfigurationSetSuppressionOptions";
+- (void)testSendBounce {
+    NSString *key = @"testSendBounce";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2466,7 +2223,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putConfigurationSetSuppressionOptions:[AWSSESPutConfigurationSetSuppressionOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] sendBounce:[AWSSESSendBounceRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -2479,8 +2236,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetSuppressionOptionsCompletionHandler {
-    NSString *key = @"testPutConfigurationSetSuppressionOptions";
+- (void)testSendBounceCompletionHandler {
+    NSString *key = @"testSendBounce";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2491,7 +2248,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] putConfigurationSetSuppressionOptions:[AWSSESPutConfigurationSetSuppressionOptionsRequest new] completionHandler:^(AWSSESPutConfigurationSetSuppressionOptionsResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] sendBounce:[AWSSESSendBounceRequest new] completionHandler:^(AWSSESSendBounceResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -2505,8 +2262,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetTrackingOptions {
-    NSString *key = @"testPutConfigurationSetTrackingOptions";
+- (void)testSendBulkTemplatedEmail {
+    NSString *key = @"testSendBulkTemplatedEmail";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2514,7 +2271,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putConfigurationSetTrackingOptions:[AWSSESPutConfigurationSetTrackingOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] sendBulkTemplatedEmail:[AWSSESSendBulkTemplatedEmailRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -2527,8 +2284,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testPutConfigurationSetTrackingOptionsCompletionHandler {
-    NSString *key = @"testPutConfigurationSetTrackingOptions";
+- (void)testSendBulkTemplatedEmailCompletionHandler {
+    NSString *key = @"testSendBulkTemplatedEmail";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -2539,439 +2296,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] putConfigurationSetTrackingOptions:[AWSSESPutConfigurationSetTrackingOptionsRequest new] completionHandler:^(AWSSESPutConfigurationSetTrackingOptionsResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutDedicatedIpInPool {
-    NSString *key = @"testPutDedicatedIpInPool";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putDedicatedIpInPool:[AWSSESPutDedicatedIpInPoolRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutDedicatedIpInPoolCompletionHandler {
-    NSString *key = @"testPutDedicatedIpInPool";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putDedicatedIpInPool:[AWSSESPutDedicatedIpInPoolRequest new] completionHandler:^(AWSSESPutDedicatedIpInPoolResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutDedicatedIpWarmupAttributes {
-    NSString *key = @"testPutDedicatedIpWarmupAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putDedicatedIpWarmupAttributes:[AWSSESPutDedicatedIpWarmupAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutDedicatedIpWarmupAttributesCompletionHandler {
-    NSString *key = @"testPutDedicatedIpWarmupAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putDedicatedIpWarmupAttributes:[AWSSESPutDedicatedIpWarmupAttributesRequest new] completionHandler:^(AWSSESPutDedicatedIpWarmupAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutDeliverabilityDashboardOption {
-    NSString *key = @"testPutDeliverabilityDashboardOption";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putDeliverabilityDashboardOption:[AWSSESPutDeliverabilityDashboardOptionRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutDeliverabilityDashboardOptionCompletionHandler {
-    NSString *key = @"testPutDeliverabilityDashboardOption";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putDeliverabilityDashboardOption:[AWSSESPutDeliverabilityDashboardOptionRequest new] completionHandler:^(AWSSESPutDeliverabilityDashboardOptionResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityDkimAttributes {
-    NSString *key = @"testPutEmailIdentityDkimAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putEmailIdentityDkimAttributes:[AWSSESPutEmailIdentityDkimAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityDkimAttributesCompletionHandler {
-    NSString *key = @"testPutEmailIdentityDkimAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putEmailIdentityDkimAttributes:[AWSSESPutEmailIdentityDkimAttributesRequest new] completionHandler:^(AWSSESPutEmailIdentityDkimAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityDkimSigningAttributes {
-    NSString *key = @"testPutEmailIdentityDkimSigningAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putEmailIdentityDkimSigningAttributes:[AWSSESPutEmailIdentityDkimSigningAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityDkimSigningAttributesCompletionHandler {
-    NSString *key = @"testPutEmailIdentityDkimSigningAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putEmailIdentityDkimSigningAttributes:[AWSSESPutEmailIdentityDkimSigningAttributesRequest new] completionHandler:^(AWSSESPutEmailIdentityDkimSigningAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityFeedbackAttributes {
-    NSString *key = @"testPutEmailIdentityFeedbackAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putEmailIdentityFeedbackAttributes:[AWSSESPutEmailIdentityFeedbackAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityFeedbackAttributesCompletionHandler {
-    NSString *key = @"testPutEmailIdentityFeedbackAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putEmailIdentityFeedbackAttributes:[AWSSESPutEmailIdentityFeedbackAttributesRequest new] completionHandler:^(AWSSESPutEmailIdentityFeedbackAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityMailFromAttributes {
-    NSString *key = @"testPutEmailIdentityMailFromAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putEmailIdentityMailFromAttributes:[AWSSESPutEmailIdentityMailFromAttributesRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutEmailIdentityMailFromAttributesCompletionHandler {
-    NSString *key = @"testPutEmailIdentityMailFromAttributes";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putEmailIdentityMailFromAttributes:[AWSSESPutEmailIdentityMailFromAttributesRequest new] completionHandler:^(AWSSESPutEmailIdentityMailFromAttributesResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutSuppressedDestination {
-    NSString *key = @"testPutSuppressedDestination";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] putSuppressedDestination:[AWSSESPutSuppressedDestinationRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testPutSuppressedDestinationCompletionHandler {
-    NSString *key = @"testPutSuppressedDestination";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] putSuppressedDestination:[AWSSESPutSuppressedDestinationRequest new] completionHandler:^(AWSSESPutSuppressedDestinationResponse* _Nullable response, NSError * _Nullable error) {
-        XCTAssertNotNil(error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
-        XCTAssertEqual(8848, error.code);
-        XCTAssertNil(response);
-        dispatch_semaphore_signal(semaphore);
-    }];
-	
- 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testSendBulkEmail {
-    NSString *key = @"testSendBulkEmail";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] sendBulkEmail:[AWSSESSendBulkEmailRequest new]] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error);
-        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
-        XCTAssertEqual(8848, task.error.code);
-        XCTAssertNil(task.result);
-        return nil;
-    }] waitUntilFinished];
-
-    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
-
-    [AWSSES removeSESForKey:key];
-}
-
-- (void)testSendBulkEmailCompletionHandler {
-    NSString *key = @"testSendBulkEmail";
-    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
-    [AWSSES registerSESWithConfiguration:configuration forKey:key];
-
-    AWSSES *awsClient = [AWSSES SESForKey:key];
-    XCTAssertNotNil(awsClient);
-    XCTAssertNotNil(mockNetworking);
-    [awsClient setValue:mockNetworking forKey:@"networking"];
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-	[[AWSSES SESForKey:key] sendBulkEmail:[AWSSESSendBulkEmailRequest new] completionHandler:^(AWSSESSendBulkEmailResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] sendBulkTemplatedEmail:[AWSSESSendBulkTemplatedEmailRequest new] completionHandler:^(AWSSESSendBulkTemplatedEmailResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -3081,8 +2406,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testTagResource {
-    NSString *key = @"testTagResource";
+- (void)testSendRawEmail {
+    NSString *key = @"testSendRawEmail";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3090,7 +2415,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] tagResource:[AWSSESTagResourceRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] sendRawEmail:[AWSSESSendRawEmailRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -3103,8 +2428,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testTagResourceCompletionHandler {
-    NSString *key = @"testTagResource";
+- (void)testSendRawEmailCompletionHandler {
+    NSString *key = @"testSendRawEmail";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3115,7 +2440,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] tagResource:[AWSSESTagResourceRequest new] completionHandler:^(AWSSESTagResourceResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] sendRawEmail:[AWSSESSendRawEmailRequest new] completionHandler:^(AWSSESSendRawEmailResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -3129,8 +2454,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testTestRenderEmailTemplate {
-    NSString *key = @"testTestRenderEmailTemplate";
+- (void)testSendTemplatedEmail {
+    NSString *key = @"testSendTemplatedEmail";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3138,7 +2463,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] testRenderEmailTemplate:[AWSSESTestRenderEmailTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] sendTemplatedEmail:[AWSSESSendTemplatedEmailRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -3151,8 +2476,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testTestRenderEmailTemplateCompletionHandler {
-    NSString *key = @"testTestRenderEmailTemplate";
+- (void)testSendTemplatedEmailCompletionHandler {
+    NSString *key = @"testSendTemplatedEmail";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3163,7 +2488,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] testRenderEmailTemplate:[AWSSESTestRenderEmailTemplateRequest new] completionHandler:^(AWSSESTestRenderEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] sendTemplatedEmail:[AWSSESSendTemplatedEmailRequest new] completionHandler:^(AWSSESSendTemplatedEmailResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -3177,8 +2502,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testUntagResource {
-    NSString *key = @"testUntagResource";
+- (void)testSetActiveReceiptRuleSet {
+    NSString *key = @"testSetActiveReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3186,7 +2511,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] untagResource:[AWSSESUntagResourceRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] setActiveReceiptRuleSet:[AWSSESSetActiveReceiptRuleSetRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -3199,8 +2524,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testUntagResourceCompletionHandler {
-    NSString *key = @"testUntagResource";
+- (void)testSetActiveReceiptRuleSetCompletionHandler {
+    NSString *key = @"testSetActiveReceiptRuleSet";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3211,11 +2536,394 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] untagResource:[AWSSESUntagResourceRequest new] completionHandler:^(AWSSESUntagResourceResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] setActiveReceiptRuleSet:[AWSSESSetActiveReceiptRuleSetRequest new] completionHandler:^(AWSSESSetActiveReceiptRuleSetResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
         XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityDkimEnabled {
+    NSString *key = @"testSetIdentityDkimEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] setIdentityDkimEnabled:[AWSSESSetIdentityDkimEnabledRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityDkimEnabledCompletionHandler {
+    NSString *key = @"testSetIdentityDkimEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] setIdentityDkimEnabled:[AWSSESSetIdentityDkimEnabledRequest new] completionHandler:^(AWSSESSetIdentityDkimEnabledResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityFeedbackForwardingEnabled {
+    NSString *key = @"testSetIdentityFeedbackForwardingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] setIdentityFeedbackForwardingEnabled:[AWSSESSetIdentityFeedbackForwardingEnabledRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityFeedbackForwardingEnabledCompletionHandler {
+    NSString *key = @"testSetIdentityFeedbackForwardingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] setIdentityFeedbackForwardingEnabled:[AWSSESSetIdentityFeedbackForwardingEnabledRequest new] completionHandler:^(AWSSESSetIdentityFeedbackForwardingEnabledResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityHeadersInNotificationsEnabled {
+    NSString *key = @"testSetIdentityHeadersInNotificationsEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] setIdentityHeadersInNotificationsEnabled:[AWSSESSetIdentityHeadersInNotificationsEnabledRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityHeadersInNotificationsEnabledCompletionHandler {
+    NSString *key = @"testSetIdentityHeadersInNotificationsEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] setIdentityHeadersInNotificationsEnabled:[AWSSESSetIdentityHeadersInNotificationsEnabledRequest new] completionHandler:^(AWSSESSetIdentityHeadersInNotificationsEnabledResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityMailFromDomain {
+    NSString *key = @"testSetIdentityMailFromDomain";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] setIdentityMailFromDomain:[AWSSESSetIdentityMailFromDomainRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityMailFromDomainCompletionHandler {
+    NSString *key = @"testSetIdentityMailFromDomain";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] setIdentityMailFromDomain:[AWSSESSetIdentityMailFromDomainRequest new] completionHandler:^(AWSSESSetIdentityMailFromDomainResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityNotificationTopic {
+    NSString *key = @"testSetIdentityNotificationTopic";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] setIdentityNotificationTopic:[AWSSESSetIdentityNotificationTopicRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetIdentityNotificationTopicCompletionHandler {
+    NSString *key = @"testSetIdentityNotificationTopic";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] setIdentityNotificationTopic:[AWSSESSetIdentityNotificationTopicRequest new] completionHandler:^(AWSSESSetIdentityNotificationTopicResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetReceiptRulePosition {
+    NSString *key = @"testSetReceiptRulePosition";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] setReceiptRulePosition:[AWSSESSetReceiptRulePositionRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testSetReceiptRulePositionCompletionHandler {
+    NSString *key = @"testSetReceiptRulePosition";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] setReceiptRulePosition:[AWSSESSetReceiptRulePositionRequest new] completionHandler:^(AWSSESSetReceiptRulePositionResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testTestRenderTemplate {
+    NSString *key = @"testTestRenderTemplate";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] testRenderTemplate:[AWSSESTestRenderTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testTestRenderTemplateCompletionHandler {
+    NSString *key = @"testTestRenderTemplate";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] testRenderTemplate:[AWSSESTestRenderTemplateRequest new] completionHandler:^(AWSSESTestRenderTemplateResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateAccountSendingEnabled {
+    NSString *key = @"testUpdateAccountSendingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] updateAccountSendingEnabled:[AWSSESUpdateAccountSendingEnabledRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateAccountSendingEnabledCompletionHandler {
+    NSString *key = @"testUpdateAccountSendingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] updateAccountSendingEnabled:[AWSSESUpdateAccountSendingEnabledRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
         dispatch_semaphore_signal(semaphore);
     }];
 	
@@ -3273,6 +2981,148 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
+- (void)testUpdateConfigurationSetReputationMetricsEnabled {
+    NSString *key = @"testUpdateConfigurationSetReputationMetricsEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] updateConfigurationSetReputationMetricsEnabled:[AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateConfigurationSetReputationMetricsEnabledCompletionHandler {
+    NSString *key = @"testUpdateConfigurationSetReputationMetricsEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] updateConfigurationSetReputationMetricsEnabled:[AWSSESUpdateConfigurationSetReputationMetricsEnabledRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateConfigurationSetSendingEnabled {
+    NSString *key = @"testUpdateConfigurationSetSendingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] updateConfigurationSetSendingEnabled:[AWSSESUpdateConfigurationSetSendingEnabledRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateConfigurationSetSendingEnabledCompletionHandler {
+    NSString *key = @"testUpdateConfigurationSetSendingEnabled";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] updateConfigurationSetSendingEnabled:[AWSSESUpdateConfigurationSetSendingEnabledRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateConfigurationSetTrackingOptions {
+    NSString *key = @"testUpdateConfigurationSetTrackingOptions";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] updateConfigurationSetTrackingOptions:[AWSSESUpdateConfigurationSetTrackingOptionsRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateConfigurationSetTrackingOptionsCompletionHandler {
+    NSString *key = @"testUpdateConfigurationSetTrackingOptions";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] updateConfigurationSetTrackingOptions:[AWSSESUpdateConfigurationSetTrackingOptionsRequest new] completionHandler:^(AWSSESUpdateConfigurationSetTrackingOptionsResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
 - (void)testUpdateCustomVerificationEmailTemplate {
     NSString *key = @"testUpdateCustomVerificationEmailTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
@@ -3307,7 +3157,54 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] updateCustomVerificationEmailTemplate:[AWSSESUpdateCustomVerificationEmailTemplateRequest new] completionHandler:^(AWSSESUpdateCustomVerificationEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] updateCustomVerificationEmailTemplate:[AWSSESUpdateCustomVerificationEmailTemplateRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateReceiptRule {
+    NSString *key = @"testUpdateReceiptRule";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] updateReceiptRule:[AWSSESUpdateReceiptRuleRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testUpdateReceiptRuleCompletionHandler {
+    NSString *key = @"testUpdateReceiptRule";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] updateReceiptRule:[AWSSESUpdateReceiptRuleRequest new] completionHandler:^(AWSSESUpdateReceiptRuleResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -3321,8 +3218,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testUpdateEmailIdentityPolicy {
-    NSString *key = @"testUpdateEmailIdentityPolicy";
+- (void)testUpdateTemplate {
+    NSString *key = @"testUpdateTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3330,7 +3227,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] updateEmailIdentityPolicy:[AWSSESUpdateEmailIdentityPolicyRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] updateTemplate:[AWSSESUpdateTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -3343,8 +3240,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testUpdateEmailIdentityPolicyCompletionHandler {
-    NSString *key = @"testUpdateEmailIdentityPolicy";
+- (void)testUpdateTemplateCompletionHandler {
+    NSString *key = @"testUpdateTemplate";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3355,7 +3252,7 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] updateEmailIdentityPolicy:[AWSSESUpdateEmailIdentityPolicyRequest new] completionHandler:^(AWSSESUpdateEmailIdentityPolicyResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] updateTemplate:[AWSSESUpdateTemplateRequest new] completionHandler:^(AWSSESUpdateTemplateResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);
@@ -3369,8 +3266,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testUpdateEmailTemplate {
-    NSString *key = @"testUpdateEmailTemplate";
+- (void)testVerifyDomainDkim {
+    NSString *key = @"testVerifyDomainDkim";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3378,7 +3275,7 @@ static id mockNetworking = nil;
     XCTAssertNotNil(awsClient);
     XCTAssertNotNil(mockNetworking);
     [awsClient setValue:mockNetworking forKey:@"networking"];
-    [[[[AWSSES SESForKey:key] updateEmailTemplate:[AWSSESUpdateEmailTemplateRequest new]] continueWithBlock:^id(AWSTask *task) {
+    [[[[AWSSES SESForKey:key] verifyDomainDkim:[AWSSESVerifyDomainDkimRequest new]] continueWithBlock:^id(AWSTask *task) {
         XCTAssertNotNil(task.error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
         XCTAssertEqual(8848, task.error.code);
@@ -3391,8 +3288,8 @@ static id mockNetworking = nil;
     [AWSSES removeSESForKey:key];
 }
 
-- (void)testUpdateEmailTemplateCompletionHandler {
-    NSString *key = @"testUpdateEmailTemplate";
+- (void)testVerifyDomainDkimCompletionHandler {
+    NSString *key = @"testVerifyDomainDkim";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
     [AWSSES registerSESWithConfiguration:configuration forKey:key];
 
@@ -3403,7 +3300,150 @@ static id mockNetworking = nil;
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-	[[AWSSES SESForKey:key] updateEmailTemplate:[AWSSESUpdateEmailTemplateRequest new] completionHandler:^(AWSSESUpdateEmailTemplateResponse* _Nullable response, NSError * _Nullable error) {
+	[[AWSSES SESForKey:key] verifyDomainDkim:[AWSSESVerifyDomainDkimRequest new] completionHandler:^(AWSSESVerifyDomainDkimResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testVerifyDomainIdentity {
+    NSString *key = @"testVerifyDomainIdentity";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] verifyDomainIdentity:[AWSSESVerifyDomainIdentityRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testVerifyDomainIdentityCompletionHandler {
+    NSString *key = @"testVerifyDomainIdentity";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] verifyDomainIdentity:[AWSSESVerifyDomainIdentityRequest new] completionHandler:^(AWSSESVerifyDomainIdentityResponse* _Nullable response, NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        XCTAssertNil(response);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testVerifyEmailAddress {
+    NSString *key = @"testVerifyEmailAddress";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] verifyEmailAddress:[AWSSESVerifyEmailAddressRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testVerifyEmailAddressCompletionHandler {
+    NSString *key = @"testVerifyEmailAddress";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] verifyEmailAddress:[AWSSESVerifyEmailAddressRequest new] completionHandler:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
+        XCTAssertEqual(8848, error.code);
+        dispatch_semaphore_signal(semaphore);
+    }];
+	
+ 	dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int)(2.0 * NSEC_PER_SEC)));
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testVerifyEmailIdentity {
+    NSString *key = @"testVerifyEmailIdentity";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+    [[[[AWSSES SESForKey:key] verifyEmailIdentity:[AWSSESVerifyEmailIdentityRequest new]] continueWithBlock:^id(AWSTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", task.error.domain);
+        XCTAssertEqual(8848, task.error.code);
+        XCTAssertNil(task.result);
+        return nil;
+    }] waitUntilFinished];
+
+    OCMVerify([mockNetworking sendRequest:[OCMArg isNotNil]]);
+
+    [AWSSES removeSESForKey:key];
+}
+
+- (void)testVerifyEmailIdentityCompletionHandler {
+    NSString *key = @"testVerifyEmailIdentity";
+    AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];
+    [AWSSES registerSESWithConfiguration:configuration forKey:key];
+
+    AWSSES *awsClient = [AWSSES SESForKey:key];
+    XCTAssertNotNil(awsClient);
+    XCTAssertNotNil(mockNetworking);
+    [awsClient setValue:mockNetworking forKey:@"networking"];
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+	[[AWSSES SESForKey:key] verifyEmailIdentity:[AWSSESVerifyEmailIdentityRequest new] completionHandler:^(AWSSESVerifyEmailIdentityResponse* _Nullable response, NSError * _Nullable error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(@"OCMockExpectedNetworkingError", error.domain);
         XCTAssertEqual(8848, error.code);


### PR DESCRIPTION
This reverts commit 28cd021ad426de371d4cf30bfa0272ae8f2cf2bd.

The SES model update breaks the API version check for credential scoping. We'll need to investigate this further before merging it back in.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
