### PR TITLE
feat(AWSKinesis Data Streams): Support NSSecureCoding

### DIFF
--- a/AWSKinesis/AWSKinesisModel.m
+++ b/AWSKinesis/AWSKinesisModel.m
@@ -20,6 +20,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisAddTagsToStreamInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"streamName" : @"StreamName",
@@ -30,6 +34,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisCreateStreamInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -42,6 +50,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisDecreaseStreamRetentionPeriodInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"retentionPeriodHours" : @"RetentionPeriodHours",
@@ -53,6 +65,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisDeleteStreamInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"streamName" : @"StreamName",
@@ -63,9 +79,17 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisDescribeLimitsInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 @end
 
 @implementation AWSKinesisDescribeLimitsOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -78,6 +102,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisDescribeStreamInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"exclusiveStartShardId" : @"ExclusiveStartShardId",
@@ -89,6 +117,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisDescribeStreamOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -104,6 +136,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisDescribeStreamSummaryInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"streamName" : @"StreamName",
@@ -113,6 +149,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisDescribeStreamSummaryOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -128,6 +168,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisDisableEnhancedMonitoringInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"shardLevelMetrics" : @"ShardLevelMetrics",
@@ -138,6 +182,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisEnableEnhancedMonitoringInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -150,6 +198,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisEnhancedMetrics
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"shardLevelMetrics" : @"ShardLevelMetrics",
@@ -159,6 +211,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisEnhancedMonitoringOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -172,6 +228,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisGetRecordsInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"limit" : @"Limit",
@@ -182,6 +242,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisGetRecordsOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -198,6 +262,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisGetShardIteratorInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -257,6 +325,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisGetShardIteratorOutput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"shardIterator" : @"ShardIterator",
@@ -266,6 +338,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisHashKeyRange
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -278,6 +354,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisIncreaseStreamRetentionPeriodInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"retentionPeriodHours" : @"RetentionPeriodHours",
@@ -288,6 +368,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisListShardsInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -311,6 +395,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisListShardsOutput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"nextToken" : @"NextToken",
@@ -326,6 +414,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisListStreamsInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"exclusiveStartStreamName" : @"ExclusiveStartStreamName",
@@ -336,6 +428,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisListStreamsOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -348,6 +444,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisListTagsForStreamInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"exclusiveStartTagKey" : @"ExclusiveStartTagKey",
@@ -359,6 +459,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisListTagsForStreamOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -375,6 +479,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisMergeShardsInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"adjacentShardToMerge" : @"AdjacentShardToMerge",
@@ -386,6 +494,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisPutRecordInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -400,6 +512,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisPutRecordOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -434,6 +550,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisPutRecordsInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"records" : @"Records",
@@ -448,6 +568,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisPutRecordsOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -486,6 +610,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisPutRecordsRequestEntry
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"data" : @"Data",
@@ -497,6 +625,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisPutRecordsResultEntry
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -510,6 +642,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisRecord
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -554,6 +690,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisRemoveTagsFromStreamInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"streamName" : @"StreamName",
@@ -565,6 +705,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisSequenceNumberRange
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"endingSequenceNumber" : @"EndingSequenceNumber",
@@ -575,6 +719,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisShard
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -598,6 +746,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisSplitShardInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"latestStartingHashKey" : @"NewStartingHashKey",
@@ -609,6 +761,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisStartStreamEncryptionInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -643,6 +799,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisStopStreamEncryptionInput
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"encryptionType" : @"EncryptionType",
@@ -675,6 +835,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisStreamDescription
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -763,6 +927,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisStreamDescriptionSummary
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"encryptionType" : @"EncryptionType",
@@ -845,6 +1013,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 
 @implementation AWSKinesisTag
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
              @"key" : @"Key",
