### PR TITLE
chore: Fix doc generation script for AWSLocationXCF

### DIFF
--- a/CircleciScripts/generate_documentation.sh
+++ b/CircleciScripts/generate_documentation.sh
@@ -80,6 +80,7 @@ OBJC_SDK_LIST=$(find $SOURCE_ROOT ${SOURCE_ROOT}/AWSAuthSDK/Sources -type d -max
   -not -name "AWSAuthSDK" \
   -not -name "AWSMobileClient" \
   -not -name "AWSMobileClientXCF" \
+  -not -name "AWSLocationXCF" \
   | sort
 )
 


### PR DESCRIPTION
*Issue #, if available:*
https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios/4569/workflows/b332dfec-661a-48a8-92cc-4557335cdebf/jobs/62088
the error 
```
error reading '/Users/distiller/project/AWSLocationXCF/AWSLocationXCF.h'
```
looks it's expecting the umbrella header which does not exist for `AWSLocationXCF`

*Description of changes:*
Similar to this change for AWSMobileClientXCF: https://github.com/aws-amplify/aws-sdk-ios/pull/3399 we exclude `AWSLocationXCF` from the `OBJC_SDK_LIST` for generating Objective-C documentation. 


*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
