### PR TITLE
chore: Fix a small typo in AWSClientContext

### DIFF
--- a/AWSCore/Service/AWSClientContext.m
+++ b/AWSCore/Service/AWSClientContext.m
@@ -67,13 +67,13 @@ static NSString *const AWSClientContextKeychainInstallationIdKey = @"com.amazona
 
         //Device Details
         UIDevice* currentDevice = [UIDevice currentDevice];
-        NSString *autoUpdatingLoaleIdentifier = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
+        NSString *autoUpdatingLocaleIdentifier = [[NSLocale autoupdatingCurrentLocale] localeIdentifier];
         _devicePlatform = [currentDevice systemName] ? [currentDevice systemName] : AWSClientContextUnknown;
         _deviceModel = [currentDevice model] ? [currentDevice model] : AWSClientContextUnknown;
         _deviceModelVersion = [self deviceModelVersionCode] ? [self deviceModelVersionCode] : AWSClientContextUnknown;
         _devicePlatformVersion = [currentDevice systemVersion] ? [currentDevice systemVersion] : AWSClientContextUnknown;
         _deviceManufacturer = @"apple";
-        _deviceLocale = autoUpdatingLoaleIdentifier ? autoUpdatingLoaleIdentifier : AWSClientContextUnknown;
+        _deviceLocale = autoUpdatingLocaleIdentifier ? autoUpdatingLocaleIdentifier : AWSClientContextUnknown;
 
         _customAttributes = @{};
         _serviceDetails = [NSMutableDictionary new];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Rename autoUpdatingLoaleIdentifier to autoUpdatingLocaleIdentifier to fix a small typo.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
