### PR TITLE
fix: Fix ignored isInitialCustomChallenge parameter in AWSCognitoIdentityUser

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -330,7 +330,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                                                password:(NSString *) password
                                          validationData:(NSArray<AWSCognitoIdentityUserAttributeType*>*) validationData
                                isInitialCustomChallenge:(BOOL) isInitialCustomChallenge {
-    return [self getSession:username password:password validationData:validationData clientMetaData:nil];
+    return [self getSession:username password:password validationData:validationData clientMetaData:nil isInitialCustomChallenge:isInitialCustomChallenge];
 }
 
 /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
--Features for next release
+### Bug fixes
 - **AWSCognitoIdentityProvider**
-  - Fix ignored `isInitialCustomChallenge` parameter in `AWSCognitoIdentityUser`
+  - Fix ignored `isInitialCustomChallenge` parameter in `AWSCognitoIdentityUser` ([PR #3461](https://github.com/aws-amplify/aws-sdk-ios/pull/3461)). Thanks @johntmcintosh!
 
 ## 2.23.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 -Features for next release
+- **AWSCognitoIdentityProvider**
+  - Fix ignored `isInitialCustomChallenge` parameter in `AWSCognitoIdentityUser`
 
 ## 2.23.1
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
I found that one of the method variants of `[AWSCognitoIdentityUser getSession]` took `isInitialCustomChallenge` as an input parameter, but didn't forward that parameter to the method variant that it called, which resulted in a value of `NO` always being used, regardless of what value the API consumer passed in.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

FYI - The AWSCognitoIdentityProviderTests fail when I run them with the following exception being thrown:

> *** Terminating app due to uncaught exception 'createUserPool error', reason: 'Error: Error Domain=com.amazonaws.AWSServiceErrorDomain Code=7 "(null)" UserInfo={__type=UnrecognizedClientException, message=The security token included in the request is invalid.}'

but they were also doing this before my change, so I don't think that my change is related.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
