### PR TITLE
fix: consider timestamp format for JSON protocol serialization

### DIFF
--- a/AWSCore/AWSCore.h
+++ b/AWSCore/AWSCore.h
@@ -53,6 +53,7 @@ FOUNDATION_EXPORT const unsigned char AWSCoreVersionString[] DEPRECATED_MSG_ATTR
 #import "AWSSynchronizedMutableDictionary.h"
 #import "AWSXMLDictionary.h"
 #import "AWSSerialization.h"
+#import "AWSTimestampSerialization.h"
 #import "AWSURLRequestSerialization.h"
 #import "AWSURLResponseSerialization.h"
 #import "AWSURLSessionManager.h"

--- a/AWSCore/Serialization/AWSTimestampSerialization.h
+++ b/AWSCore/Serialization/AWSTimestampSerialization.h
@@ -1,0 +1,48 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSString *const AWSTimestampSerializationErrorDomain;
+
+typedef NS_ENUM(NSInteger, AWSTimestampSerializationError) {
+    AWSTimestampParserError
+};
+
+@interface AWSTimestampSerialization: NSObject
+
++ (nullable NSString *)serializeTimestamp:(NSDictionary *)rules
+                                    value:(NSDate *)value
+                                    error:(NSError *__autoreleasing *)error;
+
++ (nullable NSDate *)parseTimestamp:(id)value;
+
+@end
+
+@interface AWSJSONTimestampSerialization: AWSTimestampSerialization
+@end
+
+@interface AWSXMLTimestampSerialization: AWSTimestampSerialization
+@end
+
+@interface AWSQueryTimestampSerialization: AWSTimestampSerialization
+@end
+
+@interface AWSEC2TimestampSerialization: AWSTimestampSerialization
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Serialization/AWSTimestampSerialization.m
+++ b/AWSCore/Serialization/AWSTimestampSerialization.m
@@ -1,0 +1,141 @@
+//
+// Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "AWSTimestampSerialization.h"
+#import "AWSCategory.h"
+
+NSString *const AWSTimestampSerializationErrorDomain = @"com.amazonaws.AWSTimestampSerializationErrorDomain";
+
+@implementation AWSTimestampSerialization
+
++ (BOOL)failWithCode:(NSInteger)code description:(NSString *)description error:(NSError *__autoreleasing *)error {
+    if (error) {
+        *error = [NSError errorWithDomain:AWSTimestampSerializationErrorDomain
+                                     code:code
+                                 userInfo:@{NSLocalizedDescriptionKey : description}];
+    }
+    return NO;
+}
+
++ (nullable NSDate *)parseTimestamp:(id)value{
+    NSDate *timeStampDate;
+    //maybe a NSDate type or NSNumber type or NSString type
+    if ([value isKindOfClass:[NSString class]]) {
+        //try parse the string to NSDate first
+        timeStampDate = [NSDate aws_dateFromString:value];
+        
+        //if failed, then parse it as double value represented as string
+        if (!timeStampDate) {
+            timeStampDate = [NSDate dateWithTimeIntervalSince1970:[value doubleValue]];
+        }
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+        //need to convert to NSDate type
+        timeStampDate = [NSDate dateWithTimeIntervalSince1970:[value doubleValue]];
+        
+    } else if ([value isKindOfClass:[NSDate class]]) {
+        timeStampDate = value;
+    }
+    return timeStampDate;
+}
+
+// Check and handle `timestampFormat` trait if present on a timestamp object
++ (nullable NSString *)serializeTimestamp:(NSDictionary *)rules value:(id)value error:(NSError *__autoreleasing *)error {
+    if (!value || ![rules[@"type"] isEqualToString:@"timestamp"]) {
+        return nil;
+    } else {
+        //generate string presentation of timestamp
+        NSString *timestampStr;
+        
+        NSDate *timeStampDate = [self parseTimestamp:value];
+        if (timeStampDate == nil) {
+            [self failWithCode:AWSTimestampParserError
+                   description:[NSString stringWithFormat:@"the timestamp value is invalid:%@",value]
+                         error:error];
+        } else {
+            // we are able to parse the value into NSDate
+            if ([rules[@"timestampFormat"] isEqualToString:@"iso8601"]) {
+                timestampStr = [timeStampDate aws_stringValue:AWSDateISO8601DateFormat1];
+            } else if ([rules[@"timestampFormat"] isEqualToString:@"unixTimestamp"]) {
+                timestampStr = [NSString stringWithFormat:@"%.lf",[timeStampDate timeIntervalSince1970]];
+            } else if ([rules[@"timestampFormat"] isEqualToString:@"rfc822"]) {
+                timestampStr = [timeStampDate aws_stringValue: AWSDateRFC822DateFormat1];
+            }
+        }
+        return timestampStr;
+    }
+}
+
+@end
+
+@implementation AWSJSONTimestampSerialization
+
++ (nullable NSString *)serializeTimestamp:(NSDictionary *)rules value:(id)value error:(NSError *__autoreleasing *)error {
+    NSString *timestampStr = [super serializeTimestamp:rules value:value error:error];
+    
+    if (!timestampStr.length){
+        // valid `timestampFormat` trait is not present, use protocol specific default.
+        NSDate *timeStampDate = [self parseTimestamp:value];
+        timestampStr = [NSString stringWithFormat:@"%.lf",[timeStampDate timeIntervalSince1970]];
+    }
+    return timestampStr;
+}
+
+@end
+
+@implementation AWSXMLTimestampSerialization
+
++ (nullable NSString *)serializeTimestamp:(NSDictionary *)rules value:(id)value error:(NSError *__autoreleasing *)error {
+    NSString *timestampStr = [super serializeTimestamp:rules value:value error:error];
+    
+    if (!timestampStr.length){
+        // valid `timestampFormat` trait is not present, use protocol specific default.
+        NSDate *timeStampDate = [self parseTimestamp:value];
+        timestampStr = [timeStampDate aws_stringValue: AWSDateRFC822DateFormat1];
+    }
+    return timestampStr;
+}
+
+@end
+
+@implementation AWSQueryTimestampSerialization
+
++ (nullable NSString *)serializeTimestamp:(NSDictionary *)rules value:(id)value error:(NSError *__autoreleasing *)error {
+    NSString *timestampStr = [super serializeTimestamp:rules value:value error:error];
+    
+    if (!timestampStr.length){
+        // valid `timestampFormat` trait is not present, use protocol specific default.
+        NSDate *timeStampDate = [self parseTimestamp:value];
+        timestampStr = [timeStampDate aws_stringValue: AWSDateISO8601DateFormat1];
+    }
+    return timestampStr;
+}
+
+@end
+
+@implementation AWSEC2TimestampSerialization
+
++ (nullable NSString *)serializeTimestamp:(NSDictionary *)rules value:(id)value error:(NSError *__autoreleasing *)error {
+    NSString *timestampStr = [super serializeTimestamp:rules value:value error:error];
+    
+    if (!timestampStr.length){
+        // valid `timestampFormat` trait is not present, use protocol specific default.
+        NSDate *timeStampDate = [self parseTimestamp:value];
+        timestampStr = [timeStampDate aws_stringValue: AWSDateISO8601DateFormat1];
+    }
+    return timestampStr;
+}
+
+@end

