### PR TITLE
ci: add docker hub auth to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,6 +673,9 @@ jobs:
   merge_to_main:
     docker:
       - image: circleci/android:api-27-alpha
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -708,6 +711,9 @@ jobs:
   prepare_release_sdk:
     docker:
       - image: circleci/android:api-27-alpha
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       JVM_OPTS: -Xmx1024m
     steps:
@@ -722,6 +728,9 @@ jobs:
   create_pullrequest_for_modelupdate:
     docker:
       - image: circleci/android:api-27-alpha
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_ACCESS_TOKEN
     environment:
       JVM_OPTS: -Xmx1024m
     steps:


### PR DESCRIPTION
Adding Docker Hub authentication to the CircleCI pipeline to accommodate [this change](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress) in Docker's ToS.

Here's the same change in JS for reference: https://github.com/aws-amplify/amplify-js/pull/7007

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
