### PR TITLE
feat(auth): Add support for ASWebAuthenticationSession

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -386,6 +386,30 @@ final public class AWSMobileClient: _AWSMobileClient {
     /// Shows a fully managed sign in screen which allows users to sign up and sign in.
     ///
     /// - Parameters:
+    ///   - presentationAnchor: The presentation Anchor to show the ASWEbAuthenticationSession
+    ///   - hostedUIOptions: The options object which allows showSignIn to present a hosted web UI.
+    ///   - completionHandler: The completion handler to be called when user finishes the sign in action.
+    @available(iOS 13, *)
+    public func showSignIn(presentationAnchor: ASPresentationAnchor,
+                           hostedUIOptions: HostedUIOptions,
+                           _ completionHandler: @escaping(UserState?, Error?) -> Void) {
+        developerNavigationController = nil
+        configureCognitoAuth(hostedUIOptions: hostedUIOptions, completionHandler)
+        
+        let cognitoAuth = AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey)
+        cognitoAuth.delegate = self
+        
+        cognitoAuth.getSessionWithWebUI(presentationAnchor) { (session, error) in
+            self.handleCognitoAuthGetSession(hostedUIOptions: hostedUIOptions,
+                                             session: session,
+                                             error: error,
+                                             completionHandler)
+        }
+    }
+    
+    /// Shows a fully managed sign in screen which allows users to sign up and sign in.
+    ///
+    /// - Parameters:
     ///   - navigationController: The navigation controller which would act as the anchor for this UI.
     ///   - signInUIOptions: The options object which allows changing logo, background color and if the user can cancel the sign in operation if using native auth UI. This options object will be ignored if `hostedUIOptions` is passed in.
     ///   - hostedUIOptions: The options object which allows showSignIn to present a hosted web UI. If passed, `signInUIOptions` are ignored since they are applicable only to native UI.
@@ -403,134 +427,24 @@ final public class AWSMobileClient: _AWSMobileClient {
             break
         }
         if let hostedUIOptions = hostedUIOptions {
-            
+            // Return early if the developer is trying private session without providing a presentation anchor. Private session
+            // is only available through ASWebAuthenticationSession which is supported through the api
+            // `showSignIn(presentationAnchor:hostedUIOptions:completionHandler:)`.
+            if hostedUIOptions.signInPrivateSession {
+                completionHandler(nil, AWSMobileClientError.invalidState(message: "Private session is only available if you use showSignIn(presentationAnchor:hostedUIOptions:completionHandler:) which is available for iOS > 13.0"))
+                return
+            }
             developerNavigationController = navigationController
+            configureCognitoAuth(hostedUIOptions: hostedUIOptions, completionHandler)
             
-            loadOAuthURIQueryParametersFromKeychain()
-            
-            let infoDictionaryMobileClient = AWSInfo.default().rootInfoDictionary["Auth"] as? [String: [String: Any]]
-            let infoDictionary: [String: Any]? = infoDictionaryMobileClient?["Default"]?["OAuth"] as? [String: Any]
-            
-            let clientId = infoDictionary?["AppClientId"] as? String
-            let secret = infoDictionary?["AppClientSecret"] as? String
-            let webDomain = infoDictionary?["WebDomain"] as? String
-            let hostURL = "https://\(webDomain!)"
-            
-            let signInRedirectURI = infoDictionary?["SignInRedirectURI"] as? String
-            let signInURI = infoDictionary?["SignInURI"] as? String
-            if self.signInURIQueryParameters == nil {
-                self.signInURIQueryParameters = infoDictionary?["SignInURIQueryParameters"] as? [String: String]
-            }
-            
-            let signOutRedirectURI = infoDictionary?["SignOutRedirectURI"] as? String
-            let signOutURI = infoDictionary?["SignOutURI"] as? String
-            if self.signOutURIQueryParameters == nil {
-                self.signOutURIQueryParameters = infoDictionary?["SignOutURIQueryParameters"] as? [String: String]
-            }
-            
-            let tokensURI = infoDictionary?["TokenURI"] as? String
-            if self.tokenURIQueryParameters == nil {
-                self.tokenURIQueryParameters = infoDictionary?["TokenURIQueryParameters"] as? [String: String]
-            }
-            
-            let identityProvider = hostedUIOptions.identityProvider
-            let idpIdentifier = hostedUIOptions.idpIdentifier
-            
-            let federationProviderIdentifier = hostedUIOptions.federationProviderName
-            
-            if hostedUIOptions.scopes != nil {
-                self.scopes = hostedUIOptions.scopes
-            }
-            else {
-                self.scopes = infoDictionary?["Scopes"] as? [String]
-                self.clearHostedUIOptionsScopesFromKeychain()
-            }
-            
-            if hostedUIOptions.signInURIQueryParameters != nil {
-                self.signInURIQueryParameters = hostedUIOptions.signInURIQueryParameters
-            }
-            
-            if hostedUIOptions.tokenURIQueryParameters != nil {
-                self.tokenURIQueryParameters = hostedUIOptions.tokenURIQueryParameters
-            }
-            
-            if hostedUIOptions.signOutURIQueryParameters != nil {
-                self.signOutURIQueryParameters = hostedUIOptions.signOutURIQueryParameters
-            }
-            
-            saveOAuthURIQueryParametersInKeychain()
-            
-            if (clientId == nil || scopes == nil || signInRedirectURI == nil || signOutRedirectURI == nil) {
-                completionHandler(nil, AWSMobileClientError.invalidConfiguration(message: "Please provide all configuration parameters to use the hosted UI feature."))
-            }
-            
-            let cognitoAuthConfig: AWSCognitoAuthConfiguration = AWSCognitoAuthConfiguration.init(appClientId: clientId!,
-                                             appClientSecret: secret,
-                                             scopes: Set<String>(self.scopes!.map { $0 }),
-                                             signInRedirectUri: signInRedirectURI!,
-                                             signOutRedirectUri: signOutRedirectURI!,
-                                             webDomain: hostURL,
-                                             identityProvider: identityProvider,
-                                             idpIdentifier: idpIdentifier,
-                                             signInUri: signInURI,
-                                             signOutUri: signOutURI,
-                                             tokensUri: tokensURI,
-                                             signInUriQueryParameters: self.signInURIQueryParameters,
-                                             signOutUriQueryParameters: self.signOutURIQueryParameters,
-                                             tokenUriQueryParameters: self.tokenURIQueryParameters,
-                                             userPoolServiceConfiguration: AWSMobileClient.serviceConfiguration?.userPoolServiceConfiguration)
-
-            if (isCognitoAuthRegistered) {
-                AWSCognitoAuth.remove(forKey: CognitoAuthRegistrationKey)
-            }
-            AWSCognitoAuth.registerCognitoAuth(with: cognitoAuthConfig, forKey: CognitoAuthRegistrationKey)
-            isCognitoAuthRegistered = true
             let cognitoAuth = AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey)
             cognitoAuth.delegate = self
             
             cognitoAuth.getSession(navigationController.viewControllers.first!) { (session, error) in
-                guard error == nil else {
-                    completionHandler(nil, error)
-                    return
-                }
-                
-                if let session = session {
-                    var signInInfo = [String: String]()
-                    var federationToken: String? = nil
-                    if let idToken = session.idToken?.tokenString {
-                        federationToken = idToken
-                    } else if let accessToken = session.accessToken?.tokenString {
-                        federationToken = accessToken
-                    }
-                    
-                    guard federationToken != nil else {
-                        completionHandler(nil, AWSMobileClientError.idTokenAndAcceessTokenNotIssued(message: "No ID token or access token was issued."))
-                        return
-                    }
-                    
-                    if let identityProvider = hostedUIOptions.identityProvider {
-                        signInInfo["identityProvider"] = identityProvider
-                    }
-                    if let idpIdentifier = hostedUIOptions.idpIdentifier {
-                        signInInfo["idpIdentifier"] = idpIdentifier
-                    }
-                    signInInfo[self.TokenKey] = session.accessToken!.tokenString
-                    signInInfo[self.ProviderKey] = "OAuth"
-                    
-                    // Upon successful sign in, store scopes specified using HostedUIOptions in Keychain
-                    if hostedUIOptions.scopes != nil {
-                        self.saveHostedUIOptionsScopesInKeychain()
-                    }
-                    
-                    self.performHostedUISuccessfulSignInTasks(disableFederation: hostedUIOptions.disableFederation, session: session, federationToken: federationToken!, federationProviderIdentifier: federationProviderIdentifier, signInInfo: &signInInfo)
-                    self.mobileClientStatusChanged(userState: .signedIn, additionalInfo: signInInfo)
-                    completionHandler(.signedIn, nil)
-                    if self.pendingGetTokensCompletion != nil {
-                        self.tokenFetchLock.leave()
-                    }
-                    self.pendingGetTokensCompletion?(self.getTokensForCognitoAuthSession(session: session), nil)
-                    self.pendingGetTokensCompletion = nil
-                }
+                self.handleCognitoAuthGetSession(hostedUIOptions: hostedUIOptions,
+                                                 session: session,
+                                                 error: error,
+                                                 completionHandler)
             }
             
         } else {
@@ -566,6 +480,136 @@ final public class AWSMobileClient: _AWSMobileClient {
                     completionHandler(nil, error)
                 }
             })
