### PR TITLE
chore: fix cross-module imports to support CocoaPods generate_multiple_pod_projects

### DIFF
--- a/AWSPinpoint/AWSPinpointConfiguration.m
+++ b/AWSPinpoint/AWSPinpointConfiguration.m
@@ -14,7 +14,7 @@
 //
 
 #import "AWSPinpointConfiguration.h"
-#import "AWSService.h"
+#import <AWSCore/AWSService.h>
 #import "AWSPinpointService.h"
 
 int const MAX_STORAGE_SIZE = 1024 * 1024 * 5; // 5 MB

--- a/AWSPinpoint/AWSPinpointEventRecorder.m
+++ b/AWSPinpoint/AWSPinpointEventRecorder.m
@@ -13,7 +13,7 @@
 // permissions and limitations under the License.
 //
 
-#import "AWSNSCodingUtilities.h"
+#import <AWSCore/AWSNSCodingUtilities.h>
 #import "AWSPinpointEventRecorder.h"
 #import "AWSPinpointEvent.h"
 #import "AWSPinpointTargeting.h"

--- a/AWSPinpoint/AWSPinpointService.m
+++ b/AWSPinpoint/AWSPinpointService.m
@@ -19,7 +19,7 @@
 #import "AWSPinpointContext.h"
 #import "AWSPinpointSessionClient.h"
 #import "AWSPinpointConfiguration.h"
-#import "AWSClientContext.h"
+#import <AWSCore/AWSClientContext.h>
 #import "AWSPinpointTargeting.h"
 #import "AWSPinpointNotificationManager.h"
 #import "AWSPinpointAnalyticsClient.h"

--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -13,7 +13,7 @@
 // permissions and limitations under the License.
 //
 
-#import "AWSNSCodingUtilities.h"
+#import <AWSCore/AWSNSCodingUtilities.h>
 #import "AWSPinpointSessionClient.h"
 #import "AWSPinpointContext.h"
 #import "AWSPinpointAnalyticsClient.h"

--- a/AWSPinpoint/AWSPinpointTargetingClient.m
+++ b/AWSPinpoint/AWSPinpointTargetingClient.m
@@ -13,7 +13,7 @@
  permissions and limitations under the License.
  */
 
-#import "AWSNSCodingUtilities.h"
+#import <AWSCore/AWSNSCodingUtilities.h>
 #import "AWSPinpointTargetingClient.h"
 #import "AWSPinpointEndpointProfile.h"
 #import "AWSPinpointDateUtils.h"


### PR DESCRIPTION
*Description of changes:*

Changes some cross-module imports (AWSPinpoint -> AWSCore) to support CocoaPods integration regardless of `generate_multiple_pod_projects` installer option.

Without these changes, it's impossible to integrate some Amplify modules using CP with `generate_multiple_pod_projects` enabled without hacking the search paths:
```
install! 'cocoapods', :generate_multiple_pod_projects => true

...

target 'Some-Target' do
  pod 'Amplify'
  pod 'AmplifyPlugins/AWSPinpointAnalyticsPlugin'
  pod 'AmplifyPlugins/AWSCognitoAuthPlugin'
end
```

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
