### PR TITLE
Add URL query parameter encoding to AWSSignature

### DIFF
--- a/AWSCore/Authentication/AWSSignature.m
+++ b/AWSCore/Authentication/AWSSignature.m
@@ -324,6 +324,11 @@ NSString *const AWSSignatureV4Terminator = @"aws4_request";
         query = [NSString stringWithFormat:@""];
     }
 
+    NSCharacterSet* querySet = [[NSCharacterSet characterSetWithCharactersInString:@"!*'\();:@+$,%#[] "] invertedSet];
+    // consider moving this to AWSCategory.m
+    // named something like: - (NSString *)aws_stringWithURLEncodingQuery
+    query = [query stringByAddingPercentEncodingWithAllowedCharacters:querySet];
+
     NSString *contentSha256 = [AWSSignatureSignerUtility hexEncode:[[NSString alloc] initWithData:[AWSSignatureSignerUtility hash:request.HTTPBody] encoding:NSASCIIStringEncoding]];
 
     NSString *canonicalRequest = [AWSSignatureV4Signer getCanonicalizedRequest:request.HTTPMethod


### PR DESCRIPTION
Issue #3362
Issue #3215 

*Description of changes:*
Apply URL encoding of special characters in URL query parameters for use in signing.
As mentioned in #3362, this PR is missing tests and quite rudimentary overall. Its main purpose is to advance the resolution of above mentioned issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
