### PR TITLE
Bug fix(Cognito): Use given vc for signout 

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -516,7 +516,7 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 
 - (void) signOut: (UIViewController *) vc completion: (AWSCognitoAuthSignOutBlock) completion {
     self.presentationAnchor = nil;
-    [self enqueueSignOut:nil completion:completion];
+    [self enqueueSignOut:vc completion:completion];
 }
 
 - (void) signOutWithWebUI:(ASPresentationAnchor) anchor completion:(AWSCognitoAuthSignOutBlock) completion {


### PR DESCRIPTION
https://github.com/aws-amplify/aws-sdk-ios/pull/3310 changed `AWSCognitoAuth signOut` to ignore vc parameter given as a method parameter, but the vc should be used to present SFSafariVC.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
