### PR TITLE
chore: Remove develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,16 +174,6 @@ commands:
                  circleci step halt
               fi
             fi
-      - run:
-          name: Skip the test job if this was merged from develop by CircleCI
-          command: |
-            skipflag=$(echo "${SKIPTEST_FOR_MAIN}") | tr '[:upper:]' '[:lower:]'
-            commitmessage=$(git log --format=%B -n 1 ${CIRCLE_SHA1})
-            if [ "$skipflag" == "true" ] && [[ "$commitmessage" =~ .*"[Merge develop to main by circleci]".* ]]
-            then
-               echo "This is merged from develop by CircleCI. Skip the test job"
-               circleci step halt
-            fi
 
   skip_job_unless_required:
     description: >-
@@ -621,7 +611,7 @@ jobs:
 
             bump_version_message="[bump version $release_version]"
             bump_version_pr_title="bump iOS sdk version to ${release_version}"
-            target_branch=develop
+            target_branch=main
             echo "export bumpversion_repo_user=$bumpversion_repo_user" >> $BASH_ENV
             echo "export bumpversion_repo_name=$bumpversion_repo_name" >> $BASH_ENV
             echo "export release_version=$release_version" >> $BASH_ENV
@@ -636,41 +626,6 @@ jobs:
             cp -R ${bumpversion_repo_name}/CircleciScripts/ CircleciScripts/
             python3 CircleciScripts/bump_sdk_version.py "$(pwd)/${bumpversion_repo_name}" $release_version
       - bump_version_post
-
-  merge_to_main:
-    docker:
-      - image: circleci/android:api-27-alpha
-    environment:
-      JVM_OPTS: -Xmx1024m
-    steps:
-      - skip_job_unless_required
-      - checkout
-      - set_environment_variables
-      - run:
-          name: Merge change to main
-          command: |
-            git config --local user.name AWS
-            git checkout main
-            git fetch origin
-            git reset origin/main
-            git checkout .
-            git clean -fd .
-            commitlog=$(git log main -20)
-            currentcommit="${CIRCLE_SHA1}"
-            echo "currentcommit=$currentcommit"
-            echo "$commitlog"
-            if [[ "$commitlog" =~ .*"commit $currentcommit".* ]]
-            then
-               echo "The change is already merged"
-            else
-              echo "Merging change from develop to main"
-              currentcommit="${CIRCLE_SHA1}"
-              lastcommitmessage=$(git log --format=%B -n 1 ${currentcommit})
-
-              git merge develop --no-edit --commit -m "[Merge develop to main by circleci] $lastcommitmessage"
-              echo "push change"
-              git push -q https://${GITHUB_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git
-            fi
 
   prepare_release_sdk:
     docker:
@@ -698,7 +653,7 @@ jobs:
       - run:
           name: Create pull request
           command: |
-            target_branch="develop"
+            target_branch="main"
             title=${CIRCLE_BRANCH}
             content="${CIRCLE_BRANCH}"
             python3 ./CircleciScripts/create_pullrequest.py "${GITHUB_USER}" "${GITHUB_TOKEN}" "$title" "$content" "$target_branch" "${CIRCLE_PROJECT_USERNAME}:${CIRCLE_BRANCH}" ${CIRCLE_PROJECT_USERNAME} ${CIRCLE_PROJECT_REPONAME}
@@ -1139,7 +1094,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1150,7 +1104,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1161,7 +1114,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1172,7 +1124,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1183,7 +1134,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1194,7 +1144,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1205,7 +1154,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1216,7 +1164,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1227,7 +1174,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1238,7 +1184,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1249,7 +1194,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1260,7 +1204,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1271,7 +1214,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1282,7 +1224,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1293,7 +1234,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1304,7 +1244,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1315,7 +1254,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1326,7 +1264,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1337,7 +1274,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1348,7 +1284,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1359,7 +1294,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1370,7 +1304,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1381,7 +1314,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1392,7 +1324,6 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
       - integ_test:
@@ -1403,16 +1334,8 @@ workflows:
           filters:
             branches:
               only:
-                - develop
                 - main
 
-
-      - merge_to_main:
-          <<: *all_integ_test_requires
-          filters:
-            branches:
-              only:
-                - develop
 
       - prepare_release_sdk:
           <<: *all_integ_test_requires


### PR DESCRIPTION
*Description of changes:*

Given that main doesn’t really have a use as a “latest stable branch” pointer, it makes sense to remove the develop/main distinction and its associated complications. We will adopt a Git Flow-style process that is similar to what we do in Amplify, merging approved PRs directly to main.

After I merge this into main and see the tests run successfully, I'll re-point all existing PRs to the `main` branch instead of `develop`, and then delete the `develop` branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
