### PR TITLE
fix: Add NSSecureCodingSupport to AWSIoTCreateCertificateResponse

### DIFF
--- a/AWSIoT/AWSIoTManager.m
+++ b/AWSIoT/AWSIoTManager.m
@@ -34,6 +34,10 @@ static NSString *const AWSInfoIoTManager = @"IoTManager";
 
 @implementation AWSIoTCreateCertificateResponse
 
++ (BOOL) supportsSecureCoding {
+    return YES;
+}
+
 @end
 
 @implementation AWSIoTManager

--- a/AWSIoTUnitTests/AWSIoTManagerNSSecureCodingTests.m
+++ b/AWSIoTUnitTests/AWSIoTManagerNSSecureCodingTests.m
@@ -1,0 +1,32 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <AWSNSSecureCodingTestBase/AWSNSSecureCodingTestBase.h>
+#import "AWSIoTManager.h"
+
+@interface AWSIoTManagerNSSecureCodingTests : AWSNSSecureCodingTest
+
+- (void) test_AWSIoTCreateCertificateResponse API_AVAILABLE(ios(11));
+
+@end
+
+@implementation AWSIoTManagerNSSecureCodingTests
+
+- (void) test_AWSIoTCreateCertificateResponse {
+    [self validateSecureCodingForClass:[AWSIoTCreateCertificateResponse class]];
+}
+
+@end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -1584,6 +1584,7 @@
 		FAF13AB02167C6AA008115D1 /* AWSGZIPTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAF13AAF2167C6AA008115D1 /* AWSGZIPTestHelper.m */; };
 		FAF2C31623464ABA006C5C3E /* TestDecoderDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FAF2C31523464ABA006C5C3E /* TestDecoderDelegate.m */; };
 		FAF2C31923464B44006C5C3E /* TestDataWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = FAF2C31823464B44006C5C3E /* TestDataWriter.m */; };
+		FAF522B425438B6200E2C5FE /* AWSIoTManagerNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAF522B325438B6200E2C5FE /* AWSIoTManagerNSSecureCodingTests.m */; };
 		FAFAF8C72540FAE70074FAB3 /* AWSIoTDataNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAFAF8C52540FAE60074FAB3 /* AWSIoTDataNSSecureCodingTests.m */; };
 		FAFAF8C82540FAE70074FAB3 /* AWSIoTNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAFAF8C62540FAE70074FAB3 /* AWSIoTNSSecureCodingTests.m */; };
 		FAFE10B9234D3D3E00BD2DCA /* AtomicValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA39AF32234CEC060006050D /* AtomicValue.swift */; };
@@ -4096,6 +4097,7 @@
 		FAF2C31523464ABA006C5C3E /* TestDecoderDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestDecoderDelegate.m; sourceTree = "<group>"; };
 		FAF2C31723464B44006C5C3E /* TestDataWriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestDataWriter.h; sourceTree = "<group>"; };
 		FAF2C31823464B44006C5C3E /* TestDataWriter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestDataWriter.m; sourceTree = "<group>"; };
+		FAF522B325438B6200E2C5FE /* AWSIoTManagerNSSecureCodingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSIoTManagerNSSecureCodingTests.m; sourceTree = "<group>"; };
 		FAFAF8C52540FAE60074FAB3 /* AWSIoTDataNSSecureCodingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSIoTDataNSSecureCodingTests.m; sourceTree = "<group>"; };
 		FAFAF8C62540FAE70074FAB3 /* AWSIoTNSSecureCodingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSIoTNSSecureCodingTests.m; sourceTree = "<group>"; };
 		FAFE10AF234D3CF200BD2DCA /* AWSIoTFreeRTOSOTATests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSIoTFreeRTOSOTATests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6642,6 +6644,7 @@
 			children = (
 				CE5605321C6BCE2700B4E00B /* AWSGeneralIoTDataTests.m */,
 				CE5605331C6BCE2700B4E00B /* AWSGeneralIoTTests.m */,
+				FAF522B325438B6200E2C5FE /* AWSIoTManagerNSSecureCodingTests.m */,
 				FAFAF8C52540FAE60074FAB3 /* AWSIoTDataNSSecureCodingTests.m */,
 				CE56053D1C6BD02800B4E00B /* AWSIoTDataUnitTests.m */,
 				FAFAF8C62540FAE70074FAB3 /* AWSIoTNSSecureCodingTests.m */,
@@ -12842,6 +12845,7 @@
 				CE5605351C6BCE2700B4E00B /* AWSGeneralIoTTests.m in Sources */,
 				FA9242902344F44D003F546D /* MQTTDecoderTests.m in Sources */,
 				FA924293234502C5003F546D /* MQTTDecoderTestHelpers.m in Sources */,
+				FAF522B425438B6200E2C5FE /* AWSIoTManagerNSSecureCodingTests.m in Sources */,
 				FAFAF8C72540FAE70074FAB3 /* AWSIoTDataNSSecureCodingTests.m in Sources */,
 				FAFAF8C82540FAE70074FAB3 /* AWSIoTNSSecureCodingTests.m in Sources */,
 				FA39AF132346880D0006050D /* TestMQTTSessionDelegate.m in Sources */,


### PR DESCRIPTION
*Issue #, if available:* Refs #2914

*Description of changes:*

Adds NSSecureCoding support to a hand-generated response model in the AWSIoTManager

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