+        }
+    }
+    
+    private func configureCognitoAuth(hostedUIOptions: HostedUIOptions, _ completionHandler: @escaping(UserState?, Error?) -> Void) {
+        loadOAuthURIQueryParametersFromKeychain()
+        
+        let infoDictionaryMobileClient = AWSInfo.default().rootInfoDictionary["Auth"] as? [String: [String: Any]]
+        let infoDictionary: [String: Any]? = infoDictionaryMobileClient?["Default"]?["OAuth"] as? [String: Any]
+        
+        let clientId = infoDictionary?["AppClientId"] as? String
+        let secret = infoDictionary?["AppClientSecret"] as? String
+        let webDomain = infoDictionary?["WebDomain"] as? String
+        let hostURL = "https://\(webDomain!)"
+        
+        let signInRedirectURI = infoDictionary?["SignInRedirectURI"] as? String
+        let signInURI = infoDictionary?["SignInURI"] as? String
+        if self.signInURIQueryParameters == nil {
+            self.signInURIQueryParameters = infoDictionary?["SignInURIQueryParameters"] as? [String: String]
+        }
+        
+        let signOutRedirectURI = infoDictionary?["SignOutRedirectURI"] as? String
+        let signOutURI = infoDictionary?["SignOutURI"] as? String
+        if self.signOutURIQueryParameters == nil {
+            self.signOutURIQueryParameters = infoDictionary?["SignOutURIQueryParameters"] as? [String: String]
+        }
+        
+        let tokensURI = infoDictionary?["TokenURI"] as? String
+        if self.tokenURIQueryParameters == nil {
+            self.tokenURIQueryParameters = infoDictionary?["TokenURIQueryParameters"] as? [String: String]
+        }
+        
+        let identityProvider = hostedUIOptions.identityProvider
+        let idpIdentifier = hostedUIOptions.idpIdentifier
+        
+        if hostedUIOptions.scopes != nil {
+            self.scopes = hostedUIOptions.scopes
+        }
+        else {
+            self.scopes = infoDictionary?["Scopes"] as? [String]
+            self.clearHostedUIOptionsScopesFromKeychain()
+        }
+        
+        if hostedUIOptions.signInURIQueryParameters != nil {
+            self.signInURIQueryParameters = hostedUIOptions.signInURIQueryParameters
+        }
+        
+        if hostedUIOptions.tokenURIQueryParameters != nil {
+            self.tokenURIQueryParameters = hostedUIOptions.tokenURIQueryParameters
+        }
+        
+        if hostedUIOptions.signOutURIQueryParameters != nil {
+            self.signOutURIQueryParameters = hostedUIOptions.signOutURIQueryParameters
+        }
+        
+        saveOAuthURIQueryParametersInKeychain()
+        
+        if (clientId == nil || scopes == nil || signInRedirectURI == nil || signOutRedirectURI == nil) {
+            completionHandler(nil, AWSMobileClientError.invalidConfiguration(message: "Please provide all configuration parameters to use the hosted UI feature."))
+        }
+        
+        let cognitoAuthConfig: AWSCognitoAuthConfiguration = AWSCognitoAuthConfiguration.init(appClientId: clientId!,
+                                         appClientSecret: secret,
+                                         scopes: Set<String>(self.scopes!.map { $0 }),
+                                         signInRedirectUri: signInRedirectURI!,
+                                         signOutRedirectUri: signOutRedirectURI!,
+                                         webDomain: hostURL,
+                                         identityProvider: identityProvider,
+                                         idpIdentifier: idpIdentifier,
+                                         signInUri: signInURI,
+                                         signOutUri: signOutURI,
+                                         tokensUri: tokensURI,
+                                         signInUriQueryParameters: self.signInURIQueryParameters,
+                                         signOutUriQueryParameters: self.signOutURIQueryParameters,
+                                         tokenUriQueryParameters: self.tokenURIQueryParameters,
+                                         userPoolServiceConfiguration: AWSMobileClient.serviceConfiguration?.userPoolServiceConfiguration,
+                                         signInPrivateSession: hostedUIOptions.signInPrivateSession)
+
+        if (isCognitoAuthRegistered) {
+            AWSCognitoAuth.remove(forKey: CognitoAuthRegistrationKey)
+        }
+        AWSCognitoAuth.registerCognitoAuth(with: cognitoAuthConfig, forKey: CognitoAuthRegistrationKey)
+        isCognitoAuthRegistered = true
+    }
+    
+    private func handleCognitoAuthGetSession(hostedUIOptions: HostedUIOptions,
+                                             session: AWSCognitoAuthUserSession?,
+                                             error: Error?,
+                                             _ completionHandler: @escaping(UserState?, Error?) -> Void) {
+        guard error == nil else {
+            completionHandler(nil, error)
+            return
+        }
+        
+        if let session = session {
+            var signInInfo = [String: String]()
+            var federationToken: String? = nil
+            if let idToken = session.idToken?.tokenString {
+                federationToken = idToken
+            } else if let accessToken = session.accessToken?.tokenString {
+                federationToken = accessToken
+            }
+            
+            guard federationToken != nil else {
+                completionHandler(nil, AWSMobileClientError.idTokenAndAcceessTokenNotIssued(message: "No ID token or access token was issued."))
+                return
+            }
+            
+            if let identityProvider = hostedUIOptions.identityProvider {
+                signInInfo["identityProvider"] = identityProvider
+            }
+            if let idpIdentifier = hostedUIOptions.idpIdentifier {
+                signInInfo["idpIdentifier"] = idpIdentifier
+            }
+            signInInfo[self.TokenKey] = session.accessToken!.tokenString
+            signInInfo[self.ProviderKey] = "OAuth"
+            
+            // Upon successful sign in, store scopes specified using HostedUIOptions in Keychain
+            if hostedUIOptions.scopes != nil {
+                self.saveHostedUIOptionsScopesInKeychain()
+            }
+            let federationProviderIdentifier = hostedUIOptions.federationProviderName
+            
+            self.performHostedUISuccessfulSignInTasks(disableFederation: hostedUIOptions.disableFederation, session: session, federationToken: federationToken!, federationProviderIdentifier: federationProviderIdentifier, signInInfo: &signInInfo)
+            self.mobileClientStatusChanged(userState: .signedIn, additionalInfo: signInInfo)
+            completionHandler(.signedIn, nil)
+            if self.pendingGetTokensCompletion != nil {
+                self.tokenFetchLock.leave()
+            }
+            self.pendingGetTokensCompletion?(self.getTokensForCognitoAuthSession(session: session), nil)
+            self.pendingGetTokensCompletion = nil
         }
     }
 }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -505,24 +505,6 @@ extension AWSMobileClient {
         }
     }
     
