### PR TITLE
fix: Fixed base64 decode failed contains special character such as Japanese chars

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -1045,10 +1045,8 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){
         NSString * claims = pieces[1];
-        claims = [claims stringByReplacingOccurrencesOfString:@"-"
-                                                withString:@"+"];
-        claims = [claims stringByReplacingOccurrencesOfString:@"_"
-                                                withString:@"/"];
+        claims = [claims stringByReplacingOccurrencesOfString:@"-" withString:@"+"];
+        claims = [claims stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
         //JWT is not padded with =, pad it if necessary
         NSUInteger paddedLength = claims.length + (4 - (claims.length % 4)) % 4;;
         claims = [claims stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -1045,6 +1045,10 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){
         NSString * claims = pieces[1];
+        claims = [claims stringByReplacingOccurrencesOfString:@"-"
+                                                withString:@"+"];
+        claims = [claims stringByReplacingOccurrencesOfString:@"_"
+                                                withString:@"/"];
         //JWT is not padded with =, pad it if necessary
         NSUInteger paddedLength = claims.length + (4 - (claims.length % 4)) % 4;;
         claims = [claims stringByPaddingToLength:paddedLength withString:@"=" startingAtIndex:0];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
----
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
 
--Features for next release
+### Bug fixes
+
+- **AWSMobileClient (HostedUI)**
+  - Fixed an issue Base64-decoding claims containing non-ASCII characters ([PR #3533](https://github.com/aws-amplify/aws-sdk-ios/pull/3533)). Thanks, [@NivisUnder7](https://github.com/NivisUnder7)!
 
 ## 2.19.1
 


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*

I found that decoded failed when special character decoded  by `initWithBase64EncodedString:claims` such as Japanese characters. 
Probably same issue #2928 
In other words, current code to get claims from a JWT Token works well as long as there are no special characters in encoded in the base64.
So, that code need to replace _ and - (which are invalid characters in a base64 string) with / and +, respectively.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
