### PR TITLE
feat(Pinpoint): Support NSSecureCoding

### DIFF
--- a/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h
+++ b/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "AWSJKBigInteger.h"
 
-@interface AWSJKBigDecimal : NSObject <NSCoding>
+@interface AWSJKBigDecimal : NSObject <NSSecureCoding>
 
 @property(nonatomic, retain)AWSJKBigInteger *bigInteger;
 @property(nonatomic, assign)NSUInteger figure;//小数位数

--- a/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m
+++ b/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigDecimal.m
@@ -11,6 +11,10 @@
 @implementation AWSJKBigDecimal
 @synthesize bigInteger, figure;
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (id)init
 {
     return [self initWithString:@"0"];

--- a/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h
+++ b/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #include "aws_tommath.h"
 
-@interface AWSJKBigInteger : NSObject <NSCoding>
+@interface AWSJKBigInteger : NSObject <NSSecureCoding>
 
 - (id)initWithValue:(aws_mp_int *)value;
 - (aws_mp_int *)value;

--- a/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m
+++ b/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m
@@ -89,7 +89,7 @@
 
         aws_mp_init_size(&m_value, alloc);
 		
-		NSData *data = (NSData *)[decoder decodeObjectForKey:@"AWSJKBigIntegerDP"];
+        NSData *data = (NSData *)[decoder decodeObjectOfClass:[NSData class] forKey:@"AWSJKBigIntegerDP"];
         aws_mp_digit *temp = (aws_mp_digit *)[data bytes];
         
         for (unsigned int i = 0; i < alloc; ++i) {

--- a/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m
+++ b/AWSCognitoIdentityProvider/Internal/JKBigInteger/AWSJKBigInteger.m
@@ -12,6 +12,10 @@
     aws_mp_int m_value;
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (id)initWithValue:(aws_mp_int *)value {
 
     self = [super init];

--- a/AWSCore/AWSCore.h
+++ b/AWSCore/AWSCore.h
@@ -60,6 +60,7 @@ FOUNDATION_EXPORT const unsigned char AWSCoreVersionString[] DEPRECATED_MSG_ATTR
 #import "AWSURLRequestRetryHandler.h"
 #import "AWSValidation.h"
 #import "AWSInfo.h"
+#import "AWSNSCodingUtilities.h"
 
 #import "AWSBolts.h"
 #import "AWSGZIP.h"
@@ -67,7 +68,6 @@ FOUNDATION_EXPORT const unsigned char AWSCoreVersionString[] DEPRECATED_MSG_ATTR
 #import "AWSKSReachability.h"
 #import "AWSTMCache.h"
 #import "AWSUICKeyChainStore.h"
-
 
 #import "AWSSTS.h"
 #import "AWSCognitoIdentity.h"

--- a/AWSCore/Utility/AWSNSCodingUtilities.h
+++ b/AWSCore/Utility/AWSNSCodingUtilities.h
@@ -1,0 +1,56 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AWSNSCodingUtilities: NSObject
+
+#pragma mark - Archive
+
+/// On iOS 11 and greater, uses `+[NSKeyedArchiver
+/// archivedDataWithRootObject:requiringSecureCoding:error:]` to archive data, otherwise uses
+/// `+[NSKeyedArchiver archivedDataWithRootObject:]`
++ (nullable NSData *)versionSafeArchivedDataWithRootObject:(id)obj
+                                     requiringSecureCoding:(BOOL)requireSecureCoding
+                                                     error:(NSError *__autoreleasing *)error;
+
+#pragma mark - Unarchive
+
+/// On iOS 11 and greater, uses `+[NSKeyedUnarchiver
+/// unarchivedObjectOfClass:fromData:error:]` to unarchive data, otherwise uses
+/// `+[NSKeyedUnarchiver unarchiveObjectWithData:]`
++ (nullable id)versionSafeUnarchivedObjectOfClass:(Class)cls
+                                         fromData:(NSData *)data
+                                            error:(NSError *__autoreleasing *)error;
+
+/// On iOS 11 and greater, uses `+[NSKeyedUnarchiver
+/// unarchivedObjectOfClasses:fromData:error:]` to unarchive data, otherwise uses
+/// `+[NSKeyedUnarchiver unarchiveObjectWithData:]`
++ (nullable id)versionSafeUnarchivedObjectOfClasses:(NSSet<Class> *)classes
+                                           fromData:(NSData *)data
+                                              error:(NSError *__autoreleasing *)error;
+
+/// On iOS 11 and greater, uses `+[NSKeyedUnarchiver
+/// unarchivedObjectOfClasses:fromData:error:]` to unarchive data into a mutable
+/// dictionary that allows NSDictionary and NSMutableString in its allowed class
+/// set, otherwise uses `+[NSKeyedUnarchiver unarchiveObjectWithData:]`
++ (nullable NSMutableDictionary *)versionSafeMutableDictionaryFromData:(NSData *)data
+                                                                 error:(NSError *__autoreleasing *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Utility/AWSNSCodingUtilities.m
+++ b/AWSCore/Utility/AWSNSCodingUtilities.m
@@ -1,0 +1,108 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import "AWSCocoaLumberjack.h"
+#import "AWSNSCodingUtilities.h"
+
+@implementation AWSNSCodingUtilities
+
+#pragma mark - Archive
+
++ (nullable NSData *)versionSafeArchivedDataWithRootObject:(id)obj
+                                     requiringSecureCoding:(BOOL)requireSecureCoding
+                                                     error:(NSError *__autoreleasing *)error {
+    NSData *archivedData;
+    if (@available(iOS 11, *)) {
+        archivedData = [NSKeyedArchiver archivedDataWithRootObject:obj
+                                             requiringSecureCoding:requireSecureCoding
+                                                             error:error];
+        if (error && *error) {
+            AWSDDLogError(@"Error archiving object: %@", *error);
+            return nil;
+        }
+    } else {
+        archivedData = [NSKeyedArchiver archivedDataWithRootObject:obj];
+    }
+
+    return archivedData;
+}
+
+#pragma mark - Unarchive
+
++ (nullable id)versionSafeUnarchivedObjectOfClass:(Class)cls
+                                         fromData:(NSData *)data
+                                            error:(NSError *__autoreleasing *)error {
+    id returnValue;
+
+    if (@available(iOS 11, *)) {
+        returnValue = [NSKeyedUnarchiver unarchivedObjectOfClass:cls
+                                                        fromData:data
+                                                           error:error];
+        if (error && *error) {
+            AWSDDLogError(@"Error unarchiving class `%@`: %@", cls, *error);
+            return nil;
+        }
+    } else {
+        returnValue = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
+
+    return returnValue;
+}
+
++ (nullable id)versionSafeUnarchivedObjectOfClasses:(NSSet<Class> *)classes
+                                           fromData:(NSData *)data
+                                              error:(NSError *__autoreleasing *)error {
+    id returnValue;
+
+    if (@available(iOS 11, *)) {
+        returnValue = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
+                                                          fromData:data
+                                                             error:error];
+        if (error && *error) {
+            AWSDDLogError(@"Error unarchiving data into allowed classes `%@`: %@", classes, *error);
+            return nil;
+        }
+    } else {
+        returnValue = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
+
+    return returnValue;
+}
+
++ (NSMutableDictionary *)versionSafeMutableDictionaryFromData:(NSData *)data
+                                                        error:(NSError *__autoreleasing *)error {
+    NSMutableDictionary *returnValue;
+
+    if (@available(iOS 11, *)) {
+        NSSet *allowableClasses = [[NSSet alloc] initWithObjects:[NSMutableString class],
+                                   [NSDictionary class],
+                                   nil];
+        NSDictionary *immutableDict = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClasses:allowableClasses
+                                                                                        fromData:data
+                                                                                           error:error];
+        if (error && *error) {
+            AWSDDLogError(@"Error unarchiving data into allowed classes `%@`: %@", allowableClasses, *error);
+            return nil;
+        }
+
+        returnValue = [immutableDict mutableCopy];
+    } else {
+        returnValue = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
+
+    return returnValue;
+}
+
+@end

--- a/AWSCoreUnitTests/SigV4Tests/SigV4Tests.swift
+++ b/AWSCoreUnitTests/SigV4Tests/SigV4Tests.swift
@@ -43,7 +43,7 @@ class SigV4Tests: XCTestCase {
 
         let taskIsComplete = expectation(description: "Task is complete")
 
-        let presignedURL = AWSSignatureV4Signer.sigV4SignedURL(
+        _ = AWSSignatureV4Signer.sigV4SignedURL(
             with: originalRequest,
             credentialProvider: testCase.credentialsProvider,
             regionName: SigV4TestCredentials.regionName,

--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The Endpoint profile contains information about the device/user to be target for messaging.
  */
-@interface AWSPinpointEndpointProfile : NSObject
+@interface AWSPinpointEndpointProfile : NSObject<NSSecureCoding>
 
 /**
  The Pinpoint Application ID
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The Endpoint Demographic contains information about the device to be target for messaging.
  */
-@interface AWSPinpointEndpointProfileDemographic : NSObject
+@interface AWSPinpointEndpointProfileDemographic : NSObject<NSSecureCoding>
 
 /**
  Returns an instance of AWSPinpointEndpointProfileDemographic with default values.
@@ -225,7 +225,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The Endpoint profile contains information about the location of the device/user to be target for messaging.
  */
-@interface AWSPinpointEndpointProfileLocation : NSObject
+@interface AWSPinpointEndpointProfileLocation : NSObject<NSSecureCoding>
 
 /**
  The latitude coordinate of the device
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The Endpoint profile contains information about the user to be target for messaging.
  */
-@interface AWSPinpointEndpointProfileUser : NSObject
+@interface AWSPinpointEndpointProfileUser : NSObject<NSSecureCoding>
 
 /**
  The userId of the endpoint profile.

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -42,7 +42,8 @@ NSString *const AWSPinpointOverrideDefaultOptOutKey = @"com.amazonaws.AWSPinpoin
 @property (nonatomic, strong) NSUserDefaults *userDefaults;
 @end
 
-#pragma mark - AWSPinpointEndpointProfile -
+#pragma mark - AWSPinpointEndpointProfile
+
 @implementation AWSPinpointEndpointProfile
 
 @synthesize optOut = _optOutBackingVariable;
@@ -335,20 +336,23 @@ NSString *DEBUG_CHANNEL_TYPE = @"APNS_SANDBOX";
     return dictionary;
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
 
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
-        _applicationId = [decoder decodeObjectForKey:@"applicationId"];
-        _endpointId = [decoder decodeObjectForKey:@"endpointId"];
-        _channelType = [decoder decodeObjectForKey:@"channelType"];
-        _address = [decoder decodeObjectForKey:@"address"];
-        _location = [decoder decodeObjectForKey:@"location"];
-        _demographic = [decoder decodeObjectForKey:@"demographic"];
-        _attributes = [decoder decodeObjectForKey:@"attributes"];
-        _metrics = [decoder decodeObjectForKey:@"metrics"];
-        _user = [decoder decodeObjectForKey:@"user"];
+        _applicationId = [decoder decodeObjectOfClass:[NSString class] forKey:@"applicationId"];
+        _endpointId = [decoder decodeObjectOfClass:[NSString class] forKey:@"endpointId"];
+        _channelType = [decoder decodeObjectOfClass:[NSString class] forKey:@"channelType"];
+        _address = [decoder decodeObjectOfClass:[NSString class] forKey:@"address"];
+        _optOutBackingVariable = [decoder decodeObjectOfClass:[NSString class] forKey:@"optOut"];
         _effectiveDate = [decoder decodeInt64ForKey:@"effectiveDate"];
-        _optOutBackingVariable = [decoder decodeObjectForKey:@"optOut"];
+        _location = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileLocation class] forKey:@"location"];
+        _demographic = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileDemographic class] forKey:@"demographic"];
+        _attributes = [decoder decodeObjectOfClass:[NSDictionary class] forKey:@"attributes"];
+        _metrics = [decoder decodeObjectOfClass:[NSDictionary class] forKey:@"metrics"];
+        _user = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileUser class] forKey:@"user"];
     }
     return self;
 }
@@ -434,14 +438,18 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
             [self quotedString:self.platformVersion]];
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
-        _model = [decoder decodeObjectForKey:@"model"];
-        _timezone = [decoder decodeObjectForKey:@"timezone"];
-        _locale = [decoder decodeObjectForKey:@"locale"];
-        _appVersion = [decoder decodeObjectForKey:@"appVersion"];
-        _platform = [decoder decodeObjectForKey:@"platform"];
-        _platformVersion = [decoder decodeObjectForKey:@"platformVersion"];
+        _model = [decoder decodeObjectOfClass:[NSString class] forKey:@"model"];
+        _timezone = [decoder decodeObjectOfClass:[NSString class] forKey:@"timezone"];
+        _locale = [decoder decodeObjectOfClass:[NSString class] forKey:@"locale"];
+        _appVersion = [decoder decodeObjectOfClass:[NSString class] forKey:@"appVersion"];
+        _platform = [decoder decodeObjectOfClass:[NSString class] forKey:@"platform"];
+        _platformVersion = [decoder decodeObjectOfClass:[NSString class] forKey:@"platformVersion"];
     }
     return self;
 }
@@ -458,6 +466,7 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
 @end
 
 #pragma mark - AWSPinpointEndpointProfileLocation
+
 @implementation AWSPinpointEndpointProfileLocation
 
 - (NSString*) quotedString:(NSString*) input {
@@ -480,14 +489,18 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
             [self quotedString:self.country]];
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
-        _latitude = [decoder decodeObjectForKey:@"latitude"];
-        _longitude = [decoder decodeObjectForKey:@"longitude"];
-        _postalCode = [decoder decodeObjectForKey:@"postalCode"];
-        _city = [decoder decodeObjectForKey:@"city"];
-        _region = [decoder decodeObjectForKey:@"region"];
-        _country = [decoder decodeObjectForKey:@"country"];
+        _latitude = [decoder decodeObjectOfClass:[NSNumber class] forKey:@"latitude"];
+        _longitude = [decoder decodeObjectOfClass:[NSNumber class] forKey:@"longitude"];
+        _postalCode = [decoder decodeObjectOfClass:[NSString class] forKey:@"postalCode"];
+        _city = [decoder decodeObjectOfClass:[NSString class] forKey:@"city"];
+        _region = [decoder decodeObjectOfClass:[NSString class] forKey:@"region"];
+        _country = [decoder decodeObjectOfClass:[NSString class] forKey:@"country"];
     }
     return self;
 }
@@ -504,6 +517,7 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
 @end
 
 #pragma mark - AWSPinpointEndpointProfileUser
+
 @implementation AWSPinpointEndpointProfileUser
 
 - (NSString*) quotedString:(NSString*) input {
@@ -517,9 +531,13 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
             [self quotedString:self.userId]];
 }
 
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
+
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
-        _userId = [decoder decodeObjectForKey:@"userId"];
+        _userId = [decoder decodeObjectOfClass:[NSString class] forKey:@"userId"];
     }
     return self;
 }

--- a/AWSPinpoint/AWSPinpointEventRecorder.m
+++ b/AWSPinpoint/AWSPinpointEventRecorder.m
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 
+#import "AWSNSCodingUtilities.h"
 #import "AWSPinpointEventRecorder.h"
 #import "AWSPinpointEvent.h"
 #import "AWSPinpointTargeting.h"
@@ -180,13 +181,21 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
     if (session && session.sessionId && session.sessionId.length >=1) {
         return session;
     }
+
     NSData *sessionData = [self.context.configuration.userDefaults dataForKey:AWSPinpointSessionKey];
+
     AWSPinpointSession *previousSession;
     if (sessionData) {
-        previousSession = [NSKeyedUnarchiver unarchiveObjectWithData:sessionData];
+        NSError *error;
+        previousSession = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                          fromData:sessionData
+                                                                             error:&error];
+        if (error) {
+            AWSDDLogError(@"Error restoring previous session: %@", error);
+        }
     }
-    if(!previousSession)
-    {
+
+    if (!previousSession) {
         previousSession = [[AWSPinpointSession alloc] initWithSessionId:DEFAULT_SESSION_ID withStartTime:[NSDate date] withStopTime:[NSDate date]];
     }
     return previousSession;
@@ -198,10 +207,17 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
     }
     NSData *sessionData = [self.context.configuration.userDefaults dataForKey:AWSPinpointSessionKey];
     if (sessionData) {
-        AWSPinpointSession *previousSession = [NSKeyedUnarchiver unarchiveObjectWithData:sessionData];
+        NSError *error;
+        AWSPinpointSession *previousSession = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                                              fromData:sessionData
+                                                                                                 error:&error];
+        if (error || !previousSession) {
+            AWSDDLogError(@"Error restoring previous session: %@", error);
+            return DEFAULT_SESSION_ID;
+        }
+
         sessionId = previousSession.sessionId;
-        if (sessionId && sessionId.length >= 1)
-        {
+        if (sessionId && sessionId.length >= 1) {
             return sessionId;
         }
     }
@@ -228,7 +244,27 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
             NSString *sessionId = event.session.sessionId;
             NSString *stopTime = [event.session.stopTime aws_stringValue:AWSDateISO8601DateFormat3];
             NSString *startTime = [event.session.startTime aws_stringValue:AWSDateISO8601DateFormat3];
-            
+
+            NSError *codingError;
+
+            NSData *attributesData = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:event.allAttributes
+                                                                           requiringSecureCoding:YES
+                                                                                           error:&codingError];
+            if (codingError) {
+                AWSDDLogError(@"Error archiving attributesData: %@", codingError);
+                error = codingError;
+                return;
+            }
+
+            NSData *metricsData = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:event.allMetrics
+                                                                        requiringSecureCoding:YES
+                                                                                        error:&codingError];
+            if (codingError) {
+                AWSDDLogError(@"Error archiving metricsData: %@", codingError);
+                error = codingError;
+                return;
+            }
+
             BOOL result = [db executeUpdate:
                            @"INSERT INTO Event ("
                            @"id, attributes, eventType, metrics, eventTimestamp, sessionId, sessionStartTime, sessionStopTime, timestamp, dirty, retryCount"
@@ -237,9 +273,9 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                            @")"
                     withParameterDictionary:@{
                                               @"id" : [[NSUUID UUID] UUIDString],
-                                              @"attributes" : [NSKeyedArchiver archivedDataWithRootObject:event.allAttributes],
+                                              @"attributes" : attributesData,
                                               @"eventType" : event.eventType,
-                                              @"metrics" : [NSKeyedArchiver archivedDataWithRootObject:event.allMetrics],
+                                              @"metrics" : metricsData,
                                               @"eventTimestamp" : [AWSPinpointDateUtils isoDateTimeWithTimestamp:event.eventTimestamp],
                                               @"sessionId": sessionId,
                                               @"sessionStartTime": startTime? startTime : @"",
@@ -334,13 +370,24 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
         __block NSError *error = nil;
         
         [databaseQueue inTransaction:^(AWSFMDatabase *db, BOOL *rollback) {
+            NSError *codingError;
+            NSData *attributesData = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:attributes
+                                                                           requiringSecureCoding:YES
+                                                                                           error:&codingError];
+            if (codingError) {
+                AWSDDLogError(@"Error archiving attributesData: %@", codingError);
+                error = codingError;
+                *rollback = YES;
+                return;
+            }
+
             BOOL result = [db executeUpdate:
                            @"UPDATE Event "
                            @"SET attributes = :attributes "
                            @"WHERE sessionId = :sessionId "
                            @"AND eventType = :eventType"
                     withParameterDictionary:@{
-                                              @"attributes" : [NSKeyedArchiver archivedDataWithRootObject:attributes],
+                                              @"attributes" : attributesData,
                                               @"eventType" : @"_session.start",
                                               @"sessionId" : sessionId
                                               }
@@ -385,8 +432,24 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
             }
             
             if ([rs next]) {
-                NSMutableDictionary *attributes = [NSKeyedUnarchiver unarchiveObjectWithData:[rs dataForColumn:@"attributes"]];
-                NSMutableDictionary *metrics = [NSKeyedUnarchiver unarchiveObjectWithData:[rs dataForColumn:@"metrics"]];
+                NSMutableDictionary *attributes = [AWSPinpointEventRecorder getMutableDictionaryFromResultSet:rs
+                                                                                                forColumnName:@"attributes"
+                                                                                                        error:&error];
+                if (error) {
+                    AWSDDLogError(@"Error restoring attributes from DB: %@", error);
+                    *rollback = YES;
+                    return;
+                }
+
+                NSMutableDictionary *metrics = [AWSPinpointEventRecorder getMutableDictionaryFromResultSet:rs
+                                                                                             forColumnName:@"metrics"
+                                                                                                     error:&error];
+                if (error) {
+                    AWSDDLogError(@"Error restoring metrics from DB: %@", error);
+                    *rollback = YES;
+                    return;
+                }
+
                 AWSPinpointSession *session = [[AWSPinpointSession alloc] initWithSessionId:[rs stringForColumn:@"sessionId"]
                                                                               withStartTime:[NSDate aws_dateFromString:[rs stringForColumn:@"sessionStartTime"] format:AWSDateISO8601DateFormat3]
                                                                                withStopTime:[NSDate aws_dateFromString:[rs stringForColumn:@"sessionStopTime"] format:AWSDateISO8601DateFormat3]];
@@ -429,10 +492,26 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                 *rollback = YES;
                 return;
             }
-            
+
             while ([rs next]) {
-                NSMutableDictionary *attributes = [NSKeyedUnarchiver unarchiveObjectWithData:[rs dataForColumn:@"attributes"]];
-                NSMutableDictionary *metrics = [NSKeyedUnarchiver unarchiveObjectWithData:[rs dataForColumn:@"metrics"]];
+                NSMutableDictionary *attributes = [AWSPinpointEventRecorder getMutableDictionaryFromResultSet:rs
+                                                                                                forColumnName:@"attributes"
+                                                                                                        error:&error];
+                if (error) {
+                    AWSDDLogError(@"Error restoring event attributes from DB: %@", error);
+                    *rollback = YES;
+                    return;
+                }
+
+                NSMutableDictionary *metrics = [AWSPinpointEventRecorder getMutableDictionaryFromResultSet:rs
+                                                                                             forColumnName:@"metrics"
+                                                                                                     error:&error];
+                if (error) {
+                    AWSDDLogError(@"Error restoring event metrics from DB: %@", error);
+                    *rollback = YES;
+                    return;
+                }
+
                 AWSPinpointSession *session = [[AWSPinpointSession alloc] initWithSessionId:[rs stringForColumn:@"sessionId"]
                                                                               withStartTime:[NSDate aws_dateFromString:[rs stringForColumn:@"sessionStartTime"] format:AWSDateISO8601DateFormat3]
                                                                                withStopTime:[NSDate aws_dateFromString:[rs stringForColumn:@"sessionStopTime"] format:AWSDateISO8601DateFormat3]];
@@ -478,8 +557,24 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
             }
             
             while ([rs next]) {
-                NSMutableDictionary *attributes = [NSKeyedUnarchiver unarchiveObjectWithData:[rs dataForColumn:@"attributes"]];
-                NSMutableDictionary *metrics = [NSKeyedUnarchiver unarchiveObjectWithData:[rs dataForColumn:@"metrics"]];
+                NSMutableDictionary *attributes = [AWSPinpointEventRecorder getMutableDictionaryFromResultSet:rs
+                                                                                                forColumnName:@"attributes"
+                                                                                                        error:&error];
+                if (error) {
+                    AWSDDLogError(@"Error restoring dirty event attributes from DB: %@", error);
+                    *rollback = YES;
+                    return;
+                }
+
+                NSMutableDictionary *metrics = [AWSPinpointEventRecorder getMutableDictionaryFromResultSet:rs
+                                                                                             forColumnName:@"metrics"
+                                                                                                     error:&error];
+                if (error) {
+                    AWSDDLogError(@"Error restoring dirty event metrics from DB: %@", error);
+                    *rollback = YES;
+                    return;
+                }
+
                 AWSPinpointSession *session = [[AWSPinpointSession alloc] initWithSessionId:[rs stringForColumn:@"sessionId"]
                                                                               withStartTime:[NSDate aws_dateFromString:[rs stringForColumn:@"sessionStartTime"] format:AWSDateISO8601DateFormat3]
                                                                                withStopTime:[NSDate aws_dateFromString:[rs stringForColumn:@"sessionStopTime"] format:AWSDateISO8601DateFormat3]];
@@ -616,9 +711,19 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                          @"sessionStartTime": [rs stringForColumn:@"sessionStartTime"],
                                          @"sessionStopTime": [rs stringForColumn:@"sessionStopTime"]
                                          } forKey:[rs stringForColumn:@"id"]];
-            
-            NSData *batchData = [NSKeyedArchiver archivedDataWithRootObject:temporaryEventsWithEventId];
-            if ([batchData length] > self.batchRecordsByteLimit) { // if the batch size exceeds `batchRecordsByteLimit`, stop there.
+
+            NSError *codingError;
+            NSData *batchData = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:temporaryEventsWithEventId
+                                                                      requiringSecureCoding:YES
+                                                                                      error:&codingError];
+            if (codingError) {
+                AWSDDLogError(@"Error getting size of batchData: %@", codingError);
+                error = codingError;
+                break;
+            }
+
+            if ([batchData length] > self.batchRecordsByteLimit) {
+                // if the batch size exceeds `batchRecordsByteLimit`, stop there.
                 break;
             }
         }
@@ -867,17 +972,31 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
        endpointProfile:(AWSPinpointEndpointProfile *) profile {
     AWSFMDatabaseQueue *databaseQueue = self.databaseQueue;
     
-    __block NSMutableDictionary *events = [NSMutableDictionary new]; //events to be submitted, and returned back to caller for debugging
-    __block NSDictionary *_temporaryEvents = [temporaryEvents copy]; //aggregate attributes, metrics...
+    // events to be submitted, and returned back to caller for debugging
+    // aggregate attributes, metrics...
+    __block NSMutableDictionary *events = [NSMutableDictionary new];
+
+    __block NSDictionary *_temporaryEvents = [temporaryEvents copy];
+
     for (NSString *eventId in _temporaryEvents) {
         NSMutableDictionary *attributes;
-
         if ([_temporaryEvents[eventId] objectForKey:@"attributes"]) {
-            attributes = [NSKeyedUnarchiver unarchiveObjectWithData:_temporaryEvents[eventId][@"attributes"]];
+            NSError *decodingError;
+            attributes = [AWSNSCodingUtilities versionSafeMutableDictionaryFromData:_temporaryEvents[eventId][@"attributes"]
+                                                                              error:&decodingError];
+            if (decodingError) {
+                AWSDDLogError(@"Error unarchiving attributes for eventId %@: %@", eventId, decodingError);
+            }
         }
+
         NSMutableDictionary *metrics;
         if ([_temporaryEvents[eventId] objectForKey:@"metrics"]) {
-            metrics = [NSKeyedUnarchiver unarchiveObjectWithData:_temporaryEvents[eventId][@"metrics"]];
+            NSError *decodingError;
+            metrics = [AWSNSCodingUtilities versionSafeMutableDictionaryFromData:_temporaryEvents[eventId][@"metrics"]
+                                                                           error:&decodingError];
+            if (decodingError) {
+                AWSDDLogError(@"Error unarchiving metrics for eventId %@: %@", eventId, decodingError);
+            }
         }
         
         AWSPinpointSession *session;
@@ -1147,6 +1266,22 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                   eventsPayload:parsedEventsDictionary];
     
     return putEventRequest;
+}
+
++ (NSMutableDictionary *)getMutableDictionaryFromResultSet:(AWSFMResultSet *)rs
+                                             forColumnName:(NSString *)columnName
+                                                     error:(NSError *__autoreleasing *)error {
+    NSSet *allowableClasses = [[NSSet alloc] initWithObjects:[NSMutableString class],
+                               [NSDictionary class],
+                               nil];
+    NSDictionary *immutableDict = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClasses:allowableClasses
+                                                                                    fromData:[rs dataForColumn:columnName]
+                                                                                       error:error];
+    if (*error) {
+        return nil;
+    }
+    NSMutableDictionary *mutableDict = [immutableDict mutableCopy];
+    return mutableDict;
 }
 
 @end

--- a/AWSPinpoint/AWSPinpointSessionClient.h
+++ b/AWSPinpoint/AWSPinpointSessionClient.h
@@ -26,7 +26,7 @@ typedef __nullable id(^AWSPinpointTimeoutBlock)(AWSTask *task);
 /**
  The session object needs that the session client keeps track of, the session information is added to each event recorded.
  */
-@interface AWSPinpointSession : NSObject <NSCoding, NSCopying>
+@interface AWSPinpointSession : NSObject <NSSecureCoding, NSCopying>
 
 /**
  The start timestamp is populated when the client start the session.

--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -13,6 +13,7 @@
 // permissions and limitations under the License.
 //
 
+#import "AWSNSCodingUtilities.h"
 #import "AWSPinpointSessionClient.h"
 #import "AWSPinpointContext.h"
 #import "AWSPinpointAnalyticsClient.h"
@@ -100,7 +101,17 @@ NSObject *sessionLock;
     if (self = [super init]) {
         _context = context;
         NSData *sessionData = [context.configuration.userDefaults dataForKey:AWSPinpointSessionKey];
-        _session = [NSKeyedUnarchiver unarchiveObjectWithData:sessionData];
+
+        if (sessionData) {
+            NSError *decodeError;
+            _session = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                       fromData:sessionData
+                                                                          error:&decodeError];
+            if (decodeError) {
+                AWSDDLogError(@"Error decoding session: %@", decodeError);
+            }
+        }
+
         sessionLock = [NSObject new];
         
         //Only add observers if auto session recording is enabled
@@ -133,7 +144,16 @@ NSObject *sessionLock;
         @synchronized (sessionLock) {
             sessionCopy = [_session copy];
         }
-        NSData *sessionData = [NSKeyedArchiver archivedDataWithRootObject:sessionCopy];
+
+        NSError *codingError;
+        NSData *sessionData = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:sessionCopy
+                                                                    requiringSecureCoding:YES
+                                                                                    error:&codingError];
+        if (codingError) {
+            AWSDDLogError(@"Error archiving sessionData: %@", codingError);
+            return;
+        }
+
         [self.context.configuration.userDefaults setObject:sessionData forKey:AWSPinpointSessionKey];
         [self.context.configuration.userDefaults synchronize];
     }
@@ -377,13 +397,18 @@ NSObject *sessionLock;
 @end
 
 #pragma mark - AWSPinpointSession -
+
 @implementation AWSPinpointSession
+
++ (BOOL)supportsSecureCoding {
+    return YES;
+}
 
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
-        _sessionId = [decoder decodeObjectForKey:@"sessionId"];
-        _startTime = [decoder decodeObjectForKey:@"startTime"];
-        _stopTime = [decoder decodeObjectForKey:@"stopTime"];
+        _sessionId = [decoder decodeObjectOfClass:[NSString class] forKey:@"sessionId"];
+        _startTime = [decoder decodeObjectOfClass:[NSDate class] forKey:@"startTime"];
+        _stopTime = [decoder decodeObjectOfClass:[NSDate class] forKey:@"stopTime"];
     }
     return self;
 }

--- a/AWSPinpointTests/AWSPinpointEventRecorderTests.m
+++ b/AWSPinpointTests/AWSPinpointEventRecorderTests.m
@@ -17,14 +17,13 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <AWSCore/AWSCore.h>
 #import "AWSPinpointContext.h"
 
 #import "AWSPinpointEventRecorderTestBase.h"
 
 static NSString *const AWSKinesisRecorderTestStream = @"AWSSDKForiOSv2Test";
 static NSString *const DEFAULT_SESSION_ID = @"00000000-00000000";
-static NSUInteger const AWSPinpointClientValidEvent = 0;
-static NSUInteger const AWSPinpointClientInvalidEvent = 1;
 static NSString *const TestUpdateSessionJourneyAttributes = @"testUpdateSessionJourneyAttributes";
 static NSString *const TestUpdateSessionCampaignAttributes = @"testUpdateSessionCampaignAttributes";
 static NSString *const TestUpdateSessionOverwriteCampaignAttributesWithJourney = @"testUpdateSessionOverwriteCampaignAttributesWithJourney";
@@ -153,7 +152,9 @@ targetingServiceConfiguration:(AWSServiceConfiguration*) targetingServiceConfigu
     //Tests that session info is not deleted from userdefaults
     XCTAssertNotNil([userDefaults dataForKey:AWSPinpointSessionKey]);
     NSData *sessionData = [userDefaults dataForKey:AWSPinpointSessionKey];
-    AWSPinpointSession *previousSession = [NSKeyedUnarchiver unarchiveObjectWithData:sessionData];
+    AWSPinpointSession *previousSession = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                                          fromData:sessionData
+                                                                                             error:nil];
     NSString *sessionId = previousSession.sessionId;
     
     AWSPinpointEvent *event2 = [[AWSPinpointEvent alloc] initWithEventType:@"TEST"
@@ -270,8 +271,10 @@ targetingServiceConfiguration:(AWSServiceConfiguration*) targetingServiceConfigu
     [[pinpoint.analyticsClient.eventRecorder removeAllEvents] waitUntilFinished];
     
     NSData *data = [pinpoint.pinpointContext.configuration.userDefaults dataForKey:AWSPinpointSessionKey];
-    AWSPinpointSession *session = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-    
+    AWSPinpointSession *session = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                                  fromData:data
+                                                                                     error:nil];
+
     AWSDDLogError(@"Session Object Should be Empty: %@",session.description);
     
     XCTAssertNil([pinpoint.pinpointContext.configuration.userDefaults dataForKey:AWSPinpointSessionKey]);
@@ -329,7 +332,9 @@ targetingServiceConfiguration:(AWSServiceConfiguration*) targetingServiceConfigu
     [[pinpoint.analyticsClient.eventRecorder removeAllEvents] waitUntilFinished];
 
     NSData *data = [pinpoint.pinpointContext.configuration.userDefaults dataForKey:AWSPinpointSessionKey];
-    AWSPinpointSession *session = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    AWSPinpointSession *session = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                                  fromData:data
+                                                                                     error:nil];
 
     AWSDDLogError(@"Session Object Should be Empty: %@",session.description);
 
@@ -389,8 +394,10 @@ targetingServiceConfiguration:(AWSServiceConfiguration*) targetingServiceConfigu
     [[pinpoint.analyticsClient.eventRecorder removeAllEvents] waitUntilFinished];
     
     NSData *data = [pinpoint.pinpointContext.configuration.userDefaults dataForKey:AWSPinpointSessionKey];
-    AWSPinpointSession *session = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-    
+    AWSPinpointSession *session = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                                  fromData:data
+                                                                                     error:nil];
+
     AWSDDLogError(@"Session Object Should be Empty: %@",session.description);
     
     XCTAssertNil([pinpoint.pinpointContext.configuration.userDefaults dataForKey:AWSPinpointSessionKey]);

--- a/AWSPinpointTests/AWSPinpointSessionClientTests.m
+++ b/AWSPinpointTests/AWSPinpointSessionClientTests.m
@@ -65,7 +65,9 @@ static NSString *const AWSPinpointSessionKey = @"com.amazonaws.AWSPinpointSessio
     [self.userDefaults synchronize];
     
     NSData *data = [self.userDefaults dataForKey:AWSPinpointSessionKey];
-    AWSPinpointSession *session = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    AWSPinpointSession *session = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                                  fromData:data
+                                                                                     error:nil];
 
     NSLog(@"Session Object Should be Empty: %@",session.description);
     

--- a/AWSPinpointUnitTests/AWSPinpointNSSecureCodingTests.m
+++ b/AWSPinpointUnitTests/AWSPinpointNSSecureCodingTests.m
@@ -1,0 +1,134 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWSPinpoint.h"
+
+@interface AWSPinpointEndpointProfile()
+
+- (instancetype) initWithApplicationId:(NSString *)applicationId
+                            endpointId:(NSString *)endpointId
+                applicationLevelOptOut:(BOOL)applicationLevelOptOut
+                                 debug:(BOOL)debug
+                          userDefaults:(NSUserDefaults *)userDefaults;
+
+@end
+
+@interface AWSPinpointSession()
+
+- (instancetype)initWithSessionId:(NSString *)sessionId
+                    withStartTime:(NSDate *)startTime
+                     withStopTime:(NSDate *)stopTime;
+
+@end
+
+@interface AWSPinpointNSSecureCodingTests : XCTestCase
+
+@property (nonatomic, strong) NSURL *archiveURL;
+
+// Specifically declare these methods in the interface so we can set availability
+// to iOS 11. Tests that don't use newer APIs don't need to be declared here.
+- (void)testProfileArchivesAndUnarchivesUsingSecureCoding API_AVAILABLE(ios(11));
+- (void)testProfileArchivesAndUnarchivesWithLegacyAPI API_AVAILABLE(ios(11));
+
+- (void)testSessionArchivesAndUnarchivesSecurely API_AVAILABLE(ios(11));
+- (void)testSessionArchivesAndUnarchivesWithLegacyAPI API_AVAILABLE(ios(11));
+
+@end
+
+@implementation AWSPinpointNSSecureCodingTests
+
+- (void)testProfileArchivesAndUnarchivesUsingSecureCoding {
+    AWSPinpointEndpointProfile *profile = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"app-id-123"
+                                                                                         endpointId:@"endpoint-id-123"
+                                                                             applicationLevelOptOut:YES
+                                                                                              debug:YES
+                                                                                       userDefaults:nil];
+
+    NSError *error;
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profile
+                                         requiringSecureCoding:YES
+                                                         error:&error];
+    XCTAssertNil(error);
+
+    error = nil;
+    AWSPinpointEndpointProfile *unarchivedProfile = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
+                                                                                      fromData:data
+                                                                                         error:&error];
+    XCTAssertNil(error);
+
+    // The class doesn't support `isEqual` so we'll compare string descriptions
+    XCTAssertEqualObjects([unarchivedProfile description], [profile description]);
+}
+
+- (void)testProfileSupportsSecureCoding {
+    XCTAssert([AWSPinpointEndpointProfile supportsSecureCoding]);
+}
+
+- (void)testProfileArchivesAndUnarchivesWithLegacyAPI {
+    AWSPinpointEndpointProfile *profile = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"app-id-123"
+                                                                                         endpointId:@"endpoint-id-123"
+                                                                             applicationLevelOptOut:YES
+                                                                                              debug:YES
+                                                                                       userDefaults:nil];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profile];
+
+    AWSPinpointEndpointProfile *unarchivedProfile = (AWSPinpointEndpointProfile *)[NSKeyedUnarchiver unarchiveObjectWithData:data];
+
+    // The class doesn't support `isEqual` so we'll compare string descriptions
+    XCTAssertEqualObjects([unarchivedProfile description], [profile description]);
+}
+
+- (void)testSessionArchivesAndUnarchivesSecurely {
+    AWSPinpointSession *session = [[AWSPinpointSession alloc] initWithSessionId:@"session-123"
+                                                                  withStartTime:[NSDate new]
+                                                                   withStopTime:nil];
+    NSError *error;
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:session
+                                         requiringSecureCoding:YES
+                                                         error:&error];
+    XCTAssertNil(error);
+
+    error = nil;
+    AWSPinpointSession *unarchivedSession = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointSession class]
+                                                                              fromData:data
+                                                                                 error:&error];
+    XCTAssertNil(error);
+
+    // The class doesn't support `isEqual` or `description` so we'll compare property-by-property
+    XCTAssertEqualObjects(unarchivedSession.sessionId, session.sessionId);
+    XCTAssertEqualObjects(unarchivedSession.startTime, session.startTime);
+    XCTAssertEqualObjects(unarchivedSession.stopTime, session.stopTime);
+}
+
+- (void)testSessionSupportsSecureCoding {
+    XCTAssert([AWSPinpointSession supportsSecureCoding]);
+}
+
+- (void)testSessionArchivesAndUnarchivesWithLegacyAPI {
+    AWSPinpointSession *session = [[AWSPinpointSession alloc] initWithSessionId:@"session-123"
+                                                                  withStartTime:[NSDate new]
+                                                                   withStopTime:nil];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:session];
+
+    AWSPinpointSession *unarchivedSession = (AWSPinpointSession *)[NSKeyedUnarchiver unarchiveObjectWithData:data];
+
+    // The class doesn't support `isEqual` or `description` so we'll compare property-by-property
+    XCTAssertEqualObjects(unarchivedSession.sessionId, session.sessionId);
+    XCTAssertEqualObjects(unarchivedSession.startTime, session.startTime);
+    XCTAssertEqualObjects(unarchivedSession.stopTime, session.stopTime);
+}
+
+@end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -1207,6 +1207,8 @@
 		FA53333A22D4D54800BD88AF /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		FA53334122D4D80600BD88AF /* AWSTranscribeStreamingEventDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = FA53333F22D4D80600BD88AF /* AWSTranscribeStreamingEventDecoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA53334222D4D80600BD88AF /* AWSTranscribeStreamingEventDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FA53334022D4D80600BD88AF /* AWSTranscribeStreamingEventDecoder.m */; };
+		FA5D34FC250C0D77007AA030 /* AWSNSCodingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5D34FA250C0D77007AA030 /* AWSNSCodingUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA5D34FD250C0D77007AA030 /* AWSNSCodingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = FA5D34FB250C0D77007AA030 /* AWSNSCodingUtilities.m */; };
 		FA5DFE5821FB8E4700C554E7 /* AWSCognitoIdentityASF.m in Sources */ = {isa = PBXBuildFile; fileRef = FA5DFE5721FB8E4700C554E7 /* AWSCognitoIdentityASF.m */; };
 		FA62A7172167C9F100EFB444 /* AWSGZIPBaseTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = FA62A7162167C9F100EFB444 /* AWSGZIPBaseTestCase.m */; };
 		FA643A5C246B30C800106CB1 /* amazon-developer-tools.jpg in Resources */ = {isa = PBXBuildFile; fileRef = FA643A5B246B30C800106CB1 /* amazon-developer-tools.jpg */; };
@@ -1256,6 +1258,7 @@
 		FADA6AFF22D5573F00A7599A /* AWSSRWebSocketDelegateAdaptor.h in Headers */ = {isa = PBXBuildFile; fileRef = FADA6AFD22D5573F00A7599A /* AWSSRWebSocketDelegateAdaptor.h */; };
 		FADA6B0022D5573F00A7599A /* AWSSRWebSocketDelegateAdaptor.m in Sources */ = {isa = PBXBuildFile; fileRef = FADA6AFE22D5573F00A7599A /* AWSSRWebSocketDelegateAdaptor.m */; };
 		FADAB0A3246B0FAD00CE2D11 /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAD9DD1F245CD135003F84D0 /* AWSTestResources.framework */; };
+		FADAEAE9250BDDF5009CABD4 /* AWSPinpointNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FADAEAE8250BDDF5009CABD4 /* AWSPinpointNSSecureCodingTests.m */; };
 		FAE19B6F23341A5100560F1D /* AWSCoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0D417B1C6A66E5006B91B5 /* AWSCoreTests.m */; };
 		FAE19B7123341DA900560F1D /* ec2-input.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF3F1C6A69AB0098B15B /* ec2-input.json */; };
 		FAE19B7223341DAE00560F1D /* ec2-output.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB8EF401C6A69AB0098B15B /* ec2-output.json */; };
