### PR TITLE
feat(auth): Update FB SDK to 9.0.0

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -171,6 +171,9 @@
 		B41F67E9233D56CB0060FDEE /* AWSAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B5345D0F1F366AFA009C1041 /* AWSAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B41F67EA233D5ABE0060FDEE /* AWSUserPoolsSignIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1750D0071F2D4DFA006D915E /* AWSUserPoolsSignIn.framework */; };
 		B41F67EB233D5ABE0060FDEE /* AWSUserPoolsSignIn.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1750D0071F2D4DFA006D915E /* AWSUserPoolsSignIn.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B433F93125D4656000ACA795 /* FBSDKAppLinkResolverRequestBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = B433F8C025D4656000ACA795 /* FBSDKAppLinkResolverRequestBuilder.h */; };
+		B433F93225D4656000ACA795 /* FBSDKAuthenticationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = B433F92F25D4656000ACA795 /* FBSDKAuthenticationToken.h */; };
+		B433F93325D4656000ACA795 /* FBSDKLoginConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = B433F93025D4656000ACA795 /* FBSDKLoginConfiguration.h */; };
 		B4682160233D19DF00CB404D /* AWSUserPoolNewPasswordRequiredViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B46820F6233D19DE00CB404D /* AWSUserPoolNewPasswordRequiredViewController.m */; };
 		B4682161233D19DF00CB404D /* AWSUserPoolNewPasswordRequiredViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = B468215F233D19DE00CB404D /* AWSUserPoolNewPasswordRequiredViewController.h */; };
 		B49C891724B387C3009739FC /* AWSAppleSignIn.h in Headers */ = {isa = PBXBuildFile; fileRef = B49C891124B387C3009739FC /* AWSAppleSignIn.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1337,6 +1340,9 @@
 		B412F65E23350A5000F1AC69 /* AWSCognitoIdentityUserPool+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoIdentityUserPool+Extension.h"; sourceTree = "<group>"; };
 		B41F676E233D523B0060FDEE /* DropInUIUserPoolViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInUIUserPoolViewController.swift; sourceTree = "<group>"; };
 		B41F67D8233D536E0060FDEE /* AWSDropInUIUserPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSDropInUIUserPoolTests.swift; sourceTree = "<group>"; };
+		B433F8C025D4656000ACA795 /* FBSDKAppLinkResolverRequestBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKAppLinkResolverRequestBuilder.h; sourceTree = "<group>"; };
+		B433F92F25D4656000ACA795 /* FBSDKAuthenticationToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKAuthenticationToken.h; sourceTree = "<group>"; };
+		B433F93025D4656000ACA795 /* FBSDKLoginConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKLoginConfiguration.h; sourceTree = "<group>"; };
 		B46820F6233D19DE00CB404D /* AWSUserPoolNewPasswordRequiredViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSUserPoolNewPasswordRequiredViewController.m; sourceTree = "<group>"; };
 		B468215F233D19DE00CB404D /* AWSUserPoolNewPasswordRequiredViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSUserPoolNewPasswordRequiredViewController.h; sourceTree = "<group>"; };
 		B49C889E24B38746009739FC /* AWSAppleSignIn.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSAppleSignIn.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1741,11 +1747,13 @@
 				D8FAC274251D1B98005F9FC6 /* FBSDKAppLink.h */,
 				D8FAC276251D1BBB005F9FC6 /* FBSDKAppLinkNavigation.h */,
 				17B5A0E91F31A6B000857676 /* FBSDKAppLinkResolver.h */,
+				B433F8C025D4656000ACA795 /* FBSDKAppLinkResolverRequestBuilder.h */,
 				D8FAC278251D1BF2005F9FC6 /* FBSDKAppLinkResolving.h */,
 				D8FAC27B251D1C0F005F9FC6 /* FBSDKAppLinkReturnToRefererController.h */,
 				D8FAC27C251D1C0F005F9FC6 /* FBSDKAppLinkReturnToRefererView.h */,
 				D8FAC27A251D1C0F005F9FC6 /* FBSDKAppLinkTarget.h */,
 				17B5A0EA1F31A6B000857676 /* FBSDKAppLinkUtility.h */,
+				B433F92F25D4656000ACA795 /* FBSDKAuthenticationToken.h */,
 				17B5A0EB1F31A6B000857676 /* FBSDKButton.h */,
 				17B5A0EC1F31A6B000857676 /* FBSDKConstants.h */,
 				17B5A0ED1F31A6B000857676 /* FBSDKCopying.h */,
@@ -1761,6 +1769,7 @@
 				17B5A0F11F31A6B000857676 /* FBSDKGraphRequestConnection.h */,
 				17B5A0F21F31A6B000857676 /* FBSDKGraphRequestDataAttachment.h */,
 				17B5A0F31F31A6B000857676 /* FBSDKLoginButton.h */,
+				B433F93025D4656000ACA795 /* FBSDKLoginConfiguration.h */,
 				17B5A0F41F31A6B000857676 /* FBSDKLoginConstants.h */,
 				17B5A0F51F31A6B000857676 /* FBSDKLoginKit.h */,
 				17B5A0F61F31A6B000857676 /* FBSDKLoginManager.h */,
@@ -2084,6 +2093,7 @@
 				176375551F328D310086588B /* FBSDKLoginButton.h in Headers */,
 				D8FAC273251D1A87005F9FC6 /* FBSDKCoreKitImport.h in Headers */,
 				D8FAC277251D1BBB005F9FC6 /* FBSDKAppLinkNavigation.h in Headers */,
+				B433F93125D4656000ACA795 /* FBSDKAppLinkResolverRequestBuilder.h in Headers */,
 				D8FAC279251D1BF2005F9FC6 /* FBSDKAppLinkResolving.h in Headers */,
 				176375611F328D310086588B /* FBSDKTooltipView.h in Headers */,
 				1763755F1F328D310086588B /* FBSDKSettings.h in Headers */,
@@ -2106,6 +2116,7 @@
 				D8FAC287251D1D39005F9FC6 /* FBSDKDeviceLoginManager.h in Headers */,
 				176375491F328D310086588B /* FBSDKAppEvents.h in Headers */,
 				D8FAC289251D1D3D005F9FC6 /* FBSDKDeviceLoginManagerResult.h in Headers */,
+				B433F93325D4656000ACA795 /* FBSDKLoginConfiguration.h in Headers */,
 				1763754F1F328D310086588B /* FBSDKCopying.h in Headers */,
 				1763755C1F328D310086588B /* FBSDKMutableCopying.h in Headers */,
 				D8FAC28F251D1D94005F9FC6 /* FBSDKWebViewAppLinkResolver.h in Headers */,
@@ -2124,6 +2135,7 @@
 				1763754C1F328D310086588B /* FBSDKAppLinkUtility.h in Headers */,
 				D8FAC275251D1B98005F9FC6 /* FBSDKAppLink.h in Headers */,
 				176375481F328D310086588B /* FBSDKAccessToken.h in Headers */,
+				B433F93225D4656000ACA795 /* FBSDKAuthenticationToken.h in Headers */,
 				D81624582530FEDC00816418 /* FBSDKReferralCode.h in Headers */,
 				176375511F328D310086588B /* FBSDKGraphErrorRecoveryProcessor.h in Headers */,
 			);

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKAccessToken.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKAccessToken.h
@@ -165,7 +165,7 @@ NS_REFINED_FOR_SWIFT;
 /**
   The graph domain where this access token is valid.
  */