-    private func hostedUILegacySignOut(completionHandler: @escaping ((Error?) -> Void)) {
-        AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut { (error) in
-            self.handleHostedUISignOutResult(error, completionHandler: completionHandler)
-        }
-    }
-    
-    private func hostedUISignOut(presentationAnchor: ASPresentationAnchor,
-                                 completionHandler: @escaping ((Error?) -> Void)) {
-        if #available(iOS 13, *) {
-            AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut(withWebUI: presentationAnchor) { (error) in
-                self.handleHostedUISignOutResult(error, completionHandler: completionHandler)
-            }
-        } else {
-            // Fallback on earlier versions
-            self.hostedUILegacySignOut(completionHandler: completionHandler)
-        }
-    }
-    
     private func handleHostedUISignOutResult(_ error: Error?, completionHandler: @escaping ((Error?) -> Void)) {
         if (error != nil) {
             completionHandler(AWSMobileClientError.makeMobileClientError(from: error!))
@@ -593,6 +575,24 @@ extension AWSMobileClient {
         }
         signOut()
         completionHandler(nil)
+    }
+    
+    private func hostedUISignOut(presentationAnchor: ASPresentationAnchor,
+                                 completionHandler: @escaping ((Error?) -> Void)) {
+        if #available(iOS 13, *) {
+            AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut(withWebUI: presentationAnchor) { (error) in
+                self.handleHostedUISignOutResult(error, completionHandler: completionHandler)
+            }
+        } else {
+            // Fallback on earlier versions
+            self.hostedUILegacySignOut(completionHandler: completionHandler)
+        }
+    }
+    
+    private func hostedUILegacySignOut(completionHandler: @escaping ((Error?) -> Void)) {
+        AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut { (error) in
+            self.handleHostedUISignOutResult(error, completionHandler: completionHandler)
+        }
     }
     
     /// Signs out the current logged in user and clears the local keychain store.

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -505,24 +505,73 @@ extension AWSMobileClient {
         }
     }
     
+    private func hostedUILegacySignOut(completionHandler: @escaping ((Error?) -> Void)) {
+        AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut { (error) in
+            self.handleHostedUISignOutResult(error, completionHandler: completionHandler)
+        }
+    }
+    
+    private func hostedUISignOut(presentationAnchor: ASPresentationAnchor,
+                                 completionHandler: @escaping ((Error?) -> Void)) {
+        if #available(iOS 13, *) {
+            AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut(withWebUI: presentationAnchor) { (error) in
+                self.handleHostedUISignOutResult(error, completionHandler: completionHandler)
+            }
+        } else {
+            // Fallback on earlier versions
+            self.hostedUILegacySignOut(completionHandler: completionHandler)
+        }
+    }
+    
+    private func handleHostedUISignOutResult(_ error: Error?, completionHandler: @escaping ((Error?) -> Void)) {
+        if (error != nil) {
+            completionHandler(AWSMobileClientError.makeMobileClientError(from: error!))
+        } else {
+            // If the token is successfully invalidated, we clear tokens locally and perform signout flow.
+            self.signOut()
+            completionHandler(nil)
+        }
+    }
+    
+    
+    /// Asynchronous signout method which requires network activity. Based on the options specified in `SignOutOptions`, appropriate tasks will be performed.
+    ///
+    /// - Parameters:
+    ///   - options: SignOutOptions which specify actions.
+    ///   - presentationAnchor: If you have
+    ///   - completionHandler: completion handler for success or error callback.
+    @available(iOS 13, *)
+    public func signOut(presentationAnchor: ASPresentationAnchor,
+                        options: SignOutOptions = SignOutOptions(),
+                        completionHandler: @escaping ((Error?) -> Void)) {
+        internalSignOut(presentationAnchor: presentationAnchor,
+                        options: options,
+                        completionHandler: completionHandler)
+    }
+    
+    
     /// Asynchronous signout method which requires network activity. Based on the options specified in `SignOutOptions`, appropriate tasks will be performed.
     ///
     /// - Parameters:
     ///   - options: SignOutOptions which specify actions.
     ///   - completionHandler: completion handler for success or error callback.
