### PR TITLE
fix: Create right archive for the xcframework

### DIFF
--- a/CircleciScripts/framework_list.py
+++ b/CircleciScripts/framework_list.py
@@ -89,4 +89,4 @@ def is_framework_included(framework):
 # flatten the grouped frameworks
 frameworks = [framework for group in grouped_frameworks for framework in group]
 
-xcframeworks = list(filter(is_framework_included, frameworks)) + ["AWSMobileClientXCF", "AWSLocationXCF"]
+xcframeworks = ["AWSMobileClientXCF"] #list(filter(is_framework_included, frameworks)) + ["AWSMobileClientXCF", "AWSLocationXCF"]

--- a/CircleciScripts/prepare_xcframework_archives.py
+++ b/CircleciScripts/prepare_xcframework_archives.py
@@ -16,7 +16,7 @@ def create_archives(xcframework_path, archive_path, version):
         xcframework_sdk_path = os.path.join(xcframework_path, xcframework_sdk)
         
         archive_name = f"{framework}-{version}"
-        final_archive_name_with_ext = f"{framework}-{version}.zip"
+        final_archive_name_with_ext = f"{archive_name}.zip"
         logging.info(f"Creating zip file for {archive_name}")
         
         temp_folder = os.path.join(xcframework_path, framework)
@@ -24,8 +24,9 @@ def create_archives(xcframework_path, archive_path, version):
         shutil.copytree(xcframework_sdk_path, os.path.join(temp_folder, xcframework_sdk))  
 
         logging.info(f"Generate the archive and move it to the archive directory")
+        shutil.make_archive(archive_name, "zip", root_dir=temp_folder, base_dir=xcframework_sdk)
+        
         final_archived_path = os.path.join(archive_path, final_archive_name_with_ext)
-        shutil.make_archive(archive_name, "zip", root_dir=xcframework_path, base_dir=framework)
         shutil.move(final_archive_name_with_ext, final_archived_path)  
 
         logging.info(f"Remove the temp folder")


### PR DESCRIPTION
*Description of changes:*

`<SDK>.xcframework` should reside at the root of the zip file for the swift package manager to work correctly. This change removes the` <SDK>` root folder in the zip file and places `<SDK>.xcframework` at the zip root.

```
Zip file size: 2619530 bytes, number of entries: 56
drwxr-xr-x  2.0 unx        0 b-        0 stor 21-Apr-08 18:56 AWSMobileClientXCF.xcframework/
drwxr-xr-x  2.0 unx        0 b-        0 stor 21-Apr-08 18:56 AWSMobileClientXCF.xcframework/ios-arm64_armv7/
drwxr-xr-x  2.0 unx        0 b-        0 stor 21-Apr-08 18:56 AWSMobileClientXCF.xcframework/ios-arm64_i386_x86_64-simulator/
-rw-r--r--  2.0 unx     1128 b-      401 defN 21-Apr-08 18:56 AWSMobileClientXCF.xcframework/Info.plist
drwxr-xr-x  2.0 unx        0 b-        0 stor 21-Apr-08 18:56 AWSMobileClientXCF.xcframework/ios-arm64_i386_x86_64-simulator/AWSMobileClientXCF.framework/
...
```

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