-@property (nonatomic, copy, readonly) NSString *graphDomain;
+@property (nonatomic, copy, readonly) NSString *graphDomain DEPRECATED_MSG_ATTRIBUTE("The graphDomain property will be removed from AccessToken in the next major release. Use the graphDomain property on AuthenticationToken instead.");
 
 /**
  Returns whether the access token is expired by checking its expirationDate property
@@ -241,7 +241,8 @@ NS_DESIGNATED_INITIALIZER;
                      expirationDate:(nullable NSDate *)expirationDate
                         refreshDate:(nullable NSDate *)refreshDate
            dataAccessExpirationDate:(nullable NSDate *)dataAccessExpirationDate
-                        graphDomain:(nullable NSString *)graphDomain;
+                        graphDomain:(nullable NSString *)graphDomain
+DEPRECATED_MSG_ATTRIBUTE("The graphDomain property will be removed from AccessToken in the next major release. Use initializers that do not take in graphDomain domain instead.");
 
 /**
   Convenience getter to determine if a permission has been granted

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKAppLinkResolverRequestBuilder.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKAppLinkResolverRequestBuilder.h
@@ -22,29 +22,26 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FBSDKAppLinkResolving.h"
+#import "FBSDKGraphRequest.h"
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Represent a referral code used in the referral process
-*/
-NS_SWIFT_NAME(ReferralCode)
-@interface FBSDKReferralCode : NSObject
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
+ Class responsible for generating the appropriate FBSDKGraphRequest for a given set of urls
+ */
+NS_SWIFT_NAME(AppLinkResolverRequestBuilder)
+@interface FBSDKAppLinkResolverRequestBuilder : NSObject
 
 /**
- The string value of the referral code
-*/
-@property NSString *value;
+ Generates the FBSDKGraphRequest
 
-/**
- Initializes a new instance if the referral code is valid. Otherwise returns nil.
- A code is valid if it is non-empty and contains only alphanumeric characters.
- @param string the raw string referral code
-*/
-+ (nullable instancetype)initWithString:(NSString *)string;
+ @param urls The URLs to build the requests for
+ */
+- (FBSDKGraphRequest* _Nonnull)requestForURLs:(NSArray<NSURL *> * _Nonnull)urls
+NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extension");
 