--- a/AWSCoreUnitTests/Resources/json-input.json
+++ b/AWSCoreUnitTests/Resources/json-input.json
@@ -45,6 +45,76 @@
     ]
   },
   {
+      "description": "Timestamp members",
+      "metadata": {
+        "protocol": "json",
+        "jsonVersion": 1.1,
+        "targetPrefix": "com.amazonaws.foo"
+      },
+      "shapes": {
+        "InputShape": {
+          "type": "structure",
+          "members": {
+            "TimeMember": {
+              "shape": "Timestamp"
+            },
+            "StructMember": {
+              "shape": "TimeContainer"
+            }
+          }
+        },
+        "Timestamp": {
+          "type": "timestamp"
+        },
+        "TimeContainer": {
+          "type": "structure",
+          "members": {
+            "unix": {
+              "shape": "Timestamp",
+              "timestampFormat": "unixTimestamp"
+            },
+            "rfc822": {
+              "shape": "Timestamp",
+              "timestampFormat": "rfc822"
+            },
+            "iso8601": {
+              "shape": "Timestamp",
+              "timestampFormat": "iso8601"
+            }
+          }
+        }
+      },
+      "cases": [
+        {
+          "given": {
+            "input": {
+              "shape": "InputShape"
+            },
+            "name": "OperationName",
+            "http": {
+              "method": "POST"
+            }
+          },
+          "params": {
+            "TimeMember": 1398796238,
+            "StructMember": {
+              "unix": 1398796238,
+              "rfc822": "Tue, 29 Apr 2014 18:30:38 GMT",
+              "iso8601": "2014-04-29T18:30:38Z"
+            }
+          },
+          "serialized": {
+            "body": "{\"TimeMember\": 1398796238, \"StructMember\": {\"unix\": 1398796238, \"iso8601\": \"2014-04-29T18:30:38Z\", \"rfc822\": \"Tue, 29 Apr 2014 18:30:38 GMT\"}}",
+            "headers": {
+              "X-Amz-Target": "com.amazonaws.foo.OperationName",
+              "Content-Type": "application/x-amz-json-1.1"
+            },
+            "uri": "/"
+          }
+        }
+      ]
+    },
+  {
     "description": "Recursive shapes",
     "metadata": {
       "protocol": "json",

--- a/AWSCoreUnitTests/Resources/json-output.json
+++ b/AWSCoreUnitTests/Resources/json-output.json
@@ -144,22 +144,30 @@
         "type": "structure",
         "members": {
           "TimeMember": {
-            "shape": "TimeType"
+            "shape": "Timestamp"
           },
           "StructMember": {
             "shape": "TimeContainer"
           }
         }
       },
-      "TimeType": {
+      "Timestamp": {
         "type": "timestamp"
       },
       "TimeContainer": {
         "type": "structure",
         "members": {
-          "foo": {
-            "shape": "TimeType",
+          "unix": {
+            "shape": "Timestamp",
             "timestampFormat": "unixTimestamp"
+          },
+          "rfc822": {
+              "shape": "Timestamp",
+              "timestampFormat": "rfc822"
+          },
+          "iso8601": {
+              "shape": "Timestamp",
+              "timestampFormat": "iso8601"
           }
         }
       }
@@ -175,13 +183,15 @@
         "result": {
           "TimeMember": 1398796238,
           "StructMember": {
-            "foo": 1398796238
+              "unix": 1398796238,
+              "rfc822": 1398796238,
+              "iso8601": 1398796238
           }
         },
         "response": {
           "status_code": 200,
           "headers": {},
-          "body": "{\"TimeMember\": \"2014-04-29T18:30:38Z\", \"StructMember\": {\"foo\": 1398796238}}"
+          "body": "{\"TimeMember\": \"1398796238\", \"StructMember\": {\"unix\": 1398796238, \"iso8601\": \"1398796238\", \"rfc822\": \"1398796238\"}}"
         }
       }
     ]

--- a/AWSCoreUnitTests/Resources/query-input.json
+++ b/AWSCoreUnitTests/Resources/query-input.json
@@ -283,20 +283,33 @@
       "InputShape": {
         "type": "structure",
         "members": {
-          "TimeArg": {
-            "shape": "TimestampType"
+          "TimeMember": {
+            "shape": "Timestamp"
           },
-          "TimeArg2": {
-            "shape": "TimestampType2"
+          "StructMember": {
+            "shape": "TimeContainer"
           }
         }
       },
-      "TimestampType": {
+      "Timestamp": {
         "type": "timestamp"
       },
-      "TimestampType2": {
-        "type": "timestamp",
-        "timestampFormat": "unixTimestamp"
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "unix": {
+            "shape": "Timestamp",
+            "timestampFormat": "unixTimestamp"
+          },
+          "rfc822": {
+            "shape": "Timestamp",
+            "timestampFormat": "rfc822"
+          },
+          "iso8601": {
+            "shape": "Timestamp",
+            "timestampFormat": "iso8601"
+          }
+        }
       }
     },
     "cases": [
@@ -308,26 +321,16 @@
           "name": "OperationName"
         },
         "params": {
-          "TimeArg": 1422172800
+          "TimeMember": 1398796238,
+          "StructMember": {
+            "unix": 1398796238,
+            "rfc822": "Tue, 29 Apr 2014 18:30:38 GMT",
+            "iso8601": "2014-04-29T18:30:38Z"
+          }
         },
         "serialized": {
           "uri": "/",
-          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
-        }
-      },
-      {
-        "given": {
-          "input": {
-            "shape": "InputShape"
-          },
-          "name": "OperationName"
-        },
-        "params": {
-          "TimeArg2": 1422172800
-        },
-        "serialized": {
-          "uri": "/",
-          "body": "Action=OperationName&Version=2014-01-01&TimeArg2=1422172800"
+          "body": "Action=OperationName&Version=2014-01-01&StructMember.iso8601=2014-04-29T18%3A30%3A38Z&StructMember.unix=1398796238&StructMember.rfc822=Tue%2C%2029%20Apr%202014%2018%3A30%3A38%20GMT&TimeMember=2014-04-29T18%3A30%3A38Z"
         }
       }
     ]

