### PR TITLE
AWSAppleSignIn, expose ASAuthorizationAppleIDCredential as property of AWSAppleSignInProvider

### DIFF
--- a/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.h
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.h
@@ -33,6 +33,12 @@ API_AVAILABLE(ios(13.0))
  */
 - (void)setViewControllerForAppleSignIn:(UIViewController *)signInViewController;
 
+/**
+ Provides access to the ASAuthorizationAppleIDCredential
+ Only upon initial SIWA, Apple returns name and email (if requested by scope) in the ASAuthorizationAppleIDCredential
+ */
+@property (strong, atomic) ASAuthorizationAppleIDCredential *credential;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m
@@ -113,10 +113,10 @@ static NSString *const AWSInfoAppleIdentifier = @"AppleSignIn";
     [controller performRequests];
 }
 
-- (void)authorizationController:(ASAuthorizationController *)controller
+(void)authorizationController:(ASAuthorizationController *)controller
    didCompleteWithAuthorization:(ASAuthorization *)authorization {
-    ASAuthorizationAppleIDCredential *credentials = [authorization credential];
-    NSData *idTokenData = [credentials identityToken];
+    self.credential = [authorization credential];
+    NSData *idTokenData = [self.credential identityToken];
     if (idTokenData != nil) {
         self.idToken = [[NSString alloc] initWithData:idTokenData encoding:NSUTF8StringEncoding];
         [[AWSSignInManager sharedInstance] completeLogin];


### PR DESCRIPTION
AWSAppleSignIn, expose ASAuthorizationAppleIDCredential as property of AWSAppleSignInProvider. 

*Issue #, if available: https://github.com/aws-amplify/aws-sdk-ios/issues/3143

*Description of changes:*

Upon initial user Sign in with Apple, (void)authorizationController:(ASAuthorizationController *)controller didCompleteWithAuthorization:(ASAuthorization *)authorization returns the authorization containing the authorization credential as ASAuthorizationAppleIDCredential

In order for an app to get the Apple account person name and email address, app code needs access to the credentials. Apple only returns the fullName and email on the initial login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