+- (NSString* _Nullable)getIdiomSpecificField
+NS_EXTENSION_UNAVAILABLE_IOS("Not available in app extension");
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKApplicationDelegate.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKApplicationDelegate.h
@@ -99,8 +99,6 @@ didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsK
 
 /**
   Call this method to manually initialize SDK.
-  As we initialize SDK automatically, this should only be called when auto initialization is disabled, this can be
- controlled via 'FacebookAutoInitEnabled' key in the project info plist file.
 
  @param launchOptions The launchOptions as passed to [UIApplicationDelegate application:didFinishLaunchingWithOptions:].
  Could be nil if you don't call this function from [UIApplicationDelegate application:didFinishLaunchingWithOptions:].

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKAuthenticationToken.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKAuthenticationToken.h
@@ -16,37 +16,44 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "TargetConditionals.h"
-
-#if !TARGET_OS_TV
-
 #import <Foundation/Foundation.h>
+
+#import "FBSDKCopying.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Represent a referral code used in the referral process
+ Represent an AuthenticationToken used for a login attempt
 */
-NS_SWIFT_NAME(ReferralCode)
-@interface FBSDKReferralCode : NSObject
+NS_SWIFT_NAME(AuthenticationToken)
+@interface FBSDKAuthenticationToken : NSObject<FBSDKCopying, NSSecureCoding>
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- The string value of the referral code
-*/
-@property NSString *value;
+  The "global" authentication token that represents the currently logged in user.
+
+ The `currentAuthenticationToken` represents the authentication token of the
+ current user and can be used by a client to verify an authentication attempt.
+ */
+@property (class, nonatomic, copy, nullable) FBSDKAuthenticationToken *currentAuthenticationToken;
 
 /**
- Initializes a new instance if the referral code is valid. Otherwise returns nil.
- A code is valid if it is non-empty and contains only alphanumeric characters.
- @param string the raw string referral code
-*/
-+ (nullable instancetype)initWithString:(NSString *)string;
+ The raw token string from the authentication response
+ */
+@property (nonatomic, copy, readonly) NSString *tokenString;
+
+/**
+ The nonce from the decoded authentication response
+ */
+@property (nonatomic, copy, readonly) NSString *nonce;
+
+/**
+  The graph domain where the user is authenticated.
+ */
+@property (nonatomic, copy, readonly) NSString *graphDomain;
 
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKCoreKit.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKCoreKit.h
@@ -18,17 +18,12 @@
 
 #import <UIKit/UIKit.h>
 
-#if TARGET_OS_TV
- #ifndef DEVICE_SHARING_DEPRECATED
-  #define DEVICE_SHARING_DEPRECATED DEPRECATED_MSG_ATTRIBUTE("Sharing from devices will no longer work as of Nov 2nd 2020")
- #endif
-#endif
-
 #ifdef BUCK
 
  #import <FBSDKCoreKit/FBSDKAccessToken.h>
  #import <FBSDKCoreKit/FBSDKAppEvents.h>
  #import <FBSDKCoreKit/FBSDKApplicationDelegate.h>
+ #import <FBSDKCoreKit/FBSDKAuthenticationToken.h>
  #import <FBSDKCoreKit/FBSDKButton.h>
  #import <FBSDKCoreKit/FBSDKConstants.h>
  #import <FBSDKCoreKit/FBSDKCopying.h>
@@ -43,6 +38,7 @@
   #import <FBSDKCoreKit/FBSDKAppLink.h>
   #import <FBSDKCoreKit/FBSDKAppLinkNavigation.h>
   #import <FBSDKCoreKit/FBSDKAppLinkResolver.h>
+  #import <FBSDKCoreKit/FBSDKAppLinkResolverRequestBuilder.h>
   #import <FBSDKCoreKit/FBSDKAppLinkResolving.h>
   #import <FBSDKCoreKit/FBSDKAppLinkReturnToRefererController.h>
   #import <FBSDKCoreKit/FBSDKAppLinkReturnToRefererView.h>
@@ -65,6 +61,7 @@
  #import "FBSDKAccessToken.h"
  #import "FBSDKAppEvents.h"
  #import "FBSDKApplicationDelegate.h"
+ #import "FBSDKAuthenticationToken.h"
  #import "FBSDKButton.h"
  #import "FBSDKConstants.h"
  #import "FBSDKCopying.h"
@@ -79,6 +76,7 @@
   #import "FBSDKAppLink.h"
   #import "FBSDKAppLinkNavigation.h"
   #import "FBSDKAppLinkResolver.h"
+  #import "FBSDKAppLinkResolverRequestBuilder.h"
   #import "FBSDKAppLinkResolving.h"
   #import "FBSDKAppLinkReturnToRefererController.h"
   #import "FBSDKAppLinkReturnToRefererView.h"
@@ -98,5 +96,5 @@
 
 #endif
 
-#define FBSDK_VERSION_STRING @"8.0.0"
-#define FBSDK_TARGET_PLATFORM_VERSION @"v8.0"
+#define FBSDK_VERSION_STRING @"9.0.1"
+#define FBSDK_TARGET_PLATFORM_VERSION @"v9.0"

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKCoreKitImport.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKCoreKitImport.h
@@ -23,5 +23,8 @@
 
 // Even though this file is not available from projects using SPM,
 // it is available when building the packages themselves so we need to include this check.
