### PR TITLE
chore(AWSCloudWatch): remove test due to inconsisent service response

### DIFF
--- a/AWSCloudWatchTests/AWSCloudWatchTests.m
+++ b/AWSCloudWatchTests/AWSCloudWatchTests.m
@@ -102,20 +102,4 @@
     }] waitUntilFinished];
 }
 
-- (void)testGetMetricStatisticsFailed {
-    AWSCloudWatch *cloudWatch = [AWSCloudWatch defaultCloudWatch];
-    
-    AWSCloudWatchGetMetricStatisticsInput *statisticsInput = [AWSCloudWatchGetMetricStatisticsInput new];
-    statisticsInput.namespace = @""; //namespace is empty
-    
-    [[[cloudWatch getMetricStatistics:statisticsInput] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error, @"Expected InvalidParameterCombination error not found.");
-        XCTAssertEqual(task.error.code, AWSCloudWatchErrorInvalidParameterCombination);
-        XCTAssertTrue([@"InvalidParameterCombination" isEqualToString:task.error.userInfo[@"Code"]]);
-        XCTAssertTrue([@"At least one of the parameters Statistics and ExtendedStatistics must be specified." isEqualToString:task.error.userInfo[@"Message"]]);
-        return nil;
-    }] waitUntilFinished];
-    
-}
-
 @end


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-ios/issues/3546

*Description of changes:*
This PR simply removes the test if the test is not validating much other than the request is possible and fails. The expected response from the service is inconsistent, see related issue for more details

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
