### PR TITLE
fix(core): prevent overwriting serviceName in Endpoint

### DIFF
--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -426,7 +426,10 @@ static NSString *const AWSServiceNameTranslate = @"translate";
     _regionType = regionType;
     _serviceType = serviceType;
     _regionName = [AWSEndpoint regionNameFromType:regionType];
-    _serviceName = [self serviceNameFromType:serviceType];
+    // set the `serviceName` only if it is not already set
+    if (!_serviceName.length){
+        _serviceName = [self serviceNameFromType:serviceType];
+    }
 }
 
 + (NSString *)regionNameFromType:(AWSRegionType)regionType {


### PR DESCRIPTION
*Description of changes:*
The `serviceName` property of `AWSEndpoint` could already be set in the `AWSServiceConfiguration` (using these [initializers](https://github.com/aws-amplify/aws-sdk-ios/blob/24ecaabd4f182f44bce00eef63ca600c1ea4aac1/AWSCore/Service/AWSService.m#L376)). If we look at any code generated service client for example, [this](https://github.com/aws-amplify/aws-sdk-ios/blob/24ecaabd4f182f44bce00eef63ca600c1ea4aac1/AWSAutoScaling/AWSAutoScalingService.m#L232) call to `setRegion:(AWSRegionType)regionType service:(AWSServiceType)serviceType`, seems to not only set the region, but also override the `serviceName`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