--- a/AWSCoreUnitTests/Resources/query-output.json
+++ b/AWSCoreUnitTests/Resources/query-output.json
@@ -85,6 +85,59 @@
     ]
   },
   {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "resultWrapper": "OperationNameResult",
+        "members": {
+          "default": {
+            "shape": "Timestamp"
+          },
+          "unix": {
+            "shape": "Timestamp",
+            "timestampFormat": "unixTimestamp"
+          },
+          "iso8601": {
+            "shape": "Timestamp",
+            "timestampFormat": "iso8601"
+          },
+          "rfc822": {
+            "shape": "Timestamp",
+            "timestampFormat": "rfc822"
+          }
+        }
+      },
+      "Timestamp": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "default": "2014-04-29T18:30:38Z",
+          "unix": "1398796238",
+          "rfc822": "Tue, 29 Apr 2014 18:30:38 GMT",
+          "iso8601": "2014-04-29T18:30:38Z"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><default>2014-04-29T18:30:38Z</default><unix>1398796238</unix><iso8601>1398796238</iso8601><rfc822>1398796238</rfc822></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
     "description": "Not all members in response",
     "metadata": {
       "protocol": "query"

--- a/AWSCoreUnitTests/Resources/rest-json-output.json
+++ b/AWSCoreUnitTests/Resources/rest-json-output.json
@@ -167,21 +167,30 @@
         "type": "structure",
         "members": {
           "TimeMember": {
-            "shape": "TimeType"
+            "shape": "Timestamp"
           },
           "StructMember": {
             "shape": "TimeContainer"
           }
         }
       },
