### PR TITLE
chore: fix all_integ_test_requires YAML alias

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,6 +772,7 @@ jobs:
 
 all_integ_test_requires: &all_integ_test_requires
   requires:
+    - build
     - integ_test_AWSMobileClient
     - integ_test_AWSAutoScaling
     - integ_test_AWSCloudWatch
@@ -1509,8 +1510,6 @@ workflows:
 
       - merge_to_main:
           <<: *all_integ_test_requires
-          requires:
-            - build
           filters:
             branches:
               only:
@@ -1518,8 +1517,6 @@ workflows:
 
       - prepare_release_sdk:
           <<: *all_integ_test_requires
-          requires:
-            - build
           filters:
             branches:
               only:


### PR DESCRIPTION
As shown on https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios/3562/workflows/a22c4fd7-58cd-40fc-a2c5-a0f95d5d43db, I had attempted to merge the YAML alias `all_integ_test_requires` into the `requires` stanzas for `merge_to_main` and `prepare_release_sdk`. Unfortunately, YAML aliases don't merge lists, only maps. That means my required integ tests were overridden by a single `requires: build`.

This change modifies the alias to include a requirement for the `build` job, and removes it as an explicit requirement from the two jobs that use the alias. That makes the alias unsuitable for other contexts that perhaps *don't* require the `build` job, but it is OK for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