@@ -855,6 +1027,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisUpdateShardCountInput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{
@@ -883,6 +1059,10 @@ NSString *const AWSKinesisErrorDomain = @"com.amazonaws.AWSKinesisErrorDomain";
 @end
 
 @implementation AWSKinesisUpdateShardCountOutput
+
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
 	return @{

--- a/AWSKinesisUnitTests/AWSKinesisNSSecureCodingTests.m
+++ b/AWSKinesisUnitTests/AWSKinesisNSSecureCodingTests.m
@@ -1,0 +1,253 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <AWSNSSecureCodingTestBase/AWSNSSecureCodingTestBase.h>
+#import "AWSKinesisModel.h"
+
+@interface AWSKinesisNSSecureCodingTests : AWSNSSecureCodingTest
+
+- (void) test_AWSKinesisAddTagsToStreamInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisCreateStreamInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDecreaseStreamRetentionPeriodInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDeleteStreamInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDescribeLimitsInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDescribeLimitsOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDescribeStreamInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDescribeStreamOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDescribeStreamSummaryInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDescribeStreamSummaryOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisDisableEnhancedMonitoringInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisEnableEnhancedMonitoringInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisEnhancedMetrics API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisEnhancedMonitoringOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisGetRecordsInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisGetRecordsOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisGetShardIteratorInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisGetShardIteratorOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisHashKeyRange API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisIncreaseStreamRetentionPeriodInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisListShardsInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisListShardsOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisListStreamsInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisListStreamsOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisListTagsForStreamInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisListTagsForStreamOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisMergeShardsInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisPutRecordInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisPutRecordOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisPutRecordsInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisPutRecordsOutput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisPutRecordsRequestEntry API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisPutRecordsResultEntry API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisRecord API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisRemoveTagsFromStreamInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisSequenceNumberRange API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisShard API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisSplitShardInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisStartStreamEncryptionInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisStopStreamEncryptionInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisStreamDescription API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisStreamDescriptionSummary API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisTag API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisUpdateShardCountInput API_AVAILABLE(ios(11));
+- (void) test_AWSKinesisUpdateShardCountOutput API_AVAILABLE(ios(11));
+
+@end
+
+@implementation AWSKinesisNSSecureCodingTests
+
+- (void) test_AWSKinesisAddTagsToStreamInput {
+    [self validateSecureCodingForClass:[AWSKinesisAddTagsToStreamInput class]];
+}
+
+- (void) test_AWSKinesisCreateStreamInput {
+    [self validateSecureCodingForClass:[AWSKinesisCreateStreamInput class]];
+}
+
+- (void) test_AWSKinesisDecreaseStreamRetentionPeriodInput {
+    [self validateSecureCodingForClass:[AWSKinesisDecreaseStreamRetentionPeriodInput class]];
+}
+
+- (void) test_AWSKinesisDeleteStreamInput {
+    [self validateSecureCodingForClass:[AWSKinesisDeleteStreamInput class]];
+}
+
+- (void) test_AWSKinesisDescribeLimitsInput {
+    [self validateSecureCodingForClass:[AWSKinesisDescribeLimitsInput class]];
+}
+
+- (void) test_AWSKinesisDescribeLimitsOutput {
+    [self validateSecureCodingForClass:[AWSKinesisDescribeLimitsOutput class]];
+}
+
+- (void) test_AWSKinesisDescribeStreamInput {
+    [self validateSecureCodingForClass:[AWSKinesisDescribeStreamInput class]];
+}
+
+- (void) test_AWSKinesisDescribeStreamOutput {
+    [self validateSecureCodingForClass:[AWSKinesisDescribeStreamOutput class]];
+}
+
+- (void) test_AWSKinesisDescribeStreamSummaryInput {
+    [self validateSecureCodingForClass:[AWSKinesisDescribeStreamSummaryInput class]];
+}
+
+- (void) test_AWSKinesisDescribeStreamSummaryOutput {
+    [self validateSecureCodingForClass:[AWSKinesisDescribeStreamSummaryOutput class]];
+}
+
+- (void) test_AWSKinesisDisableEnhancedMonitoringInput {
+    [self validateSecureCodingForClass:[AWSKinesisDisableEnhancedMonitoringInput class]];
+}
+
+- (void) test_AWSKinesisEnableEnhancedMonitoringInput {
+    [self validateSecureCodingForClass:[AWSKinesisEnableEnhancedMonitoringInput class]];
+}
+
+- (void) test_AWSKinesisEnhancedMetrics {
+    [self validateSecureCodingForClass:[AWSKinesisEnhancedMetrics class]];
+}
+
+- (void) test_AWSKinesisEnhancedMonitoringOutput {
+    [self validateSecureCodingForClass:[AWSKinesisEnhancedMonitoringOutput class]];
+}
+
+- (void) test_AWSKinesisGetRecordsInput {
+    [self validateSecureCodingForClass:[AWSKinesisGetRecordsInput class]];
+}
+
+- (void) test_AWSKinesisGetRecordsOutput {
+    [self validateSecureCodingForClass:[AWSKinesisGetRecordsOutput class]];
+}
+
+- (void) test_AWSKinesisGetShardIteratorInput {
+    [self validateSecureCodingForClass:[AWSKinesisGetShardIteratorInput class]];
+}
+
+- (void) test_AWSKinesisGetShardIteratorOutput {
+    [self validateSecureCodingForClass:[AWSKinesisGetShardIteratorOutput class]];
+}
+
+- (void) test_AWSKinesisHashKeyRange {
+    [self validateSecureCodingForClass:[AWSKinesisHashKeyRange class]];
+}
+
+- (void) test_AWSKinesisIncreaseStreamRetentionPeriodInput {
+    [self validateSecureCodingForClass:[AWSKinesisIncreaseStreamRetentionPeriodInput class]];
+}
+
+- (void) test_AWSKinesisListShardsInput {
+    [self validateSecureCodingForClass:[AWSKinesisListShardsInput class]];
+}
+
+- (void) test_AWSKinesisListShardsOutput {
+    [self validateSecureCodingForClass:[AWSKinesisListShardsOutput class]];
+}
+
+- (void) test_AWSKinesisListStreamsInput {
+    [self validateSecureCodingForClass:[AWSKinesisListStreamsInput class]];
+}
+
+- (void) test_AWSKinesisListStreamsOutput {
+    [self validateSecureCodingForClass:[AWSKinesisListStreamsOutput class]];
+}
+
+- (void) test_AWSKinesisListTagsForStreamInput {
+    [self validateSecureCodingForClass:[AWSKinesisListTagsForStreamInput class]];
+}
+
+- (void) test_AWSKinesisListTagsForStreamOutput {
+    [self validateSecureCodingForClass:[AWSKinesisListTagsForStreamOutput class]];
+}
+
+- (void) test_AWSKinesisMergeShardsInput {
+    [self validateSecureCodingForClass:[AWSKinesisMergeShardsInput class]];
+}
+
+- (void) test_AWSKinesisPutRecordInput {
+    [self validateSecureCodingForClass:[AWSKinesisPutRecordInput class]];
+}
+
+- (void) test_AWSKinesisPutRecordOutput {
+    [self validateSecureCodingForClass:[AWSKinesisPutRecordOutput class]];
+}
+
+- (void) test_AWSKinesisPutRecordsInput {
+    [self validateSecureCodingForClass:[AWSKinesisPutRecordsInput class]];
+}
+
+- (void) test_AWSKinesisPutRecordsOutput {
+    [self validateSecureCodingForClass:[AWSKinesisPutRecordsOutput class]];
+}
+
+- (void) test_AWSKinesisPutRecordsRequestEntry {
+    [self validateSecureCodingForClass:[AWSKinesisPutRecordsRequestEntry class]];
+}
+
+- (void) test_AWSKinesisPutRecordsResultEntry {
+    [self validateSecureCodingForClass:[AWSKinesisPutRecordsResultEntry class]];
+}
+
+- (void) test_AWSKinesisRecord {
+    [self validateSecureCodingForClass:[AWSKinesisRecord class]];
+}
+
+- (void) test_AWSKinesisRemoveTagsFromStreamInput {
+    [self validateSecureCodingForClass:[AWSKinesisRemoveTagsFromStreamInput class]];
+}
+
+- (void) test_AWSKinesisSequenceNumberRange {
+    [self validateSecureCodingForClass:[AWSKinesisSequenceNumberRange class]];
+}
+
+- (void) test_AWSKinesisShard {
+    [self validateSecureCodingForClass:[AWSKinesisShard class]];
+}
+
+- (void) test_AWSKinesisSplitShardInput {
+    [self validateSecureCodingForClass:[AWSKinesisSplitShardInput class]];
+}
+
+- (void) test_AWSKinesisStartStreamEncryptionInput {
+    [self validateSecureCodingForClass:[AWSKinesisStartStreamEncryptionInput class]];
+}
+
+- (void) test_AWSKinesisStopStreamEncryptionInput {
+    [self validateSecureCodingForClass:[AWSKinesisStopStreamEncryptionInput class]];
+}
+
+- (void) test_AWSKinesisStreamDescription {
+    [self validateSecureCodingForClass:[AWSKinesisStreamDescription class]];
+}
+
+- (void) test_AWSKinesisStreamDescriptionSummary {
+    [self validateSecureCodingForClass:[AWSKinesisStreamDescriptionSummary class]];
+}
+
+- (void) test_AWSKinesisTag {
+    [self validateSecureCodingForClass:[AWSKinesisTag class]];
+}
+
+- (void) test_AWSKinesisUpdateShardCountInput {
+    [self validateSecureCodingForClass:[AWSKinesisUpdateShardCountInput class]];
+}
+
+- (void) test_AWSKinesisUpdateShardCountOutput {
+    [self validateSecureCodingForClass:[AWSKinesisUpdateShardCountOutput class]];
+}
+
+
+@end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -1372,6 +1372,7 @@
 		FA1C5B492539EA8D00DBC24C /* AWSNSSecureCodingTestBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA1C57E42539E80C00DBC24C /* AWSNSSecureCodingTestBase.framework */; };
 		FA1C5B4A2539EA9700DBC24C /* AWSNSSecureCodingTestBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA1C57E42539E80C00DBC24C /* AWSNSSecureCodingTestBase.framework */; };
 		FA2800EE22C9C1E1000B41F4 /* AWSStringValue.m in Sources */ = {isa = PBXBuildFile; fileRef = FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */; };
