### PR TITLE
chore: Update AWSCognitoIdentityProviderASF to 1.1.0

### DIFF
--- a/AWSCognitoAuth.podspec
+++ b/AWSCognitoAuth.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'AWSCore', '2.16.0'
-  s.dependency 'AWSCognitoIdentityProviderASF', '1.0.2'
+  s.dependency 'AWSCognitoIdentityProviderASF', '1.1.0'
 
   s.source_files = 'AWSCognitoAuth/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoAuth/*.h'

--- a/AWSCognitoIdentityProvider.podspec
+++ b/AWSCognitoIdentityProvider.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks   = 'Security', 'UIKit'
   s.dependency 'AWSCore', '2.16.0'
-  s.dependency 'AWSCognitoIdentityProviderASF', '1.0.2'
+  s.dependency 'AWSCognitoIdentityProviderASF', '1.1.0'
 
   s.source_files = 'AWSCognitoIdentityProvider/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoIdentityProvider/*.h'

--- a/AWSCognitoIdentityProviderASF.podspec
+++ b/AWSCognitoIdentityProviderASF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSCognitoIdentityProviderASF'
-  s.version      = '1.0.2'
+  s.version      = '1.1.0'
   s.summary      = 'Amazon Cognito Identity Provider Advanced Security Features library (Beta)'
 
   s.description  = 'Amazon Cognito Identity Provider ASF provides the information necessary to support adaptive authentication'

--- a/AWSCognitoIdentityProviderASF/Info.plist
+++ b/AWSCognitoIdentityProviderASF/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the previous PR https://github.com/aws-amplify/aws-sdk-ios/pull/2981, the platform version was bumped to 9.0 from 8.0. the version in the AWSCognitoIdentityProviderASF podspec did not get bumped in the release and is done manually, so no new pod was released for this. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