-
-#import <FBSDKCoreKit.h>
+#if FBSDK_SWIFT_PACKAGE
+ #import <FBSDKCoreKit.h>
+#else
+ #import <FBSDKCoreKit/FBSDKCoreKit.h>
+#endif

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKCoreKitImport.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKCoreKitImport.h
@@ -23,8 +23,4 @@
 
 // Even though this file is not available from projects using SPM,
 // it is available when building the packages themselves so we need to include this check.
-#if FBSDK_SWIFT_PACKAGE
- #import <FBSDKCoreKit.h>
-#else
- #import <FBSDKCoreKit/FBSDKCoreKit.h>
-#endif
+#import <FBSDKCoreKit.h>

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginButton.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginButton.h
@@ -58,7 +58,7 @@ typedef NS_ENUM(NSUInteger, FBSDKLoginButtonTooltipBehavior)
 /**
   A button that initiates a log in or log out flow upon tapping.
 
- `FBSDKLoginButton` works with `[FBSDKAccessToken currentAccessToken]` to
+ `FBSDKLoginButton` works with `FBSDKProfile.currentProfile` to
   determine what to display, and automatically starts authentication when tapped (i.e.,
   you do not need to manually subscribe action targets).
 
@@ -98,6 +98,15 @@ NS_SWIFT_NAME(FBLoginButton)
   Gets or sets the desired tooltip color style.
  */
 @property (assign, nonatomic) FBSDKTooltipColorStyle tooltipColorStyle;
+/**
+  Gets or sets the desired tracking preference to use for login attempts. Defaults to `.enabled`
+ */
+@property (assign, nonatomic) FBSDKLoginTracking loginTracking;
+/**
+  Gets or sets an optional nonce to use for login attempts. A valid nonce must be a non-empty string without whitespace.
+ An invalid nonce will not be set. Instead, default unique nonces will be used for login attempts.
+ */
+@property (copy, nonatomic, nullable) NSString *nonce;
 
 @end
 

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginConfiguration.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginConfiguration.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class FBSDKPermission;
+
+/// The login tracking preference to use for a login attempt. For more information on the differences between
+/// `enabled` and `limited` see: https://developers.facebook.com/docs/facebook-login/ios/limited-login/
+typedef NS_ENUM(NSUInteger, FBSDKLoginTracking)
+{
+  FBSDKLoginTrackingEnabled,
+  FBSDKLoginTrackingLimited,
+} NS_SWIFT_NAME(LoginTracking);
+
+/// A configuration to use for modifying the behavior of a login attempt.
+NS_SWIFT_NAME(LoginConfiguration)
+@interface FBSDKLoginConfiguration : NSObject
+
+/// The nonce that the configuration was created with.
+/// A unique nonce will be used if none is provided to the initializer.
+@property (nonatomic, readonly, copy) NSString *nonce;
+
+/// The tracking  preference. Defaults to `.enabled`.
+@property (nonatomic, readonly) FBSDKLoginTracking tracking;
+
+/// The requested permissions for the login attempt. Defaults to an empty set.
+@property (nonatomic, readonly, copy) NSSet<FBSDKPermission *> *requestedPermissions;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ Attempts to initialize a new configuration with the expected parameters.
+
+ @param permissions the requested permissions for a login attempt. Permissions must be an array of strings that do not contain whitespace.
+ The only permissions allowed when the `loginTracking` is `.limited` are 'email', 'public_profile', 'gaming_profile' and 'gaming_user_picture'
+ @param tracking the tracking preference to use for a login attempt.
+ @param nonce an optional nonce to use for the login attempt. A valid nonce must be a non-empty string without whitespace.
+ Creation of the configuration will fail if the nonce is invalid.
+ */
+- (nullable instancetype)initWithPermissions:(NSArray<NSString *> *)permissions
+                         tracking:(FBSDKLoginTracking)tracking
+                                       nonce:(NSString *)nonce
+NS_REFINED_FOR_SWIFT;
+
+/**
+ Attempts to initialize a new configuration with the expected parameters.
+
+ @param permissions the requested permissions for the login attempt. Permissions must be an array of strings that do not contain whitespace.
+  The only permissions allowed when the `loginTracking` is `.limited` are 'email', 'public_profile', 'gaming_profile' and 'gaming_user_picture'
+ @param tracking the tracking preference to use for a login attempt.
+ */
+- (nullable instancetype)initWithPermissions:(NSArray<NSString *> *)permissions
+                         tracking:(FBSDKLoginTracking)tracking
+NS_REFINED_FOR_SWIFT;
+
+/**
+ Attempts to initialize a new configuration with the expected parameters.
+
+ @param tracking the login tracking preference to use for a login attempt.
+ */
+- (nullable instancetype)initWithTracking:(FBSDKLoginTracking)tracking
+NS_REFINED_FOR_SWIFT;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginConstants.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginConstants.h
@@ -100,6 +100,16 @@ typedef NS_ERROR_ENUM(FBSDKLoginErrorDomain, FBSDKLoginError)
     The login response was missing a valid challenge string.
   */
   FBSDKLoginErrorBadChallengeString,