+		FA28E8C52543837B0064E20B /* AWSKinesisNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA28E8C42543837B0064E20B /* AWSKinesisNSSecureCodingTests.m */; };
 		FA37083C2540C8180070FFDC /* AWSEC2NSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA37083B2540C8180070FFDC /* AWSEC2NSSecureCodingTests.m */; };
 		FA39AF102346847A0006050D /* MQTTSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FA39AF0F2346847A0006050D /* MQTTSessionTests.m */; };
 		FA39AF132346880D0006050D /* TestMQTTSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FA39AF122346880D0006050D /* TestMQTTSessionDelegate.m */; };
@@ -3967,6 +3968,7 @@
 		FA1C5A392539E8FB00DBC24C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		FA2800ED22C9C1E1000B41F4 /* AWSStringValue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSStringValue.m; sourceTree = "<group>"; };
 		FA2800EF22C9C1E5000B41F4 /* AWSStringValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSStringValue.h; sourceTree = "<group>"; };
+		FA28E8C42543837B0064E20B /* AWSKinesisNSSecureCodingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSKinesisNSSecureCodingTests.m; sourceTree = "<group>"; };
 		FA37083B2540C8180070FFDC /* AWSEC2NSSecureCodingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSEC2NSSecureCodingTests.m; sourceTree = "<group>"; };
 		FA39AF0F2346847A0006050D /* MQTTSessionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MQTTSessionTests.m; sourceTree = "<group>"; };
 		FA39AF112346880D0006050D /* TestMQTTSessionDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestMQTTSessionDelegate.h; sourceTree = "<group>"; };
@@ -6654,15 +6656,16 @@
 		CE5604641C6BC92E00B4E00B /* AWSKinesisUnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				FA62A7152167C9F100EFB444 /* AWSGZIPBaseTestCase.h */,
