### PR TITLE
feat: Remove deprecated public MD5 methods

### DIFF
--- a/AWSCore/Utility/AWSCategory.h
+++ b/AWSCore/Utility/AWSCategory.h
@@ -92,12 +92,6 @@ FOUNDATION_EXPORT NSString *const AWSDateShortDateFormat2;
 - (NSString *)aws_stringWithURLEncodingPath;
 - (NSString *)aws_stringWithURLEncodingPathWithoutPriorDecoding;
 
-/// Deprecated. This method will be removed in an upcoming version of the SDK.
-- (NSString *)aws_md5String DEPRECATED_MSG_ATTRIBUTE("This method will be removed in an upcoming version of the SDK.");
-
-/// Deprecated. This method will be removed in an upcoming version of the SDK.
-- (NSString *)aws_md5StringLittleEndian DEPRECATED_MSG_ATTRIBUTE("This method will be removed in an upcoming version of the SDK.");
-
 - (BOOL)aws_isVirtualHostedStyleCompliant;
 
 - (AWSRegionType)aws_regionTypeValue;

--- a/AWSCore/Utility/AWSCategory.m
+++ b/AWSCore/Utility/AWSCategory.m
@@ -427,30 +427,6 @@ static NSTimeInterval _clockskew = 0.0;
     return result?result:self;
 }
 
-- (NSString *)aws_md5String {
-    NSData *dataString = [self dataUsingEncoding:NSUTF8StringEncoding];
-    unsigned char digestArray[CC_MD5_DIGEST_LENGTH];
-    CC_MD5([dataString bytes], (CC_LONG)[dataString length], digestArray);
-
-    NSMutableString *md5String = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
-        [md5String appendFormat:@"%02x", digestArray[i]];
-    }
-    return md5String;
-}
-
-- (NSString *)aws_md5StringLittleEndian {
-    NSData *dataString = [self dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
-    unsigned char digestArray[CC_MD5_DIGEST_LENGTH];
-    CC_MD5([dataString bytes], (CC_LONG)[dataString length], digestArray);
-
-    NSMutableString *md5String = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
-        [md5String appendFormat:@"%02x", digestArray[i]];
-    }
-    return md5String;
-}
-
 - (BOOL)aws_isDNSBucketName {
     if ([self length] < 3 || [self length] > 63) {
         return NO;

--- a/AWSCoreTests/AWSUtilityTests.m
+++ b/AWSCoreTests/AWSUtilityTests.m
@@ -67,12 +67,6 @@
 
     inputString = @"abcDefg";
     XCTAssertFalse([inputString aws_isVirtualHostedStyleCompliant]);
-
-    inputString = @"Some random input";
-    XCTAssertEqualObjects([inputString aws_md5String], @"07d2d230c1227ff3d0004abb395e8bf2");
-
-    inputString = @"Some random input";
-    XCTAssertEqualObjects([inputString aws_md5StringLittleEndian], @"cba39458a339ee8fe133ae72974471a1");
 }
 
 - (void)testCategoryNSJSONSerialization {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR removes 2 public methods and their implementations, that were flagged for removal in August in [2.15.2](https://github.com/aws-amplify/aws-sdk-ios/releases/tag/2.15.2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