-    public func signOut(options: SignOutOptions = SignOutOptions(), completionHandler: @escaping ((Error?) -> Void)) {
-        // If using hosted UI, we need to launch SFSafariVC or SFAuthSession to invalidate token
+    public func signOut(options: SignOutOptions = SignOutOptions(),
+                        completionHandler: @escaping ((Error?) -> Void)) {
+        internalSignOut(presentationAnchor: nil,
+                        options: options,
+                        completionHandler: completionHandler)
+    }
+
+    private func internalSignOut(presentationAnchor: ASPresentationAnchor? = nil,
+                                 options: SignOutOptions = SignOutOptions(),
+                        completionHandler: @escaping ((Error?) -> Void)) {
+        // If using hosted UI, we need to launch SFSafariVC/SFAuthSession/ASWebAuthenticationSession to invalidate token
         if federationProvider == .hostedUI {
             if options.invalidateTokens {
-                AWSCognitoAuth.init(forKey: CognitoAuthRegistrationKey).signOut { (error) in
-                    // If there is an error invalidating tokens, we return error to the developer.
-                    if (error != nil) {
-                        completionHandler(AWSMobileClientError.makeMobileClientError(from: error!))
-                    } else {
-                        // If the token is successfully invalidated, we clear tokens locally and perform signout flow.
-                        self.signOut()
-                        completionHandler(nil)
-                    }
+                if let anchor = presentationAnchor {
+                    self.hostedUISignOut(presentationAnchor: anchor, completionHandler: completionHandler)
+                } else {
+                    self.hostedUILegacySignOut(completionHandler: completionHandler)
                 }
             }
             return

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileOptions.swift
@@ -92,6 +92,7 @@ public struct HostedUIOptions {
     let tokenURIQueryParameters: [String: String]?
     let signOutURIQueryParameters: [String: String]?
     
+    let signInPrivateSession: Bool
     
     /// Initializer for hosted UI options.
     ///
@@ -111,7 +112,8 @@ public struct HostedUIOptions {
                 federationProviderName: String? = nil,
                 signInURIQueryParameters: [String: String]? = nil,
                 tokenURIQueryParameters: [String: String]? = nil,
-                signOutURIQueryParameters: [String: String]? = nil) {
+                signOutURIQueryParameters: [String: String]? = nil,
+                signInPrivateSession: Bool = false) {
         self.disableFederation = disableFederation
         self.scopes = scopes
         if let identityProvider = identityProvider {
@@ -129,6 +131,7 @@ public struct HostedUIOptions {
         self.signInURIQueryParameters = signInURIQueryParameters
         self.tokenURIQueryParameters = tokenURIQueryParameters
         self.signOutURIQueryParameters = signOutURIQueryParameters
+        self.signInPrivateSession = signInPrivateSession
     }
 }
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
@@ -36,22 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
        userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration
                signInPrivateSession:(BOOL)signInPrivateSession;
 
-- (instancetype)initWithAppClientId:(NSString *) appClientId
-                    appClientSecret:(nullable NSString *)appClientSecret
-                             scopes:(NSSet<NSString *> *) scopes
-                  signInRedirectUri:(NSString *) signInRedirectUri
-                 signOutRedirectUri:(NSString *) signOutRedirectUri
-                          webDomain:(NSString *) webDomain
-                   identityProvider:(nullable NSString *)identityProvider
-                      idpIdentifier:(nullable NSString *)idpIdentifier
-                          signInUri:(nullable NSString *) signInUri
-                         signOutUri:(nullable NSString *) signOutUri
-                          tokensUri:(nullable NSString *) tokensUri
-           signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
-          signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
-       userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
@@ -33,6 +33,23 @@ NS_ASSUME_NONNULL_BEGIN
            signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
           signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
             tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
+       userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration
+               signInPrivateSession:(BOOL)signInPrivateSession;
+
+- (instancetype)initWithAppClientId:(NSString *) appClientId
+                    appClientSecret:(nullable NSString *)appClientSecret
+                             scopes:(NSSet<NSString *> *) scopes
+                  signInRedirectUri:(NSString *) signInRedirectUri
+                 signOutRedirectUri:(NSString *) signOutRedirectUri
+                          webDomain:(NSString *) webDomain
+                   identityProvider:(nullable NSString *)identityProvider
+                      idpIdentifier:(nullable NSString *)idpIdentifier
+                          signInUri:(nullable NSString *) signInUri
+                         signOutUri:(nullable NSString *) signOutUri
+                          tokensUri:(nullable NSString *) tokensUri
+           signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
+          signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
+            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
        userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration;
 
 @end

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
@@ -36,7 +36,8 @@
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
                     tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
                          isProviderExternal:(BOOL) isProviderExternal
-               cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig;
+               cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig
+                       signInPrivateSession:(BOOL)isSignInPrivateSession;
 
 @end
 
@@ -57,7 +58,41 @@
           signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
             tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
        userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration {
+    return [self initWithAppClientId:appClientId
+                     appClientSecret:appClientSecret
+                              scopes:scopes
+                   signInRedirectUri:signInRedirectUri
+                  signOutRedirectUri:signOutRedirectUri
+                           webDomain:webDomain
+                    identityProvider:identityProvider
+                       idpIdentifier:idpIdentifier
+                           signInUri:signInUri
+                          signOutUri:signOutUri
+                           tokensUri:tokensUri
+            signInUriQueryParameters:signInUriQueryParameters
+           signOutUriQueryParameters:signOutUriQueryParameters
+             tokenUriQueryParameters:tokenUriQueryParameters
+        userPoolServiceConfiguration:serviceConfiguration
+                signInPrivateSession:NO];
     
+}
+
+- (instancetype)initWithAppClientId:(NSString *) appClientId
+                    appClientSecret:(nullable NSString *)appClientSecret
+                             scopes:(NSSet<NSString *> *) scopes
+                  signInRedirectUri:(NSString *) signInRedirectUri
+                 signOutRedirectUri:(NSString *) signOutRedirectUri
+                          webDomain:(NSString *) webDomain
+                   identityProvider:(nullable NSString *)identityProvider
+                      idpIdentifier:(nullable NSString *)idpIdentifier
+                          signInUri:(nullable NSString *) signInUri
+                         signOutUri:(nullable NSString *) signOutUri
+                          tokensUri:(nullable NSString *) tokensUri
+           signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
+          signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
+            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
+       userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration
+               signInPrivateSession:(BOOL)signInPrivateSession {
     BOOL isProviderExternal = YES;
     if (signInUri == nil && signOutUri == nil && tokensUri == nil) {
         isProviderExternal = NO;
@@ -80,7 +115,8 @@
                    signOutUriQueryParameters:signOutUriQueryParameters
                      tokenUriQueryParameters:tokenUriQueryParameters
                           isProviderExternal:isProviderExternal
-                cognitoUserPoolServiceConfig:serviceConfiguration];
+                cognitoUserPoolServiceConfig:serviceConfiguration
+                        signInPrivateSession:signInPrivateSession];
 }
 
 @end

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
@@ -57,40 +57,6 @@
            signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
           signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
             tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
-       userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration {
-    return [self initWithAppClientId:appClientId
-                     appClientSecret:appClientSecret
-                              scopes:scopes
-                   signInRedirectUri:signInRedirectUri
-                  signOutRedirectUri:signOutRedirectUri
-                           webDomain:webDomain
-                    identityProvider:identityProvider
-                       idpIdentifier:idpIdentifier
-                           signInUri:signInUri
-                          signOutUri:signOutUri
-                           tokensUri:tokensUri
-            signInUriQueryParameters:signInUriQueryParameters
-           signOutUriQueryParameters:signOutUriQueryParameters
-             tokenUriQueryParameters:tokenUriQueryParameters
-        userPoolServiceConfiguration:serviceConfiguration
-                signInPrivateSession:NO];
-    
-}
-
-- (instancetype)initWithAppClientId:(NSString *) appClientId
-                    appClientSecret:(nullable NSString *)appClientSecret
-                             scopes:(NSSet<NSString *> *) scopes
-                  signInRedirectUri:(NSString *) signInRedirectUri
-                 signOutRedirectUri:(NSString *) signOutRedirectUri
-                          webDomain:(NSString *) webDomain
-                   identityProvider:(nullable NSString *)identityProvider
-                      idpIdentifier:(nullable NSString *)idpIdentifier
-                          signInUri:(nullable NSString *) signInUri
-                         signOutUri:(nullable NSString *) signOutUri
-                          tokensUri:(nullable NSString *) tokensUri
-           signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
-          signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
        userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration
                signInPrivateSession:(BOOL)signInPrivateSession {
     BOOL isProviderExternal = YES;

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -15,9 +15,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#if __has_include(<AuthenticationServices/AuthenticationServices.h>)
 #import <AuthenticationServices/AuthenticationServices.h>
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -15,6 +15,9 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#if __has_include(<AuthenticationServices/AuthenticationServices.h>)
+#import <AuthenticationServices/AuthenticationServices.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -104,6 +107,9 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  */
 + (void)removeCognitoAuthForKey:(NSString *)key;
 
+- (void)getSessionWithWebUI:(nonnull ASPresentationAnchor) anchor
+                 completion:(nullable AWSCognitoAuthGetSessionBlock) completion API_AVAILABLE(ios(13));
+
 /**
  Get a session with id, access and refresh tokens.
  @param vc viewController to display the UI on if needed during sign in.
@@ -116,6 +122,9 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param completion completion block to invoke on completion
  */
 - (void)getSession: (nullable AWSCognitoAuthGetSessionBlock) completion;
+
+- (void) signOutWithWebUI:(nonnull ASPresentationAnchor) anchor
+               completion:(AWSCognitoAuthSignOutBlock)completion API_AVAILABLE(ios(13));
 
 /**
  Sign out locally and from the server.

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -55,6 +55,15 @@ API_AVAILABLE(ios(11.0))
 
 @end
 
+API_AVAILABLE(ios(13.0))
+@interface AWSCognitoAuth()<ASWebAuthenticationPresentationContextProviding>
+
+@property (nonatomic, strong) ASWebAuthenticationSession *asAuthSession;
+@property (nonatomic, weak) ASPresentationAnchor presentationAnchor;
+
+
+@end
+
 @interface AWSCognitoAuthConfiguration()
 
 @property (nonatomic, readwrite) NSString * signInUri;
@@ -64,6 +73,7 @@ API_AVAILABLE(ios(11.0))
 @property (nonatomic, readwrite) NSDictionary<NSString *, NSString *> * tokensUriQueryParameters;
 @property (nonatomic, readwrite) NSDictionary<NSString *, NSString *> * signOutUriQueryParameters;
 @property (nonatomic) BOOL isAuthProviderExternal;
+@property (nonatomic) BOOL isSignInPrivateSession;
 @property (nonatomic) AWSServiceConfiguration * userPoolConfig;
 
 @end
@@ -209,11 +219,19 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 #pragma mark sign in
 
 - (void)getSession:(AWSCognitoAuthGetSessionBlock) completion {
+    self.presentationAnchor = nil;
     [self enqueueGetSession:nil completion:completion];
 }
 
 - (void)getSession:(UIViewController *) vc completion: (AWSCognitoAuthGetSessionBlock) completion {
+    self.presentationAnchor = nil;
     [self enqueueGetSession:vc completion:completion];
+}
+
+- (void)getSessionWithWebUI: (ASPresentationAnchor) anchor
+                 completion: (nullable AWSCognitoAuthGetSessionBlock) completion {
+    self.presentationAnchor = anchor;
+    [self enqueueGetSession:nil completion:completion];
 }
 
 /**
@@ -256,36 +274,94 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         }
     }
     if(self.authConfiguration.asfEnabled){
-        NSString *userContextEncoded = [AWSCognitoIdentityProviderASF userContextData:self.authConfiguration.userPoolId username:@"unknown" deviceId:[self asfDeviceId] userPoolClientId:self.authConfiguration.appClientId];
+        NSString *userContextEncoded = [AWSCognitoIdentityProviderASF userContextData:self.authConfiguration.userPoolId
+                                                                             username:@"unknown"
+                                                                             deviceId:[self asfDeviceId]
+                                                                     userPoolClientId:self.authConfiguration.appClientId];
         NSString * userContext = [NSString stringWithFormat:@"&userContextData=%@",[self urlEncode:userContextEncoded]];
         suffix = [suffix stringByAppendingString:userContext];
     }
 
-    NSString *url = [NSString stringWithFormat:@"%@?response_type=code&client_id=%@&state=%@&redirect_uri=%@&scope=%@&code_challenge=%@&code_challenge_method=S256%@&%@",self.authConfiguration.signInUri, self.authConfiguration.appClientId, self.state,[self urlEncode:self.authConfiguration.signInRedirectUri], [self urlEncode:[self normalizeScopes]], self.proofKeyHash, suffix, [self getQueryStringSuffixForParameters: self.authConfiguration.signInUriQueryParameters]];
+    NSString *urlString = [NSString stringWithFormat:@"%@?response_type=code&client_id=%@&state=%@&redirect_uri=%@&scope=%@&code_challenge=%@&code_challenge_method=S256%@&%@",
+                     self.authConfiguration.signInUri,
+                     self.authConfiguration.appClientId,
+                     self.state,
+                     [self urlEncode:self.authConfiguration.signInRedirectUri],
+                     [self urlEncode:[self normalizeScopes]],
+                     self.proofKeyHash,
+                     suffix,
+                     [self getQueryStringSuffixForParameters: self.authConfiguration.signInUriQueryParameters]];
 
-    if (self.useSFAuthenticationSession) {
-        if (@available(iOS 11.0, *)) {
-            self.sfAuthenticationSessionAvailable = YES;
-            self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:[NSURL URLWithString:url] callbackURLScheme:[self urlEncode:self.authConfiguration.signInRedirectUri] completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
-                if (url) {
-                    [self processURL:url forRedirection:NO];
-                } else {
-                    [self dismissSafariViewControllerAndCompleteGetSession:nil error:error];
-                }
-            }];
-            [self.sfAuthSession start];
+    NSURL *url = [NSURL URLWithString:urlString];
+    if(@available(iOS 13.0, *)) {
+        if (self.presentationAnchor) {
+            [self launchASWebAuthenticationSession: url];
         } else {
-            // Fallback on earlier versions
-            [self showSFSafariViewControllerForURL:url withPresentingViewController:vc];
+            [self launchLegacySession:url withPresentingViewController:vc];
         }
     } else {
-        [self showSFSafariViewControllerForURL:url withPresentingViewController:vc];
+        [self launchLegacySession:url withPresentingViewController:vc];
     }
 }
 
--(void)showSFSafariViewControllerForURL:(NSString *)url
+- (void)launchLegacySession:(NSURL *)url
+withPresentingViewController:(UIViewController *)presentingViewController {
+    if (self.useSFAuthenticationSession) {
+        if (@available(iOS 11.0, *)) {
+            [self launchSFWebAuthenticationSession: url];
+        } else {
+            // Fallback on earlier versions
+            [self showSFSafariViewControllerForURL:url withPresentingViewController:presentingViewController];
+        }
+    } else {
+        [self showSFSafariViewControllerForURL:url withPresentingViewController:presentingViewController];
+    }
+}
+
+- (void)launchSFWebAuthenticationSession:(NSURL *)hostedUIURL API_AVAILABLE(ios(11.0)) {
+    self.sfAuthenticationSessionAvailable = YES;
+    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signInRedirectUri] copy];
+    self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:hostedUIURL
+                                                    callbackURLScheme:callbackURLScheme
+                                                    completionHandler:^(NSURL * _Nullable url,
+                                                                        NSError * _Nullable error) {
+        [self handleSignInCallbackWithURL:url error:error];
+    }];
+    [self.sfAuthSession start];
+}
+
+- (void)launchASWebAuthenticationSession:(NSURL *)hostedUIURL API_AVAILABLE(ios(13.0)) {
+    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signInRedirectUri] copy];
+    self.asAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:hostedUIURL
+                                                       callbackURLScheme:callbackURLScheme
+                                                       completionHandler:^(NSURL * _Nullable url,
+                                                                           NSError * _Nullable error) {
+        [self handleSignInCallbackWithURL:url error:error];
+    }];
+    
+    if (@available(iOS 13.0, *)) {
+        self.asAuthSession.prefersEphemeralWebBrowserSession = self.authConfiguration.isSignInPrivateSession;
+        self.asAuthSession.presentationContextProvider = self;
+    }
+    [self.asAuthSession start];
+}
+
+- (nonnull ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(nonnull ASWebAuthenticationSession *)session  API_AVAILABLE(ios(13.0)) {
+    return self.presentationAnchor;
+}
+
+- (void)handleSignInCallbackWithURL:(NSURL * _Nullable) url
+                              error:(NSError * _Nullable) error {
+    if (url) {
+        [self processURL:url forRedirection:NO];
+    } else {
+        [self dismissSafariViewControllerAndCompleteGetSession:nil error:error];
+    }
+}
+
+-(void)showSFSafariViewControllerForURL:(NSURL *)url
            withPresentingViewController:(UIViewController *)presentingViewController{
-    self.svc = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:url] entersReaderIfAvailable:NO];
+    self.svc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:NO];
     self.svc.delegate = self;
     self.svc.modalPresentationStyle = UIModalPresentationPopover;
     self.isProcessingSignIn = YES;
@@ -430,6 +506,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 }
 
 - (void) signOut: (AWSCognitoAuthSignOutBlock) completion {
+    self.presentationAnchor = nil;
     if(!self.delegate){
         completion([self getError:@"delegate must be set to a valid AWSCognitoAuthDelegate" code:AWSCognitoAuthClientInvalidAuthenticationDelegate]);
     }else {
@@ -438,6 +515,17 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 }
 
 - (void) signOut: (UIViewController *) vc completion: (AWSCognitoAuthSignOutBlock) completion {
+    self.presentationAnchor = nil;
+    [self enqueueSignOut:nil completion:completion];
+}
+
+- (void) signOutWithWebUI:(ASPresentationAnchor) anchor completion:(AWSCognitoAuthSignOutBlock) completion {
+    self.presentationAnchor = anchor;
+    [self enqueueSignOut:nil completion:completion];
+}
+
+- (void)enqueueSignOut:(nullable UIViewController *) vc
+            completion: (AWSCognitoAuthSignOutBlock) completion {
     __block __weak NSOperation *weakSignOutOperation;
     NSOperation *signOutOperation =  [NSBlockOperation blockOperationWithBlock:^{
         if(weakSignOutOperation.isCancelled){
@@ -447,7 +535,6 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
     }];
     weakSignOutOperation = signOutOperation;
     [self.signOutQueue addOperation:signOutOperation];
-
 }
 
 - (NSString *)getQueryStringSuffixForParameters:(NSDictionary<NSString *, NSString *> *)queryParameters {
@@ -473,37 +560,78 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
  */
 - (void) signOutInternal: (UIViewController *) vc completion: (AWSCognitoAuthSignOutBlock) completion {
     self.signOutBlock = completion;
-    NSString *url = [NSString stringWithFormat:@"%@?%@",
+    NSString *urlString = [NSString stringWithFormat:@"%@?%@",
                      self.authConfiguration.signOutUri,
                      [self getQueryStringSuffixForParameters:self.authConfiguration.signOutUriQueryParameters]];
-
-    if (self.useSFAuthenticationSession) {
-        if (@available(iOS 11.0, *)) {
-            self.sfAuthenticationSessionAvailable = YES;
-            self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:[NSURL URLWithString:url] callbackURLScheme:[self urlEncode:self.authConfiguration.signOutRedirectUri] completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
-                if (url) {
-                    [self processURL:url forRedirection:NO];
-                } else {
-                    if (error.code != SFAuthenticationErrorCanceledLogin) {
-                        [self signOutLocallyAndClearLastKnownUser];
-                    }
-                    [self dismissSafariViewControllerAndCompleteSignOut:error];
-                }
-            }];
-            [self.sfAuthSession start];
+    NSURL *url = [NSURL URLWithString:urlString];
+    if(@available(iOS 13.0, *)) {
+        if (self.presentationAnchor) {
+            [self launchASWebAuthenticationSessionForSignOut: url];
         } else {
-            [self signOutSFSafariVC:vc
-                                url:url];
+            [self launchLegacySessionForSignOut:url withPresentingViewController:vc];
         }
     } else {
-        [self signOutSFSafariVC:vc
-                            url:url];
+        [self launchLegacySessionForSignOut:url withPresentingViewController:vc];
+    }
+}
+
+
+- (void)launchSFAuthenticationSessionForSignOut:(NSURL *) url API_AVAILABLE(ios(11.0)) {
+    self.sfAuthenticationSessionAvailable = YES;
+    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
+    self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:url
+                                                    callbackURLScheme:callbackURLScheme
+                                                    completionHandler:^(NSURL * _Nullable url,
+                                                                        NSError * _Nullable error) {
+        if (url) {
+            [self processURL:url forRedirection:NO];
+        } else {
+            if (error.code != SFAuthenticationErrorCanceledLogin) {
+                [self signOutLocallyAndClearLastKnownUser];
+            }
+            [self dismissSafariViewControllerAndCompleteSignOut:error];
+        }
+    }];
+    [self.sfAuthSession start];
+}
+
+- (void)launchASWebAuthenticationSessionForSignOut:(NSURL *) url API_AVAILABLE(ios(13.0)) {
+    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
+    self.asAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:url
+                                                    callbackURLScheme:callbackURLScheme
+                                                    completionHandler:^(NSURL * _Nullable url,
+                                                                        NSError * _Nullable error) {
+        if (url) {
+            [self processURL:url forRedirection:NO];
+        } else {
+            if (error.code != ASWebAuthenticationSessionErrorCodeCanceledLogin) {
+                [self signOutLocallyAndClearLastKnownUser];
+            }
+            [self dismissSafariViewControllerAndCompleteSignOut:error];
+        }
+    }];
+    if (@available(iOS 13.0, *)) {
+        self.asAuthSession.presentationContextProvider = self;
+    }
+    [self.asAuthSession start];
+}
+
+- (void)launchLegacySessionForSignOut:(NSURL *) url
+         withPresentingViewController:(UIViewController *) presentingViewController {
+    if (self.useSFAuthenticationSession) {
+        if (@available(iOS 11.0, *)) {
+            [self launchSFAuthenticationSessionForSignOut:url];
+        } else {
+            [self signOutSFSafariVC:presentingViewController url:url];
+        }
+    } else {
+        [self signOutSFSafariVC:presentingViewController url:url];
     }
 }
 
 - (void)signOutSFSafariVC: (UIViewController *) vc
-                      url:(NSString *)url {
-    self.svc = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:url] entersReaderIfAvailable:NO];
+                      url:(NSURL *)url {
+    self.svc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:NO];
     self.svc.delegate = self;
     self.svc.modalPresentationStyle = UIModalPresentationPopover;
     self.isProcessingSignOut = YES;
@@ -1172,7 +1300,8 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                    signOutUriQueryParameters:signOutUriQueryParameters
                      tokenUriQueryParameters:tokenUriQueryParameters
                           isProviderExternal:isProviderExternal
-                cognitoUserPoolServiceConfig: nil];
+                cognitoUserPoolServiceConfig:nil
+                        signInPrivateSession:NO];
 }
 
 - (instancetype)initWithAppClientIdInternal:(NSString *) appClientId
@@ -1192,7 +1321,8 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
                     tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
                          isProviderExternal:(BOOL) isProviderExternal
-               cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig {
+               cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig
+                       signInPrivateSession:(BOOL)isSignInPrivateSession {
     if (self = [super init]) {
         
         if (!isProviderExternal) {
@@ -1221,6 +1351,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
         _tokensUriQueryParameters = tokenUriQueryParameters;
         _isAuthProviderExternal = isProviderExternal;
         _userPoolConfig = serviceConfig;
+        _isSignInPrivateSession = isSignInPrivateSession;
     }
     
     return self;
@@ -1245,7 +1376,9 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                                                                                        signInUriQueryParameters:self.signInUriQueryParameters
                                                                                       signOutUriQueryParameters:self.signOutUriQueryParameters
                                                                                         tokenUriQueryParameters:self.tokensUriQueryParameters
-                                                                                             isProviderExternal:self.isAuthProviderExternal];
+                                                                                             isProviderExternal:self.isAuthProviderExternal
+                                                                                   cognitoUserPoolServiceConfig:self.userPoolConfig
+                                                                                           signInPrivateSession:self.isSignInPrivateSession];
     return configuration;
 }
 

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -575,26 +575,6 @@ withPresentingViewController:(UIViewController *)presentingViewController {
     }
 }
 
