### PR TITLE
feat(Pinpoint): support for adding user attributes to PinpointEndpointProfileUser

### DIFF
--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -280,16 +280,30 @@ NS_ASSUME_NONNULL_BEGIN
  Returns an Dictionary of all user attributes contained within this AWSPinpointEndpointProfile
  @returns an Dictionary of all user attributes, where the attribute keys are the keys and the attribute values are the values
  */
-- (NSDictionary *) allUserAttributes;
+- (NSDictionary *)allUserAttributes;
 
 /**
-Adds an userAttribute to this AWSPinpointEndpointProfileUser with the specified key. Only 40 attributes/metrics
+Adds an user attribute to this AWSPinpointEndpointProfileUser with the specified key. Only 40 attributes
 are allowed to be added to an AWSPinpointEndpointProfileUser. If 40 attributes already exist on this AWSPinpointEndpointProfileUser, the call is ignored.
-@param theValue The value of the userAttribute. The value will be truncated if it exceeds 200 characters.
-@param theKey The key of the userAttribute. The key will be truncated if it exceeds 50 characters.
+@param theValue The value of the user attribute. The value will be truncated if it exceeds 200 characters.
+@param theKey The key of the user attribute. The key will be truncated if it exceeds 50 characters.
 */
 - (void)addUserAttribute:(NSArray *)theValue
                   forKey:(NSString *)theKey;
+
+/**
+ Returns the value of the user attribute with the specified key.
+ @param theKey The key of the user attribute to return
+ @returns The user attribute with the specified key, or null if user attribute does not exist
+ */
+- (NSArray *)userAttributeForKey:(NSString *)theKey;
+
+/**
+ Determines if this AWSPinpointEndpointProfileUser contains a specific user attribute
+ @param theKey The key of the user attribute
+ @returns YES if this AWSPinpointEndpointProfileUser has an user attribute with the specified key, NO otherwise
+ */
+- (BOOL)hasUserAttributeForKey:(NSString *)theKey;
 
 @end
 

--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -104,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Adds an attribute to this AWSPinpointEndpointProfile with the specified key. Only 40 attributes/metrics
  are allowed to be added to an AWSPinpointEndpointProfile. If 40 attributes/metrics already exist on this AWSPinpointEndpointProfile, the call is ignored.
- @param theValue The value of the attribute. The value will be truncated if it exceeds 200 characters.
+ @param theValue The value of the attribute. The value will be truncated if it exceeds 100 characters.
  @param theKey The key of the attribute. The key will be truncated if it exceeds 50 characters.
  */
 - (void)addAttribute:(NSArray *)theValue
@@ -277,17 +277,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *_Nullable userId;
 
 /**
- Returns an Dictionary of all user attributes contained within this AWSPinpointEndpointProfileUser
- @returns an Dictionary of all user attributes, where the user attribute keys are the keys and the user attribute values are the values
+ Returns an NSDictionary of all user attributes contained within this AWSPinpointEndpointProfileUser
+ @returns an NSDictionary of all user attributes, where the user attribute keys are the keys and the user attribute values are the values
  */
 - (NSDictionary *)allUserAttributes;
 
 /**
-Adds an user attribute to this AWSPinpointEndpointProfileUser with the specified key. Only 40 attributes
-are allowed to be added to an AWSPinpointEndpointProfileUser. If 40 user attributes already exist on this AWSPinpointEndpointProfileUser, the call is ignored.
-@param theValue The value of the user attribute. The value will be truncated if it exceeds 200 characters.
+Adds an user attribute to this AWSPinpointEndpointProfileUser with the specified key.
+@param theValue The value of the user attribute. The value will be truncated if it exceeds 100 characters.
 @param theKey The key of the user attribute. The key will be truncated if it exceeds 50 characters.
-*/
+ */
 - (void)addUserAttribute:(NSArray *)theValue
                   forKey:(NSString *)theKey;
 

--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -277,14 +277,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSString *_Nullable userId;
 
 /**
- Returns an Dictionary of all user attributes contained within this AWSPinpointEndpointProfile
- @returns an Dictionary of all user attributes, where the attribute keys are the keys and the attribute values are the values
+ Returns an Dictionary of all user attributes contained within this AWSPinpointEndpointProfileUser
+ @returns an Dictionary of all user attributes, where the user attribute keys are the keys and the user attribute values are the values
  */
 - (NSDictionary *)allUserAttributes;
 
 /**
 Adds an user attribute to this AWSPinpointEndpointProfileUser with the specified key. Only 40 attributes
-are allowed to be added to an AWSPinpointEndpointProfileUser. If 40 attributes already exist on this AWSPinpointEndpointProfileUser, the call is ignored.
+are allowed to be added to an AWSPinpointEndpointProfileUser. If 40 user attributes already exist on this AWSPinpointEndpointProfileUser, the call is ignored.
 @param theValue The value of the user attribute. The value will be truncated if it exceeds 200 characters.
 @param theKey The key of the user attribute. The key will be truncated if it exceeds 50 characters.
 */

