### PR TITLE
chore: Update source branch of ci-support repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,7 @@
 ## 2.13.4
 ### New features
 - **Integration tests**
-    - AWS Mobile SDK for iOS integration tests are now provisioned from a CloudFormation stack created by [the new amplify-ci-support package](LINK TBD). See [the README](LINK TBD) for details on how to provision your account to run integration tests.
+    - AWS Mobile SDK for iOS integration tests are now provisioned from a CloudFormation stack created by [the new amplify-ci-support package](https://github.com/aws-amplify/amplify-ci-support). See [the README](LINK TBD) for details on how to provision your account to run integration tests.
 
 - **AWSMobileClient**
     - Added api to fetch userSub for the loggedin user. [PR #2599](https://github.com/aws-amplify/aws-sdk-ios/pull/2599)

--- a/Scripts/generate-test-config.sh
+++ b/Scripts/generate-test-config.sh
@@ -4,12 +4,12 @@
 
 ##################################################
 # CANONICAL SOURCE OF THIS FILE IS
-#   https://github.com/aws-amplify/amplify-ci-support/blob/master/src/integ_test_resources/common/scripts/generate-test-config.sh
+#   https://github.com/aws-amplify/amplify-ci-support/blob/main/src/integ_test_resources/common/scripts/generate-test-config.sh
 #
 # As of this writing (06-May-2020), we manually copy this file into the CI
 # support directories for the projects that use it:
-# - https://github.com/aws-amplify/aws-sdk-ios/tree/master/Scripts/generate-test-config.sh
-# - https://github.com/aws-amplify/aws-sdk-android/tree/master/build-support/generate-test-config.sh
+# - https://github.com/aws-amplify/aws-sdk-ios/tree/main/Scripts/generate-test-config.sh
+# - https://github.com/aws-amplify/aws-sdk-android/tree/main/build-support/generate-test-config.sh
 #
 # From there, this script will be invoked by the CircleCI build process during
 # test setup, or it may be invoked manually for local integration test runs
@@ -120,7 +120,7 @@ OPTIONS:
         'AWS_SECRET_ACCESS_KEY', and 'AWS_SESSION_TOKEN'.
 
     -b <branch>
-        The branch of the ci-support repo to check out. Defaults to 'master'.
+        The branch of the ci-support repo to check out. Defaults to 'main'.
 
     -p <android|ios>
         Generate configuration file for platform="<val>"
@@ -145,7 +145,7 @@ EOF
 # PARSE ARGUMENTS
 
 assume_role=""
-branch="master"
+branch="main"
 platform=""
 region=${AWS_DEFAULT_REGION}
 


### PR DESCRIPTION
*Description of changes:*

Default branch of https://github.com/aws-amplify/amplify-ci-support is now `main`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
