### PR TITLE
fix(AWSMobileClient): getUserAttribute crashes when token is invalidated

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		D8FAC28B251D1D78005F9FC6 /* FBSDKMeasurementEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = D8FAC28A251D1D78005F9FC6 /* FBSDKMeasurementEvent.h */; };
 		D8FAC28D251D1D8F005F9FC6 /* FBSDKURL.h in Headers */ = {isa = PBXBuildFile; fileRef = D8FAC28C251D1D8F005F9FC6 /* FBSDKURL.h */; };
 		D8FAC28F251D1D94005F9FC6 /* FBSDKWebViewAppLinkResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = D8FAC28E251D1D94005F9FC6 /* FBSDKWebViewAppLinkResolver.h */; };
+		D8FB43AD26290118008CB525 /* AWSAuthSDKUITestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FB43AC26290118008CB525 /* AWSAuthSDKUITestBase.swift */; };
 		FA47B5DF246C6CDD0071196D /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
 		FA5B0F11246A475500B4185B /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
 		FA5B0F12246A477D00B4185B /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
@@ -1165,6 +1166,13 @@
 			remoteGlobalIDString = FA53332B22D4D47D00BD88AF;
 			remoteInfo = AWSTranscribeStreamingUnitTests;
 		};
+		D8FB425B2628D1F9008CB525 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 21863B3E2602660A0070CD1B;
+			remoteInfo = AWSLocationXCF;
+		};
 		E496D9411FDB0632000CF290 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
@@ -1434,8 +1442,9 @@
 		D8FAC28A251D1D78005F9FC6 /* FBSDKMeasurementEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKMeasurementEvent.h; sourceTree = "<group>"; };
 		D8FAC28C251D1D8F005F9FC6 /* FBSDKURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKURL.h; sourceTree = "<group>"; };
 		D8FAC28E251D1D94005F9FC6 /* FBSDKWebViewAppLinkResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKWebViewAppLinkResolver.h; sourceTree = "<group>"; };
+		D8FB43AC26290118008CB525 /* AWSAuthSDKUITestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAuthSDKUITestBase.swift; sourceTree = "<group>"; };
 		FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientCustomEndpointTest.swift; sourceTree = "<group>"; };
-		FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSMobileClientCustomEndpointTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSMobileClientCustomEndpointTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };		
 		FA77118C260BEFCA0030966D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1741,9 +1750,10 @@
 		177B8AE721E81B7D0051068F /* AWSAuthSDKTestAppUITests */ = {
 			isa = PBXGroup;
 			children = (
-				B40EA1842339774200135711 /* AWSHostedUIUserPoolTests.swift */,
-				B41F67D8233D536E0060FDEE /* AWSDropInUIUserPoolTests.swift */,
 				177B8AE821E81B7D0051068F /* AWSAuthSDKTestAppUITests.swift */,
+				D8FB43AC26290118008CB525 /* AWSAuthSDKUITestBase.swift */,
+				B41F67D8233D536E0060FDEE /* AWSDropInUIUserPoolTests.swift */,
+				B40EA1842339774200135711 /* AWSHostedUIUserPoolTests.swift */,
 				177B8AEA21E81B7D0051068F /* Info.plist */,
 			);
 			path = AWSAuthSDKTestAppUITests;
@@ -3439,6 +3449,13 @@
 			remoteRef = B97FFF0F234D49A000DC327D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		D8FB425C2628D1F9008CB525 /* AWSLocationXCF.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = AWSLocationXCF.framework;
+			remoteRef = D8FB425B2628D1F9008CB525 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		E496D9421FDB0632000CF290 /* AWSCognitoIdentityProviderASF.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -3625,6 +3642,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				177B8AE921E81B7D0051068F /* AWSAuthSDKTestAppUITests.swift in Sources */,
+				D8FB43AD26290118008CB525 /* AWSAuthSDKUITestBase.swift in Sources */,
 				B41F67D9233D536E0060FDEE /* AWSDropInUIUserPoolTests.swift in Sources */,
 				B40EA1852339774200135711 /* AWSHostedUIUserPoolTests.swift in Sources */,
 			);

--- a/AWSAuthSDK/AWSAuthSDKTestApp/Base.lproj/Main.storyboard
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xWh-de-mYM">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xWh-de-mYM">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,13 +17,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SignInState:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zFB-Q1-zsK">
-                                <rect key="frame" x="16" y="79" width="93" height="21"/>
+                                <rect key="frame" x="16" y="59" width="92" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UNKNOWN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Sy-3d-vMx">
-                                <rect key="frame" x="135" y="79" width="88" height="21"/>
+                                <rect key="frame" x="134" y="59" width="88" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="signInStateLabel">
                                     <accessibilityTraits key="traits" none="YES"/>
                                 </accessibility>
@@ -33,41 +31,41 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eLk-CO-U3Z">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eLk-CO-U3Z">
                                 <rect key="frame" x="159.5" y="540" width="56" height="30"/>
                                 <state key="normal" title="SignOut"/>
                                 <connections>
                                     <action selector="onSignOutClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="k6R-7W-Ekf"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kQI-9m-PM5">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kQI-9m-PM5">
                                 <rect key="frame" x="59" y="356.5" width="257" height="30"/>
                                 <state key="normal" title="Launch CognitoAuth SignIn Facebook"/>
                                 <connections>
                                     <action selector="onLaunchCognitoAuthFacebookSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Fiz-Hg-eZr"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dXG-RY-1M5">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dXG-RY-1M5">
                                 <rect key="frame" x="59" y="318.5" width="257" height="30"/>
                                 <state key="normal" title="Launch CognitoAuth SignIn Google"/>
                                 <connections>
                                     <action selector="onLaunchCognitoAuthGoogleSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="K7o-Zd-vxP"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YPp-C0-XL7">
-                                <rect key="frame" x="118" y="578" width="139" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YPp-C0-XL7">
+                                <rect key="frame" x="117.5" y="578" width="140" height="30"/>
                                 <state key="normal" title="Get AWSCredentials"/>
                                 <connections>
                                     <action selector="onGetAWSCredentials:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YaW-EC-yYH"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CREDENTIALS_HERE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbK-2g-jrL">
-                                <rect key="frame" x="106.5" y="616" width="162" height="21"/>
+                                <rect key="frame" x="106" y="616" width="163" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DV8-wD-Nqh">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DV8-wD-Nqh">
                                 <rect key="frame" x="59" y="280.5" width="257" height="30"/>
                                 <state key="normal" title="Launch Auth0 SignIn"/>
                                 <connections>
@@ -75,21 +73,22 @@
                                     <action selector="onLaunchCognitoAuthGoogleSignIn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="LuO-mc-bXq"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="in7-KF-uyG">
-                                <rect key="frame" x="101.5" y="142" width="172" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="in7-KF-uyG">
+                                <rect key="frame" x="101.5" y="122" width="172" height="30"/>
                                 <state key="normal" title="Hosted UI Userpool tests"/>
                                 <connections>
                                     <segue destination="4xE-Wp-lW2" kind="show" id="x9R-5r-cB0"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dDE-Go-KtQ">
-                                <rect key="frame" x="135" y="180" width="105" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dDE-Go-KtQ">
+                                <rect key="frame" x="135" y="160" width="105" height="30"/>
                                 <state key="normal" title="DropIn UI Tests"/>
                                 <connections>
                                     <segue destination="zxF-Vv-Hr2" kind="show" id="MRs-QE-nRB"/>
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="dXG-RY-1M5" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="10d-bi-MCA"/>
@@ -115,7 +114,6 @@
                             <constraint firstItem="zFB-Q1-zsK" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="xbW-bq-1it"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="SbK-2g-jrL" secondAttribute="bottom" constant="30" id="yWq-Hl-m88"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="uZ3-pB-3JT"/>
                     <connections>
@@ -135,18 +133,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vhd-B0-ND4">
-                                <rect key="frame" x="107" y="112" width="161" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vhd-B0-ND4">
+                                <rect key="frame" x="107" y="92" width="161" height="30"/>
                                 <state key="normal" title="Drop In User Pool Tests"/>
                                 <connections>
                                     <segue destination="r46-A3-owT" kind="show" id="wW5-3F-S6b"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PV2-vt-knq">
-                                <rect key="frame" x="107" y="172" width="161" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PV2-vt-knq">
+                                <rect key="frame" x="107" y="152" width="161" height="30"/>
                                 <state key="normal" title="Drop In Facebook Tests"/>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="bvx-Jk-aZp"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="vhd-B0-ND4" firstAttribute="top" secondItem="bvx-Jk-aZp" secondAttribute="top" constant="48" id="8KT-Uj-ww1"/>
@@ -154,7 +153,6 @@
                             <constraint firstItem="PV2-vt-knq" firstAttribute="centerX" secondItem="VYG-KW-gSd" secondAttribute="centerX" id="npc-nt-tzS"/>
                             <constraint firstItem="vhd-B0-ND4" firstAttribute="centerX" secondItem="VYG-KW-gSd" secondAttribute="centerX" id="qWV-RX-SQb"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="bvx-Jk-aZp"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IMw-e4-4mt" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -170,38 +168,39 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current user state:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jez-Dt-yK2">
-                                <rect key="frame" x="16" y="112" width="144" height="21"/>
+                                <rect key="frame" x="16" y="92" width="142.5" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="userPoolStateLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bSk-IR-WaP">
-                                <rect key="frame" x="148" y="166" width="79" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bSk-IR-WaP">
+                                <rect key="frame" x="148" y="146" width="79" height="30"/>
                                 <state key="normal" title="SignIn User"/>
                                 <connections>
                                     <action selector="onLaunchCognitoAuthSignIn:" destination="r46-A3-owT" eventType="touchUpInside" id="HS0-xc-BaT"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y5w-Zy-VWM">
-                                <rect key="frame" x="141.5" y="229" width="92" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y5w-Zy-VWM">
+                                <rect key="frame" x="141.5" y="209" width="92" height="30"/>
                                 <state key="normal" title="SignOut User"/>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BAf-Rr-YwL">
-                                <rect key="frame" x="116" y="292" width="143" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BAf-Rr-YwL">
+                                <rect key="frame" x="116" y="272" width="143" height="30"/>
                                 <state key="normal" title="User pool operations"/>
                                 <connections>
                                     <segue destination="mG6-DT-ukZ" kind="show" id="oIV-qf-1As"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nlk-8p-X7B">
-                                <rect key="frame" x="168" y="112" width="24" height="21"/>
+                                <rect key="frame" x="166.5" y="92" width="24" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="userPoolSignInStateLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.1166862764" green="0.24307424650000001" blue="0.60000404789999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="luC-Xq-6f3"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="y5w-Zy-VWM" firstAttribute="centerX" secondItem="hc9-ol-7Uc" secondAttribute="centerX" id="5zd-jj-R7w"/>
@@ -216,7 +215,6 @@
                             <constraint firstItem="bSk-IR-WaP" firstAttribute="centerX" secondItem="hc9-ol-7Uc" secondAttribute="centerX" id="sbw-Oe-mlH"/>
                             <constraint firstItem="nlk-8p-X7B" firstAttribute="leading" secondItem="jez-Dt-yK2" secondAttribute="trailing" constant="8" id="ymg-Rf-Ax1"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="luC-Xq-6f3"/>
                     </view>
                     <connections>
                         <outlet property="signInStateLabel" destination="nlk-8p-X7B" id="Mie-Vs-yUL"/>