+
+  /**
+    The ID token returned in login response was invalid
+  */
+  FBSDKLoginErrorInvalidIDToken,
+
+  /**
+   A current access token was required and not provided
+   */
+  FBSDKLoginErrorMissingAccessToken,
 } NS_SWIFT_NAME(LoginError);
 
 /**

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginKit.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginKit.h
@@ -22,6 +22,7 @@
 #import "FBSDKDeviceLoginCodeInfo.h"
 #import "FBSDKDeviceLoginManager.h"
 #import "FBSDKDeviceLoginManagerResult.h"
+#import "FBSDKLoginConfiguration.h"
 #import "FBSDKLoginConstants.h"
 
 #if !TARGET_OS_TV

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginManager.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginManager.h
@@ -18,6 +18,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "FBSDKLoginConfiguration.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_TV
@@ -32,9 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
 // The way to fix this is to remove extensions of ObjC types in Swift.
 
 @class LoginManagerLoginResult;
+@class FBSDKLoginConfiguration;
 
 typedef NS_ENUM(NSUInteger, LoginBehavior) { LoginBehaviorBrowser };
 typedef NS_ENUM(NSUInteger, DefaultAudience) { DefaultAudienceFriends };
+
 typedef void (^LoginManagerLoginResultBlock)(LoginManagerLoginResult *_Nullable result,
                                              NSError *_Nullable error);
 
@@ -47,6 +51,11 @@ typedef void (^LoginManagerLoginResultBlock)(LoginManagerLoginResult *_Nullable 
               fromViewController:(nullable UIViewController *)fromViewController
                          handler:(nullable LoginManagerLoginResultBlock)handler
 NS_SWIFT_NAME(logIn(permissions:from:handler:));
+
+- (void)logInFromViewController:(nullable UIViewController *)viewController
+                  configuration:(FBSDKLoginConfiguration *)configuration
+                     completion:(LoginManagerLoginResultBlock)completion
+NS_REFINED_FOR_SWIFT;
 
 @end
 
@@ -76,9 +85,7 @@ NS_SWIFT_NAME(LoginManagerLoginResultBlock);
 /**
  FBSDKDefaultAudience enum
 
-  Passed to open to indicate which default audience to use for sessions that post data to Facebook.
-
-
+  Passed to openURL to indicate which default audience to use for sessions that post data to Facebook.
 
  Certain operations such as publishing a status or publishing a photo require an audience. When the user
  grants an application permission to perform a publish operation, a default audience is selected as the
@@ -98,14 +105,15 @@ typedef NS_ENUM(NSUInteger, FBSDKDefaultAudience)
 /**
   `FBSDKLoginManager` provides methods for logging the user in and out.
 
- `FBSDKLoginManager` works directly with `[FBSDKAccessToken currentAccessToken]` and
-  sets the "currentAccessToken" upon successful authorizations (or sets `nil` in case of `logOut`).
+ `FBSDKLoginManager` serves to help manage sessions represented by tokens for authentication,
+ `AuthenticationToken`, and data access, `AccessToken`.
 
- You should check `[FBSDKAccessToken currentAccessToken]` before calling logIn* to see if there is
- a cached token available (typically in your viewDidLoad).
+ You should check if the type of token you expect is present as a singleton instance, either `AccessToken.current`
+ or `AuthenticationToken.current` before calling any of the login methods to see if there is a cached token
+ available. A standard place to do this is in `viewDidLoad`.
 
- If you are managing your own token instances outside of "currentAccessToken", you will need to set
- "currentAccessToken" before calling logIn* to authorize further permissions on your tokens.
+ @warning If you are managing your own token instances outside of `AccessToken.current`, you will need to set
+ `AccessToken.current` before calling any of the login methods to authorize further permissions on your tokens.
  */
 NS_SWIFT_NAME(LoginManager)
 @interface FBSDKLoginManager : NSObject
