### PR TITLE
feat(AWSCognitoIdentityProvider): Support custom endpoint

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -248,6 +248,14 @@
 		FA47B5DF246C6CDD0071196D /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
 		FA5B0F11246A475500B4185B /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
 		FA5B0F12246A477D00B4185B /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
+		FA77118D260BEFCA0030966D /* AWSMobileClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5FC69011FAFA1AA004790CB /* AWSMobileClient.framework */; };
+		FA771251260BF06B0030966D /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
+		FA771252260BF0740030966D /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57361F44EC3F005A0E56 /* AWSCognitoIdentityProvider.framework */; };
+		FA771253260BF0740030966D /* AWSCognitoIdentityProviderASF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E496D9421FDB0632000CF290 /* AWSCognitoIdentityProviderASF.framework */; };
+		FA771254260BF07D0030966D /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
+		FA771255260BF0820030966D /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
+		FA771274260BF0AB0030966D /* AWSMobileClientCustomEndpointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */; };
+		FA7712A2260BF1520030966D /* AWSMobileClientTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */; };
 		FAA39965251AAF7100F9D762 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
 		FAA39AD5251AB01F00F9D762 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
 		FAA39AF0251AB02B00F9D762 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
@@ -1185,6 +1193,20 @@
 			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
 			remoteInfo = AWSTestResources;
 		};
+		FA771201260BEFCA0030966D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 21863B3E2602660A0070CD1B;
+			remoteInfo = AWSLocationXCF;
+		};
+		FA77124F260BF0590030966D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 175869971EF8899700F1452C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B412F63523347D1B00F1AC69;
+			remoteInfo = AWSMobileClientIntegTestApp;
+		};
 		FAF1B87C2339175B007F1435 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
@@ -1412,6 +1434,9 @@
 		D8FAC28A251D1D78005F9FC6 /* FBSDKMeasurementEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKMeasurementEvent.h; sourceTree = "<group>"; };
 		D8FAC28C251D1D8F005F9FC6 /* FBSDKURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKURL.h; sourceTree = "<group>"; };
 		D8FAC28E251D1D94005F9FC6 /* FBSDKWebViewAppLinkResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKWebViewAppLinkResolver.h; sourceTree = "<group>"; };
+		FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientCustomEndpointTest.swift; sourceTree = "<group>"; };
+		FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSMobileClientCustomEndpointTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA77118C260BEFCA0030966D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1571,6 +1596,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA771185260BEFCA0030966D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA771251260BF06B0030966D /* AWSAuthCore.framework in Frameworks */,
+				FA771252260BF0740030966D /* AWSCognitoIdentityProvider.framework in Frameworks */,
+				FA771253260BF0740030966D /* AWSCognitoIdentityProviderASF.framework in Frameworks */,
+				FA771254260BF07D0030966D /* AWSCore.framework in Frameworks */,
+				FA77118D260BEFCA0030966D /* AWSMobileClient.framework in Frameworks */,
+				FA771255260BF0820030966D /* AWSTestResources.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1663,6 +1701,7 @@
 				B412F63623347D1B00F1AC69 /* AWSMobileClientIntegTestApp.app */,
 				B49C889E24B38746009739FC /* AWSAppleSignIn.framework */,
 				B402CD3F2580672F0020B83B /* AWSMobileClientXCF.framework */,
+				FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1809,14 +1848,14 @@
 			isa = PBXGroup;
 			children = (
 				17CD4AA8218241AD00953483 /* Info.plist */,
-				B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */,
 				B4C8E4A92307447F0064C158 /* AWSMobileClientCredentialsTest.swift */,
 				B4C8E4A32307415C0064C158 /* AWSMobileClientDeviceTests.swift */,
 				B4C8E4A7230743780064C158 /* AWSMobileClientPasswordTests.swift */,
+				B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */,
 				B4C8E4A1230740200064C158 /* AWSMobileClientSignoutTests.swift */,
+				B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */,
 				17CD4AA6218241AD00953483 /* AWSMobileClientTests.swift */,
 				B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */,
-				B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */,
 			);
 			path = AWSMobileClientTests;
 			sourceTree = "<group>";
