### PR TITLE
chore: Remove restore_cache step from non-macos images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -702,9 +702,6 @@ jobs:
       JVM_OPTS: -Xmx1024m
     steps:
       - skip_job_unless_required
-      - restore_cache:
-          keys:
-            - v1-source-{{ .Revision }}
       - checkout
       - set_environment_variables
       - run:
@@ -740,9 +737,6 @@ jobs:
       JVM_OPTS: -Xmx1024m
     steps:
       - skip_job_unless_required
-      - restore_cache:
-          keys:
-            - v1-source-{{ .Revision }}
       - checkout
       - set_environment_variables
       - run:
@@ -758,9 +752,6 @@ jobs:
     steps:
       - skip_job_unless_required
       - set_environment_variables
-      - restore_cache:
-          keys:
-            - v1-source-{{ .Revision }}
       - checkout
       - run:
           name: Create pull request


### PR DESCRIPTION
*Description of changes:*

Removed `restore_cache` step from jobs that don't use macOS images. Should fix errors such as https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios/3560/workflows/726f1b50-ce35-487d-a8ee-466d9872d02a/jobs/30663

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