-
-- (void)launchSFAuthenticationSessionForSignOut:(NSURL *) url API_AVAILABLE(ios(11.0)) {
-    self.sfAuthenticationSessionAvailable = YES;
-    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
-    self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:url
-                                                    callbackURLScheme:callbackURLScheme
-                                                    completionHandler:^(NSURL * _Nullable url,
-                                                                        NSError * _Nullable error) {
-        if (url) {
-            [self processURL:url forRedirection:NO];
-        } else {
-            if (error.code != SFAuthenticationErrorCanceledLogin) {
-                [self signOutLocallyAndClearLastKnownUser];
-            }
-            [self dismissSafariViewControllerAndCompleteSignOut:error];
-        }
-    }];
-    [self.sfAuthSession start];
-}
-
 - (void)launchASWebAuthenticationSessionForSignOut:(NSURL *) url API_AVAILABLE(ios(13.0)) {
     NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
     self.asAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:url
@@ -627,6 +607,25 @@ withPresentingViewController:(UIViewController *)presentingViewController {
     } else {
         [self signOutSFSafariVC:presentingViewController url:url];
     }
+}
+
+- (void)launchSFAuthenticationSessionForSignOut:(NSURL *) url API_AVAILABLE(ios(11.0)) {
+    self.sfAuthenticationSessionAvailable = YES;
+    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
+    self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:url
+                                                    callbackURLScheme:callbackURLScheme
+                                                    completionHandler:^(NSURL * _Nullable url,
+                                                                        NSError * _Nullable error) {
+        if (url) {
+            [self processURL:url forRedirection:NO];
+        } else {
+            if (error.code != SFAuthenticationErrorCanceledLogin) {
+                [self signOutLocallyAndClearLastKnownUser];
+            }
+            [self dismissSafariViewControllerAndCompleteSignOut:error];
+        }
+    }];
+    [self.sfAuthSession start];
 }
 
 - (void)signOutSFSafariVC: (UIViewController *) vc