@@ -1824,8 +1863,9 @@
 		17CD4B0D218241B800953483 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				B412F64A23347FBD00F1AC69 /* AWSMobileClientIntegTestApp */,
 				B412F5EE2334783D00F1AC69 /* AWSMobileClientCustomAuthTests */,
+				FA771189260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */,
+				B412F64A23347FBD00F1AC69 /* AWSMobileClientIntegTestApp */,
 				17CD4AA5218241AD00953483 /* AWSMobileClientTests */,
 				B92BA3C72318859D007C1175 /* AWSMobileClientUnitTests */,
 			);
@@ -1969,6 +2009,7 @@
 				B55D57681F44EC3F005A0E56 /* AWSLexTests.xctest */,
 				B55D576A1F44EC3F005A0E56 /* AWSLexUnitTests.xctest */,
 				B4BD3DB425C381DD00AA9034 /* AWSLocation.framework */,
+				FA771202260BEFCA0030966D /* AWSLocationXCF.framework */,
 				B4BD3DB625C381DD00AA9034 /* AWSLocationTests.xctest */,
 				B4BD3DB825C381DD00AA9034 /* AWSLocationUnitTests.xctest */,
 				B55D576C1F44EC3F005A0E56 /* AWSLogs.framework */,
@@ -2062,6 +2103,15 @@
 				B92BA3CA2318859D007C1175 /* Info.plist */,
 			);
 			path = AWSMobileClientUnitTests;
+			sourceTree = "<group>";
+		};
+		FA771189260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */ = {
+			isa = PBXGroup;
+			children = (
+				FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */,
+				FA77118C260BEFCA0030966D /* Info.plist */,
+			);
+			path = AWSMobileClientCustomEndpointTest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2494,13 +2544,31 @@
 			productReference = B92BA3C62318859D007C1175 /* AWSMobileClientUnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FA771187260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA771203260BEFCA0030966D /* Build configuration list for PBXNativeTarget "AWSMobileClientCustomEndpointTest" */;
+			buildPhases = (
+				FA771184260BEFCA0030966D /* Sources */,
+				FA771185260BEFCA0030966D /* Frameworks */,
+				FA771186260BEFCA0030966D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA771250260BF0590030966D /* PBXTargetDependency */,
+			);
+			name = AWSMobileClientCustomEndpointTest;
+			productName = AWSMobileClientCustomEndpointTest;
+			productReference = FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		175869971EF8899700F1452C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1030;
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = "Amazon Web Services";
 				TargetAttributes = {
@@ -2568,6 +2636,11 @@
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
+					FA771187260BEFCA0030966D = {
+						CreatedOnToolsVersion = 12.4;
+						ProvisioningStyle = Automatic;
+						TestTargetID = B412F63523347D1B00F1AC69;
+					};
 				};
 			};
 			buildConfigurationList = 1758699A1EF8899700F1452C /* Build configuration list for PBXProject "AWSAuthSDK" */;
@@ -2599,6 +2672,7 @@
 				17CD4AA3218241AD00953483 /* AWSMobileClientTests */,
 				B92BA3C52318859D007C1175 /* AWSMobileClientUnitTests */,
 				B412F5DE233445A500F1AC69 /* AWSMobileClientCustomAuthTests */,
+				FA771187260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */,
 				1750D0061F2D4DFA006D915E /* AWSUserPoolsSignIn */,
 				17CD4B1F218244EA00953483 /* AWSAuthSDKTestApp */,
 				177B8AE521E81B7D0051068F /* AWSAuthSDKTestAppUITests */,
@@ -3379,6 +3453,13 @@
 			remoteRef = FA4A69C12462317A00230849 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		FA771202260BEFCA0030966D /* AWSLocationXCF.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = AWSLocationXCF.framework;
+			remoteRef = FA771201260BEFCA0030966D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		FAF1B87D2339175B007F1435 /* AWSCoreConfigurationTest.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
@@ -3498,6 +3579,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B92BA3C42318859D007C1175 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA771186260BEFCA0030966D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3674,6 +3762,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA771184260BEFCA0030966D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA771274260BF0AB0030966D /* AWSMobileClientCustomEndpointTest.swift in Sources */,
+				FA7712A2260BF1520030966D /* AWSMobileClientTestBase.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3771,6 +3868,11 @@
 			isa = PBXTargetDependency;
 			name = AWSTestResources;
 			targetProxy = FA5B0F0F246A474E00B4185B /* PBXContainerItemProxy */;
