### PR TITLE
fix(AWSMobileClient): Remove cached AWS Credentials when token expire

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -774,6 +774,7 @@ extension AWSMobileClient {
                         let errorType = AWSCognitoAuthClientErrorType(rawValue: (sessionError as NSError).code),
                         (errorType == .errorExpiredRefreshToken) {
                         self.pendingGetTokensCompletion = completionHandler
+                        self.invalidateCachedTemporaryCredentials()
                         self.mobileClientStatusChanged(userState: .signedOutUserPoolsTokenInvalid,
                                                        additionalInfo: [self.ProviderKey:"OAuth"])
                         // return early without releasing the tokenFetch lock.
@@ -953,6 +954,7 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
         switch self.currentUserState {
         case .signedIn, .signedOutUserPoolsTokenInvalid:
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource = passwordAuthenticationCompletionSource
+            self.invalidateCachedTemporaryCredentials()
             self.mobileClientStatusChanged(userState: .signedOutUserPoolsTokenInvalid, additionalInfo: ["username":self.userPoolClient?.currentUser()?.username ?? ""])
         default:
             break
@@ -990,6 +992,7 @@ extension AWSMobileClient: UserPoolAuthHelperlCallbacks {
         if ((self.currentUserState == .signedIn || self.currentUserState == .signedOutUserPoolsTokenInvalid) &&
             customAuthenticationInput.challengeParameters.isEmpty) {
             let username = self.userPoolClient?.currentUser()?.username ?? ""
+            self.invalidateCachedTemporaryCredentials()
             self.mobileClientStatusChanged(userState: .signedOutUserPoolsTokenInvalid,
                                            additionalInfo: ["username": username])
         } else {

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -220,7 +220,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     __block NSString * keyChainNamespace = [self keyChainNamespaceClientId];
     NSString * expirationTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserTokenExpiration];
     NSString * expirationDate = self.pool.keychain[expirationTokenKey];
-
+    
     if(expirationDate){
         NSDate *expiration = [NSDate aws_dateFromString:expirationDate format:AWSDateISO8601DateFormat1];
         NSString * refreshToken = [self refreshTokenFromKeyChain:keyChainNamespace];

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -220,7 +220,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     __block NSString * keyChainNamespace = [self keyChainNamespaceClientId];
     NSString * expirationTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserTokenExpiration];
     NSString * expirationDate = self.pool.keychain[expirationTokenKey];
-    BOOL invalidateTokens = [[NSUserDefaults standardUserDefaults] boolForKey:@"InvalidateTokens"];
+
     if(expirationDate){
         NSDate *expiration = [NSDate aws_dateFromString:expirationDate format:AWSDateISO8601DateFormat1];
         NSString * refreshToken = [self refreshTokenFromKeyChain:keyChainNamespace];
@@ -246,17 +246,13 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 
         // If the session expires > 2 minutes return it. We need to check both accessToken and id Token expiry
         // since user can change both of them in Cognito console.
-        if(!invalidateTokens &&
-           session
+        if(session
            && [self isSessionValid:session]
            && [expiration compare:[NSDate dateWithTimeIntervalSinceNow:2 * 60]] == NSOrderedDescending) {
             return [AWSTask taskWithResult:session];
         }
         //else refresh it using the refresh token
         else if(refreshToken){
-            if (invalidateTokens) {
-                return [self interactiveAuth];
-            }
             AWSCognitoIdentityProviderInitiateAuthRequest * request = [AWSCognitoIdentityProviderInitiateAuthRequest new];
             request.authFlow = AWSCognitoIdentityProviderAuthFlowTypeRefreshTokenAuth;
             request.clientId = self.pool.userPoolConfiguration.clientId;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