@@ -123,6 +131,7 @@ NS_SWIFT_NAME(LoginManager)
 
 /**
  Logs the user in or authorizes additional permissions.
+
  @param permissions the optional array of permissions. Note this is converted to NSSet and is only
  an NSArray for the convenience of literal syntax.
  @param fromViewController the view controller to present from. If nil, the topmost view controller will be
@@ -130,41 +139,73 @@ NS_SWIFT_NAME(LoginManager)
  @param handler the callback.
 
  Use this method when asking for read permissions. You should only ask for permissions when they
- are needed and explain the value to the user. You can inspect the result.declinedPermissions to also
- provide more information to the user if they decline permissions.
+ are needed and explain the value to the user. You can inspect the `FBSDKLoginManagerLoginResultBlock`'s
+ `result.declinedPermissions` to provide more information to the user if they decline permissions.
+ You typically should check if `AccessToken.current` already contains the permissions you need before
+ asking to reduce unnecessary login attempts. For example, you could perform that check in `viewDidLoad`.
 
- This method will present UI the user. You typically should check if `[FBSDKAccessToken currentAccessToken]`
- already contains the permissions you need before asking to reduce unnecessary app switching. For example,
- you could make that check at viewDidLoad.
- You can only do one login call at a time. Calling a login method before the completion handler is called
- on a previous login will return an error.
+ @warning You can only perform one login call at a time. Calling a login method before the completion handler is called
+ on a previous login attempt will result in an error.
+ @warning This method will present a UI to the user and thus should be called on the main thread.
  */
 - (void)logInWithPermissions:(NSArray<NSString *> *)permissions
-              fromViewController:(nullable UIViewController *)fromViewController
-                         handler:(nullable FBSDKLoginManagerLoginResultBlock)handler
+          fromViewController:(nullable UIViewController *)fromViewController
+                     handler:(nullable FBSDKLoginManagerLoginResultBlock)handler
 NS_SWIFT_NAME(logIn(permissions:from:handler:));
+
+/**
+ Logs the user in or authorizes additional permissions.
+
+ @param viewController the view controller from which to present the login UI. If nil, the topmost view
+ controller will be automatically determined and used.
+ @param configuration the login configuration to use.
+ @param completion the login completion handler.
+
+ Use this method when asking for permissions. You should only ask for permissions when they
+ are needed and the value should be explained to the user. You can inspect the
+ `FBSDKLoginManagerLoginResultBlock`'s `result.declinedPermissions` to provide more information
+ to the user if they decline permissions.
+ To reduce unnecessary login attempts, you should typically check if `AccessToken.current`
+ already contains the permissions you need. If it does, you probably do not need to call this method.
+
+ @warning You can only perform one login call at a time. Calling a login method before the completion handler is called
+ on a previous login attempt will result in an error.
+ @warning This method will present a UI to the user and thus should be called on the main thread.
+ */
+- (void)logInFromViewController:(nullable UIViewController *)viewController
+                  configuration:(FBSDKLoginConfiguration *)configuration
+                     completion:(FBSDKLoginManagerLoginResultBlock)completion
+NS_REFINED_FOR_SWIFT;
 
 /**
  Logs the user in with the given deep link url. Will only log user in if the given url contains valid login data.
  @param url the deep link url
  @param handler the callback.
 
- This method should be called with the url from the openURL method.
+This method will present a UI to the user and thus should be called on the main thread.
+This method should be called with the url from the openURL method.
+
+ @warning This method will present a UI to the user and thus should be called on the main thread.
  */
 - (void)logInWithURL:(NSURL *)url
              handler:(nullable FBSDKLoginManagerLoginResultBlock)handler
 NS_SWIFT_NAME(logIn(url:handler:));
 
 /**
-  Requests user's permission to reathorize application's data access, after it has expired due to inactivity.
- @param fromViewController the view controller to present from. If nil, the topmost view controller will be
- automatically determined as best as possible.
+ Requests user's permission to reathorize application's data access, after it has expired due to inactivity.
+ @param fromViewController the view controller from which to present the login UI. If nil, the topmost view
+ controller will be automatically determined and used.
  @param handler the callback.
- Use this method when you need to reathorize your app's access to user data via Graph API, after such an access has expired.
- You should provide as much context to the user as possible as to why you need to reauthorize the access, the scope of
- access being reathorized, and what added value your app provides when the access is reathorized.
- You can inspect the result.declinedPermissions to also provide more information to the user if they decline permissions.
- This method will present UI the user. You typically should call this if `[FBSDKAccessToken isDataAccessExpired]` returns true.
+
+Use this method when you need to reathorize your app's access to user data via the Graph API.
+You should only call this after access has expired.
+You should provide as much context to the user as possible as to why you need to reauthorize the access, the
+scope of access being reathorized, and what added value your app provides when the access is reathorized.
+You can inspect the `result.declinedPermissions` to determine if you should provide more information to the
+user based on any declined permissions.
+
+ @warning This method will reauthorize using a `LoginConfiguration` with `FBSDKLoginTracking` set to `.enabled`.
+ @warning This method will present UI the user. You typically should call this if `AccessToken.isDataAccessExpired` is true.
  */
 - (void)reauthorizeDataAccess:(UIViewController *)fromViewController
                       handler:(FBSDKLoginManagerLoginResultBlock)handler
@@ -173,7 +214,9 @@ NS_SWIFT_NAME(reauthorizeDataAccess(from:handler:));
 /**
   Logs the user out
 
- This calls [FBSDKAccessToken setCurrentAccessToken:nil] and [FBSDKProfile setCurrentProfile:nil].
+ This nils out the singleton instances of `AccessToken` `AuthenticationToken` and `Profle`.
+
+ @note This is only a client side logout. It will not log the user out of their Facebook account.
  */
 - (void)logOut;
 

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginManagerLoginResult.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKLoginManagerLoginResult.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface LoginManagerLoginResult : NSObject
 
 @property (copy, nonatomic, nullable) FBSDKAccessToken *token;
