### PR TITLE
feat(AWSIoT): Use SHA256 digest for createKeysAndCertificateFromCsr

### DIFF
--- a/AWSIoT/Internal/AWSIoTCSR.m
+++ b/AWSIoT/Internal/AWSIoTCSR.m
@@ -72,21 +72,34 @@ unsigned char setTag = 0x31;
     
     NSMutableData * certRequestData = [self createCertificateRequestData];
     
-    CC_SHA1_CTX SHA1Struct;
-    CC_SHA1_Init(&SHA1Struct);
-    CC_SHA1_Update(&SHA1Struct, [certRequestData mutableBytes], (unsigned int)[certRequestData length]);
-    unsigned char SHA1Digest[CC_SHA1_DIGEST_LENGTH];
-    CC_SHA1_Final(SHA1Digest, &SHA1Struct);
+    CC_SHA256_CTX SHA256Struct;
+    CC_SHA256_Init(&SHA256Struct);
+    CC_SHA256_Update(&SHA256Struct, [certRequestData mutableBytes], (unsigned int)[certRequestData length]);
+    unsigned char SHA256Digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256_Final(SHA256Digest, &SHA256Struct);
     
     unsigned char sig[256];
     size_t sigLen = sizeof(sig);
-    OSStatus sanityCheck = SecKeyRawSign(privateKeyRef, kSecPaddingPKCS1SHA1, SHA1Digest, sizeof(SHA1Digest), sig, &sigLen);
+    OSStatus sanityCheck = SecKeyRawSign(privateKeyRef, kSecPaddingPKCS1SHA256, SHA256Digest, sizeof(SHA256Digest), sig, &sigLen);
     if (sanityCheck != noErr) {
         return nil;
     }
     
     NSMutableData * scr = [[NSMutableData alloc] initWithData:certRequestData];
-    unsigned char tag[] = {0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 1, 1, 5, 0x05, 0x00};
+
+    // DER encoded value of digest algorithm sha256WithRSAEncryption
+    // http://oid-info.com/get/1.2.840.113549.1.1.11
+    // Structure:
+    // 0x30         DER SEQUENCE type
+    // 0x0D         - Length 13
+    // 0x06             DER OBJECT IDENTIFIER type
+    //                  (https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-object-identifier)
+    // 0x09             - Length 9
+    // 0x2A...0x0B      - Encoded value of OID 1.2.840.113549.1.1.11
+    // 0x05             DER NULL type
+    // 0x00             - Length 0
+    unsigned char tag[] = {0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x0B, 0x05, 0x00};
+
     [scr appendBytes:tag length:sizeof(tag)];
     
     NSMutableData * signdata = [NSMutableData new];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,16 @@
----
-
-MOVE THIS SECTION TO THE CORRECT LOCATION
-
-### Misc. Updates
-
-- Model updates for the following services
----AWSKMS
----AWSEC2
----AWSSQS
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
 
--Features for next release
+### Misc. Updates
+
+- **AWSIoT**
+  - The `generateCSRForCertificate` method now uses SHA256 to sign Certificate Signing Requests. (See [PR #3345](https://github.com/aws-amplify/aws-sdk-ios/pull/3345))
+
+- Model updates for the following services
+  - AWSEC2
+  - AWSKMS
+  - AWSSQS
 
 ## 2.21.0
 


### PR DESCRIPTION
*Issue #, if available:* #3304

*Description of changes:*

- Updated to use SHA256
- Confirmed with IoT team that even if the client uses SHA1 to sign the Certificate Signing Request, the IoT service generates a certificate signed with an appropriate strong hashing algorithm.
- Tested locally and confirmed that the certificates resulting from the changed code are signed with  `sha256WithRSAEncryption`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
