### PR TITLE
chore: Fix bump version job to use macos image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,20 +681,12 @@ jobs:
             python3 CircleciScripts/cloudfront_invalidate.py sdk_s3_release "${S3_RELEASE_DISTRIBUTION_ID}" "latest/$sdkName.zip"
 
   bump_sdk_version:
-    docker:
-      - image: circleci/android:api-27-alpha
-    environment:
-      JVM_OPTS: -Xmx1024m
+    macos:
+      xcode: "12.0.0"
     steps:
       - skip_job_unless_required
       - set_environment_variables
       - checkout
-      - run:
-          name: Install python3-pip
-          command: |
-            echo "${newsdkversion}"
-            sudo apt-get update
-            sudo apt-get -y install python3-pip
       - run:
           name: Install JSON parser
           command: sudo pip3 install demjson


### PR DESCRIPTION
*Description of changes:*

This change migrates the `bump_sdk_version` job to use a MacOS image, and removes the no-longer-necessary installations of `pip3`.

The `bump_sdk_version` job is declared to use the `circleci/android:api-27-alpha` docker image, which has python 3.5 installed. In order to upgrade, we'd need to either pick a new docker image, or locally upgrade python as part of the build process. Neither of those are optimal, since developing and testing are all performed on local mac workstations, and it's confusing to remember which jobs execute on non-Mac hardware in the pipeline. While running this job on a Mac will be slightly more expensive, the consistency and reduced maintenance burden is worth it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