### PR DESCRIPTION
*Description of changes:* Adds support for `ASWebAuthenticationSession` to `AWSCognitoAuth` and `AWSMobileClient`. Since ASWebAuthenticationSession require a presentation anchor to show the UI, the following new apis are added:

AWSCognitoAuth

```objc

- (void)getSessionWithWebUI:(nonnull ASPresentationAnchor) anchor
                  completion:(nullable AWSCognitoAuthGetSessionBlock) completion API_AVAILABLE(ios(13));

- (void) signOutWithWebUI:(nonnull ASPresentationAnchor) anchor
                completion:(AWSCognitoAuthSignOutBlock)completion API_AVAILABLE(ios(13));
```

AWSMobileClient

```swift

@available(iOS 13, *)
     public func showSignIn(presentationAnchor: ASPresentationAnchor,
                            hostedUIOptions: HostedUIOptions,
                            _ completionHandler: @escaping(UserState?, Error?) -> Void) 

@available(iOS 13, *)
     public func signOut(presentationAnchor: ASPresentationAnchor,
                         options: SignOutOptions = SignOutOptions(),
                         completionHandler: @escaping ((Error?) -> Void))
```

Also a new parameter is also added for private session in `HostedUIOptions` and `AWSCognitoAuthConfiguration`. 

