### PR TITLE
chore: Fix doc generation script

### DIFF
--- a/CircleciScripts/generate_documentation.sh
+++ b/CircleciScripts/generate_documentation.sh
@@ -79,6 +79,7 @@ OBJC_SDK_LIST=$(find $SOURCE_ROOT ${SOURCE_ROOT}/AWSAuthSDK/Sources -type d -max
   -not -name "*Test*" \
   -not -name "AWSAuthSDK" \
   -not -name "AWSMobileClient" \
+  -not -name "AWSMobileClientXCF" \
   | sort
 )
 


### PR DESCRIPTION
Suppresses AWSMobileClientXCF pseudo-framework from doc generation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