-      "TimeType": {
+      "Timestamp": {
         "type": "timestamp"
       },
       "TimeContainer": {
         "type": "structure",
         "members": {
-          "foo": {
-            "shape": "TimeType"
+          "unix": {
+            "shape": "Timestamp",
+            "timestampFormat": "unixTimestamp"
+          },
+          "rfc822": {
+            "shape": "Timestamp",
+            "timestampFormat": "rfc822"
+          },
+          "iso8601": {
+            "shape": "Timestamp",
+            "timestampFormat": "iso8601"
           }
         }
       }
@@ -197,13 +206,15 @@
         "result": {
           "TimeMember": 1398796238,
           "StructMember": {
-            "foo": 1398796238
+            "unix": 1398796238,
+            "rfc822": 1398796238,
+            "iso8601": 1398796238
           }
         },
         "response": {
           "status_code": 200,
           "headers": {},
-          "body": "{\"TimeMember\": 1398796238, \"StructMember\": {\"foo\": 1398796238}}"
+          "body": "{\"TimeMember\": \"1398796238\", \"StructMember\": {\"unix\": 1398796238, \"iso8601\": \"1398796238\", \"rfc822\": \"1398796238\"}}"
         }
       }
     ]

--- a/AWSCoreUnitTests/Resources/rest-xml-input.json
+++ b/AWSCoreUnitTests/Resources/rest-xml-input.json
@@ -565,7 +565,10 @@
       "InputShape": {
         "type": "structure",
         "members": {
-          "StructureParam": {
+          "TimeMember": {
+            "shape": "Timestamp"
+          },
+          "StructMember": {
             "shape": "StructureShape"
           }
         }
@@ -573,17 +576,25 @@
       "StructureShape": {
         "type": "structure",
         "members": {
-          "t": {
-            "shape": "TShape"
+          "unix": {
+            "shape": "Timestamp",
+            "timestampFormat": "unixTimestamp"
+          },
+          "rfc822": {
+            "shape": "Timestamp",
+            "timestampFormat": "rfc822"
+          },
+          "iso8601": {
+            "shape": "Timestamp",
+            "timestampFormat": "iso8601"
           },
           "b": {
-            "shape": "BShape"
+              "shape": "BShape"
           }
         }
       },
-      "TShape": {
-        "type": "timestamp",
-        "timestampFormat": "iso8601"
+      "Timestamp": {
+        "type": "timestamp"
       },
       "BShape": {
         "type": "blob"
@@ -604,14 +615,17 @@
           "name": "OperationName"
         },
         "params": {
-          "StructureParam": {
-            "t": 1422172800,
+          "TimeMember": 1398796238,
+          "StructMember": {
+            "unix": 1398796238,
+            "rfc822": "Tue, 29 Apr 2014 18:30:38 GMT",
+            "iso8601": "2014-04-29T18:30:38Z",
             "b": "foo"
           }
         },
         "serialized": {
           "method": "POST",
-          "body": "<OperationRequest xmlns=\"https://foo/\"><StructureParam><t>2015-01-25T08:00:00Z</t><b>Zm9v</b></StructureParam></OperationRequest>",
+          "body": "<OperationRequest xmlns=\"https://foo/\"><TimeMember>Tue, 29 Apr 2014 18:30:38 GMT</TimeMember><StructMember><unix>1398796238</unix><iso8601>2014-04-29T18:30:38Z</iso8601><rfc822>Tue, 29 Apr 2014 18:30:38 GMT</rfc822><b>Zm9v</b></StructMember></OperationRequest>",
           "uri": "/2014-01-01/hostedzone",
           "headers": {}
         }

--- a/AWSCoreUnitTests/Resources/rest-xml-output.json
+++ b/AWSCoreUnitTests/Resources/rest-xml-output.json
@@ -104,6 +104,61 @@
     ]
   },
   {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "default": {
+            "shape": "Timestamp"
+          },
+          "unix": {
+            "shape": "Timestamp",
+            "timestampFormat": "unixTimestamp"
+          },
+          "iso8601": {
+            "shape": "Timestamp",
+            "timestampFormat": "iso8601"
+          },
+          "rfc822": {
+            "shape": "Timestamp",
+            "timestampFormat": "rfc822"
+          }
+        }
+      },
+      "Timestamp": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "default": "2014-04-29T18:30:38Z",
+          "unix": "1398796238",
+          "rfc822": "Tue, 29 Apr 2014 18:30:38 GMT",
+          "iso8601": "2014-04-29T18:30:38Z"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "ImaHeader": "test",
+            "X-Foo": "abc"
+          },
+          "body": "<OperationNameResponse><default>1398796238</default><unix>1398796238</unix><iso8601>1398796238</iso8601><rfc822>1398796238</rfc822></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
     "description": "Blob",
     "metadata": {
       "protocol": "rest-xml"

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -430,6 +430,8 @@
 		211167352399CD0600902FC1 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		211167392399D25000902FC1 /* AWSGeneralKinesisVideoSignalingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 211167382399D25000902FC1 /* AWSGeneralKinesisVideoSignalingTests.m */; };
 		2111673C2399D82100902FC1 /* AWSKinesisVideoSignalingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2111673B2399D82100902FC1 /* AWSKinesisVideoSignalingIntegrationTests.swift */; };
