### PR TITLE
chore: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+*Issue #, if available:*
+
+*Description of changes:*
+
+*Check points:*
+
+- [ ] Added new tests to cover change, if needed
+- [ ] All unit tests pass
+- [ ] All integration tests pass
+- [ ] Updated CHANGELOG.md
+- [ ] Documentation update for the change if required
+- [ ] PR title conforms to conventional commit style
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
I keep forgetting to update the CHANGELOG for changes, and since @royjit added a [shiny new PR template in Amplify](https://github.com/aws-amplify/amplify-ios/blob/main/.github/PULL_REQUEST_TEMPLATE.md), I thought I'd just steal that for the SDK repo, with appropriate modification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