+@property (copy, nonatomic, nullable) FBSDKAuthenticationToken *authenticationToken;
 @property (readonly, nonatomic) BOOL isCancelled;
 @property (copy, nonatomic) NSSet<NSString *> *grantedPermissions;
 @property (copy, nonatomic) NSSet<NSString *> *declinedPermissions;
@@ -43,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 #else
 
 @class FBSDKAccessToken;
+@class FBSDKAuthenticationToken;
 
 /**
   Describes the result of a login attempt.
@@ -57,6 +59,11 @@ NS_SWIFT_NAME(LoginManagerLoginResult)
   the access token.
  */
 @property (copy, nonatomic, nullable) FBSDKAccessToken *token;
+
+/**
+  the authentication token.
+ */
+@property (copy, nonatomic, nullable) FBSDKAuthenticationToken *authenticationToken;
 
 /**
   whether the login was cancelled by the user.
@@ -80,11 +87,13 @@ NS_SWIFT_NAME(LoginManagerLoginResult)
 /**
   Initializes a new instance.
  @param token the access token
+ @param authenticationToken the authentication token
  @param isCancelled whether the login was cancelled by the user
  @param grantedPermissions the set of granted permissions
  @param declinedPermissions the set of declined permissions
  */
 - (instancetype)initWithToken:(nullable FBSDKAccessToken *)token
+          authenticationToken:(nullable FBSDKAuthenticationToken *)authenticationToken
                   isCancelled:(BOOL)isCancelled
            grantedPermissions:(NSSet<NSString *> *)grantedPermissions
           declinedPermissions:(NSSet<NSString *> *)declinedPermissions

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKProfile.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKProfile.h
@@ -22,6 +22,7 @@
 
 #import "FBSDKProfilePictureView.h"
 
+@class FBSDKAuthenticationTokenClaims;
 @class FBSDKProfile;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -109,7 +110,30 @@ NS_SWIFT_NAME(Profile)
                       lastName:(nullable NSString *)lastName
                           name:(nullable NSString *)name
                        linkURL:(nullable NSURL *)linkURL
-                   refreshDate:(nullable NSDate *)refreshDate NS_DESIGNATED_INITIALIZER;
+                   refreshDate:(nullable NSDate *)refreshDate;
+
+/**
+  initializes a new instance.
+ @param userID the user ID
+ @param firstName the user's first name
+ @param middleName the user's middle name
+ @param lastName the user's last name
+ @param name the user's complete name
+ @param linkURL the link for this profile
+ @param refreshDate the optional date this profile was fetched. Defaults to [NSDate date].
+ @param imageURL an optional URL to use for fetching a user's profile image
+ @param email the user's email
+ */
+- (instancetype)initWithUserID:(NSString *)userID
+                     firstName:(nullable NSString *)firstName
+                    middleName:(nullable NSString *)middleName
+                      lastName:(nullable NSString *)lastName
+                          name:(nullable NSString *)name
+                       linkURL:(nullable NSURL *)linkURL
+                   refreshDate:(nullable NSDate *)refreshDate
+                      imageURL:(nullable NSURL *)imageURL
+                         email:(nullable NSString *)email
+NS_DESIGNATED_INITIALIZER;
 
 /**
  The current profile instance and posts the appropriate notification
@@ -145,6 +169,8 @@ NS_SWIFT_NAME(current);
 /**
   A URL to the user's profile.
 
+  IMPORTANT: This field will only be populated if your user has granted your application the 'user_link' permission
+
  Consider using `FBSDKAppLinkResolver` to resolve this
  to an app link to link directly to the user's profile in the Facebook app.
  */
@@ -154,6 +180,16 @@ NS_SWIFT_NAME(current);
   The last time the profile data was fetched.
  */
 @property (nonatomic, readonly) NSDate *refreshDate;
+/**
+  A URL to use for fetching a user's profile image.
+ */
+@property (nonatomic, readonly, nullable) NSURL *imageURL;
+/**
+  The user's email.
+
+ IMPORTANT: This field will only be populated if your user has granted your application the 'email' permission.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *email;
 
 /**
   Indicates if `currentProfile` will automatically observe `FBSDKAccessTokenDidChangeNotification` notifications

--- a/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKSettings.h
+++ b/AWSAuthSDK/Dependencies/FacebookHeaders/FBSDKSettings.h
@@ -86,13 +86,6 @@ NS_SWIFT_NAME(Settings)
 NS_SWIFT_NAME(jpegCompressionQuality);
 
 /**
- Controls sdk auto initailization.
- If not explicitly set, the default is true
- */
-@property (class, nonatomic, assign, getter=isAutoInitEnabled) BOOL autoInitEnabled
-DEPRECATED_MSG_ATTRIBUTE("Auto-initialization will be removed in the next major version release.");
-
-/**
  Controls the auto logging of basic app events, such as activateApp and deactivateApp.
  If not explicitly set, the default is true
  */