@@ -4374,6 +4377,8 @@
 		FA53332F22D4D47E00BD88AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FA53333F22D4D80600BD88AF /* AWSTranscribeStreamingEventDecoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSTranscribeStreamingEventDecoder.h; sourceTree = "<group>"; };
 		FA53334022D4D80600BD88AF /* AWSTranscribeStreamingEventDecoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSTranscribeStreamingEventDecoder.m; sourceTree = "<group>"; };
+		FA5D34FA250C0D77007AA030 /* AWSNSCodingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSNSCodingUtilities.h; sourceTree = "<group>"; };
+		FA5D34FB250C0D77007AA030 /* AWSNSCodingUtilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSNSCodingUtilities.m; sourceTree = "<group>"; };
 		FA5DFE5721FB8E4700C554E7 /* AWSCognitoIdentityASF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSCognitoIdentityASF.m; sourceTree = "<group>"; };
 		FA62A7152167C9F100EFB444 /* AWSGZIPBaseTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSGZIPBaseTestCase.h; sourceTree = "<group>"; };
 		FA62A7162167C9F100EFB444 /* AWSGZIPBaseTestCase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSGZIPBaseTestCase.m; sourceTree = "<group>"; };
@@ -4443,6 +4448,7 @@
 		FAD9DD2A245CD193003F84D0 /* AWSTestConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSTestConfiguration.m; sourceTree = "<group>"; };
 		FADA6AFD22D5573F00A7599A /* AWSSRWebSocketDelegateAdaptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSSRWebSocketDelegateAdaptor.h; sourceTree = "<group>"; };
 		FADA6AFE22D5573F00A7599A /* AWSSRWebSocketDelegateAdaptor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSSRWebSocketDelegateAdaptor.m; sourceTree = "<group>"; };
+		FADAEAE8250BDDF5009CABD4 /* AWSPinpointNSSecureCodingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSPinpointNSSecureCodingTests.m; sourceTree = "<group>"; };
 		FAEE86AB2167AAA900738F8E /* AWSGZIPEncodingKinesisTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSGZIPEncodingKinesisTests.m; sourceTree = "<group>"; };
 		FAF13AAE2167C6AA008115D1 /* AWSGZIPTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSGZIPTestHelper.h; sourceTree = "<group>"; };
 		FAF13AAF2167C6AA008115D1 /* AWSGZIPTestHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGZIPTestHelper.m; sourceTree = "<group>"; };
@@ -5744,6 +5750,7 @@
 			children = (
 				1879900A1DEFCBFC00BC419B /* AWSGeneralPinpointTargetingTests.m */,
 				C436FB092437EBE30004738F /* AWSPinpointNotificationManagerTests.m */,
