### PR TITLE
fix(Cognito)!: Assign the correct username for custom challenge

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -383,6 +383,9 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                 authenticationDelegate = [self.pool.delegate startCustomAuthentication];
             }
             if (authenticationDelegate != nil) {
+                if ([authenticateResult.challengeParameters objectForKey:@"USERNAME"] != nil) {
+                    self.username = [authenticateResult.challengeParameters objectForKey:@"USERNAME"];
+                }
                 AWSCognitoIdentityCustomAuthenticationInput *input = [AWSCognitoIdentityCustomAuthenticationInput new];
                 input.challengeParameters = authenticateResult.challengeParameters;
                 AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails *> *challengeDetails = [AWSTaskCompletionSource<AWSCognitoIdentityCustomChallengeDetails *> new];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -Features for next release
 
+### Breaking Changes
+- **Amazon Cognito**
+  - **Breaking Change** Custom auth will set the right username after a signin flow. Earlier if you use an alias (ex email) for custom auth signin, after successfull signIn `AWSMobileClient.default.username` would return the entered alias. This has been changed in this release and instead of the entering the alias, `AWSMobileClient.default.username` will return the actual Cognito username of the user. (See [Issue #3194](https://github.com/aws-amplify/aws-sdk-ios/issues/3194), [PR #3198](https://github.com/aws-amplify/aws-sdk-ios/pull/3198))
+
 ## 2.18.1
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 - **Amazon Cognito**
-  - **Breaking Change** Custom auth will set the right username after a signin flow. Earlier if you use an alias (ex email) for custom auth signin, after successfull signIn `AWSMobileClient.default.username` would return the entered alias. This has been changed in this release and instead of the returning the alias, `AWSMobileClient.default.username` will return the actual Cognito username of the user. (See [Issue #3194](https://github.com/aws-amplify/aws-sdk-ios/issues/3194), [PR #3198](https://github.com/aws-amplify/aws-sdk-ios/pull/3198))
+  - **Breaking Change** Custom auth now sets the correct `username` after a sign in flow. Before, if a user signed in with an alias (for example, an email) in a custom auth sign in flow, after a successful signIn, `AWSMobileClient.default().username` would return that entered alias. This has been fixed in this release to conform to the behavior in the standard SRP flow: instead of the returning the alias, `AWSMobileClient.default().username` will return the actual Cognito username of the user. (See [Issue #3194](https://github.com/aws-amplify/aws-sdk-ios/issues/3194), [PR #3198](https://github.com/aws-amplify/aws-sdk-ios/pull/3198))
 
 ## 2.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 - **Amazon Cognito**
-  - **Breaking Change** Custom auth will set the right username after a signin flow. Earlier if you use an alias (ex email) for custom auth signin, after successfull signIn `AWSMobileClient.default.username` would return the entered alias. This has been changed in this release and instead of the entering the alias, `AWSMobileClient.default.username` will return the actual Cognito username of the user. (See [Issue #3194](https://github.com/aws-amplify/aws-sdk-ios/issues/3194), [PR #3198](https://github.com/aws-amplify/aws-sdk-ios/pull/3198))
+  - **Breaking Change** Custom auth will set the right username after a signin flow. Earlier if you use an alias (ex email) for custom auth signin, after successfull signIn `AWSMobileClient.default.username` would return the entered alias. This has been changed in this release and instead of the returning the alias, `AWSMobileClient.default.username` will return the actual Cognito username of the user. (See [Issue #3194](https://github.com/aws-amplify/aws-sdk-ios/issues/3194), [PR #3198](https://github.com/aws-amplify/aws-sdk-ios/pull/3198))
 
 ## 2.18.1
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/aws-sdk-ios/issues/3194

*Description of changes:*
**BREAKING CHANGE:** Custom authentication flow was not assigning the right username. So if you enter an email alias as username during signIn for custom authentication, `AWSMobileClient.default().username` will return the entered email as the username. This is different from other authentication flow like SRP_A where it returns the actual Cognito username after signIn. So this PR fixes this behavior for custom auth so that after signIn using custom auth `AWSMobileClient.default().username` will return the right username.

---
Example:

Suppose I have a Cognito user pool setup to signIn using username or email id with custom lambda triggers.
Consider a user with the following details in the user pool:

**Cognito Username:**  `royjit`
**Email:** `someemail@someemail.com`

Before this PR: 
Step 1: Invoke signIn with email `AWSMobileClient.default().signIn(username: "someemail@someemail.com",..)` 
Step 2: After successful signIn invoking `AWSMobileClient.default().username` will return "someemail@someemail.com"

After this PR:
Step 1: Invoke signIn with email `AWSMobileClient.default().signIn(username: "someemail@someemail.com",..)` 
Step 2: After successful signIn invoking `AWSMobileClient.default().username` will return "royjit"

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