@@ -235,38 +233,39 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current user state:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b3h-ZP-AQx">
-                                <rect key="frame" x="15" y="134" width="144" height="21"/>
+                                <rect key="frame" x="15" y="114" width="142.5" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="userPoolStateLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z83-mT-Ha2">
-                                <rect key="frame" x="148" y="188" width="79" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="z83-mT-Ha2">
+                                <rect key="frame" x="148" y="168" width="79" height="30"/>
                                 <state key="normal" title="SignIn User"/>
                                 <connections>
                                     <action selector="onLaunchCognitoAuthSignIn:" destination="4xE-Wp-lW2" eventType="touchUpInside" id="qjf-om-Ea8"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jx1-9H-Bdf">
-                                <rect key="frame" x="141" y="251" width="93" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jx1-9H-Bdf">
+                                <rect key="frame" x="141" y="231" width="93" height="30"/>
                                 <state key="normal" title="SignOut User"/>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="de6-2m-IB4">
-                                <rect key="frame" x="116" y="314" width="143" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="de6-2m-IB4">
+                                <rect key="frame" x="116" y="294" width="143" height="30"/>
                                 <state key="normal" title="User pool operations"/>
                                 <connections>
                                     <segue destination="mG6-DT-ukZ" kind="show" id="Uyr-Pg-JMc"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eks-a4-vTN">
-                                <rect key="frame" x="167" y="134" width="24" height="21"/>
+                                <rect key="frame" x="165.5" y="114" width="24" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="userPoolSignInStateLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.1166862764" green="0.24307424650000001" blue="0.60000404789999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="ozC-cu-NWH"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="b3h-ZP-AQx" firstAttribute="top" secondItem="ozC-cu-NWH" secondAttribute="top" constant="70" id="3kA-Pk-kIM"/>
@@ -283,7 +282,6 @@
                             <constraint firstItem="Jx1-9H-Bdf" firstAttribute="top" secondItem="z83-mT-Ha2" secondAttribute="bottom" constant="33" id="rb3-qT-6Qn"/>
                             <constraint firstItem="Jx1-9H-Bdf" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="141" id="wpl-IX-COC"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="ozC-cu-NWH"/>
                     </view>
                     <connections>
                         <outlet property="signInStateLabel" destination="Eks-a4-vTN" id="bzH-Co-Dzs"/>
@@ -302,161 +300,198 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Token Details:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nt3-dm-BAC">
-                                <rect key="frame" x="16" y="99" width="107" height="21"/>
+                                <rect key="frame" x="16" y="74" width="107" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.1166862764" green="0.24307424650000001" blue="0.60000404789999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Credentials:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Sz-sS-1FN">
-                                <rect key="frame" x="16" y="280" width="92" height="21"/>
+                                <rect key="frame" x="16" y="215" width="92" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.1166862764" green="0.24307424650000001" blue="0.60000404789999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User attributes:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cLx-hx-vic">
-                                <rect key="frame" x="16" y="461" width="119" height="21"/>
+                                <rect key="frame" x="16" y="356" width="118" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.1166862764" green="0.24307424650000001" blue="0.60000404789999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ID Token:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HGP-tA-ibG">
-                                <rect key="frame" x="16" y="135" width="53" height="15"/>
+                                <rect key="frame" x="16" y="105" width="53" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="center" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zLI-09-drv">
-                                <rect key="frame" x="77" y="135.5" width="17" height="14.5"/>
+                                <rect key="frame" x="77" y="105.5" width="17" height="14.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="idTokenLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ziK-LP-NrU">
-                                <rect key="frame" x="106" y="165.5" width="17" height="14.5"/>
+                                <rect key="frame" x="106" y="130.5" width="17" height="14.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="accessTokenLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cRM-3a-3E0">
-                                <rect key="frame" x="109" y="195.5" width="17" height="14.5"/>
+                                <rect key="frame" x="108" y="155.5" width="17" height="14.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="refreshTokenLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ItA-ZJ-WAH">
-                                <rect key="frame" x="84" y="225" width="17" height="15"/>
+                                <rect key="frame" x="84" y="180" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="tokenExpirationLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gne-gx-5Sv">
-                                <rect key="frame" x="93" y="316" width="17" height="15"/>
+                                <rect key="frame" x="93" y="246" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="accessKeyLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="taA-kR-dux">
-                                <rect key="frame" x="89" y="346" width="17" height="15"/>
+                                <rect key="frame" x="89" y="271" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="secretKeyLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ot2-cM-oYk">
-                                <rect key="frame" x="96" y="376" width="17" height="15"/>
+                                <rect key="frame" x="96" y="296" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="sessionKeyLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Access Token:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xt3-O0-ESK">
-                                <rect key="frame" x="16" y="165" width="82" height="15"/>
+                                <rect key="frame" x="16" y="130" width="82" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Refresh Token:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W1c-kg-6gb">
-                                <rect key="frame" x="16" y="195" width="85" height="15"/>
+                                <rect key="frame" x="16" y="155" width="84" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Expiration:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XWB-U0-HBM">
-                                <rect key="frame" x="16" y="225" width="60" height="15"/>
+                                <rect key="frame" x="16" y="180" width="60" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Access Key:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xyb-c0-l8R">
-                                <rect key="frame" x="16" y="316" width="69" height="15"/>
+                                <rect key="frame" x="16" y="246" width="69" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Secret Key:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H1N-WR-a8c">
-                                <rect key="frame" x="16" y="346" width="65" height="15"/>
+                                <rect key="frame" x="16" y="271" width="65" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Session Key:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xyb-BD-wHA">
-                                <rect key="frame" x="16" y="376" width="72" height="15"/>
+                                <rect key="frame" x="16" y="296" width="72" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Expiration:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iaD-qm-dNr">
-                                <rect key="frame" x="16" y="406" width="60" height="15"/>
+                                <rect key="frame" x="16" y="321" width="60" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Fi-Fa-jJ1">
-                                <rect key="frame" x="84" y="406" width="17" height="15"/>
+                                <rect key="frame" x="84" y="321" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="credentialExpirationLabel"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom Attribute 1:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JM8-m0-SBO">
-                                <rect key="frame" x="16" y="497" width="110" height="15"/>
+                                <rect key="frame" x="16" y="462" width="109" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IqN-tt-co0">
-                                <rect key="frame" x="134" y="497" width="17" height="15"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IqN-tt-co0">
+                                <rect key="frame" x="132" y="462" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="attribute1Label"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom Attribute 2:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bgr-Jm-OR1">
-                                <rect key="frame" x="16" y="527" width="111" height="15"/>
+                                <rect key="frame" x="16" y="487" width="111" height="15"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tjp-bi-Swj">
-                                <rect key="frame" x="112" y="571" width="151" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tjp-bi-Swj">
+                                <rect key="frame" x="112" y="531" width="151" height="30"/>
                                 <state key="normal" title="Update User Attribute"/>
                                 <connections>
                                     <action selector="updateUserAttributeAction:" destination="mG6-DT-ukZ" eventType="touchUpInside" id="HNC-kP-PDW"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Jf-c9-2Pn">
-                                <rect key="frame" x="135" y="527" width="17" height="15"/>
+                                <rect key="frame" x="135" y="487" width="17" height="15"/>
                                 <accessibility key="accessibilityConfiguration" identifier="attribute2Label"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attribute 1:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OYD-f9-Krl">
+                                <rect key="frame" x="16" y="387" width="62" height="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gOc-EK-DQ2">
+                                <rect key="frame" x="86" y="387" width="17" height="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="blW-jL-BmK">
+                                <rect key="frame" x="88" y="412" width="17" height="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attribute 2:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sfA-Ba-pRM">
+                                <rect key="frame" x="16" y="412" width="64" height="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attribute 3:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lrV-Jd-Kd5">
+                                <rect key="frame" x="16" y="437" width="64" height="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NA" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cef-qJ-TBK">
+                                <rect key="frame" x="88" y="437" width="17" height="15"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="NoO-R4-kaN"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="H1N-WR-a8c" secondAttribute="trailing" symbolic="YES" id="10y-Yq-zQa"/>
@@ -465,18 +500,21 @@
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Gne-gx-5Sv" secondAttribute="trailing" symbolic="YES" id="34P-4m-Gw2"/>
                             <constraint firstItem="cRM-3a-3E0" firstAttribute="centerY" secondItem="W1c-kg-6gb" secondAttribute="centerY" id="39a-s5-R1p"/>
                             <constraint firstItem="iaD-qm-dNr" firstAttribute="leading" secondItem="xyb-BD-wHA" secondAttribute="leading" id="3u1-3l-YkY"/>
+                            <constraint firstItem="blW-jL-BmK" firstAttribute="top" secondItem="gOc-EK-DQ2" secondAttribute="bottom" constant="10" id="5pM-0h-hIC"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Nt3-dm-BAC" secondAttribute="trailing" symbolic="YES" id="7BU-no-tAs"/>
                             <constraint firstItem="Nt3-dm-BAC" firstAttribute="leading" secondItem="NoO-R4-kaN" secondAttribute="leading" constant="16" id="7m7-jw-JNu"/>
-                            <constraint firstItem="H1N-WR-a8c" firstAttribute="top" secondItem="xyb-c0-l8R" secondAttribute="bottom" constant="15" id="91Q-7b-xR5"/>
+                            <constraint firstItem="H1N-WR-a8c" firstAttribute="top" secondItem="xyb-c0-l8R" secondAttribute="bottom" constant="10" id="91Q-7b-xR5"/>
                             <constraint firstItem="zLI-09-drv" firstAttribute="centerY" secondItem="HGP-tA-ibG" secondAttribute="centerY" id="AJX-Zu-bO6"/>
+                            <constraint firstItem="OYD-f9-Krl" firstAttribute="top" secondItem="cLx-hx-vic" secondAttribute="bottom" constant="10" id="Bdz-d8-xdp"/>
                             <constraint firstItem="cLx-hx-vic" firstAttribute="leading" secondItem="iaD-qm-dNr" secondAttribute="leading" id="BqE-xj-aVd"/>
-                            <constraint firstItem="xyb-BD-wHA" firstAttribute="top" secondItem="H1N-WR-a8c" secondAttribute="bottom" constant="15" id="Ctf-ak-RJb"/>
-                            <constraint firstItem="XWB-U0-HBM" firstAttribute="top" secondItem="W1c-kg-6gb" secondAttribute="bottom" constant="15" id="DUD-Nb-iSj"/>
+                            <constraint firstItem="xyb-BD-wHA" firstAttribute="top" secondItem="H1N-WR-a8c" secondAttribute="bottom" constant="10" id="Ctf-ak-RJb"/>
+                            <constraint firstItem="XWB-U0-HBM" firstAttribute="top" secondItem="W1c-kg-6gb" secondAttribute="bottom" constant="10" id="DUD-Nb-iSj"/>
+                            <constraint firstItem="lrV-Jd-Kd5" firstAttribute="top" secondItem="sfA-Ba-pRM" secondAttribute="bottom" constant="10" id="Fep-Dl-Vyw"/>
                             <constraint firstItem="iaD-qm-dNr" firstAttribute="leading" secondItem="9Sz-sS-1FN" secondAttribute="leading" id="Hhr-FM-7JJ"/>
+                            <constraint firstItem="lrV-Jd-Kd5" firstAttribute="leading" secondItem="NoO-R4-kaN" secondAttribute="leading" constant="16" id="I7O-nL-whn"/>
                             <constraint firstItem="ziK-LP-NrU" firstAttribute="centerY" secondItem="xt3-O0-ESK" secondAttribute="centerY" id="IOg-7d-6Xn"/>
-                            <constraint firstItem="cLx-hx-vic" firstAttribute="top" secondItem="iaD-qm-dNr" secondAttribute="bottom" constant="40" id="IY2-UP-KgA"/>
+                            <constraint firstItem="cLx-hx-vic" firstAttribute="top" secondItem="iaD-qm-dNr" secondAttribute="bottom" constant="20" id="IY2-UP-KgA"/>
                             <constraint firstItem="9Sz-sS-1FN" firstAttribute="leading" secondItem="W1c-kg-6gb" secondAttribute="leading" id="J4t-Ci-ZK3"/>