+				FAF13AAE2167C6AA008115D1 /* AWSGZIPTestHelper.h */,
 				FAB5DA68253A37B2002ECF1D /* AWSFirehoseNSSecureCodingTests.m */,
 				CE56052E1C6BCE1700B4E00B /* AWSGeneralFirehoseTests.m */,
 				CE56052F1C6BCE1700B4E00B /* AWSGeneralKinesisTests.m */,
-				FA62A7152167C9F100EFB444 /* AWSGZIPBaseTestCase.h */,
 				FA62A7162167C9F100EFB444 /* AWSGZIPBaseTestCase.m */,
 				FABCFA622167D1F800C6F1FF /* AWSGZIPEncodingFirehoseTests.m */,
 				FAEE86AB2167AAA900738F8E /* AWSGZIPEncodingKinesisTests.m */,
-				FAF13AAE2167C6AA008115D1 /* AWSGZIPTestHelper.h */,
 				FAF13AAF2167C6AA008115D1 /* AWSGZIPTestHelper.m */,
+				FA28E8C42543837B0064E20B /* AWSKinesisNSSecureCodingTests.m */,
 				CE5604671C6BC92E00B4E00B /* Info.plist */,
 			);
 			path = AWSKinesisUnitTests;
@@ -12850,6 +12853,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA28E8C52543837B0064E20B /* AWSKinesisNSSecureCodingTests.m in Sources */,
 				FAF13AB02167C6AA008115D1 /* AWSGZIPTestHelper.m in Sources */,
 				FABCFA632167D1F800C6F1FF /* AWSGZIPEncodingFirehoseTests.m in Sources */,
 				FAEE86AC2167AAA900738F8E /* AWSGZIPEncodingKinesisTests.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - `AWSIoTDataPublishRequest`
     - `AWSIoTDataUpdateThingShadowRequest`
     - `AWSIoTDataUpdateThingShadowResponse`
+  - Amazon Kinesis Data Streams ([PR #3163](https://github.com/aws-amplify/aws-sdk-ios/pull/3163))
   - Amazon Kinesis Video Streams ([PR #3161](https://github.com/aws-amplify/aws-sdk-ios/pull/3161))
   - Amazon Kinesis Video Streams Archived Media ([PR #3161](https://github.com/aws-amplify/aws-sdk-ios/pull/3161))
   - Amazon Lambda ([PR #3154](https://github.com/aws-amplify/aws-sdk-ios/pull/3154)). Note that the following base request and response objects that include untyped (i.e., `id`) properties do not support `NSSecureCoding`. To support `NSSecureCoding` for those types, create a subclass of the base type, and override the appropriate `initWithCoder:` methods to provide a type-safe unarchiving method:
@@ -46,7 +47,6 @@
   - Amazon Connect Participant Service
   - Amazon DynamoDB
   - Amazon Kinesis Firehose
-  - Amazon Kinesis Streams
   - Amazon Kinesis Video Signaling
   - AWS Key Management Service (KMS)
   - Amazon Lex


### PR DESCRIPTION
*Issue #, if available:* Refs #2914 

*Description of changes:*

This PR adds support for Kinesis Data Streams. I incorrectly reported support on the 2.18.0 release. This PR includes a CHANGELOG update to rectify that, and I have edited the 2.18.0 release notes to rectify the error https://github.com/aws-amplify/aws-sdk-ios/releases/tag/2.18.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