+				FADAEAE8250BDDF5009CABD4 /* AWSPinpointNSSecureCodingTests.m */,
 				18798F9D1DEF9EF900BC419B /* Info.plist */,
 			);
 			path = AWSPinpointUnitTests;
@@ -6602,6 +6609,8 @@
 				CE0D42161C6A673E006B91B5 /* AWSLogging.m */,
 				CE0D42171C6A673E006B91B5 /* AWSModel.h */,
 				CE0D42181C6A673E006B91B5 /* AWSModel.m */,
+				FA5D34FA250C0D77007AA030 /* AWSNSCodingUtilities.h */,
+				FA5D34FB250C0D77007AA030 /* AWSNSCodingUtilities.m */,
 				CE0D42191C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.h */,
 				CE0D421A1C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.m */,
 			);
@@ -8343,6 +8352,7 @@
 				CE0D42A11C6A673E006B91B5 /* AWSCategory.h in Headers */,
 				184F431D1E930A2D004F3FE2 /* AWSDDLogMacros.h in Headers */,
 				184F43141E930A2D004F3FE2 /* AWSDDASLLogger.h in Headers */,
+				FA5D34FC250C0D77007AA030 /* AWSNSCodingUtilities.h in Headers */,
 				CE0D42291C6A673E006B91B5 /* AWSBolts.h in Headers */,
 				CE0D42561C6A673E006B91B5 /* AWSMTLJSONAdapter.h in Headers */,
 				184F43121E930A2D004F3FE2 /* AWSDDASLLogCapture.h in Headers */,