+		};
+		FA771250260BF0590030966D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B412F63523347D1B00F1AC69 /* AWSMobileClientIntegTestApp */;
+			targetProxy = FA77124F260BF0590030966D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -4650,6 +4752,54 @@
 			};
 			name = Release;
 		};
+		FA771190260BEFCA0030966D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/AWSMobileClientCustomEndpointTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClientCustomEndpointTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSMobileClientIntegTestApp.app/AWSMobileClientIntegTestApp";
+			};
+			name = Debug;
+		};
+		FA771191260BEFCA0030966D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/AWSMobileClientCustomEndpointTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClientCustomEndpointTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSMobileClientIntegTestApp.app/AWSMobileClientIntegTestApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4793,6 +4943,15 @@
 			buildConfigurations = (
 				B92BA3CF2318859D007C1175 /* Debug */,
 				B92BA3D02318859D007C1175 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FA771203260BEFCA0030966D /* Build configuration list for PBXNativeTarget "AWSMobileClientCustomEndpointTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA771190260BEFCA0030966D /* Debug */,
+				FA771191260BEFCA0030966D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
@@ -69,6 +69,16 @@
                ReferencedContainer = "container:AWSAuthSDK.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA771187260BEFCA0030966D"
+               BuildableName = "AWSMobileClientCustomEndpointTest.xctest"
+               BlueprintName = "AWSMobileClientCustomEndpointTest"
+               ReferencedContainer = "container:AWSAuthSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
@@ -54,12 +54,6 @@ class AWSMobileClientCustomEndpointTest: AWSMobileClientTestBase {
 
         signUpAndVerifyUser(username: username)
 
-        let clientInitialized = expectation(description: "clientInitialized")
-        AWSMobileClient.default().initialize { _, _ in
-            clientInitialized.fulfill()
-        }
-        wait(for: [clientInitialized], timeout: 0.1)
-
         let signInComplete = expectation(description: "signInComplete")
         AWSMobileClient.default().signIn(
             username: username,

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
@@ -1,0 +1,84 @@
+//
+//  AWSMobileClientCustomEndpointTest.swift
+//  AWSMobileClientCustomEndpointTest
+//
+
+import XCTest
+import AWSMobileClient
+import AWSTestResources
+
+/// All tests in this class run against a configuration that specifies an "Endpoint" to override
+/// the default User Pool endpoint construction of `cognito-idp.<region>.amazonaws.com`.
+class AWSMobileClientCustomEndpointTest: AWSMobileClientTestBase {
+    override class func setUp() {
+        loadConfigurationForCustomEndpoint()
+        super.setUp()
+    }
+
+    override func tearDown() {
+        let signedOut = expectation(description: "signedOut")
+        AWSMobileClient.default().signOut() { _ in
+            signedOut.fulfill()
+        }
+        wait(for: [signedOut], timeout: 1.0)
+        AWSMobileClient.default().clearKeychain()
+        AWSMobileClient.default().clearCredentials()
+    }
+
+    /// Manipulates the configs in-memory to swap the Custom Endpoint config into the Default slot
+    /// Since this modifies the config singleton, the custom endpoint tests must be run in a
+    /// separate execution context from other tests. Also defensively removes unused configs to
+    /// reduce possibility of conflict.
+    static func loadConfigurationForCustomEndpoint() {
+        var configurationJson = getAWSConfiguration()
+
+        configurationJson.removeValue(forKey: "S3TransferUtility")
+
+        // Use NSMutableDictionary rather than `var cognitoUserPoolConfig...` to retain class
+        // semantics and make it easier to modify deeply-nested structures
+        let cognitoUserPoolConfig = configurationJson["CognitoUserPool"] as! NSMutableDictionary
+        cognitoUserPoolConfig["Default"] = cognitoUserPoolConfig["CustomEndpoint"]
+
+        cognitoUserPoolConfig.removeObject(forKey: "DefaultCustomAuth")
+        cognitoUserPoolConfig.removeObject(forKey: "CustomEndpoint")
+
+        let authConfig = configurationJson["Auth"] as! NSMutableDictionary
+        authConfig["Default"] = ["authenticationFlowType": "USER_SRP_AUTH"]
+        authConfig.removeObject(forKey: "DefaultCustomAuth")
+
+        AWSInfo.configureDefaultAWSInfo(configurationJson)
+    }
+
+    func testSignIn() {
+        let username = "awsmobileclient-\(UUID().uuidString)"
+
+        signUpAndVerifyUser(username: username)
+
+        let clientInitialized = expectation(description: "clientInitialized")
+        AWSMobileClient.default().initialize { _, _ in
+            clientInitialized.fulfill()
+        }
+        wait(for: [clientInitialized], timeout: 0.1)
+
+        let signInComplete = expectation(description: "signInComplete")
+        AWSMobileClient.default().signIn(
+            username: username,
+            password: AWSMobileClientCustomEndpointTest.sharedPassword
+        ) { result, error in
+            defer {
+                signInComplete.fulfill()
+            }
+
+            XCTAssertNil(error)
+
+            guard let signInResult = result else {
+                XCTAssertNotNil(result)
+                return
+            }
+
+            XCTAssertEqual(signInResult.signInState, .signedIn)
+        }
+        wait(for: [signInComplete], timeout: AWSMobileClientCustomEndpointTest.networkRequestTimeout)
+    }
+
+}

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/Info.plist
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -137,8 +137,6 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     NSString *pinpointAppId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolPinpointAppId];
     NSNumber *migrationEnabled = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolMigrationEnabled];
 
-    NSString *serviceEndpoint = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolEndpoint];
-
     BOOL migrationEnabledBoolean = NO;
     if (migrationEnabled != nil) {
         migrationEnabledBoolean = [migrationEnabled boolValue];

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -44,6 +44,7 @@ static NSString *const AWSCognitoUserPoolAppClientId = @"AppClientId";
 static NSString *const AWSCognitoUserPoolAppClientSecret = @"AppClientSecret";
 static NSString *const AWSCognitoUserPoolPinpointAppId = @"PinpointAppId";
 static NSString *const AWSCognitoUserPoolMigrationEnabled = @"MigrationEnabled";
+static NSString *const AWSCognitoUserPoolEndpoint = @"Endpoint";
 
 static NSString *const AWSPinpointContextKeychainService = @"com.amazonaws.AWSPinpointContext";
 static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.AWSPinpointContextKeychainUniqueIdKey";
@@ -61,12 +62,26 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     dispatch_once(&onceToken, ^{
         AWSServiceConfiguration *serviceConfiguration = nil;
         AWSServiceInfo *serviceInfo = [[AWSInfo defaultAWSInfo] defaultServiceInfo:AWSInfoCognitoUserPool];
-
         if (serviceInfo) {
-            serviceConfiguration = [[AWSServiceConfiguration alloc] initWithRegion:serviceInfo.region
-                                                               credentialsProvider:nil];
+            NSString *endpointOverride = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolEndpoint];
+            if (endpointOverride) {
+                NSURLComponents *components = [NSURLComponents new];
+                components.scheme = @"https";
+                components.host = endpointOverride;
+                NSURL *endpointURL = [components URL];
+                AWSEndpoint *endpoint = [[AWSEndpoint alloc] initWithRegion:serviceInfo.region
+                                                                    service:AWSServiceCognitoIdentityProvider
+                                                                        URL:endpointURL];
+                serviceConfiguration = [[AWSServiceConfiguration alloc] initWithRegion:serviceInfo.region
+                                                                              endpoint:endpoint
+                                                                   credentialsProvider:nil
+                                                                   localTestingEnabled:NO];
+            } else {
+                serviceConfiguration = [[AWSServiceConfiguration alloc] initWithRegion:serviceInfo.region
+                                                                   credentialsProvider:nil];
+            }
         }
-        AWSCognitoIdentityUserPoolConfiguration *configuration = [AWSCognitoIdentityUserPool buildUserPoolConfiguration: serviceInfo];
+        AWSCognitoIdentityUserPoolConfiguration *configuration = [AWSCognitoIdentityUserPool buildUserPoolConfiguration:serviceInfo];
         _defaultUserPool = [[AWSCognitoIdentityUserPool alloc] initWithConfiguration:serviceConfiguration
                                                                userPoolConfiguration:configuration];
     });