--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns an Dictionary of all attributes contained within this AWSPinpointEndpointProfile
  @returns an Dictionary of all attributes, where the attribute keys are the keys and the attribute values are the values
  */
-- (NSDictionary*) allAttributes;
+- (NSDictionary *)allAttributes;
 
 /**
  Adds a metric to this AWSPinpointEndpointProfile with the specified key. Only 40 attributes/metrics
@@ -157,13 +157,13 @@ NS_ASSUME_NONNULL_BEGIN
  Returns an Dictionary of all metrics contained within this AWSPinpointEndpointProfile
  @returns an Dictionary of all metrics, where the metric keys are the keys and the metric values are the values
  */
-- (NSDictionary*) allMetrics;
+- (NSDictionary *)allMetrics;
 
 /**
  Returns an Dictionary representation of this object.
  @returns an Dictionary representation of this AWSPinpointEndpointProfile object.
  */
-- (NSDictionary *) toDictionary;
+- (NSDictionary *)toDictionary;
 
 @end
 
@@ -276,7 +276,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) NSString *_Nullable userId;
 
+/**
+ Returns an Dictionary of all user attributes contained within this AWSPinpointEndpointProfile
+ @returns an Dictionary of all user attributes, where the attribute keys are the keys and the attribute values are the values
+ */
+- (NSDictionary *) allUserAttributes;
+
+/**
+Adds an userAttribute to this AWSPinpointEndpointProfileUser with the specified key. Only 40 attributes/metrics
+are allowed to be added to an AWSPinpointEndpointProfileUser. If 40 attributes already exist on this AWSPinpointEndpointProfileUser, the call is ignored.
+@param theValue The value of the userAttribute. The value will be truncated if it exceeds 200 characters.
+@param theKey The key of the userAttribute. The key will be truncated if it exceeds 50 characters.
+*/
+- (void)addUserAttribute:(NSArray *)theValue
+                  forKey:(NSString *)theKey;
+
+- (void)setUserAttributes:(NSDictionary<NSString*,NSArray*> *)userAttributes;
+
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -291,8 +291,6 @@ are allowed to be added to an AWSPinpointEndpointProfileUser. If 40 attributes a
 - (void)addUserAttribute:(NSArray *)theValue
                   forKey:(NSString *)theKey;
 
-- (void)setUserAttributes:(NSDictionary<NSString*,NSArray*> *)userAttributes;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -567,7 +567,7 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
 
 - (void)addUserAttribute:(NSArray *)theValue
                   forKey:(NSString *)theKey {
-    if (!theKey) {
+    if (!theKey.length) {
         AWSDDLogWarn(@"The key of user attribute you tried to add is empty.");
         return;
     }

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -530,11 +530,16 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
 }
 
 - (NSString *)description {
+    if (!self.userAttributes) {
+        self.userAttributes = [NSMutableDictionary dictionary];
+    }
+    
+    NSError *error;
     NSData *userAttributesData = [NSJSONSerialization dataWithJSONObject:self.userAttributes
                                                                  options:0
-                                                                   error:nil];
+                                                                   error:&error];
     NSString *userAttributesString = [[NSString alloc] initWithData:userAttributesData
-                                                       encoding:NSUTF8StringEncoding];
+                                                           encoding:NSUTF8StringEncoding];
     return [NSString stringWithFormat:
             @"{"
             "\"UserId\" : %@,"

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -581,10 +581,6 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
     }
 }
 