@@ -12575,6 +12585,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FADAEAE9250BDDF5009CABD4 /* AWSPinpointNSSecureCodingTests.m in Sources */,
 				18F455471DEFE875000D2F68 /* AWSTestUtility.m in Sources */,
 				C436FB0A2437EBE30004738F /* AWSPinpointNotificationManagerTests.m in Sources */,
 				1879900C1DEFCBFC00BC419B /* AWSGeneralPinpointTargetingTests.m in Sources */,
@@ -12890,6 +12901,7 @@
 				CE0D42981C6A673E006B91B5 /* AWSTMDiskCache.m in Sources */,
 				CE0D42571C6A673E006B91B5 /* AWSMTLJSONAdapter.m in Sources */,
 				CE0D42281C6A673E006B91B5 /* AWSSignature.m in Sources */,
+				FA5D34FD250C0D77007AA030 /* AWSNSCodingUtilities.m in Sources */,
 				CE0D42701C6A673E006B91B5 /* NSObject+AWSMTLComparisonAdditions.m in Sources */,
 				CE0D42241C6A673E006B91B5 /* AWSCredentialsProvider.m in Sources */,
 				184F431B1E930A2D004F3FE2 /* AWSDDLog.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Misc. Updates
 - **AWSPinpoint**
-  - The SDK now uses [`NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding?language=objc) and version-appropriate methods of `NSKeyedUnarchiver` to encode and decode `AWSPinpointSession` and `AWSPinpointEndpointProfile`. ([PR #XXXX](https://github.com/aws-amplify/aws-sdk-ios/pull/XXXX))
+  - The SDK now uses [`NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding?language=objc) and version-appropriate methods of `NSKeyedUnarchiver` to encode and decode `AWSPinpointSession` and `AWSPinpointEndpointProfile`. ([PR #3031](https://github.com/aws-amplify/aws-sdk-ios/pull/3031))
 
 ## 2.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
     - [Virtual host style addressing](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#virtual-hosted-style-access)
     - [Path-style deprecation](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)
 
+### Misc. Updates
+- **AWSPinpoint**
+  - The SDK now uses [`NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding?language=objc) and version-appropriate methods of `NSKeyedUnarchiver` to encode and decode `AWSPinpointSession` and `AWSPinpointEndpointProfile`. ([PR #XXXX](https://github.com/aws-amplify/aws-sdk-ios/pull/XXXX))
+
 ## 2.16.0
 
 ### Note for Xcode 12 support


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/aws-sdk-ios/issues/2914

*Description of changes:*

- Patches AWSPinpoint high-level client, and the fork of JKBigInteger, to support NSSecureCoding
- Introduces an NSCodingUtilities helper class for version-safe `NSKeyedArchiver` and `NSKeyedUnarchiver` functions that default to NSSecureCoding if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