@@ -121,24 +136,27 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
     NSString *clientSecret = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecret] ?: [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolAppClientSecretLegacy];
     NSString *pinpointAppId = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolPinpointAppId];
     NSNumber *migrationEnabled = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolMigrationEnabled];
+
+    NSString *serviceEndpoint = [serviceInfo.infoDictionary objectForKey:AWSCognitoUserPoolEndpoint];
+
     BOOL migrationEnabledBoolean = NO;
     if (migrationEnabled != nil) {
         migrationEnabledBoolean = [migrationEnabled boolValue];
     }
 
-    if (poolId && clientId) {
-        return [[AWSCognitoIdentityUserPoolConfiguration alloc] initWithClientId:clientId
-                                                                    clientSecret:clientSecret
-                                                                          poolId:poolId
-                                              shouldProvideCognitoValidationData:YES
-                                                                   pinpointAppId:pinpointAppId
-                                                                migrationEnabled:migrationEnabledBoolean ];
-
-    } else {
+    if (!poolId || !clientId) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                        reason:@"The service configuration is `nil`. You need to configure `Info.plist` before using this method."
                                      userInfo:nil];
     }
+
+    return [[AWSCognitoIdentityUserPoolConfiguration alloc] initWithClientId:clientId
+                                                                clientSecret:clientSecret
+                                                                      poolId:poolId
+                                          shouldProvideCognitoValidationData:YES
+                                                               pinpointAppId:pinpointAppId
+                                                            migrationEnabled:migrationEnabledBoolean ];
+
 }
 
 // Internal init method

