### PR TITLE
chore(IoT): optimistic workaround for cleaning up nsoutputstream

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -647,8 +647,8 @@
 
 - (void)cleanUpToDecoderStream {
     self.toDecoderStream.delegate = nil;
-    [self.toDecoderStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [self.toDecoderStream close];
+    [self.toDecoderStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     self.toDecoderStream = nil;
 }
 


### PR DESCRIPTION
Currently do not have a good way to test this.

The code we currently have deployed to production follows the sample here:
https://developer.apple.com/library/archive/samplecode/SimpleURLConnections/Introduction/Intro.html#//apple_ref/doc/uid/DTS40009245

But just found that the documentation seems to explicitly state ordering of closing then removing from the runloop:
https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Streams/Articles/WritingOutputStreams.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