---

The support for `ASWebAuthenticationSession` in the Auth SDK is from 13.0 because `ASPresentationAnchor` support is from 13.0. The following test cases were manually tested:

AWSMobileClient

*Case a: SignIn with SFAuth and SignOut with SFAuth (iOS > 13.0, iOS 12.0)*


1. SignIn using SFAuthentication was successful and successfully retrieved credentials
```swift
AWSMobileClient.default().showSignIn(navigationController: self.navigationController,
                                    hostedUIOptions: hostedUIOptions)
```
2. SignOut using SFAuthentication flow was successful
```swift
AWSMobileClient.default().signOut { (error) in

}
```
Worked in iOS 14.0 and iOS 12.0


*Case b: SignIn With SFAuth and SignOut using ASWebAuth*

1. SignIn using SFAuthentication was successful and successfully retrieved credentials
```swift
AWSMobileClient.default().showSignIn(navigationController: self.navigationController,
                                    hostedUIOptions: hostedUIOptions)
```
2. SignOut using ASWebAuthenticationSession flow was successful
```swift
AWSMobileClient.default().signOut (presentationAnchor: self.view.window!) { (error) in

}
```

*Case c: SignIn with ASWebAuth and SignOut using ASWebAuth*

1. SignIn using ASWebAuthenticationSession was successful and successfully retrieved credentials
```swift
AWSMobileClient.default().showSignIn(presentationAnchor: self.view.window!,
                                    hostedUIOptions: hostedUIOptions)
```
2. SignOut using ASWebAuthenticationSession flow was successful
```swift
AWSMobileClient.default().signOut (presentationAnchor: self.view.window!) { (error) in

}
```

*Case d: SignIn with ASWebAuth and SignOut using SFAuth*

1. SignIn using ASWebAuth was successful and successfully retrieved credentials
```swift
AWSMobileClient.default().showSignIn(presentationAnchor: self.view.window!,
                                    hostedUIOptions: hostedUIOptions)
```
2. SignOut using SFAuthentication flow was successful
```swift
AWSMobileClient.default().signOut { (error) in

}
```
*Case e: SignIn with ASWebAuth with private mode and SignOut using ASWebAuth*

1. SignIn using ASWebAuthenticationSession was successful and successfully retrieved credentials
```swift
let hostedUIOptions = HostedUIOptions(scopes: ["openid", "email"], 
                        signInPrivateSession: true)
AWSMobileClient.default().showSignIn(presentationAnchor: self.view.window!,
                                    hostedUIOptions: hostedUIOptions)
```
2. SignOut using ASWebAuthenticationSession flow was successful
```swift
AWSMobileClient.default().signOut (presentationAnchor: self.view.window!) { (error) in

}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