-                            <constraint firstItem="IqN-tt-co0" firstAttribute="leading" secondItem="JM8-m0-SBO" secondAttribute="trailing" constant="8" id="KOD-Wy-hrm"/>
                             <constraint firstItem="1Jf-c9-2Pn" firstAttribute="centerY" secondItem="bgr-Jm-OR1" secondAttribute="centerY" id="LCR-ZG-6j8"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ItA-ZJ-WAH" secondAttribute="trailing" symbolic="YES" id="LqQ-nI-y4X"/>
                             <constraint firstItem="ot2-cM-oYk" firstAttribute="centerY" secondItem="xyb-BD-wHA" secondAttribute="centerY" id="MMq-AP-z4h"/>
@@ -486,52 +524,63 @@
                             <constraint firstItem="tjp-bi-Swj" firstAttribute="top" secondItem="1Jf-c9-2Pn" secondAttribute="bottom" constant="29" id="Qae-tN-Ny6"/>
                             <constraint firstItem="taA-kR-dux" firstAttribute="centerY" secondItem="H1N-WR-a8c" secondAttribute="centerY" id="SRG-GM-u3x"/>
                             <constraint firstItem="ot2-cM-oYk" firstAttribute="leading" secondItem="xyb-BD-wHA" secondAttribute="trailing" constant="8" id="ST8-Ts-6x3"/>
+                            <constraint firstItem="cef-qJ-TBK" firstAttribute="top" secondItem="blW-jL-BmK" secondAttribute="bottom" constant="10" id="UO7-Av-1pD"/>
                             <constraint firstItem="3Fi-Fa-jJ1" firstAttribute="leading" secondItem="iaD-qm-dNr" secondAttribute="trailing" constant="8" id="UUw-cd-qv9"/>
                             <constraint firstItem="3Fi-Fa-jJ1" firstAttribute="centerY" secondItem="iaD-qm-dNr" secondAttribute="centerY" id="V4L-9a-KKw"/>
-                            <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IqN-tt-co0" secondAttribute="trailing" symbolic="YES" id="XUh-uE-qFf"/>
+                            <constraint firstItem="sfA-Ba-pRM" firstAttribute="leading" secondItem="NoO-R4-kaN" secondAttribute="leading" constant="16" id="VQw-KK-BA4"/>
                             <constraint firstItem="zLI-09-drv" firstAttribute="leading" secondItem="HGP-tA-ibG" secondAttribute="trailing" constant="8" id="Xu6-Hd-uiV"/>
                             <constraint firstItem="tjp-bi-Swj" firstAttribute="leading" secondItem="NoO-R4-kaN" secondAttribute="leading" constant="112" id="YKm-tR-jL5"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cRM-3a-3E0" secondAttribute="trailing" symbolic="YES" id="Zqo-G8-hwS"/>
-                            <constraint firstItem="9Sz-sS-1FN" firstAttribute="top" secondItem="XWB-U0-HBM" secondAttribute="bottom" constant="40" id="adX-AH-zWa"/>
+                            <constraint firstItem="9Sz-sS-1FN" firstAttribute="top" secondItem="XWB-U0-HBM" secondAttribute="bottom" constant="20" id="adX-AH-zWa"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3Fi-Fa-jJ1" secondAttribute="trailing" symbolic="YES" id="ave-Tc-6et"/>
                             <constraint firstItem="Gne-gx-5Sv" firstAttribute="centerY" secondItem="xyb-c0-l8R" secondAttribute="centerY" id="b7E-d9-0Ii"/>
-                            <constraint firstItem="W1c-kg-6gb" firstAttribute="top" secondItem="xt3-O0-ESK" secondAttribute="bottom" constant="15" id="br2-ji-6El"/>
-                            <constraint firstItem="HGP-tA-ibG" firstAttribute="top" secondItem="Nt3-dm-BAC" secondAttribute="bottom" constant="15" id="cvf-HN-vzt"/>
+                            <constraint firstItem="cef-qJ-TBK" firstAttribute="leading" secondItem="lrV-Jd-Kd5" secondAttribute="trailing" constant="8" id="bVF-uK-JQs"/>
+                            <constraint firstItem="W1c-kg-6gb" firstAttribute="top" secondItem="xt3-O0-ESK" secondAttribute="bottom" constant="10" id="br2-ji-6El"/>
+                            <constraint firstItem="HGP-tA-ibG" firstAttribute="top" secondItem="Nt3-dm-BAC" secondAttribute="bottom" constant="10" id="cvf-HN-vzt"/>
                             <constraint firstItem="ItA-ZJ-WAH" firstAttribute="centerY" secondItem="XWB-U0-HBM" secondAttribute="centerY" id="dR1-pc-6cK"/>
+                            <constraint firstItem="IqN-tt-co0" firstAttribute="leading" secondItem="JM8-m0-SBO" secondAttribute="trailing" constant="8" id="e8c-9C-5SY"/>
                             <constraint firstItem="ItA-ZJ-WAH" firstAttribute="leading" secondItem="XWB-U0-HBM" secondAttribute="trailing" constant="8" id="f5H-ll-Pti"/>
-                            <constraint firstItem="xt3-O0-ESK" firstAttribute="top" secondItem="HGP-tA-ibG" secondAttribute="bottom" constant="15" id="f9Z-qV-fZo"/>
-                            <constraint firstItem="Nt3-dm-BAC" firstAttribute="top" secondItem="NoO-R4-kaN" secondAttribute="top" constant="35" id="fHR-8m-rLn"/>
+                            <constraint firstItem="xt3-O0-ESK" firstAttribute="top" secondItem="HGP-tA-ibG" secondAttribute="bottom" constant="10" id="f9Z-qV-fZo"/>
+                            <constraint firstItem="Nt3-dm-BAC" firstAttribute="top" secondItem="NoO-R4-kaN" secondAttribute="top" constant="30" id="fHR-8m-rLn"/>
                             <constraint firstItem="xt3-O0-ESK" firstAttribute="leading" secondItem="Nt3-dm-BAC" secondAttribute="leading" id="guX-Za-ajy"/>
                             <constraint firstItem="taA-kR-dux" firstAttribute="leading" secondItem="H1N-WR-a8c" secondAttribute="trailing" constant="8" id="h5X-Cn-eoN"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1Jf-c9-2Pn" secondAttribute="trailing" symbolic="YES" id="jT8-nH-wTz"/>
+                            <constraint firstItem="OYD-f9-Krl" firstAttribute="leading" secondItem="NoO-R4-kaN" secondAttribute="leading" constant="16" id="kZn-BR-k4S"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" secondItem="tjp-bi-Swj" secondAttribute="trailing" constant="112" id="mCQ-nr-zK9"/>
-                            <constraint firstItem="bgr-Jm-OR1" firstAttribute="top" secondItem="JM8-m0-SBO" secondAttribute="bottom" constant="15" id="mht-uQ-Mek"/>
-                            <constraint firstItem="xyb-c0-l8R" firstAttribute="top" secondItem="9Sz-sS-1FN" secondAttribute="bottom" constant="15" id="nAZ-lD-60g"/>
+                            <constraint firstItem="bgr-Jm-OR1" firstAttribute="top" secondItem="JM8-m0-SBO" secondAttribute="bottom" constant="10" id="mht-uQ-Mek"/>
+                            <constraint firstItem="xyb-c0-l8R" firstAttribute="top" secondItem="9Sz-sS-1FN" secondAttribute="bottom" constant="10" id="nAZ-lD-60g"/>
+                            <constraint firstItem="1Jf-c9-2Pn" firstAttribute="top" secondItem="IqN-tt-co0" secondAttribute="bottom" constant="10" id="nAm-Eg-dj0"/>
                             <constraint firstItem="bgr-Jm-OR1" firstAttribute="leading" secondItem="cLx-hx-vic" secondAttribute="leading" id="nGH-qW-P3U"/>
-                            <constraint firstItem="IqN-tt-co0" firstAttribute="centerY" secondItem="JM8-m0-SBO" secondAttribute="centerY" id="pn1-Cy-KFu"/>
                             <constraint firstItem="H1N-WR-a8c" firstAttribute="leading" secondItem="9Sz-sS-1FN" secondAttribute="leading" id="qFq-io-LpY"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9Sz-sS-1FN" secondAttribute="trailing" symbolic="YES" id="qeu-92-7P6"/>
-                            <constraint firstItem="JM8-m0-SBO" firstAttribute="top" secondItem="cLx-hx-vic" secondAttribute="bottom" constant="15" id="sBo-d7-BqT"/>
+                            <constraint firstItem="JM8-m0-SBO" firstAttribute="top" secondItem="lrV-Jd-Kd5" secondAttribute="bottom" constant="10" id="rZr-Xk-KXy"/>
+                            <constraint firstItem="gOc-EK-DQ2" firstAttribute="top" secondItem="cLx-hx-vic" secondAttribute="bottom" constant="10" id="rkJ-49-IqP"/>
+                            <constraint firstItem="JM8-m0-SBO" firstAttribute="top" secondItem="lrV-Jd-Kd5" secondAttribute="bottom" constant="10" id="sBo-d7-BqT"/>
                             <constraint firstItem="JM8-m0-SBO" firstAttribute="leading" secondItem="cLx-hx-vic" secondAttribute="leading" id="tn9-76-nAK"/>
+                            <constraint firstItem="gOc-EK-DQ2" firstAttribute="leading" secondItem="OYD-f9-Krl" secondAttribute="trailing" constant="8" id="uyL-Xg-u7X"/>
                             <constraint firstItem="xyb-BD-wHA" firstAttribute="leading" secondItem="9Sz-sS-1FN" secondAttribute="leading" id="vaT-P0-WWk"/>
                             <constraint firstItem="XWB-U0-HBM" firstAttribute="leading" secondItem="W1c-kg-6gb" secondAttribute="leading" id="veK-D7-wAb"/>
                             <constraint firstItem="xyb-c0-l8R" firstAttribute="leading" secondItem="9Sz-sS-1FN" secondAttribute="leading" id="w0p-ba-CB2"/>
                             <constraint firstItem="cRM-3a-3E0" firstAttribute="leading" secondItem="W1c-kg-6gb" secondAttribute="trailing" constant="8" id="we4-aJ-aq8"/>
-                            <constraint firstItem="iaD-qm-dNr" firstAttribute="top" secondItem="xyb-BD-wHA" secondAttribute="bottom" constant="15" id="wrn-Xo-w45"/>
+                            <constraint firstItem="iaD-qm-dNr" firstAttribute="top" secondItem="xyb-BD-wHA" secondAttribute="bottom" constant="10" id="wrn-Xo-w45"/>
                             <constraint firstItem="HGP-tA-ibG" firstAttribute="leading" secondItem="Nt3-dm-BAC" secondAttribute="leading" id="xKh-6a-iWy"/>
+                            <constraint firstItem="blW-jL-BmK" firstAttribute="leading" secondItem="sfA-Ba-pRM" secondAttribute="trailing" constant="8" id="yOn-bv-dv6"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cLx-hx-vic" secondAttribute="trailing" symbolic="YES" id="ytg-Sp-Gg9"/>
+                            <constraint firstItem="sfA-Ba-pRM" firstAttribute="top" secondItem="OYD-f9-Krl" secondAttribute="bottom" constant="10" id="ywO-9X-loU"/>
                             <constraint firstItem="Gne-gx-5Sv" firstAttribute="leading" secondItem="xyb-c0-l8R" secondAttribute="trailing" constant="8" id="zLh-3A-eMb"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zLI-09-drv" secondAttribute="trailing" symbolic="YES" id="zO0-5P-zuI"/>
                             <constraint firstItem="NoO-R4-kaN" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="taA-kR-dux" secondAttribute="trailing" symbolic="YES" id="zX8-Fb-dcK"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="NoO-R4-kaN"/>
                     </view>
                     <connections>
                         <outlet property="accesKeyLabel" destination="Gne-gx-5Sv" id="UFA-V3-eeg"/>
                         <outlet property="accessTokenLabel" destination="ziK-LP-NrU" id="dcF-cl-m4F"/>