@@ -109,6 +102,12 @@ DEPRECATED_MSG_ATTRIBUTE("Auto-initialization will be removed in the next major 
  If not explicitly set, the default is true
  */
 @property (class, nonatomic, assign, getter=isAdvertiserIDCollectionEnabled) BOOL advertiserIDCollectionEnabled;
+
+/**
+ Controls the SKAdNetwork report
+ If not explicitly set, the default is true
+ */
+@property (class, nonatomic, assign, getter=isSKAdNetworkReportEnabled) BOOL SKAdNetworkReportEnabled;
 
 /**
  Whether data such as that generated through FBSDKAppEvents and sent to Facebook

--- a/AWSFacebookSignIn.podspec
+++ b/AWSFacebookSignIn.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
    s.requires_arc = true
    s.dependency 'AWSAuthCore', '2.22.3'
    s.dependency 'AWSCore', '2.22.3'
-   s.dependency 'FBSDKLoginKit', '8.0'
-   s.dependency 'FBSDKCoreKit', '8.0'
+   s.dependency 'FBSDKLoginKit', '9.0'
+   s.dependency 'FBSDKCoreKit', '9.0'
 
    s.source_files = 'AWSAuthSDK/Sources/AWSFacebookSignIn/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSFacebookSignIn/*.h'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Misc. Updates
 
+- **AWSAuthSDK**
+   - Upgrade Facebook SDK to 9.0.0 ([PR #xx](https://github.com/aws-amplify/aws-sdk-ios/pull/xxx))
+
 - Model updates for the following services
   - AWSElasticLoadBalancing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking Changes
 
 - **AWSAuthSDK**
-   - Upgrade Facebook SDK to 9.0.0 ([PR #3433](https://github.com/aws-amplify/aws-sdk-ios/pull/3433)). Facebook SDK has removed automatic initialization of the SDK in v9.0.0. Follow the steps provided [here](https://developers.facebook.com/docs/ios/getting-started/#step-3--connect-the-app-delegate) to initialize the SDK during app setup.
+   - Upgrade Facebook SDK to 9.0.0 ([PR #3433](https://github.com/aws-amplify/aws-sdk-ios/pull/3433)). Facebook SDK has removed automatic initialization of the SDK in v9.0.0. Follow the steps provided [here](https://developers.facebook.com/docs/ios/getting-started/#step-3--connect-the-app-delegate) to initialize the Facebook SDK during app setup.
    Support for `limited` signin configuration will be added in a later release.
 
 ### Misc. Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@
 
 ## 2.22.2
 
--Features for next release
-
 ### Misc. Updates
 
 - **AWSMobileClientXCF**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Misc. Updates
 
 - **AWSAuthSDK**
-   - Upgrade Facebook SDK to 9.0.0 ([PR #xx](https://github.com/aws-amplify/aws-sdk-ios/pull/xxx))
+   - Upgrade Facebook SDK to 9.0.0 ([PR #3433](https://github.com/aws-amplify/aws-sdk-ios/pull/3433))
 
 - Model updates for the following services
   - AWSElasticLoadBalancing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **AWSAuthSDK**
    - Upgrade Facebook SDK to 9.0.0 ([PR #3433](https://github.com/aws-amplify/aws-sdk-ios/pull/3433)). Facebook SDK has removed automatic initialization of the SDK in v9.0.0. Follow the steps provided [here](https://developers.facebook.com/docs/ios/getting-started/#step-3--connect-the-app-delegate) to initialize the SDK during app setup.
+   Support for `limited` signin configuration will be added in a later release.
 
 ### Misc. Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 -Features for next release
 
-### Misc. Updates
+### Breaking Changes
 
 - **AWSAuthSDK**
-   - Upgrade Facebook SDK to 9.0.0 ([PR #3433](https://github.com/aws-amplify/aws-sdk-ios/pull/3433))
+   - Upgrade Facebook SDK to 9.0.0 ([PR #3433](https://github.com/aws-amplify/aws-sdk-ios/pull/3433)). Facebook SDK has removed automatic initialization of the SDK in v9.0.0. Follow the steps provided [here](https://developers.facebook.com/docs/ios/getting-started/#step-3--connect-the-app-delegate) to initialize the SDK during app setup.
+
+### Misc. Updates
 
 - Model updates for the following services
   - AWSElasticLoadBalancing


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/aws-sdk-ios/issues/3432

*Description of changes:* 

Updates FB SDK to 9.0. This is a breaking change since FB has removed automatic initialization of the SDK. Customer should call initialization methods in app startup - https://developers.facebook.com/docs/ios/getting-started/#step-3--connect-the-app-delegate

*Testing:*

Manually tested using a sample app with dropinUI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
