### PR TITLE
fix: apple signin import AuthenticationServices

### DIFF
--- a/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.h
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.h
@@ -14,6 +14,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 #import <AWSAuthCore/AWSSignInProvider.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m
@@ -113,7 +113,7 @@ static NSString *const AWSInfoAppleIdentifier = @"AppleSignIn";
     [controller performRequests];
 }
 
-(void)authorizationController:(ASAuthorizationController *)controller
+- (void)authorizationController:(ASAuthorizationController *)controller
    didCompleteWithAuthorization:(ASAuthorization *)authorization {
     self.credential = [authorization credential];
     NSData *idTokenData = [self.credential identityToken];


### PR DESCRIPTION
*Issue #, if available:*
```
/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.h:40:28: error: unknown type name 'ASAuthorizationAppleIDCredential'
@property (strong, atomic) ASAuthorizationAppleIDCredential *credential;
                           ^
/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.h:40:1: error: property with 'retain (or strong)' attribute must be of object type
@property (strong, atomic) ASAuthorizationAppleIDCredential *credential;
^
/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m:116:2: error: expected identifier or '('
(void)authorizationController:(ASAuthorizationController *)controller
 ^
/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m:116:2: error: expected ')'
/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m:116:1: note: to match this '('
(void)authorizationController:(ASAuthorizationController *)controller
^
4 errors generated.
```
*Description of changes:*
this fix is based off of https://github.com/aws-amplify/aws-sdk-ios/pull/3308

- Build from xcode for AWSAppleSignIn target successful
- the carthage step that it failed on was tested locally and was successful
ran
```
/usr/bin/xcrun xcodebuild -project AWSAuthSDK/AWSAuthSDK.xcodeproj -scheme AWSAppleSignIn -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive -archivePath /var/folders/6y/gy9gggt14379c_k39vwb50lc0000gn/T/project SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
