### PR TITLE
chore(AWSLex): Dropped support for arm64 iphonesimulator

### DIFF
--- a/AWSLex/Bluefront/include/BFAudioRecorder.h
+++ b/AWSLex/Bluefront/include/BFAudioRecorder.h
@@ -30,6 +30,25 @@ voiceActivityDetectorConfiguration:(BFVADConfig *)vadConfig
                 allowAudioPlayback:(BOOL)allowAudioPlayback;
 
 /**
+ * Initializes the audio recorder with an encoder, a voice activity detector
+ * given the configuration and allows audio session to be defined to either allow or
+ * disallow playback from phone speakers during recording.
+ *
+ * @param encoding the encoding to use for the audio, either Opus or 16-bit LPCM.
+ * @param vadConfig the configuration of the voice activity detection used. Set to nil
+ * for no voice activity detection to be run on the audio samples.
+ * @param allowAudioPlayback if set to YES then this flag will not stop the sound coming
+ * out of the speakers before recording. Useful for VoIP applications.
+ * @param manageAVAudioSessionActive if set to NO then the BFAudioRecordingOrchestrator will not
+ * control the activity state of the AVAudioSession. Defaults to YES. Useful if consumers wish to
+ * explicitly handle AVAudioSession activity states.
+ */
+- (id)initWithEncoding:(BFAudioEncoding)encoding
+voiceActivityDetectorConfiguration:(BFVADConfig *)vadConfig
+    allowAudioPlayback:(BOOL)allowAudioPlayback
+manageAVAudioSessionActive:(BOOL)manageAVAudioSessionActive;
+
+/**
  * Initializes the audio recorder with an encoder and a voice activity detector
  * given the configuration.
  *

--- a/AWSLex/Bluefront/include/BFAudioSource.h
+++ b/AWSLex/Bluefront/include/BFAudioSource.h
@@ -71,7 +71,7 @@ voiceActivityDetectorConfiguration:(BFVADConfig *)vadConfig;
 /**
  * Marks the BFAudioSource as having stopped and stops any recording
  * processes required underneath.
-*/
+ */
 - (void)stop;
 
 /**

--- a/AWSLex/Bluefront/include/BFAudioSource.h
+++ b/AWSLex/Bluefront/include/BFAudioSource.h
@@ -71,8 +71,15 @@ voiceActivityDetectorConfiguration:(BFVADConfig *)vadConfig;
 /**
  * Marks the BFAudioSource as having stopped and stops any recording
  * processes required underneath.
- */
+*/
 - (void)stop;
+
+/**
+ * Marks the BFAudioSource as having stopped and stops any recording
+ * processes required underneath.
+ * @param completionHandler The completion handler to call when recording has stopped.
+ */
+- (void)stopWithCompletionHandler:(void (^)(void))completionHandler;
 
 /**
  * Gives the length of a buffer given the audio encoding of the audio source

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -530,6 +530,8 @@
 		B4A4E03322B423C700379396 /* AWSGeneralSageMakerRuntimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A4E03222B423C700379396 /* AWSGeneralSageMakerRuntimeTests.m */; };
 		B4A4E03422B425A300379396 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		B4A4E03522B425C900379396 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8EF551C6A6A2E0098B15B /* libOCMock.a */; };
+		B4B8C4BF25ACC10F0054E723 /* AWSLexConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B4B8C4BE25ACC10E0054E723 /* AWSLexConfig.xcconfig */; };
+		B4B8C61325ACC1270054E723 /* AWSLexConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = B4B8C4BE25ACC10E0054E723 /* AWSLexConfig.xcconfig */; };
 		B4D61CCC23285D8C007E7A12 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		B4D61CD523285DF5007E7A12 /* AWSConnectParticipant.h in Headers */ = {isa = PBXBuildFile; fileRef = B4D61CCD23285DF3007E7A12 /* AWSConnectParticipant.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B4D61CD623285DF5007E7A12 /* AWSConnectParticipantService.h in Headers */ = {isa = PBXBuildFile; fileRef = B4D61CCE23285DF4007E7A12 /* AWSConnectParticipantService.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2930,6 +2932,7 @@
 		B4A4E02722B4233B00379396 /* AWSSageMakerRuntimeUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSSageMakerRuntimeUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4A4E02B22B4233B00379396 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B4A4E03222B423C700379396 /* AWSGeneralSageMakerRuntimeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralSageMakerRuntimeTests.m; sourceTree = "<group>"; };
+		B4B8C4BE25ACC10E0054E723 /* AWSLexConfig.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = AWSLexConfig.xcconfig; sourceTree = "<group>"; };
 		B4D61CAF23285D16007E7A12 /* AWSConnectParticipant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSConnectParticipant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4D61CCD23285DF3007E7A12 /* AWSConnectParticipant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSConnectParticipant.h; sourceTree = "<group>"; };
 		B4D61CCE23285DF4007E7A12 /* AWSConnectParticipantService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSConnectParticipantService.h; sourceTree = "<group>"; };
@@ -5523,6 +5526,14 @@
 			path = AWSSageMakerRuntimeUnitTests;
 			sourceTree = "<group>";
 		};
+		B4B8C4BD25ACC10E0054E723 /* XcodeConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				B4B8C4BE25ACC10E0054E723 /* AWSLexConfig.xcconfig */,
+			);
+			path = XcodeConfiguration;
+			sourceTree = "<group>";
+		};
 		B4D61CB023285D16007E7A12 /* AWSConnectParticipant */ = {
 			isa = PBXGroup;
 			children = (
@@ -5747,6 +5758,7 @@
 				9A7ACC4F20B0FF1000DDBEC1 /* AWSTranslateUnitTests */,
 				17E6B467209BB99A0079B286 /* Frameworks */,
 				CE0D415E1C6A66AA006B91B5 /* Products */,
+				B4B8C4BD25ACC10E0054E723 /* XcodeConfiguration */,
 			);
 			sourceTree = "<group>";
 		};
