### PR TITLE
fix: polly lexicon not found test

### DIFF
--- a/AWSPollyTests/AWSPollyTests.m
+++ b/AWSPollyTests/AWSPollyTests.m
@@ -79,7 +79,6 @@ static NSDictionary<NSString *,NSString *> *lexicons;
 
 - (void)tearDown {
     [super tearDown];
-    [self deleteLexicon];
 }
 
 - (void)setUpLexicon {
@@ -96,16 +95,6 @@ static NSDictionary<NSString *,NSString *> *lexicons;
             return nil;
         }] waitUntilFinished];
     }
-}
-
-- (void)deleteLexicon {
-    AWSPolly *polly = [AWSPolly defaultPolly];
-    for (NSString *lexiconName in lexicons) {
-        AWSPollyDeleteLexiconInput *input = [AWSPollyDeleteLexiconInput new];
-        input.name = lexiconName;
-        [polly deleteLexicon:input];
-    }
-    
 }
 
 - (void)testSynthesizeIntoAudioStream {
@@ -269,8 +258,6 @@ static NSDictionary<NSString *,NSString *> *lexicons;
     [request setLexiconNames:@[w2cLexiconName, w3cLexiconName]]; // W3C will be spoken as World Wide Web Consortium.
     
     AWSPolly *Polly = [AWSPolly defaultPolly];
-    // wait for lexicons to be ready for usage
-    sleep(20);
     [[[Polly synthesizeSpeech:request] continueWithBlock:^id _Nullable(AWSTask<AWSPollySynthesizeSpeechOutput *> * _Nonnull task) {
         XCTAssertNil(task.error);
         XCTAssertNotNil(task.result);


### PR DESCRIPTION
*Issue #, if available:*
The integration tests is sometimes failing with the [error](https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios/4375/workflows/63e6e816-d734-4193-8bfb-13942ddb919d/jobs/56684/steps)
```
  testSynthesize, ((task.error) == nil) failed: "Error Domain=com.amazonaws.AWSPollyErrorDomain Code=11 "Lexicon not found" UserInfo={NSLocalizedDescription=Lexicon not found, NSLocalizedFailureReason=LexiconNotFoundException:http://polly.amazonaws.com/doc/v1}"
```

*Description of changes:*
It appears that the lexicons are being added and deleted on every test, when the test is set up and teared down. According to the docs for [PutLexicon](https://docs.aws.amazon.com/polly/latest/dg/API_PutLexicon.html) there is an eventual consistency which is probably why there is a `sleep(20)` in the test. 

My proposal in this fix is to remove the deletion of the lexicons, and keep them in the region for use across all the tests. We continue to update the lexicons on every test run, which will have no impact on the tests as it will eventually overwrite the previous lexicon of the same name, and this also sets up the tests so that it can be run from a new region or an region with no lexicons.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