-- (void)setUserAttributes:(NSDictionary<NSString*,NSArray*> *)userAttributes {
-    self.userAttributes = userAttributes;
-}
-
 - (NSDictionary *)allUserAttributes {
     @synchronized(self) {
         return [NSDictionary dictionaryWithDictionary:self.userAttributes];

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -534,11 +534,11 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
     return self;
 }
 
-- (NSString*) quotedString:(NSString*) input {
+- (NSString *)quotedString:(NSString*) input {
     return [NSString stringWithFormat:@"\"%@\"", input];
 }
 
-- (NSString*) description {
+- (NSString *)description {
     return [NSString stringWithFormat:
             @"{"
             "\"UserId\" : %@}",
@@ -598,7 +598,13 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
     }
 }
 
-+ (NSArray*) processUserAttributeValues:(NSArray*) values {
+- (NSArray *)userAttributeForKey:(NSString *)theKey {
+    @synchronized(self) {
+        return [self.userAttributes objectForKey:theKey];
+    }
+}
+
++ (NSArray *)processUserAttributeValues:(NSArray*) values {
     NSMutableArray *trimmedValues = [NSMutableArray arrayWithCapacity:MAX_ENDPOINT_ATTRIBUTE_VALUES];
     int valuesCount = 0;
     for (NSString *val in values) {
@@ -611,7 +617,7 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
     return trimmedValues;
 }
 
-+ (NSString*) trimKey:(NSString*)theKey
++ (NSString *)trimKey:(NSString*)theKey
               forType:(NSString*)theType {
     NSString* trimmedKey = [AWSPinpointStringUtils clipString:theKey
                                                    toMaxChars:MAX_ENDPOINT_ATTRIBUTE_METRIC_KEY_LENGTH
@@ -623,7 +629,7 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
     return trimmedKey;
 }
 
-+ (NSString*) trimValue:(NSString*)theValue {
++ (NSString *)trimValue:(NSString*)theValue {
     NSString* trimmedValue = [AWSPinpointStringUtils clipString:theValue
                                                      toMaxChars:MAX_ENDPOINT_ATTRIBUTE_VALUE_LENGTH
                                               andAppendEllipses:NO];

--- a/AWSPinpoint/AWSPinpointTargetingClient.m
+++ b/AWSPinpoint/AWSPinpointTargetingClient.m
@@ -151,12 +151,8 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
     return [self executeUpdate:endpointProfile];
 }
 
-- (AWSTask *)extracted {
-    return [self executeUpdate:[self currentEndpointProfile]];
-}
-
 - (AWSTask *)updateEndpointProfile {
-    return [self extracted];
+    return [self executeUpdate:[self currentEndpointProfile]];
 }
 
 - (AWSTask *)executeUpdate:(AWSPinpointEndpointProfile *) endpointProfile {

--- a/AWSPinpoint/AWSPinpointTargetingClient.m
+++ b/AWSPinpoint/AWSPinpointTargetingClient.m
@@ -151,8 +151,12 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
     return [self executeUpdate:endpointProfile];
 }
 
-- (AWSTask *)updateEndpointProfile {
+- (AWSTask *)extracted {
     return [self executeUpdate:[self currentEndpointProfile]];
+}
+
+- (AWSTask *)updateEndpointProfile {
+    return [self extracted];
 }
 
 - (AWSTask *)executeUpdate:(AWSPinpointEndpointProfile *) endpointProfile {
@@ -289,6 +293,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
 - (AWSPinpointTargetingEndpointUser*) userModelForUser:(AWSPinpointEndpointProfileUser *) user {
     AWSPinpointTargetingEndpointUser *userModel = [AWSPinpointTargetingEndpointUser new];
     userModel.userId = user.userId;
+    userModel.userAttributes = user.allUserAttributes;
     return userModel;
 }
 

--- a/AWSPinpoint/AWSPinpointTargetingClient.m
+++ b/AWSPinpoint/AWSPinpointTargetingClient.m
@@ -77,7 +77,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
     if (!self.endpointProfile) {
         if ([self.context.configuration.userDefaults objectForKey:AWSPinpointEndpointProfileKey] != nil) {
             NSData *endpointProfileData = [self.context.configuration.userDefaults objectForKey:AWSPinpointEndpointProfileKey];
-            
+
             NSError *decodingError;
             localEndpointProfile = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
                                                                                    fromData:endpointProfileData
@@ -85,7 +85,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
             if (decodingError) {
                 AWSDDLogError(@"Error decoding local endpoint profile: %@", decodingError);
             }
-            
+
             if ([localEndpointProfile.applicationId isEqualToString:self.context.configuration.appId]) {
                 // This is to verify that same appId is being used. Anyone can modify the plist and test with a different app id
                 [localEndpointProfile removeAllMetrics];
@@ -111,9 +111,9 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
     //update opt outs
     BOOL applicationLevelOptOut = [localEndpointProfile isApplicationLevelOptOut:self.context];
     [localEndpointProfile setEndpointOptOut:applicationLevelOptOut];
-    
+
     [self addMetricsAndAttributesToEndpointProfile:localEndpointProfile];
-    
+
     return localEndpointProfile;
 }
 
@@ -165,11 +165,11 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
         if (codingError) {
             AWSDDLogError(@"Error archiving endpointProfileData. Updating service but not persisting locally: %@", codingError);
         }
-        
+
         [self.context.configuration.userDefaults setObject:endpointProfileData forKey:AWSPinpointEndpointProfileKey];
         [self.context.configuration.userDefaults synchronize];
     }
-    
+
     return [[self.context.targetingService updateEndpoint:[self updateEndpointRequestForEndpoint:self.endpointProfile]] continueWithBlock:^id _Nullable(AWSTask * _Nonnull task) {
         if (task.error) {
             AWSDDLogError(@"Unable to successfully update endpoint. Error Message:%@", task.error);

--- a/AWSPinpoint/AWSPinpointTargetingClient.m
+++ b/AWSPinpoint/AWSPinpointTargetingClient.m
@@ -77,7 +77,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
     if (!self.endpointProfile) {
         if ([self.context.configuration.userDefaults objectForKey:AWSPinpointEndpointProfileKey] != nil) {
             NSData *endpointProfileData = [self.context.configuration.userDefaults objectForKey:AWSPinpointEndpointProfileKey];
-
+            
             NSError *decodingError;
             localEndpointProfile = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
                                                                                    fromData:endpointProfileData
@@ -85,7 +85,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
             if (decodingError) {
                 AWSDDLogError(@"Error decoding local endpoint profile: %@", decodingError);
             }
-
+            
             if ([localEndpointProfile.applicationId isEqualToString:self.context.configuration.appId]) {
                 // This is to verify that same appId is being used. Anyone can modify the plist and test with a different app id
                 [localEndpointProfile removeAllMetrics];
@@ -111,7 +111,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
     //update opt outs
     BOOL applicationLevelOptOut = [localEndpointProfile isApplicationLevelOptOut:self.context];
     [localEndpointProfile setEndpointOptOut:applicationLevelOptOut];
-
+    
     [self addMetricsAndAttributesToEndpointProfile:localEndpointProfile];
     
     return localEndpointProfile;
@@ -165,11 +165,11 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
         if (codingError) {
             AWSDDLogError(@"Error archiving endpointProfileData. Updating service but not persisting locally: %@", codingError);
         }
-
+        
         [self.context.configuration.userDefaults setObject:endpointProfileData forKey:AWSPinpointEndpointProfileKey];
         [self.context.configuration.userDefaults synchronize];
     }
-
+    
     return [[self.context.targetingService updateEndpoint:[self updateEndpointRequestForEndpoint:self.endpointProfile]] continueWithBlock:^id _Nullable(AWSTask * _Nonnull task) {
         if (task.error) {
             AWSDDLogError(@"Unable to successfully update endpoint. Error Message:%@", task.error);
@@ -190,7 +190,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
 }
 
 - (void)addAttribute:(NSArray *)theValue
-                    forKey:(NSString *)theKey {
+              forKey:(NSString *)theKey {
     if (theValue == nil) {
         @throw [NSException exceptionWithName:AWSPinpointTargetingClientErrorDomain
                                        reason:@"Nil value provided to addGlobalAttribute"
@@ -227,7 +227,7 @@ NSString *const APNS_CHANNEL_TYPE = @"APNS";
 }
 
 - (void)addMetric:(NSNumber *)theValue
-                 forKey:(NSString *)theKey {
+           forKey:(NSString *)theKey {
     if (theValue == nil) {
         @throw [NSException exceptionWithName:AWSPinpointTargetingClientErrorDomain
                                        reason:@"Nil value provided to addGlobalMetric"


### PR DESCRIPTION
*Description of changes:*
Amazon Pinpoint [doc](https://docs.aws.amazon.com/pinpoint/latest/apireference/apps-application-id-users-user-id.html)
Regarding this issue: https://github.com/aws-amplify/aws-sdk-ios/issues/3086
- Added property `userAttributes`

- Added public methods for `userAttributes`: 
```objective-c
- (void)addUserAttribute:(NSArray *)theValue
                  forKey:(NSString *)theKey;
```
,
```objective-c
- (NSDictionary *)allUserAttributes;
```
,
```objective-c
- (NSArray *)userAttributeForKey:(NSString *)theKey;
```
and
```objective-c
- (BOOL)hasUserAttributeForKey:(NSString *)theKey;
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
