### PR TITLE
test: Fix unstable AWSMobileClient device test

### DIFF
--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientDeviceTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientDeviceTests.swift
@@ -55,98 +55,80 @@ class AWSMobileClientDeviceTests: AWSMobileClientTestBase {
         
         
         let initialRememberDeviceExpectation = expectation(description: "initial remember device expectation.")
-        
         AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
-            if error != nil {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
+                initialRememberDeviceExpectation.fulfill()
             }
-            initialRememberDeviceExpectation.fulfill()
+            XCTAssertNil(error)
+            XCTAssertNotNil(result)
         }
-        
         wait(for: [initialRememberDeviceExpectation], timeout: 5)
         
         let listDevicesExpectation = expectation(description: "list devices expectation.")
-        
         AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
-            
-            guard error == nil else {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
                 listDevicesExpectation.fulfill()
-                return
             }
-            XCTAssertTrue(result?.devices?.count == 1, "Expecting current device to be remembered, get count 1. Service Response: \(result!.devices!.count)")
-            listDevicesExpectation.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(result?.devices?.count, 1, "Expecting current device to be remembered, get count 1. Service Response: \(result!.devices!.count)")
         }
-        
         wait(for: [listDevicesExpectation], timeout: 5)
         
         let getDeviceExpectation = expectation(description: "get device expectation.")
-        
         AWSMobileClient.default().deviceOperations.get { (device, error) in
-            guard error == nil else {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
                 getDeviceExpectation.fulfill()
+            }
+            XCTAssertNil(error)
+
+            // Allow a little bit of slop to account for clock differences
+            let maxExpectedCreationDate = Date(timeIntervalSinceNow: 30.0)
+            guard let createDate = device?.createDate else {
+                XCTFail("device.createDate is nil")
                 return
             }
-            
-            XCTAssertTrue(device!.createDate! < Date(), "Device create date should be before now.")
-            print("Device create date: \(device!.createDate!)")
-            getDeviceExpectation.fulfill()
+            XCTAssertLessThanOrEqual(createDate, maxExpectedCreationDate, "Device create date should be before 30 seconds from now, received: \(device!.createDate!)")
         }
-        
         wait(for: [getDeviceExpectation], timeout: 5)
         
         let notRememberDeviceExpectation = expectation(description: "forget device expectation.")
-        
         AWSMobileClient.default().deviceOperations.updateStatus(remembered: false) { (result, error) in
-            if error != nil {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
+                notRememberDeviceExpectation.fulfill()
             }
-            notRememberDeviceExpectation.fulfill()
+            XCTAssertNil(error)
+            XCTAssertNotNil(result)
         }
-        
         wait(for: [notRememberDeviceExpectation], timeout: 5)
         
         let listDevicesExpectation2 = expectation(description: "list devices expectation2.")
-        
         AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
-            
-            guard error == nil else {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
                 listDevicesExpectation2.fulfill()
-                return
             }
-            XCTAssertTrue(result?.devices?.count == 0, "Expecting current device to be NOT remembered, get count 0. Service Response: \(result!.devices!.count)")
-            listDevicesExpectation2.fulfill()
+            XCTAssertNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertEqual(result?.devices?.count, 0, "Expecting current device to be NOT remembered, get count 0. Service Response: \(result!.devices!.count)")
         }
-        
         wait(for: [listDevicesExpectation2], timeout: 5)
         
         let rememberDeviceExpectation = expectation(description: "remember device expectation.")
-        
         AWSMobileClient.default().deviceOperations.updateStatus(remembered: true) { (result, error) in
-            if error != nil {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
+                rememberDeviceExpectation.fulfill()
             }
-            rememberDeviceExpectation.fulfill()
-            
+            XCTAssertNil(error)
         }
-        
         wait(for: [rememberDeviceExpectation], timeout: 5)
         
         let listDevicesExpectation3 = expectation(description: "list devices expectation3.")
-        
         AWSMobileClient.default().deviceOperations.list(limit: 60) { (result, error) in
-            
-            guard error == nil else {
-                XCTFail("Received un-expected error: \(error!.localizedDescription)")
+            defer {
                 listDevicesExpectation3.fulfill()
-                return
             }
-            XCTAssertTrue(result?.devices?.count == 1, "Expecting current device to be remembered, get count 1. Service Response: \(result!.devices!.count)")
-            listDevicesExpectation3.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(result?.devices?.count, 1, "Expecting current device to be remembered, get count 1. Service Response: \(result!.devices!.count)")
         }
-        
         wait(for: [listDevicesExpectation3], timeout: 5)
     }
     


### PR DESCRIPTION
*Description of changes:*

We see intermittent [test failures in the pipeline](https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios/4339/workflows/21d2e9f0-9539-40a5-af73-44b7eecc805a/jobs/55465/tests) validating the creation date of a device. This attempts to stabilize the test by allowing a 30-second window to account for differences in client & server clocks.

This PR also includes a bit of cleanup/refactoring to use purpose-built XCT assertion methods and `defer` blocks for fulfilling assertions inside of callbacks.

Since the test has always passed reliably locally, this hasn't been tested beyond simply running it and validating that it still passes locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