+		2171EB6A254C721E00FAB22F /* AWSTimestampSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 2171EB69254C721E00FAB22F /* AWSTimestampSerialization.m */; };
+		2171EBE0254C725C00FAB22F /* AWSTimestampSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 2171EB68254C71ED00FAB22F /* AWSTimestampSerialization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21BBD1EB239D556B00DDF1F7 /* AWSKinesisVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1778554320F9A72800D083BB /* AWSKinesisVideo.framework */; };
 		95CEF9F423BFF67D006D4663 /* AWSTranscribeStreamingClientWebSocketProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95CEF9F323BFF67D006D4663 /* AWSTranscribeStreamingClientWebSocketProviderTests.swift */; };
 		95CEF9F623BFFCB4006D4663 /* AWSSRWebSocket+TranscribeStreaming.h in Headers */ = {isa = PBXBuildFile; fileRef = 95CEF9F223BEC583006D4663 /* AWSSRWebSocket+TranscribeStreaming.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3060,6 +3062,8 @@
 		211167372399CE8400902FC1 /* AWSKinesisVideoSignalingTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSKinesisVideoSignalingTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		211167382399D25000902FC1 /* AWSGeneralKinesisVideoSignalingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralKinesisVideoSignalingTests.m; sourceTree = "<group>"; };
 		2111673B2399D82100902FC1 /* AWSKinesisVideoSignalingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSKinesisVideoSignalingIntegrationTests.swift; sourceTree = "<group>"; };
+		2171EB68254C71ED00FAB22F /* AWSTimestampSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSTimestampSerialization.h; sourceTree = "<group>"; };
+		2171EB69254C721E00FAB22F /* AWSTimestampSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSTimestampSerialization.m; sourceTree = "<group>"; };
 		95CEF9F223BEC583006D4663 /* AWSSRWebSocket+TranscribeStreaming.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSSRWebSocket+TranscribeStreaming.h"; sourceTree = "<group>"; };
 		95CEF9F323BFF67D006D4663 /* AWSTranscribeStreamingClientWebSocketProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSTranscribeStreamingClientWebSocketProviderTests.swift; sourceTree = "<group>"; };
 		95DED98F23B1ACD500F7D354 /* AWSTranscribeStreamingWebSocketProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSTranscribeStreamingWebSocketProvider.h; sourceTree = "<group>"; };
@@ -6446,6 +6450,8 @@
 			children = (
 				CE0D41EB1C6A673E006B91B5 /* AWSSerialization.h */,
 				CE0D41EC1C6A673E006B91B5 /* AWSSerialization.m */,
+				2171EB68254C71ED00FAB22F /* AWSTimestampSerialization.h */,
+				2171EB69254C721E00FAB22F /* AWSTimestampSerialization.m */,
 				CE0D41ED1C6A673E006B91B5 /* AWSURLRequestRetryHandler.h */,
 				CE0D41EE1C6A673E006B91B5 /* AWSURLRequestRetryHandler.m */,
 				CE0D41EF1C6A673E006B91B5 /* AWSURLRequestSerialization.h */,
@@ -8301,6 +8307,7 @@
 				184F432E1E930E05004F3FE2 /* AWSDDOSLogger.h in Headers */,
 				184F431E1E930A2D004F3FE2 /* AWSDDTTYLogger.h in Headers */,
 				184F430F1E930A2D004F3FE2 /* AWSCocoaLumberjack.h in Headers */,
+				2171EBE0254C725C00FAB22F /* AWSTimestampSerialization.h in Headers */,
 				184F431A1E930A2D004F3FE2 /* AWSDDLog.h in Headers */,
 				184F43161E930A2D004F3FE2 /* AWSDDAssertMacros.h in Headers */,
 				CE0D42341C6A673E006B91B5 /* AWSTask.h in Headers */,
@@ -12696,6 +12703,7 @@
 				CE0D426A1C6A673E006B91B5 /* NSArray+AWSMTLManipulationAdditions.m in Sources */,
 				18DF08D51D347633004C7D19 /* AWSCognitoIdentity+Fabric.m in Sources */,
 				184F43271E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m in Sources */,
+				2171EB6A254C721E00FAB22F /* AWSTimestampSerialization.m in Sources */,
 				CE0D42491C6A673E006B91B5 /* AWSFMDatabasePool.m in Sources */,
 				CE0D424E1C6A673E006B91B5 /* AWSFMResultSet.m in Sources */,
 				CE0D429A1C6A673E006B91B5 /* AWSTMMemoryCache.m in Sources */,


### PR DESCRIPTION
*Issue #, if available:*
The JSON protocol (Rest-JSON, JSON 1.1) serialization ignores the timestampFormat trait of timestamp shapes in c2j model which causes it to default to unixTimetsamp format instead of the prescribed format.

*Description of changes:*
These changes add support for timestampFormat trait for JSON protocols. It also abstracts out the handling of timestamp shape serialization for different serialization protocols as they tend to share similar implementations.
Added tests around these changes for various protocols.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