-                        <outlet property="attribute1Label" destination="IqN-tt-co0" id="xd3-DT-euf"/>
-                        <outlet property="attribute2Label" destination="1Jf-c9-2Pn" id="92O-ti-rlF"/>
+                        <outlet property="attribute1Label" destination="gOc-EK-DQ2" id="dfs-2H-0no"/>
+                        <outlet property="attribute2Label" destination="blW-jL-BmK" id="MQA-hH-P28"/>
+                        <outlet property="attribute3Label" destination="cef-qJ-TBK" id="Zz9-bL-1B5"/>
                         <outlet property="credentialExpirationLabel" destination="3Fi-Fa-jJ1" id="yAa-H4-lx1"/>
+                        <outlet property="customeAttribute1Label" destination="IqN-tt-co0" id="b1Z-AU-Tsd"/>
+                        <outlet property="customeAttribute2Label" destination="1Jf-c9-2Pn" id="w5R-PQ-q0A"/>
                         <outlet property="idTokenLabel" destination="zLI-09-drv" id="I34-QA-ve1"/>
                         <outlet property="refreshTokenLabel" destination="cRM-3a-3E0" id="qzE-x4-rkd"/>
                         <outlet property="secretKeyLabel" destination="taA-kR-dux" id="h54-bV-Xvh"/>
@@ -541,14 +590,14 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="N22-y7-J96" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3078" y="-94"/>
+            <point key="canvasLocation" x="3077.5999999999999" y="-94.002998500749626"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="vw2-jQ-YFw">
             <objects>
                 <navigationController id="xWh-de-mYM" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="RDY-f5-ujd">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -561,6 +610,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="oIV-qf-1As"/>
+        <segue reference="Uyr-Pg-JMc"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/AWSAuthSDK/AWSAuthSDKTestApp/Base.lproj/Main.storyboard
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/Base.lproj/Main.storyboard
@@ -264,22 +264,44 @@
                                 <color key="textColor" red="0.1166862764" green="0.24307424650000001" blue="0.60000404789999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pAF-TL-32k">
+                                <rect key="frame" x="112" y="357" width="151" height="29"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <state key="normal" title="invalidateAccessToken"/>
+                                <connections>
+                                    <action selector="invalidateAccessToken:" destination="4xE-Wp-lW2" eventType="touchUpInside" id="UvZ-Re-h3A"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="n5x-dr-3dO">
+                                <rect key="frame" x="112" y="419" width="151" height="29"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <state key="normal" title="invalidateRefreshToken"/>
+                                <connections>
+                                    <action selector="invalidateRefreshToken:" destination="4xE-Wp-lW2" eventType="touchUpInside" id="rnE-cD-hXN"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ozC-cu-NWH"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="ozC-cu-NWH" firstAttribute="trailing" secondItem="n5x-dr-3dO" secondAttribute="trailing" constant="112" id="3CU-Th-GiJ"/>
                             <constraint firstItem="b3h-ZP-AQx" firstAttribute="top" secondItem="ozC-cu-NWH" secondAttribute="top" constant="70" id="3kA-Pk-kIM"/>
                             <constraint firstItem="z83-mT-Ha2" firstAttribute="top" secondItem="b3h-ZP-AQx" secondAttribute="bottom" constant="33" id="5bk-Q4-4IQ"/>
                             <constraint firstItem="Eks-a4-vTN" firstAttribute="leading" secondItem="b3h-ZP-AQx" secondAttribute="trailing" constant="8" id="JYa-rH-2Zl"/>
                             <constraint firstItem="ozC-cu-NWH" firstAttribute="trailing" secondItem="de6-2m-IB4" secondAttribute="trailing" constant="116" id="KDL-5D-7GY"/>
                             <constraint firstItem="z83-mT-Ha2" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="148" id="KJ8-7Z-NMy"/>
+                            <constraint firstItem="pAF-TL-32k" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="112" id="NQf-Qu-9MF"/>
                             <constraint firstItem="ozC-cu-NWH" firstAttribute="trailing" secondItem="Jx1-9H-Bdf" secondAttribute="trailing" constant="141" id="Rlw-aj-zBB"/>
+                            <constraint firstItem="n5x-dr-3dO" firstAttribute="top" secondItem="pAF-TL-32k" secondAttribute="bottom" constant="33" id="d7K-d5-gNt"/>
                             <constraint firstItem="de6-2m-IB4" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="116" id="dnr-qC-f9C"/>
                             <constraint firstItem="de6-2m-IB4" firstAttribute="top" secondItem="Jx1-9H-Bdf" secondAttribute="bottom" constant="33" id="iNP-3C-kLb"/>
                             <constraint firstItem="ozC-cu-NWH" firstAttribute="trailing" secondItem="z83-mT-Ha2" secondAttribute="trailing" constant="148" id="j6H-qR-quN"/>
                             <constraint firstItem="Eks-a4-vTN" firstAttribute="top" secondItem="ozC-cu-NWH" secondAttribute="top" constant="70" id="lFL-gh-HAg"/>
                             <constraint firstItem="b3h-ZP-AQx" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="15" id="nPg-TV-hsc"/>
+                            <constraint firstItem="n5x-dr-3dO" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="112" id="qgb-AL-cWi"/>
                             <constraint firstItem="Jx1-9H-Bdf" firstAttribute="top" secondItem="z83-mT-Ha2" secondAttribute="bottom" constant="33" id="rb3-qT-6Qn"/>
+                            <constraint firstItem="pAF-TL-32k" firstAttribute="top" secondItem="de6-2m-IB4" secondAttribute="bottom" constant="33" id="rn6-wE-Eo7"/>
+                            <constraint firstItem="ozC-cu-NWH" firstAttribute="trailing" secondItem="pAF-TL-32k" secondAttribute="trailing" constant="112" id="w2y-h6-ht9"/>
                             <constraint firstItem="Jx1-9H-Bdf" firstAttribute="leading" secondItem="ozC-cu-NWH" secondAttribute="leading" constant="141" id="wpl-IX-COC"/>
                         </constraints>
                     </view>
@@ -289,7 +311,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aW1-hY-27I" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="887" y="-462"/>
+            <point key="canvasLocation" x="885.60000000000002" y="-462.8185907046477"/>
         </scene>
         <!--User Details-->
         <scene sceneID="WNH-XR-mxG">
@@ -441,7 +463,8 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tjp-bi-Swj">
-                                <rect key="frame" x="112" y="531" width="151" height="30"/>
+                                <rect key="frame" x="112" y="512" width="151" height="29"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <state key="normal" title="Update User Attribute"/>
                                 <connections>
                                     <action selector="updateUserAttributeAction:" destination="mG6-DT-ukZ" eventType="touchUpInside" id="HNC-kP-PDW"/>
@@ -521,7 +544,7 @@
                             <constraint firstItem="ziK-LP-NrU" firstAttribute="leading" secondItem="xt3-O0-ESK" secondAttribute="trailing" constant="8" id="MmT-Uy-Iw4"/>
                             <constraint firstItem="W1c-kg-6gb" firstAttribute="leading" secondItem="Nt3-dm-BAC" secondAttribute="leading" id="NMN-tr-TcJ"/>
                             <constraint firstItem="1Jf-c9-2Pn" firstAttribute="leading" secondItem="bgr-Jm-OR1" secondAttribute="trailing" constant="8" id="Oi2-vA-vg9"/>
-                            <constraint firstItem="tjp-bi-Swj" firstAttribute="top" secondItem="1Jf-c9-2Pn" secondAttribute="bottom" constant="29" id="Qae-tN-Ny6"/>
+                            <constraint firstItem="tjp-bi-Swj" firstAttribute="top" secondItem="1Jf-c9-2Pn" secondAttribute="bottom" constant="10" id="Qae-tN-Ny6"/>
                             <constraint firstItem="taA-kR-dux" firstAttribute="centerY" secondItem="H1N-WR-a8c" secondAttribute="centerY" id="SRG-GM-u3x"/>
                             <constraint firstItem="ot2-cM-oYk" firstAttribute="leading" secondItem="xyb-BD-wHA" secondAttribute="trailing" constant="8" id="ST8-Ts-6x3"/>
                             <constraint firstItem="cef-qJ-TBK" firstAttribute="top" secondItem="blW-jL-BmK" secondAttribute="bottom" constant="10" id="UO7-Av-1pD"/>

--- a/AWSAuthSDK/AWSAuthSDKTestApp/HostedUIUserPoolViewController.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/HostedUIUserPoolViewController.swift
@@ -6,9 +6,11 @@
 import UIKit
 import AWSMobileClient
 import AWSCore
+import AWSTestResources
 
 /// View controller to handle user pool operation with hosted UI.
 ///
+@available(iOS 10.0, *)
 class HostedUIUserPoolViewController: UIViewController {
     
     @IBOutlet weak var signInStateLabel: UILabel!
@@ -36,5 +38,41 @@ class HostedUIUserPoolViewController: UIViewController {
         }
     }
     
+    @IBAction func invalidateAccessToken(_ sender: Any) {
+        invalidateAccessToken()
+    }
+
+    @IBAction func invalidateRefreshToken(_ sender: Any) {
+        invalidateRefreshToken()
+    }
+
+    private func invalidateRefreshToken() {
+        let key = getTokenKeychain()
+        getKeychain().removeItem(forKey: key)
+    }
+
+    private func invalidateAccessToken() {
+        let key = getTokenKeychain()
+        let pastDate = Date(timeIntervalSinceNow: -1)
+        let formattedDate = ISO8601DateFormatter().string(from: pastDate)
+        let dateData = formattedDate.data(using: .utf8)
+        getKeychain().setData(dateData, forKey: key)
+    }
+
+    private func getKeychain() -> AWSUICKeyChainStore {
+        let bundleID = Bundle.main.bundleIdentifier
+        let keychain = AWSUICKeyChainStore(service: "\(bundleID!).\(AWSCognitoIdentityUserPool.self)")
+        return keychain
+    }
+
+    private func getTokenKeychain() -> String {
+        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
+        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
+        let userPoolConfig = awsconfiguration["CognitoUserPool"] as! [String: [String: Any]]
+        let appClientId = (userPoolConfig["Default"]!["AppClientId"] as! String)
+        let namespace = "\(appClientId).\(AWSMobileClient.default().username ?? "")"
+        let key = "\(namespace).tokenExpiration"
+        return key
+    }
 }
 

--- a/AWSAuthSDK/AWSAuthSDKTestApp/UserDetailsViewController.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/UserDetailsViewController.swift
@@ -6,6 +6,7 @@
 import UIKit
 import AWSMobileClient
 import AWSCore
+import AWSTestResources
 
 /// View controller to handle user details.
 ///