--- a/AWSCore/Service/AWSService.h
+++ b/AWSCore/Service/AWSService.h
@@ -111,7 +111,12 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
                       endpoint:(AWSEndpoint *)endpoint
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider;
 
-- (void)addUserAgentProductToken:(NSString *)productToken;
+- (instancetype)initWithRegion:(AWSRegionType)regionType
+                      endpoint:(AWSEndpoint *)endpoint
+           credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
+           localTestingEnabled:(BOOL)localTestingEnabled;
+
+    - (void)addUserAgentProductToken:(NSString *)productToken;
 
 @end
 

--- a/AWSCore/Service/AWSService.h
+++ b/AWSCore/Service/AWSService.h
@@ -116,7 +116,7 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
            localTestingEnabled:(BOOL)localTestingEnabled;
 
-    - (void)addUserAgentProductToken:(NSString *)productToken;
+- (void)addUserAgentProductToken:(NSString *)productToken;
 
 @end
 

--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -122,36 +122,45 @@ static NSString *const AWSServiceConfigurationUnknown = @"Unknown";
                    serviceType:(AWSServiceType)serviceType
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
            localTestingEnabled:(BOOL)localTestingEnabled {
-    if(self = [self initWithRegion:regionType credentialsProvider:credentialsProvider]){
-        _localTestingEnabled = localTestingEnabled;
-        if(localTestingEnabled) {
-            _endpoint = [[AWSEndpoint alloc] initLocalEndpointWithRegion:regionType
-                                                                 service:serviceType
-                                                            useUnsafeURL:YES];
-        }
+    AWSEndpoint *endpoint;
+    if (localTestingEnabled) {
+        endpoint = [[AWSEndpoint alloc] initLocalEndpointWithRegion:regionType
+                                                            service:serviceType
+                                                       useUnsafeURL:YES];
     }
-    
-    return self;
+    return [self initWithRegion:regionType
+                       endpoint:endpoint
+            credentialsProvider:credentialsProvider
+            localTestingEnabled:localTestingEnabled];
 }
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
-    if (self = [super init]) {
-        _regionType = regionType;
-        _credentialsProvider = credentialsProvider;
-        _localTestingEnabled = NO;
-    }
-
-    return self;
+    return [self initWithRegion:regionType
+                       endpoint:nil
+            credentialsProvider:credentialsProvider
+            localTestingEnabled:NO];
 }
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
                       endpoint:(AWSEndpoint *)endpoint
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
-    if(self = [self initWithRegion:regionType credentialsProvider:credentialsProvider]){
+    return [self initWithRegion:regionType
+                       endpoint:endpoint
+            credentialsProvider:credentialsProvider
+            localTestingEnabled:NO];
+}
+
+- (instancetype)initWithRegion:(AWSRegionType)regionType
+                      endpoint:(AWSEndpoint *)endpoint
+           credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
+           localTestingEnabled:(BOOL)localTestingEnabled {
+    if (self = [super init]) {
+        _regionType = regionType;
         _endpoint = endpoint;
+        _credentialsProvider = credentialsProvider;
+        _localTestingEnabled = localTestingEnabled;
     }
-    
     return self;
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 
 - **AWSMobileClient**, **AWSCognitoIdentityProvider**
-  - AWSCognitoIdentityProvider now accepts an `Endpoint` configuration value that can be used to override the default endpoint of `cognito-idp.<region>.amazonaws.com`. (See (PR #3481)[https://github.com/aws-amplify/aws-sdk-ios/pull/3481].)
+  - AWSCognitoIdentityProvider now accepts an `Endpoint` configuration value that can be used to override the default endpoint of `cognito-idp.<region>.amazonaws.com`. (See (PR #3482)[https://github.com/aws-amplify/aws-sdk-ios/pull/3482].)
 
     You can use this override value to specify the domain name of, for example, a CloudFront distribution fronted by a Web Application Firewall for DDOS protection on your Cognito User Pool account. The value of `Endpoint` should be a fully-qualified host name, not a URL. Example:
 
@@ -21,7 +21,7 @@
     }
     ```
 
-    > **WARNING** The Amplify CLI will overwrite customizations to the `awsconfiguration.json` and `amplifyconfiguration.json` files if you do an `amplify push` or `amplify pull`. You will need to re-apply the `Endpoint` customization if you use the CLI to modify your cloud backend.
+    > **WARNING** The Amplify CLI will overwrite customizations to the `awsconfiguration.json` and `amplifyconfiguration.json` files if you do an `amplify push` or `amplify pull`. You will need to manually re-apply the `Endpoint` customization if you use the CLI to modify your cloud backend.
 
 ## 2.23.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 ## Unreleased
 
--Features for next release
+### New Features
+
+- **AWSMobileClient**, **AWSCognitoIdentityProvider**
+  - AWSCognitoIdentityProvider now accepts an `Endpoint` configuration value that can be used to override the default endpoint of `cognito-idp.<region>.amazonaws.com`. (See (PR #3481)[https://github.com/aws-amplify/aws-sdk-ios/pull/3481].)
+
+    You can use this override value to specify the domain name of, for example, a CloudFront distribution fronted by a Web Application Firewall for DDOS protection on your Cognito User Pool account. The value of `Endpoint` should be a fully-qualified host name, not a URL. Example:
+
+    ```json
+    "CognitoUserPool": {
+      "Default": {
+        "AppClientId": "xxx",
+        "AppClientSecret": "xxx",
+        "Endpoint": "d2XXXXXXXXXXXX.cloudfront.net",
+        "PoolId": "xxxxx",
+        "Region": "xx-xxx-1"
+      }
+    }
+    ```
+
+    > **WARNING** The Amplify CLI will overwrite customizations to the `awsconfiguration.json` and `amplifyconfiguration.json` files if you do an `amplify push` or `amplify pull`. You will need to re-apply the `Endpoint` customization if you use the CLI to modify your cloud backend.
 
 ## 2.23.2
 


### PR DESCRIPTION
*Description of changes:* Support the ability to specify a custom endpoint for Cognito User Pools. This PR includes a simple integ test, but we'll add more in a separate PR.

*Check points:*

- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