@@ -10526,6 +10538,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4B8C61325ACC1270054E723 /* AWSLexConfig.xcconfig in Resources */,
 				B52FBE921F17414A000F0C00 /* Media.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10681,6 +10694,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4B8C4BF25ACC10F0054E723 /* AWSLexConfig.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14044,6 +14058,7 @@
 		};
 		185111DC1D78F03B0009F5C3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4B8C4BE25ACC10E0054E723 /* AWSLexConfig.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -14069,6 +14084,7 @@
 		};
 		185111DD1D78F03B0009F5C3 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4B8C4BE25ACC10E0054E723 /* AWSLexConfig.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ### Misc. Updates
  - AWSMobileClient
-    - Created a new target named AWSMobileClientXCF for the support of XCFramework. [PR #3334](https://github.com/aws-amplify/aws-sdk-ios/pull/3334)
+    - Created a new target named `AWSMobileClientXCF` for the support of XCFramework. [PR #3334](https://github.com/aws-amplify/aws-sdk-ios/pull/3334)
  - AWSLex
-    - Updated the AWSLex with the latest version of libBlueAudioSourceiOS and added arm64 iphonesimulator into Excluded Architecture. [PR - TBD]
+    - Updated the AWSLex with the latest version of libBlueAudioSourceiOS and added arm64 iphonesimulator into Excluded Architecture. [PR #3365](https://github.com/aws-amplify/aws-sdk-ios/pull/3365)
 
 ## 2.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Misc. Updates
  - AWSMobileClient
-    - Created a new target named `AWSMobileClientXCF` for the support of XCFramework. [PR #3334](https://github.com/aws-amplify/aws-sdk-ios/pull/3334)
+    - Created a new target named `AWSMobileClientXCF` to support building AWSMobileClient as an XCFramework. [PR #3334](https://github.com/aws-amplify/aws-sdk-ios/pull/3334)
  - AWSLex
     - Updated the AWSLex with the latest version of libBlueAudioSourceiOS and added arm64 iphonesimulator into Excluded Architecture. [PR #3365](https://github.com/aws-amplify/aws-sdk-ios/pull/3365)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 -Features for next release
 
+### Misc. Updates
+ - AWSMobileClient
+    - Created a new target named AWSMobileClientXCF for the support of XCFramework. [PR #3334](https://github.com/aws-amplify/aws-sdk-ios/pull/3334)
+ - AWSLex
+    - Updated the AWSLex with the latest version of libBlueAudioSourceiOS and added arm64 iphonesimulator into Excluded Architecture. [PR - TBD]
+
 ## 2.22.0
 
 ### New Features

--- a/XcodeConfiguration/AWSLexConfig.xcconfig
+++ b/XcodeConfiguration/AWSLexConfig.xcconfig
@@ -1,0 +1,25 @@
+//
+// Copyright 2010-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+// Add arm64 to EXCLUDED_ARCHS for iOS simulator version 14
+// This is to temporarily fix issues with Xcode 12, since Xcode 12 supports Apple Silicon Macs using arm64,
+// but most libraries currently haven't been built with arm64 support for simulator. AWSLex internally uses
+// libBlueAudioSourceiOS static library which do not have support for arm64 simulator
+//
+// NOTE: EXCLUDED_ARCHS is a new feature of Xcode 12. https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#Build-System
+// Nevertheless, it appears that while Xcode 11 does not support this feature, it notices the build setting and does
+// weird things as a result, breaking the build on Xcode 11. To keep using Xcode 11, we found that we can
+// use 14* instead of *. also we can just comment this line out.
+EXCLUDED_ARCHS[sdk=iphonesimulator14*] = arm64


### PR DESCRIPTION
*Issues:*  https://github.com/aws-amplify/aws-sdk-ios/issues/3348

*Description of changes:* This PR contains the following changes:
- Drop the support for arm64 iphonesimulator 
- Updates the libAudioSourceiOS.a library

The arm64 iphonesimulator are the simulator in the new M1 mac systems. The internal libraries like `libAudioSourceiOS.a` do not currently have support for arm64 simulators. This PR is to temporary drop the support for arm64 iphonesimulator for AWSLex so that we can move forward with XCFramework support and SPM for the whole SDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