@@ -29,6 +30,9 @@ class UserDetailsViewController: UIViewController {
     
     @IBOutlet weak var attribute1Label: UILabel!
     @IBOutlet weak var attribute2Label: UILabel!
+    @IBOutlet weak var attribute3Label: UILabel!
+    @IBOutlet weak var customeAttribute1Label: UILabel!
+    @IBOutlet weak var customeAttribute2Label: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,6 +45,7 @@ class UserDetailsViewController: UIViewController {
     }
     
     func refreshData() {
+        invalidateSessionOrNot()
         fetchUserAttributes()
         fetchToken()
         fetchCredentials()
@@ -58,9 +63,19 @@ class UserDetailsViewController: UIViewController {
             self.credentialExpirationLabel.text = "NA"
             self.attribute1Label.text = "NA"
             self.attribute2Label.text = "NA"
+            self.attribute3Label.text = "NA"
+            self.customeAttribute1Label.text = "NA"
+            self.customeAttribute2Label.text = "NA"
         }
     }
-    
+
+    func invalidateSessionOrNot() {
+        let username = AWSMobileClient.default().username
+        if username?.prefix(7) == "session" {
+            invalidateSession()
+        }
+    }
+
     func fetchToken() {
         AWSMobileClient.default().getTokens { (token, error) in
             
@@ -125,12 +140,21 @@ class UserDetailsViewController: UIViewController {
         AWSMobileClient.default().getUserAttributes { attributes, error in
             DispatchQueue.main.async {
                 guard let attributes = attributes else {
-                    self.attribute1Label.text = "NA"
-                    self.attribute2Label.text = "NA"
                     return
                 }
-                self.attribute1Label.text = attributes[self.CUSTOM_ATTRIBUTE_KEY1]
-                self.attribute2Label.text = String(attributes[self.CUSTOM_ATTRIBUTE_KEY2]!)
+                if attributes.count == 3 {
+                    self.attribute1Label.text = attributes["email_verified"]
+                    self.attribute2Label.text = attributes["email"]
+                    self.attribute3Label.text = attributes["sub"]
+                    self.customeAttribute1Label.text = "NA"
+                    self.customeAttribute2Label.text = "NA"
+                } else {
+                    self.attribute1Label.text = attributes["email_verified"]
+                    self.attribute2Label.text = attributes["email"]
+                    self.attribute3Label.text = attributes["sub"]
+                    self.customeAttribute1Label.text = attributes[self.CUSTOM_ATTRIBUTE_KEY1]
+                    self.customeAttribute2Label.text = attributes[self.CUSTOM_ATTRIBUTE_KEY2]
+                }
             }
         }
     }
@@ -144,5 +168,17 @@ class UserDetailsViewController: UIViewController {
         AWSMobileClient.default().updateUserAttributes(attributeMap: newUserAttributes) { result, error in
             self.refreshData()
         }
+    }
+    
+    func invalidateSession() {
+        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
+        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
+        let userPoolConfig = awsconfiguration["CognitoUserPool"] as! [String: [String: Any]]
+        let appClientId = (userPoolConfig["Default"]!["AppClientId"] as! String)
+        let bundleID = Bundle.main.bundleIdentifier
+        let keychain = AWSUICKeyChainStore(service: "\(bundleID!).\(AWSCognitoIdentityUserPool.self)")
+        let namespace = "\(appClientId).\(AWSMobileClient.default().username ?? "")"
+        let key = "\(namespace).tokenExpiration"
+        keychain.removeItem(forKey: key)
     }
 }

--- a/AWSAuthSDK/AWSAuthSDKTestApp/UserDetailsViewController.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/UserDetailsViewController.swift
@@ -178,12 +178,12 @@ class UserDetailsViewController: UIViewController {
         }
     }
     
-    func invalidateRefreshToken() {
+    private func invalidateRefreshToken() {
         let key = getTokenKeychain()
         getKeychain().removeItem(forKey: key)
     }
 
-    func invalidateAccessToken() {
+    private func invalidateAccessToken() {
         let key = getTokenKeychain()
         let pastDate = Date(timeIntervalSinceNow: -1)
         let formattedDate = ISO8601DateFormatter().string(from: pastDate)

--- a/AWSAuthSDK/AWSAuthSDKTestApp/UserDetailsViewController.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestApp/UserDetailsViewController.swift
@@ -45,7 +45,7 @@ class UserDetailsViewController: UIViewController {
     }
     
     func refreshData() {
-        invalidateSessionOrNot()
+        invalidateRefreshTokenOrNot()
         fetchUserAttributes()
         fetchToken()
         fetchCredentials()
@@ -69,10 +69,14 @@ class UserDetailsViewController: UIViewController {
         }
     }
 
-    func invalidateSessionOrNot() {
+    /// There is one test case `testHostedUIGetAttributesWhenSessionExpired` in `AWSHostedUIUserPoolTests.swift`
+    /// that requires the refresh token to be invalidated. But `UserDetailsViewController` doesn't have context which test case it is in
+    /// The workaround is to create a user `sessionExpired+UUID` so that when `UserDetailsViewController` sees that,
+    /// it knows it should call `mockIncalidateRefreshToken()`
+    func invalidateRefreshTokenOrNot() {
         let username = AWSMobileClient.default().username
-        if username?.prefix(7) == "session" {
-            invalidateSession()
+        if username?.prefix(14) == "sessionExpired" {
+            mockInvalidateRefreshToken()
         }
     }
 
@@ -170,7 +174,7 @@ class UserDetailsViewController: UIViewController {
         }
     }
     
-    func invalidateSession() {
+    func mockInvalidateRefreshToken() {
         let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
         let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
         let userPoolConfig = awsconfiguration["CognitoUserPool"] as! [String: [String: Any]]

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSAuthSDKUITestBase.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSAuthSDKUITestBase.swift
@@ -1,0 +1,264 @@
+//
+//  AWSMobileClientBaseTests.swift
+//  AWSMobileClientTests
+//
+
+import XCTest
+
+@testable import AWSMobileClient
+import AWSAuthCore
+import AWSCognitoIdentityProvider
+import AWSTestResources
+
+class AWSAuthSDKUITestBase: XCTestCase {
+    static let networkRequestTimeout: TimeInterval = 60.0
+    
+    static var cognitoIdentity: AWSCognitoIdentity!
+    static var userPoolsAdminClient: AWSCognitoIdentityProvider!
+    
+    static var userPoolId: String!
+    static var appClientId: String!
+    static var sharedEmail: String!
+    static var identityPoolId: String!
+    static var sharedPassword: String!
+    
+    override class func setUp() {
+        sharedEmail = AWSTestConfiguration.getIntegrationTestConfigurationValue(forPackageId: "mobileclient",
+                                                                                configKey: "email_address")
+        sharedPassword = AWSTestConfiguration.getIntegrationTestConfigurationValue(forPackageId: "mobileclient",
+                                                                                configKey: "test_password")
+
+        let commonTestConfiguration = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "common")
+        
+        let awsConfig = getAWSConfiguration()
+        AWSInfo.configureDefaultAWSInfo(awsConfig)
+        let userPoolConfig = awsConfig["CognitoUserPool"] as! [String: [String: Any]]
+        userPoolId = (userPoolConfig["Default"]!["PoolId"] as! String)
+        appClientId = (userPoolConfig["Default"]!["AppClientId"] as! String)
+        
+        let credentialProviderConfig = awsConfig["CredentialsProvider"] as! [String: [String: [String: String]]]
+        identityPoolId = credentialProviderConfig["CognitoIdentity"]!["Default"]!["PoolId"]
+        
+        let testConfigurationJSON = loadTestConfigurationFromFile()
+        let credentialsTestConfiguration = testConfigurationJSON["credentials"] as! [String: Any]
+        let credentialsProvider = AWSBasicSessionCredentialsProvider(accessKey: credentialsTestConfiguration["accessKey"] as! String,
+                                                                     secretKey: credentialsTestConfiguration["secretKey"] as! String,
+                                                                     sessionToken: credentialsTestConfiguration["sessionToken"] as! String)
+        
+        let region = (commonTestConfiguration["region"] as! String).aws_regionTypeValue()
+        let configuration = AWSServiceConfiguration(region: region, credentialsProvider: credentialsProvider)!
+        
+        AWSCognitoIdentityProvider.register(with: configuration, forKey: "TEST")
+        AWSCognitoIdentity.register(with: configuration, forKey: "TEST")
+        
+        cognitoIdentity = AWSCognitoIdentity(forKey: "TEST")
+        userPoolsAdminClient = AWSCognitoIdentityProvider(forKey: "TEST")
+        initializeMobileClient()
+    }
+
+    override func setUp() {
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+
+    override func tearDown() {
+        AWSMobileClient.default().signOut()
+        AWSMobileClient.default().clearCredentials()
+        AWSMobileClient.default().clearKeychain()
+    }
+    
+    //MARK: Helper methods
+    
+    static func loadTestConfigurationFromFile() -> [String: Any] {
+        return AWSTestConfiguration.getTestConfiguration() as! [String: Any]
+    }
+
+    static func initializeMobileClient() {
+        let testCase = XCTestCase()
+        let mobileClientIsInitialized = testCase.expectation(description: "AWSMobileClient is initialized")
+        
+        AWSMobileClient.default().initialize() { (userState, error) in
+            if let error = error {
+                XCTFail("Encountered unexpected error in initialize: \(error.localizedDescription)")
+                return
+            }
+            
+            guard let userState = userState else {
+                XCTFail("userState is unexpectedly empty initializing AWSMobileClient")
+                return
+            }
+            
+            if userState != UserState.signedOut {
+                AWSMobileClient.default().signOut()
+            }
+            mobileClientIsInitialized.fulfill()
+        }
+        testCase.wait(for: [mobileClientIsInitialized], timeout: 5)
+    }
+    
+    func signUpUser(username: String,
+                    customUserAttributes: [String: String]? = nil,
+                    clientMetaData: [String: String]? = nil,
+                    signupState: SignUpConfirmationState = .unconfirmed) {
+        var userAttributes = ["email": AWSAuthSDKUITestBase.sharedEmail!]
+        if let customUserAttributes = customUserAttributes {
+            userAttributes.merge(customUserAttributes) { current, _ in current }
+        }
+        
+        let signUpExpectation = expectation(description: "successful sign up expectation.")
+        AWSMobileClient.default().signUp(
+            username: username,
+            password: AWSAuthSDKUITestBase.sharedPassword,
+            userAttributes: userAttributes,
+            clientMetaData: clientMetaData ?? [:]) { (signUpResult, error) in
+                if let error = error {
+                    var errorMessage: String
+                    if let mobileClientError = error as? AWSMobileClientError {
+                        errorMessage = mobileClientError.message
+                    } else {
+                        errorMessage = error.localizedDescription
+                    }
+                    XCTFail("Unexpected failure: \(errorMessage)")
+                    return
+                }
+                
+                guard let signUpResult = signUpResult else {
+                    XCTFail("signUpResult unexpectedly nil")
+                    return
+                }
+                
+                switch(signUpResult.signUpConfirmationState) {
+                case .confirmed:
+                    print("User is signed up and confirmed.")
+                case .unconfirmed:
+                    if let codeDeliveryDetails = signUpResult.codeDeliveryDetails {
+                        print("User is not confirmed and needs verification via \(codeDeliveryDetails.deliveryMedium) sent at \(codeDeliveryDetails.destination!)")
+                    } else {
+                        print("User is not confirmed but no code delivery details were set")
+                    }
+                case .unknown:
+                    print("Unexpected case")
+                }
+                
+                XCTAssertTrue(signUpResult.signUpConfirmationState == signupState, "User is expected to be marked as \(signupState).")
+                
+                signUpExpectation.fulfill()
+        }
+        
+        wait(for: [signUpExpectation], timeout: AWSAuthSDKUITestBase.networkRequestTimeout)
+    }
+    
+    func adminVerifyUser(username: String) {
+        guard let adminConfirmSignUpRequest = AWSCognitoIdentityProviderAdminConfirmSignUpRequest() else {
+            XCTFail("Unable to create adminConfirmSignUpRequest")
+            return
+        }
+        
+        adminConfirmSignUpRequest.username = username
+        adminConfirmSignUpRequest.userPoolId = AWSAuthSDKUITestBase.userPoolId
+        
+        AWSAuthSDKUITestBase.userPoolsAdminClient.adminConfirmSignUp(adminConfirmSignUpRequest).continueWith(block: { (task) -> Any? in
+            if let error = task.error {
+                XCTFail("Could not confirm user. Failing the test: \(error)")
+            }
+            return nil
+        }).waitUntilFinished()
+    }
+    
+    func signUpAndVerifyUser(username: String, customUserAttributes: [String: String]? = nil) {
+        signUpUser(username: username, customUserAttributes: customUserAttributes)
+        adminVerifyUser(username: username)
+    }
+    
+    static func getAWSConfiguration() -> [String: Any] {
+        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
+        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
+        return awsconfiguration
+    }
+
+    /// Sign in the user
+    func signInUserpool(application: XCUIApplication, username: String) {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        springboard.buttons["Continue"].tap()
+        
+        let webViewsQuery = application.webViews
+        webViewsQuery.textFields["Username"].tap()
+        webViewsQuery/*@START_MENU_TOKEN@*/.textFields["Username"]/*[[".otherElements[\"Signin\"].textFields[\"Username\"]",".textFields[\"Username\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.typeText(username)
+        
+        let passwordSecureTextField = webViewsQuery/*@START_MENU_TOKEN@*/.secureTextFields["Password"]/*[[".otherElements[\"Signin\"].secureTextFields[\"Password\"]",".secureTextFields[\"Password\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        passwordSecureTextField.tap()
+        passwordSecureTextField.typeText(AWSAuthSDKUITestBase.sharedPassword)
+        
+        application.buttons["Done"].tap()
+        
+        let signInButton = webViewsQuery.buttons["submit"]
+                signInButton.tap()
+    }
+    
+    func signInUserpoolAgain(application: XCUIApplication, username: String) {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        springboard.buttons["Continue"].tap()
+    }
+    
+    /// Sign out the active user in the home page.
+    func signOutUserpool(application: XCUIApplication) {
+        let signinstatelabelElement = application.staticTexts["signInStateLabel"]
+        if signinstatelabelElement.label == "signedIn" {
+            application.buttons["SignOut"].tap()
+            let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+            springboard.buttons["Continue"].tap()
+            let predicate = NSPredicate(format: "label CONTAINS[c] %@", "signedOut")
+            let signOutExpectation = expectation(for: predicate, evaluatedWith: signinstatelabelElement,
+                                                 handler: nil)
+            wait(for: [signOutExpectation], timeout: 5)
+        }
+        XCTAssertEqual("signedOut", signinstatelabelElement.label)
+    }
+    
+    /// Inspect if we have all the token details. We fail if
+    /// the token values are still 'NA'
+    func inspectTokenDetails(application: XCUIApplication) {
+        
+        let labelValidityPredicate = NSPredicate(format: "NOT label BEGINSWITH 'NA'")
+        
+        let idTokenLabelElement = application.staticTexts["idTokenLabel"]
+        let accessTokenLabelElement = application.staticTexts["accessTokenLabel"]
+        let refreshTokenLabelElement = application.staticTexts["refreshTokenLabel"]
+        
+        let idTokenExpectation = expectation(for: labelValidityPredicate,
+                                             evaluatedWith: idTokenLabelElement,
+                                             handler: nil)
+        let accessTokenExpectation = expectation(for: labelValidityPredicate,
+                                                 evaluatedWith: accessTokenLabelElement,
+                                                 handler: nil)
+        let refreshTokenExpectation = expectation(for: labelValidityPredicate,
+                                                  evaluatedWith: refreshTokenLabelElement,
+                                                  handler: nil)
+        
+        wait(for: [idTokenExpectation, accessTokenExpectation, refreshTokenExpectation], timeout: 10)
+    }
+    
+    /// Inspect if we have all the credential details. We fail if
+    /// the credential values are still 'NA'
+    func inspectCredentialDetails(application: XCUIApplication) {
+        
+        let labelValidityPredicate = NSPredicate(format: "NOT label BEGINSWITH 'NA'")
+        
+        let accessKeyLabelElement = application.staticTexts["idTokenLabel"]
+        let secretKeyLabelElement = application.staticTexts["accessTokenLabel"]
+        let sessionKeyLabelElement = application.staticTexts["refreshTokenLabel"]
+        
+        let accessKeyExpectation = expectation(for: labelValidityPredicate,
+                                               evaluatedWith: accessKeyLabelElement,
+                                               handler: nil)
+        let secretKeyExpectation = expectation(for: labelValidityPredicate,
+                                               evaluatedWith: secretKeyLabelElement,
+                                               handler: nil)
+        let sessionKeyExpectation = expectation(for: labelValidityPredicate,
+                                                evaluatedWith: sessionKeyLabelElement,
+                                                handler: nil)
+        
+        wait(for: [accessKeyExpectation, secretKeyExpectation, sessionKeyExpectation], timeout: 10)
+    }
+}
+

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSAuthSDKUITestBase.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSAuthSDKUITestBase.swift
@@ -13,13 +13,10 @@ import AWSTestResources
 class AWSAuthSDKUITestBase: XCTestCase {
     static let networkRequestTimeout: TimeInterval = 60.0
     
-    static var cognitoIdentity: AWSCognitoIdentity!
     static var userPoolsAdminClient: AWSCognitoIdentityProvider!
     
     static var userPoolId: String!
-    static var appClientId: String!
     static var sharedEmail: String!
-    static var identityPoolId: String!
     static var sharedPassword: String!
     
     override class func setUp() {
@@ -34,10 +31,6 @@ class AWSAuthSDKUITestBase: XCTestCase {
         AWSInfo.configureDefaultAWSInfo(awsConfig)
         let userPoolConfig = awsConfig["CognitoUserPool"] as! [String: [String: Any]]
         userPoolId = (userPoolConfig["Default"]!["PoolId"] as! String)
-        appClientId = (userPoolConfig["Default"]!["AppClientId"] as! String)
-        
-        let credentialProviderConfig = awsConfig["CredentialsProvider"] as! [String: [String: [String: String]]]
-        identityPoolId = credentialProviderConfig["CognitoIdentity"]!["Default"]!["PoolId"]
         
         let testConfigurationJSON = loadTestConfigurationFromFile()
         let credentialsTestConfiguration = testConfigurationJSON["credentials"] as! [String: Any]
@@ -51,7 +44,6 @@ class AWSAuthSDKUITestBase: XCTestCase {
         AWSCognitoIdentityProvider.register(with: configuration, forKey: "TEST")
         AWSCognitoIdentity.register(with: configuration, forKey: "TEST")
         
-        cognitoIdentity = AWSCognitoIdentity(forKey: "TEST")
         userPoolsAdminClient = AWSCognitoIdentityProvider(forKey: "TEST")
         initializeMobileClient()
     }
@@ -71,6 +63,12 @@ class AWSAuthSDKUITestBase: XCTestCase {
     
     static func loadTestConfigurationFromFile() -> [String: Any] {
         return AWSTestConfiguration.getTestConfiguration() as! [String: Any]
+    }
+
+    static func getAWSConfiguration() -> [String: Any] {
+        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
+        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
+        return awsconfiguration
     }
 
     static func initializeMobileClient() {
@@ -168,12 +166,6 @@ class AWSAuthSDKUITestBase: XCTestCase {
     func signUpAndVerifyUser(username: String, customUserAttributes: [String: String]? = nil) {
         signUpUser(username: username, customUserAttributes: customUserAttributes)
         adminVerifyUser(username: username)
-    }
-    
-    static func getAWSConfiguration() -> [String: Any] {
-        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
-        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
-        return awsconfiguration
     }
 
     /// Sign in the user

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSAuthSDKUITestBase.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSAuthSDKUITestBase.swift
@@ -187,7 +187,7 @@ class AWSAuthSDKUITestBase: XCTestCase {
                 signInButton.tap()
     }
     
-    func signInUserpoolAgain(application: XCUIApplication, username: String) {
+    func signInUserpoolWhenRefreshTokenExpires(application: XCUIApplication, username: String) {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         springboard.buttons["Continue"].tap()
     }

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
@@ -57,13 +57,13 @@ class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
         inspectCredentialDetails(application: app)
     }
 
-    /// Test successful re-authentication in user pool when session expires using hosted UI and get user attributes
+    /// Test successful refresh access token and get user attributes
     ///
-    /// - Given: Expire an user session after signing in
+    /// - Given: Invalidate the access token of an user after signing in
     /// - When:
-    ///    - I try to get user attributes
+    ///    - I try to get user attributes after access token is invalidated
     /// - Then:
-    ///    - I should re-authenticate and successfully get user attributes
+    ///    - I should successfully get user attributes
     ///
     func testHostedUIGetAttributesWhenAccessTokenInvalidated() {
         let username = "accessToken" + UUID().uuidString
@@ -97,13 +97,13 @@ class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
         inspectCredentialDetails(application: app)
     }
 
-    /// Test successful re-authentication in user pool when session expires using hosted UI and get user attributes
+    /// Test successful re-authentication in user pool with hosted UI when refresh token expires and get user attributes
     ///
-    /// - Given: Expire an user session after signing in
+    /// - Given: Invalidate the refresh token of an user after signing in
     /// - When:
-    ///    - I try to get user attributes
+    ///    - I try to get user attributes after refresh token is invalidated
     /// - Then:
-    ///    - I should re-authenticate and successfully get user attributes
+    ///    - I should re-authenticate with hostedUI and successfully get user attributes
     ///
     func testHostedUIGetAttributesWhenRefreshTokenInvalidated() {
         let username = "refreshToken" + UUID().uuidString

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
@@ -5,22 +5,98 @@
 
 import XCTest
 import AWSTestResources
+import AWSAuthCore
+import AWSAuthCore
+import AWSCognitoIdentityProvider
 
-class AWSHostedUIUserPoolTests: XCTestCase {
-    
-    static var userpoolUsername: String?
-    static var userpoolPassword: String?
-    
-    override class func setUp() {
-        userpoolUsername = AWSTestConfiguration.getIntegrationTestConfigurationValue(forPackageId: "mobileclient",
-                                                                                     configKey: "userpool_username")
-        userpoolPassword = AWSTestConfiguration.getIntegrationTestConfigurationValue(forPackageId: "mobileclient",
-                                                                                     configKey: "userpool_password")
-    }
-    
+class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
+
     override func setUp() {
         continueAfterFailure = false
         XCUIApplication().launch()
+    }
+    
+    /// Test successful authentication in user pool using hosted UI and get user attributes
+    ///
+    /// - Given: An unauthenticated user session
+    /// - When:
+    ///    - I try to sign in using hosted UI
+    /// - Then:
+    ///    - I should get a signed in session
+    ///    - I should get my user attributes
+    ///
+    func testHostedUIGetAttributes() {
+        let username = "testUser" + UUID().uuidString
+        let app = XCUIApplication()
+        signOutUserpool(application: app)
+        
+        signUpAndVerifyUser(username: username)
+        
+        // Push the hosted UI view controller
+        app.buttons["Hosted UI Userpool tests"].tap()
+        XCTAssertTrue(app.navigationBars["UserPool"].exists)
+        
+        //Initiate signIn
+        app.buttons["SignIn User"].tap()
+        signInUserpool(application: app, username: username)
+        
+        // Check if successfully signed in
+        let userPoolSignInStateLabelElement = app.staticTexts["userPoolSignInStateLabel"]
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "signedIn")
+        let expectation1 = expectation(for: predicate,
+                                       evaluatedWith: userPoolSignInStateLabelElement,
+                                       handler: nil)
+        wait(for: [expectation1], timeout: 5)
+        
+        // Push the user detail page
+        app.buttons["User pool operations"].tap()
+        XCTAssertTrue(app.navigationBars["User Details"].exists)
+        
+        // Check if all user details are present
+        inspectTokenDetails(application: app)
+        inspectCredentialDetails(application: app)
+    }
+
+    /// Test successful re-authentication in user pool when session expires using hosted UI and get user attributes
+    ///
+    /// - Given: Expire an user session after signing in
+    /// - When:
+    ///    - I try to get user attributes
+    /// - Then:
+    ///    - I should re-authenticate and successfully get user attributes
+    ///
+    func testHostedUIGetAttributesWhenSessionExpired() {
+        let username = "sessionExpired" + UUID().uuidString
+        let app = XCUIApplication()
+        signOutUserpool(application: app)
+        
+        signUpAndVerifyUser(username: username)
+        
+        // Push the hosted UI view controller
+        app.buttons["Hosted UI Userpool tests"].tap()
+        XCTAssertTrue(app.navigationBars["UserPool"].exists)
+        
+        //Initiate signIn
+        app.buttons["SignIn User"].tap()
+        signInUserpool(application: app, username: username)
+        
+        // Check if successfully signed in
+        let userPoolSignInStateLabelElement = app.staticTexts["userPoolSignInStateLabel"]
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "signedIn")
+        let expectation1 = expectation(for: predicate,
+                                       evaluatedWith: userPoolSignInStateLabelElement,
+                                       handler: nil)
+        wait(for: [expectation1], timeout: 5)
+
+        // Push the user detail page
+        app.buttons["User pool operations"].tap()
+        XCTAssertTrue(app.navigationBars["User Details"].exists)
+        
+        signInUserpoolAgain(application: app, username: username)
+        
+        // Check if all user details are present
+        inspectTokenDetails(application: app)
+        inspectCredentialDetails(application: app)
     }
     
     /// Test whether after update attribute, we have valid token and credentials
@@ -32,8 +108,11 @@ class AWSHostedUIUserPoolTests: XCTestCase {
     ///    - I should have all the valid tokens
     ///
     func testHostedUIUpdateAttribute() {
+        let username = "testUser" + UUID().uuidString
         let app = XCUIApplication()
         signOutUserpool(application: app)
+        
+        signUpAndVerifyUser(username: username)
         
         // Push the hosted UI view controller
         app.buttons["Hosted UI Userpool tests"].tap()
@@ -41,7 +120,7 @@ class AWSHostedUIUserPoolTests: XCTestCase {
         
         //Initiate signIn
         app.buttons["SignIn User"].tap()
-        signInUserpool(application: app)
+        signInUserpool(application: app, username: username)
         
         // Check if successfully signed in
         let userPoolSignInStateLabelElement = app.staticTexts["userPoolSignInStateLabel"]
@@ -66,124 +145,4 @@ class AWSHostedUIUserPoolTests: XCTestCase {
         inspectTokenDetails(application: app)
         inspectCredentialDetails(application: app)
     }
-    
-    /// Test successful authentication in user pool using hosted UI
-    ///
-    /// - Given: An unauthenticated user session
-    /// - When:
-    ///    - I try to sign in using hosted UI
-    /// - Then:
-    ///    - I should get a signed in session
-    ///
-    func testHostedUIUsernamePasswordSignIn() {
-        let app = XCUIApplication()
-        signOutUserpool(application: app)
-        
-        // Push the hosted UI view controller
-        app.buttons["Hosted UI Userpool tests"].tap()
-        XCTAssertTrue(app.navigationBars["UserPool"].exists)
-        
-        //Initiate signIn
-        app.buttons["SignIn User"].tap()
-        signInUserpool(application: app)
-        
-        // Check if successfully signed in
-        let userPoolSignInStateLabelElement = app.staticTexts["userPoolSignInStateLabel"]
-        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "signedIn")
-        let expectation1 = expectation(for: predicate,
-                                       evaluatedWith: userPoolSignInStateLabelElement,
-                                       handler: nil)
-        wait(for: [expectation1], timeout: 5)
-        
-        // Push the user detail page
-        app.buttons["User pool operations"].tap()
-        XCTAssertTrue(app.navigationBars["User Details"].exists)
-        
-        // Check if all user details are present
-        inspectTokenDetails(application: app)
-        inspectCredentialDetails(application: app)
-    }
-    
-    /// Sign in the user
-    func signInUserpool(application: XCUIApplication) {
-        let statusBarsQuery = application.statusBars
-        if #available(iOS 11.0, *) {
-            statusBarsQuery.element.tap()
-        } else {
-            // or use some work around
-        }
-        
-        let webViewsQuery = application.webViews
-        webViewsQuery.textFields["Username"].tap()
-        webViewsQuery/*@START_MENU_TOKEN@*/.textFields["Username"]/*[[".otherElements[\"Signin\"].textFields[\"Username\"]",".textFields[\"Username\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.typeText(AWSHostedUIUserPoolTests.userpoolUsername!)
-        
-        let passwordSecureTextField = webViewsQuery/*@START_MENU_TOKEN@*/.secureTextFields["Password"]/*[[".otherElements[\"Signin\"].secureTextFields[\"Password\"]",".secureTextFields[\"Password\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-        passwordSecureTextField.tap()
-        passwordSecureTextField.typeText(AWSHostedUIUserPoolTests.userpoolPassword!)
-        
-        let signInButton = webViewsQuery/*@START_MENU_TOKEN@*/.buttons["Sign in"]/*[[".otherElements[\"Signin\"].buttons[\"Sign in\"]",".buttons[\"Sign in\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
-        signInButton.tap()
-    }
-    
-    /// Sign out the active user in the home page.
-    func signOutUserpool(application: XCUIApplication) {
-        let signinstatelabelElement = application.otherElements["signInStateLabel"]
-        if signinstatelabelElement.label == "signedIn" {
-            application.buttons["SignOut"].tap()
-            let statusBarsQuery = application.statusBars
-            statusBarsQuery.element.tap()
-            let predicate = NSPredicate(format: "label CONTAINS[c] %@", "signedOut")
-            let signOutExpectation = expectation(for: predicate, evaluatedWith: signinstatelabelElement,
-                                                 handler: nil)
-            wait(for: [signOutExpectation], timeout: 5)
-        }
-        XCTAssertEqual("signedOut", signinstatelabelElement.label)
-    }
-    
-    /// Inspect if we have all the token details. We fail if
-    /// the token values are still 'NA'
-    func inspectTokenDetails(application: XCUIApplication) {
-        
-        let labelValidityPredicate = NSPredicate(format: "NOT label BEGINSWITH 'NA'")
-        
-        let idTokenLabelElement = application.staticTexts["idTokenLabel"]
-        let accessTokenLabelElement = application.staticTexts["accessTokenLabel"]
-        let refreshTokenLabelElement = application.staticTexts["refreshTokenLabel"]
-        
-        let idTokenExpectation = expectation(for: labelValidityPredicate,
-                                             evaluatedWith: idTokenLabelElement,
-                                             handler: nil)
-        let accessTokenExpectation = expectation(for: labelValidityPredicate,
-                                                 evaluatedWith: accessTokenLabelElement,
-                                                 handler: nil)
-        let refreshTokenExpectation = expectation(for: labelValidityPredicate,
-                                                  evaluatedWith: refreshTokenLabelElement,
-                                                  handler: nil)
-        
-        wait(for: [idTokenExpectation, accessTokenExpectation, refreshTokenExpectation], timeout: 10)
-    }
-    
-    /// Inspect if we have all the credential details. We fail if
-    /// the credential values are still 'NA'
-    func inspectCredentialDetails(application: XCUIApplication) {
-        
-        let labelValidityPredicate = NSPredicate(format: "NOT label BEGINSWITH 'NA'")
-        
-        let accessKeyLabelElement = application.staticTexts["idTokenLabel"]
-        let secretKeyLabelElement = application.staticTexts["accessTokenLabel"]
-        let sessionKeyLabelElement = application.staticTexts["refreshTokenLabel"]
-        
-        let accessKeyExpectation = expectation(for: labelValidityPredicate,
-                                               evaluatedWith: accessKeyLabelElement,
-                                               handler: nil)
-        let secretKeyExpectation = expectation(for: labelValidityPredicate,
-                                               evaluatedWith: secretKeyLabelElement,
-                                               handler: nil)
-        let sessionKeyExpectation = expectation(for: labelValidityPredicate,
-                                                evaluatedWith: sessionKeyLabelElement,
-                                                handler: nil)
-        
-        wait(for: [accessKeyExpectation, secretKeyExpectation, sessionKeyExpectation], timeout: 10)
-    }
-    
 }

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
@@ -6,7 +6,6 @@
 import XCTest
 import AWSTestResources
 import AWSAuthCore
-import AWSAuthCore
 import AWSCognitoIdentityProvider
 
 class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {

--- a/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
+++ b/AWSAuthSDK/AWSAuthSDKTestAppUITests/AWSHostedUIUserPoolTests.swift
@@ -66,7 +66,7 @@ class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
     ///    - I should successfully get user attributes
     ///
     func testHostedUIGetAttributesWhenAccessTokenInvalidated() {
-        let username = "accessToken" + UUID().uuidString
+        let username = "testUser" + UUID().uuidString
         let app = XCUIApplication()
         signOutUserpool(application: app)
         
@@ -87,6 +87,8 @@ class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
                                        evaluatedWith: userPoolSignInStateLabelElement,
                                        handler: nil)
         wait(for: [expectation1], timeout: 5)
+
+        app.buttons["invalidateAccessToken"].tap()
 
         // Push the user detail page
         app.buttons["User pool operations"].tap()
@@ -106,7 +108,7 @@ class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
     ///    - I should re-authenticate with hostedUI and successfully get user attributes
     ///
     func testHostedUIGetAttributesWhenRefreshTokenInvalidated() {
-        let username = "refreshToken" + UUID().uuidString
+        let username = "testUser" + UUID().uuidString
         let app = XCUIApplication()
         signOutUserpool(application: app)
         
@@ -127,6 +129,8 @@ class AWSHostedUIUserPoolTests: AWSAuthSDKUITestBase {
                                        evaluatedWith: userPoolSignInStateLabelElement,
                                        handler: nil)
         wait(for: [expectation1], timeout: 5)
+
+        app.buttons["invalidateRefreshToken"].tap()
 
         // Push the user detail page
         app.buttons["User pool operations"].tap()

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -940,8 +940,14 @@ extension AWSMobileClient {
             completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
-        let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
-        userDetails.getUserAttributes(completionHandler: completionHandler)
+        self.getTokens { _, error in
+            guard error == nil else {
+                completionHandler(nil, error)
+                return
+            }
+            let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
+            userDetails.getUserAttributes(completionHandler: completionHandler)
+        }
     }
     
     /// Confirm the updated attributes using a confirmation code.

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -940,13 +940,13 @@ extension AWSMobileClient {
             completionHandler(nil, AWSMobileClientError.notSignedIn(message: notSignedInErrorMessage))
             return
         }
+        guard let currentActiveUser = self.userpoolOpsHelper.currentActiveUser else {
+            completionHandler(nil, AWSMobileClientError.notSignedIn(message: self.notSignedInErrorMessage))
+            return
+        }
         self.getTokens { _, error in
             guard error == nil else {
                 completionHandler(nil, error)
-                return
-            }
-            guard let currentActiveUser = self.userpoolOpsHelper.currentActiveUser else {
-                completionHandler(nil, AWSMobileClientError.notSignedIn(message: self.notSignedInErrorMessage))
                 return
             }
             let userDetails = AWSMobileClientUserDetails(with: currentActiveUser)

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -945,7 +945,11 @@ extension AWSMobileClient {
                 completionHandler(nil, error)
                 return
             }
-            let userDetails = AWSMobileClientUserDetails(with: self.userpoolOpsHelper.currentActiveUser!)
+            guard let currentActiveUser = self.userpoolOpsHelper.currentActiveUser else {
+                completionHandler(nil, AWSMobileClientError.notSignedIn(message: self.notSignedInErrorMessage))
+                return
+            }
+            let userDetails = AWSMobileClientUserDetails(with: currentActiveUser)
             userDetails.getUserAttributes(completionHandler: completionHandler)
         }
     }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -783,16 +783,16 @@ extension AWSMobileClient {
     /// When you receive a notifcation which is `signedOutFederatedTokensInvalid` or `signedOutUserPoolsTokensInvalid` you need to proovide SDK the token via `federate` method or call the `signIn` method and complete the sign-in flow. If you can't get the latest token from the user, you can call this method to un-block any waiting calls.
     public func releaseSignInWait() {
         if self.federationProvider == .userPools {
-            self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
+            self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.invalidState(message: "Unable to get valid sign in session from the end user."))
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
-            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
+            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(error: AWSMobileClientError.invalidState(message: "Unable to get valid sign in session from the end user."))
             self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = nil
         } else if self.federationProvider == .hostedUI {
-            self.pendingGetTokensCompletion?(nil, AWSMobileClientError.unableToSignIn(message: "Could not get valid token from the user."))
+            self.pendingGetTokensCompletion?(nil, AWSMobileClientError.invalidState(message: "Could not get valid token from the user."))
             self.pendingGetTokensCompletion = nil
             self.tokenFetchLock.leave()
         } else if self.federationProvider == .oidcFederation {
-            self.pendingAWSCredentialsCompletion?(nil, AWSMobileClientError.unableToSignIn(message: "Could not get valid federation token from the user."))
+            self.pendingAWSCredentialsCompletion?(nil, AWSMobileClientError.invalidState(message: "Could not get valid federation token from the user."))
             self.pendingAWSCredentialsCompletion = nil
             self.credentialsFetchLock.leave()
         }

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -783,16 +783,16 @@ extension AWSMobileClient {
     /// When you receive a notifcation which is `signedOutFederatedTokensInvalid` or `signedOutUserPoolsTokensInvalid` you need to proovide SDK the token via `federate` method or call the `signIn` method and complete the sign-in flow. If you can't get the latest token from the user, you can call this method to un-block any waiting calls.
     public func releaseSignInWait() {
         if self.federationProvider == .userPools {
-            self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.invalidState(message: "Unable to get valid sign in session from the end user."))
+            self.userpoolOpsHelper.passwordAuthTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
             self.userpoolOpsHelper.passwordAuthTaskCompletionSource = nil
-            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(error: AWSMobileClientError.invalidState(message: "Unable to get valid sign in session from the end user."))
+            self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource?.set(error: AWSMobileClientError.unableToSignIn(message: "Unable to get valid sign in session from the end user."))
             self.userpoolOpsHelper.customAuthChallengeTaskCompletionSource = nil
         } else if self.federationProvider == .hostedUI {
-            self.pendingGetTokensCompletion?(nil, AWSMobileClientError.invalidState(message: "Could not get valid token from the user."))
+            self.pendingGetTokensCompletion?(nil, AWSMobileClientError.unableToSignIn(message: "Could not get valid token from the user."))
             self.pendingGetTokensCompletion = nil
             self.tokenFetchLock.leave()
         } else if self.federationProvider == .oidcFederation {
-            self.pendingAWSCredentialsCompletion?(nil, AWSMobileClientError.invalidState(message: "Could not get valid federation token from the user."))
+            self.pendingAWSCredentialsCompletion?(nil, AWSMobileClientError.unableToSignIn(message: "Could not get valid federation token from the user."))
             self.pendingAWSCredentialsCompletion = nil
             self.credentialsFetchLock.leave()
         }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -64,6 +64,12 @@ class AWSMobileClientTestBase: XCTestCase {
     static func loadTestConfigurationFromFile() -> [String: Any] {
         return AWSTestConfiguration.getTestConfiguration() as! [String: Any]
     }
+
+    static func getAWSConfiguration() -> [String: Any] {
+        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
+        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
+        return awsconfiguration
+    }
     
     static func initializeMobileClient() {
         let testCase = XCTestCase()
@@ -248,12 +254,6 @@ class AWSMobileClientTestBase: XCTestCase {
         let bundleID = Bundle.main.bundleIdentifier
         let keychain = AWSUICKeyChainStore(service: "\(bundleID!).\(AWSCognitoIdentityUserPool.self)")
         return keychain
-    }
-
-    static func getAWSConfiguration() -> [String: Any] {
-        let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
-        let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]
-        return awsconfiguration
     }
 }
 

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
@@ -28,6 +28,15 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
         wait(for: [verifyAttrExpectation], timeout: 5)
     }
     
+    /// Test successful authentication in user pool using sign in api and get user attributes
+    ///
+    /// - Given: An unauthenticated user session
+    /// - When:
+    ///    - I try to sign in
+    /// - Then:
+    ///    - I should get a signed in session
+    ///    - I should get my user attributes
+    ///
     // Note: This test relies on the configuration of the test UserPools to have at least one mutable custom attribute:
     // custom:mutableStringAttr1
     func testGetAttributes() {
@@ -49,6 +58,16 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
         wait(for: [getAttrExpectation], timeout: 5)
     }
     
+    /// Test successful refresh access token and get user attributes
+    ///
+    /// - Given: Invalidate the access token of an user after signing in
+    /// - When:
+    ///    - I try to get user attributes after access token is invalidated
+    /// - Then:
+    ///    - I should successfully get user attributes
+    ///
+    // Note: This test relies on the configuration of the test UserPools to have at least one mutable custom attribute:
+    // custom:mutableStringAttr1
     func testGetAttributesWhenAccessTokenInvalidated() {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username, customUserAttributes: ["custom:mutableStringAttr1": "Value for mutableStringAttr1"])
@@ -69,6 +88,16 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
         wait(for: [getAttrExpectation], timeout: 5)
     }
 
+    /// Test successful re-authentication in user pool with sigin in api when refresh token expires and get user attributes
+    ///
+    /// - Given: Invalidate the refresh token of an user after signing in
+    /// - When:
+    ///    - I try to get user attributes after refresh token is invalidated
+    /// - Then:
+    ///    - I should re-authenticate with sign in api and successfully get user attributes
+    ///
+    // Note: This test relies on the configuration of the test UserPools to have at least one mutable custom attribute:
+    // custom:mutableStringAttr1
     func testGetAttributesWhenRefreshTokenInvalidated() {
         let username = "testUser" + UUID().uuidString
         signUpAndVerifyUser(username: username, customUserAttributes: ["custom:mutableStringAttr1": "Value for mutableStringAttr1"])

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
@@ -49,6 +49,49 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
         wait(for: [getAttrExpectation], timeout: 5)
     }
     
+    func testGetAttributesWhenAccessTokenInvalidated() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username, customUserAttributes: ["custom:mutableStringAttr1": "Value for mutableStringAttr1"])
+        signIn(username: username)
+        invalidateAccessToken(username: username)
+        let getAttrExpectation = expectation(description: "get attributes expectation.")
+        
+        AWSMobileClient.default().getUserAttributes { (attributes, error) in
+            if let attributes = attributes {
+                XCTAssertEqual(attributes.count, 4, "Expected 4 attributes for user.")
+                XCTAssertEqual(attributes["email_verified"], "false", "Email should not be verified.")
+            }else if let error = error {
+                XCTFail("Received un-expected error: \(error.localizedDescription)")
+            }
+            getAttrExpectation.fulfill()
+        }
+        
+        wait(for: [getAttrExpectation], timeout: 5)
+    }
+
+    func testGetAttributesWhenRefreshTokenInvalidated() {
+        let username = "testUser" + UUID().uuidString
+        signUpAndVerifyUser(username: username, customUserAttributes: ["custom:mutableStringAttr1": "Value for mutableStringAttr1"])
+        signIn(username: username)
+        invalidateRefreshToken(username: username)
+        let getAttrExpectation = expectation(description: "get attributes expectation.")
+        
+        AWSMobileClient.default().getUserAttributes { (attributes, error) in
+            if let attributes = attributes {
+                XCTAssertEqual(attributes.count, 4, "Expected 4 attributes for user.")
+                XCTAssertEqual(attributes["email_verified"], "false", "Email should not be verified.")
+            }else if let error = error {
+                XCTFail("Received un-expected error: \(error.localizedDescription)")
+            }
+            getAttrExpectation.fulfill()
+        }
+        sleep(1)
+        signIn(username: username)
+
+        wait(for: [getAttrExpectation], timeout: 5)
+
+    }
+    
     // Note: This test relies on the configuration of the test UserPools to have two mutable custom attributes:
     // custom:mutableStringAttr1; custom:mutableStringAttr2
     func testUpdateAttributes() {

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientUserAttributeTests.swift
@@ -49,7 +49,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
             if let attributes = attributes {
                 XCTAssertEqual(attributes.count, 4, "Expected 4 attributes for user.")
                 XCTAssertEqual(attributes["email_verified"], "false", "Email should not be verified.")
-            }else if let error = error {
+            } else if let error = error {
                 XCTFail("Received un-expected error: \(error.localizedDescription)")
             }
             getAttrExpectation.fulfill()
@@ -79,7 +79,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
             if let attributes = attributes {
                 XCTAssertEqual(attributes.count, 4, "Expected 4 attributes for user.")
                 XCTAssertEqual(attributes["email_verified"], "false", "Email should not be verified.")
-            }else if let error = error {
+            } else if let error = error {
                 XCTFail("Received un-expected error: \(error.localizedDescription)")
             }
             getAttrExpectation.fulfill()
@@ -109,7 +109,7 @@ class AWSMobileClientUserAttributeTests: AWSMobileClientTestBase {
             if let attributes = attributes {
                 XCTAssertEqual(attributes.count, 4, "Expected 4 attributes for user.")
                 XCTAssertEqual(attributes["email_verified"], "false", "Email should not be verified.")
-            }else if let error = error {
+            } else if let error = error {
                 XCTFail("Received un-expected error: \(error.localizedDescription)")
             }
             getAttrExpectation.fulfill()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 
 ### Bug fixes
 - **AWSMobileClient**
-  - Fix getUserAttribute crashes App when session expired ([PR #3501](https://github.com/aws-amplify/aws-sdk-ios/pull/3501))
+  - Fix crash in getUserAttribute api  ([PR #3501](https://github.com/aws-amplify/aws-sdk-ios/pull/3501))
 
 ### Misc. Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 
     > **WARNING** The Amplify CLI will overwrite customizations to the `awsconfiguration.json` and `amplifyconfiguration.json` files if you do an `amplify push` or `amplify pull`. You will need to manually re-apply the `Endpoint` customization if you use the CLI to modify your cloud backend.
 
+### Bug fixes
+- **AWSMobileClient**
+  - Fix getUserAttribute crashes App when session expired ([PR #3501](https://github.com/aws-amplify/aws-sdk-ios/pull/3501))
+
 ### Misc. Updates
 
 - Model updates for the following services
@@ -68,7 +72,7 @@
   - AWSLex
   - AWSSQS
   - AWSTranscribe
-  
+
 ## 2.23.3
 
 ### New Features


### PR DESCRIPTION
**Description of changes:**

- call `getTokens` and assert for no failure before making `getUserAttributes` call
- Re-implement HostedUI Tests that are broken

This PR to fix [issue](https://github.com/aws-amplify/amplify-ios/issues/1099)

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
