### PR TITLE
fix(Cognito): Refresh Cognito user pool token if id token expired

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -243,11 +243,9 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                                                                 refreshToken:refreshToken
                                                               expirationTime:expiration];
         }
-        
-        
+
         // If the session expires > 2 minutes return it. We need to check both accessToken and id Token expiry
-        // since user can change both of them in Cognito console. We are also checking `expiration` time returned
-        // from Cognito auth result to keep the logic similar to before.
+        // since user can change both of them in Cognito console.
         if(session
            && [self isSessionValid:session]
            && [expiration compare:[NSDate dateWithTimeIntervalSinceNow:2 * 60]] == NSOrderedDescending) {

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -185,6 +185,32 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     }];
 }
 
+- (BOOL) isSessionValid:(AWSCognitoIdentityUserSession * _Nonnull)session {
+    // If id token is not present we only need to check the accessToken to determine the validity of the token.
+    if (!session.idToken) {
+        return [self isTokenValid:session.accessToken];
+    } else {
+        return [self isTokenValid:session.accessToken] && [self isTokenValid:session.idToken];
+    }
+    return false;
+}
+
+// Check if the token is valid or not. Returns true if the token is valid.
+//
+// The token is consider invalid if the token expiry is less than or equal to 2 min. This 2 minute buffer is
+// given so that we do not hand over a token to the user which will get expired immediately. This guarrantees that the
+// returned session tokens are valid for atleast 2 min.
+- (BOOL) isTokenValid:(AWSCognitoIdentityUserSessionToken * _Nonnull)token {
+    if ([token.tokenClaims valueForKey:@"exp"]) {
+        int expiryWindow = 2 * 60;
+        NSTimeInterval expiryInterval = [[token.tokenClaims valueForKey:@"exp"] doubleValue];
+        NSDate *tokenExpiration =  [NSDate dateWithTimeIntervalSince1970:expiryInterval];
+        return (tokenExpiration &&
+                [tokenExpiration compare:[NSDate dateWithTimeIntervalSinceNow:expiryWindow]] == NSOrderedDescending);
+    }
+    return false;
+}
+
 /**
  Get a session
  */
@@ -203,13 +229,28 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
         self.confirmedStatus = AWSCognitoIdentityUserStatusConfirmed;
 
         NSString * accessTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserAccessToken];
-        NSString * accessToken = self.pool.keychain[accessTokenKey];
-        //if the session expires > 5 minutes return it and there is at least an accessToken.
-        if(expiration && [expiration compare:[NSDate dateWithTimeIntervalSinceNow:5 * 60]] == NSOrderedDescending && accessToken){
-            NSString * idTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserIdToken];
-            AWSCognitoIdentityUserSession * session = [[AWSCognitoIdentityUserSession alloc] initWithIdToken:self.pool.keychain[idTokenKey] accessToken:accessToken refreshToken:refreshToken expirationTime:expiration];
+        NSString * idTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserIdToken];
         
-            session.expirationTime = expiration;
+        NSString * idToken = self.pool.keychain[idTokenKey];
+        NSString * accessToken = self.pool.keychain[accessTokenKey];
+        
+        AWSCognitoIdentityUserSession * session;
+        
+        // Session is available if we have expiration and accessToken.
+        if (expiration && accessToken) {
+            session = [[AWSCognitoIdentityUserSession alloc] initWithIdToken:idToken
+                                                                 accessToken:accessToken
+                                                                refreshToken:refreshToken
+                                                              expirationTime:expiration];
+        }
+        
+        
+        // If the session expires > 2 minutes return it. We need to check both accessToken and id Token expiry
+        // since user can change both of them in Cognito console. We are also checking `expiration` time returned
+        // from Cognito auth result to keep the logic similar to before.
+        if(session
+           && [self isSessionValid:session]
+           && [expiration compare:[NSDate dateWithTimeIntervalSinceNow:2 * 60]] == NSOrderedDescending) {
             return [AWSTask taskWithResult:session];
         }
         //else refresh it using the refresh token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes
 
-- Fixed an issue where id token is not refreshed automatically (See [Issue #869](https://github.com/aws-amplify/amplify-ios/issues/869), [PR #3220](https://github.com/aws-amplify/aws-sdk-ios/pull/3220/))
+- Fixed an issue where id token is not refreshed automatically for customers who set short custom expiration intervals (See [Issue #869](https://github.com/aws-amplify/amplify-ios/issues/869), [PR #3220](https://github.com/aws-amplify/aws-sdk-ios/pull/3220/))
 
 ## 2.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -Features for next release
 
+### Bug fixes
+
+- Fixed an issue where id token is not refreshed automatically (See [Issue #869](https://github.com/aws-amplify/amplify-ios/issues/869), [PR #3220](https://github.com/aws-amplify/aws-sdk-ios/pull/3220/))
+
 ## 2.19.0
 
 ### Breaking Changes


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/869

*Description of changes:* Cognito SDK does automatic token refresh only if the access token is expired. Now since Cognito added a new feature to change the expiry of id token as well, we need to check the validity of id token before returning from getSession call. 

Also reduced the time window to check for expiry from 5 min to 2 min. This avoids refreshing the token more often if the token expiry is set to 5 min. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
