### PR TITLE
Revert "Revert: feat: Support AWSCognitoIdentityProvider custom endpoint and AWSMobileClient integ tests"

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -248,6 +248,14 @@
 		FA47B5DF246C6CDD0071196D /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
 		FA5B0F11246A475500B4185B /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
 		FA5B0F12246A477D00B4185B /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
+		FA77118D260BEFCA0030966D /* AWSMobileClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5FC69011FAFA1AA004790CB /* AWSMobileClient.framework */; };
+		FA771251260BF06B0030966D /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
+		FA771252260BF0740030966D /* AWSCognitoIdentityProvider.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57361F44EC3F005A0E56 /* AWSCognitoIdentityProvider.framework */; };
+		FA771253260BF0740030966D /* AWSCognitoIdentityProviderASF.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E496D9421FDB0632000CF290 /* AWSCognitoIdentityProviderASF.framework */; };
+		FA771254260BF07D0030966D /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
+		FA771255260BF0820030966D /* AWSTestResources.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4A69C22462317A00230849 /* AWSTestResources.framework */; };
+		FA771274260BF0AB0030966D /* AWSMobileClientCustomEndpointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */; };
+		FA7712A2260BF1520030966D /* AWSMobileClientTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */; };
 		FAA39965251AAF7100F9D762 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
 		FAA39AD5251AB01F00F9D762 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B55D57121F44EC3F005A0E56 /* AWSCore.framework */; };
 		FAA39AF0251AB02B00F9D762 /* AWSAuthCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5170D981F466CE5008FD811 /* AWSAuthCore.framework */; };
@@ -1185,6 +1193,20 @@
 			remoteGlobalIDString = FAD9DD1E245CD135003F84D0;
 			remoteInfo = AWSTestResources;
 		};
+		FA771201260BEFCA0030966D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 21863B3E2602660A0070CD1B;
+			remoteInfo = AWSLocationXCF;
+		};
+		FA77124F260BF0590030966D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 175869971EF8899700F1452C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B412F63523347D1B00F1AC69;
+			remoteInfo = AWSMobileClientIntegTestApp;
+		};
 		FAF1B87C2339175B007F1435 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
@@ -1412,6 +1434,9 @@
 		D8FAC28A251D1D78005F9FC6 /* FBSDKMeasurementEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKMeasurementEvent.h; sourceTree = "<group>"; };
 		D8FAC28C251D1D8F005F9FC6 /* FBSDKURL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKURL.h; sourceTree = "<group>"; };
 		D8FAC28E251D1D94005F9FC6 /* FBSDKWebViewAppLinkResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKWebViewAppLinkResolver.h; sourceTree = "<group>"; };
+		FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientCustomEndpointTest.swift; sourceTree = "<group>"; };
+		FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSMobileClientCustomEndpointTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA77118C260BEFCA0030966D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1571,6 +1596,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA771185260BEFCA0030966D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA771251260BF06B0030966D /* AWSAuthCore.framework in Frameworks */,
+				FA771252260BF0740030966D /* AWSCognitoIdentityProvider.framework in Frameworks */,
+				FA771253260BF0740030966D /* AWSCognitoIdentityProviderASF.framework in Frameworks */,
+				FA771254260BF07D0030966D /* AWSCore.framework in Frameworks */,
+				FA77118D260BEFCA0030966D /* AWSMobileClient.framework in Frameworks */,
+				FA771255260BF0820030966D /* AWSTestResources.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1663,6 +1701,7 @@
 				B412F63623347D1B00F1AC69 /* AWSMobileClientIntegTestApp.app */,
 				B49C889E24B38746009739FC /* AWSAppleSignIn.framework */,
 				B402CD3F2580672F0020B83B /* AWSMobileClientXCF.framework */,
+				FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1809,14 +1848,14 @@
 			isa = PBXGroup;
 			children = (
 				17CD4AA8218241AD00953483 /* Info.plist */,
-				B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */,
 				B4C8E4A92307447F0064C158 /* AWSMobileClientCredentialsTest.swift */,
 				B4C8E4A32307415C0064C158 /* AWSMobileClientDeviceTests.swift */,
 				B4C8E4A7230743780064C158 /* AWSMobileClientPasswordTests.swift */,
+				B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */,
 				B4C8E4A1230740200064C158 /* AWSMobileClientSignoutTests.swift */,
+				B4C8E49F23073D7B0064C158 /* AWSMobileClientTestBase.swift */,
 				17CD4AA6218241AD00953483 /* AWSMobileClientTests.swift */,
 				B4C8E4A5230742200064C158 /* AWSMobileClientUserAttributeTests.swift */,
-				B4031BE523105727009EB524 /* AWSMobileClientSignInTests.swift */,
 			);
 			path = AWSMobileClientTests;
 			sourceTree = "<group>";
@@ -1824,8 +1863,9 @@
 		17CD4B0D218241B800953483 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				B412F64A23347FBD00F1AC69 /* AWSMobileClientIntegTestApp */,
 				B412F5EE2334783D00F1AC69 /* AWSMobileClientCustomAuthTests */,
+				FA771189260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */,
+				B412F64A23347FBD00F1AC69 /* AWSMobileClientIntegTestApp */,
 				17CD4AA5218241AD00953483 /* AWSMobileClientTests */,
 				B92BA3C72318859D007C1175 /* AWSMobileClientUnitTests */,
 			);
@@ -1969,6 +2009,7 @@
 				B55D57681F44EC3F005A0E56 /* AWSLexTests.xctest */,
 				B55D576A1F44EC3F005A0E56 /* AWSLexUnitTests.xctest */,
 				B4BD3DB425C381DD00AA9034 /* AWSLocation.framework */,
+				FA771202260BEFCA0030966D /* AWSLocationXCF.framework */,
 				B4BD3DB625C381DD00AA9034 /* AWSLocationTests.xctest */,
 				B4BD3DB825C381DD00AA9034 /* AWSLocationUnitTests.xctest */,
 				B55D576C1F44EC3F005A0E56 /* AWSLogs.framework */,
@@ -2062,6 +2103,15 @@
 				B92BA3CA2318859D007C1175 /* Info.plist */,
 			);
 			path = AWSMobileClientUnitTests;
+			sourceTree = "<group>";
+		};
+		FA771189260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */ = {
+			isa = PBXGroup;
+			children = (
+				FA25453125E5C1D1006D77ED /* AWSMobileClientCustomEndpointTest.swift */,
+				FA77118C260BEFCA0030966D /* Info.plist */,
+			);
+			path = AWSMobileClientCustomEndpointTest;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2494,13 +2544,31 @@
 			productReference = B92BA3C62318859D007C1175 /* AWSMobileClientUnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FA771187260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA771203260BEFCA0030966D /* Build configuration list for PBXNativeTarget "AWSMobileClientCustomEndpointTest" */;
+			buildPhases = (
+				FA771184260BEFCA0030966D /* Sources */,
+				FA771185260BEFCA0030966D /* Frameworks */,
+				FA771186260BEFCA0030966D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FA771250260BF0590030966D /* PBXTargetDependency */,
+			);
+			name = AWSMobileClientCustomEndpointTest;
+			productName = AWSMobileClientCustomEndpointTest;
+			productReference = FA771188260BEFCA0030966D /* AWSMobileClientCustomEndpointTest.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		175869971EF8899700F1452C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1030;
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = "Amazon Web Services";
 				TargetAttributes = {
@@ -2568,6 +2636,11 @@
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
+					FA771187260BEFCA0030966D = {
+						CreatedOnToolsVersion = 12.4;
+						ProvisioningStyle = Automatic;
+						TestTargetID = B412F63523347D1B00F1AC69;
+					};
 				};
 			};
 			buildConfigurationList = 1758699A1EF8899700F1452C /* Build configuration list for PBXProject "AWSAuthSDK" */;
@@ -2599,6 +2672,7 @@
 				17CD4AA3218241AD00953483 /* AWSMobileClientTests */,
 				B92BA3C52318859D007C1175 /* AWSMobileClientUnitTests */,
 				B412F5DE233445A500F1AC69 /* AWSMobileClientCustomAuthTests */,
+				FA771187260BEFCA0030966D /* AWSMobileClientCustomEndpointTest */,
 				1750D0061F2D4DFA006D915E /* AWSUserPoolsSignIn */,
 				17CD4B1F218244EA00953483 /* AWSAuthSDKTestApp */,
 				177B8AE521E81B7D0051068F /* AWSAuthSDKTestAppUITests */,
@@ -3379,6 +3453,13 @@
 			remoteRef = FA4A69C12462317A00230849 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		FA771202260BEFCA0030966D /* AWSLocationXCF.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = AWSLocationXCF.framework;
+			remoteRef = FA771201260BEFCA0030966D /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		FAF1B87D2339175B007F1435 /* AWSCoreConfigurationTest.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
@@ -3498,6 +3579,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		B92BA3C42318859D007C1175 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FA771186260BEFCA0030966D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3674,6 +3762,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FA771184260BEFCA0030966D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA771274260BF0AB0030966D /* AWSMobileClientCustomEndpointTest.swift in Sources */,
+				FA7712A2260BF1520030966D /* AWSMobileClientTestBase.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3771,6 +3868,11 @@
 			isa = PBXTargetDependency;
 			name = AWSTestResources;
 			targetProxy = FA5B0F0F246A474E00B4185B /* PBXContainerItemProxy */;
+		};
+		FA771250260BF0590030966D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B412F63523347D1B00F1AC69 /* AWSMobileClientIntegTestApp */;
+			targetProxy = FA77124F260BF0590030966D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -4650,6 +4752,54 @@
 			};
 			name = Release;
 		};
+		FA771190260BEFCA0030966D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/AWSMobileClientCustomEndpointTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClientCustomEndpointTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSMobileClientIntegTestApp.app/AWSMobileClientIntegTestApp";
+			};
+			name = Debug;
+		};
+		FA771191260BEFCA0030966D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/AWSMobileClientCustomEndpointTest/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClientCustomEndpointTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSMobileClientIntegTestApp.app/AWSMobileClientIntegTestApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4793,6 +4943,15 @@
 			buildConfigurations = (
 				B92BA3CF2318859D007C1175 /* Debug */,
 				B92BA3D02318859D007C1175 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FA771203260BEFCA0030966D /* Build configuration list for PBXNativeTarget "AWSMobileClientCustomEndpointTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FA771190260BEFCA0030966D /* Debug */,
+				FA771191260BEFCA0030966D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/xcshareddata/xcschemes/AWSMobileClient.xcscheme
@@ -69,6 +69,16 @@
                ReferencedContainer = "container:AWSAuthSDK.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA771187260BEFCA0030966D"
+               BuildableName = "AWSMobileClientCustomEndpointTest.xctest"
+               BlueprintName = "AWSMobileClientCustomEndpointTest"
+               ReferencedContainer = "container:AWSAuthSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomAuthTests/AWSMobileClientCustomAuthTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomAuthTests/AWSMobileClientCustomAuthTests.swift
@@ -185,7 +185,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
             }
         }
         wait(for: [tokenFetchExpectation], timeout: 20)
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
         
         let signOutExpectation = expectation(description: "signout was called")
         AWSMobileClient.default().addUserStateListener(self) { (userstate, info) in
@@ -247,7 +247,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
         }
 
         // Now invalidate the session and then try to call getToken
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         AWSMobileClient.default().getTokens { (token, error) in
@@ -299,7 +299,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
         }
 
         // Now invalidate the session and then try to call getToken
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         tokenFetchFailExpectation.expectedFulfillmentCount = 50
@@ -356,7 +356,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
         }
 
         // Now invalidate the session and then try to call getToken
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         AWSMobileClient.default().getTokens { (token, error) in

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
@@ -1,0 +1,260 @@
+//
+//  AWSMobileClientCustomEndpointTest.swift
+//  AWSMobileClientCustomEndpointTest
+//
+
+import XCTest
+import AWSMobileClient
+import AWSTestResources
+
+/// All tests in this class run against a configuration that specifies an "Endpoint" to override
+/// the default User Pool endpoint construction of `cognito-idp.<region>.amazonaws.com`.
+class AWSMobileClientCustomEndpointTest: AWSMobileClientTestBase {
+    override class func setUp() {
+        loadConfigurationForCustomEndpoint()
+        super.setUp()
+    }
+
+    override func setUp() {
+        _ = AWSMobileClient.default().getCredentialsProvider()
+        continueAfterFailure = false
+    }
+
+    override func tearDown() {
+        let signedOut = expectation(description: "signedOut")
+        AWSMobileClient.default().signOut() { _ in
+            signedOut.fulfill()
+        }
+        wait(for: [signedOut], timeout: 1.0)
+        AWSMobileClient.default().clearKeychain()
+        AWSMobileClient.default().clearCredentials()
+    }
+
+    /// Manipulates the configs in-memory to swap the Custom Endpoint config into the Default slot
+    /// Since this modifies the config singleton, the custom endpoint tests must be run in a
+    /// separate execution context from other tests. Also defensively removes unused configs to
+    /// reduce possibility of conflict.
+    static func loadConfigurationForCustomEndpoint() {
+        var configurationJson = getAWSConfiguration()
+
+        configurationJson.removeValue(forKey: "S3TransferUtility")
+
+        // Use NSMutableDictionary rather than `var cognitoUserPoolConfig...` to retain class
+        // semantics and make it easier to modify deeply-nested structures
+        let cognitoUserPoolConfig = configurationJson["CognitoUserPool"] as! NSMutableDictionary
+        cognitoUserPoolConfig["Default"] = cognitoUserPoolConfig["CustomEndpoint"]
+
+        cognitoUserPoolConfig.removeObject(forKey: "DefaultCustomAuth")
+        cognitoUserPoolConfig.removeObject(forKey: "CustomEndpoint")
+
+        let authConfig = configurationJson["Auth"] as! NSMutableDictionary
+        authConfig["Default"] = ["authenticationFlowType": "USER_SRP_AUTH"]
+        authConfig.removeObject(forKey: "DefaultCustomAuth")
+
+        AWSInfo.configureDefaultAWSInfo(configurationJson)
+    }
+
+    /// Simply tests that the method completes without errors. We make this an explicit test,
+    /// even though `testSignIn` uses `AWSMobileClient.signUp` behind the scenes,
+    /// so that we're not dependent on the internals of the test base `signUpAndVerifyUser`
+    /// utility method
+    func testSignUp() {
+        let username = "awsmobileclient-testSignUp-\(UUID().uuidString)"
+        let userAttributes = ["email": AWSMobileClientTestBase.sharedEmail!]
+
+        let signUpComplete = expectation(description: "signUpComplete")
+
+        AWSMobileClient.default().signUp(
+            username: username,
+            password: AWSMobileClientTestBase.sharedPassword,
+            userAttributes: userAttributes
+        ) { result, error in
+            defer {
+                signUpComplete.fulfill()
+            }
+
+            guard error == nil else {
+                XCTAssertNil(error)
+                return
+            }
+
+            guard let result = result else {
+                XCTFail("result unexpectedly nil")
+                return
+            }
+
+            XCTAssertEqual(result.signUpConfirmationState, .unconfirmed)
+        }
+
+        waitForExpectations(timeout: AWSMobileClientTestBase.networkRequestTimeout)
+    }
+
+    func testSignSRPIn() {
+        let username = "awsmobileclient-testSignIn-\(UUID().uuidString)"
+
+        signUpAndVerifyUser(username: username)
+
+        let signInComplete = expectation(description: "signInComplete")
+        AWSMobileClient.default().signIn(
+            username: username,
+            password: AWSMobileClientCustomEndpointTest.sharedPassword
+        ) { result, error in
+            defer {
+                signInComplete.fulfill()
+            }
+
+            XCTAssertNil(error)
+
+            guard let signInResult = result else {
+                XCTAssertNotNil(result)
+                return
+            }
+
+            XCTAssertEqual(signInResult.signInState, .signedIn)
+        }
+
+        wait(for: [signInComplete], timeout: AWSMobileClientCustomEndpointTest.networkRequestTimeout)
+    }
+
+    func testForgotPassword() {
+        let username = "awsmobileclient-testForgotPassword-\(UUID().uuidString)"
+
+        signUpAndVerifyUser(username: username)
+
+        let confirmEmailRequest = AWSCognitoIdentityProviderAdminUpdateUserAttributesRequest()!
+        confirmEmailRequest.username = username
+        confirmEmailRequest.userPoolId = AWSMobileClientTestBase.userPoolId
+        confirmEmailRequest.userAttributes = [
+            AWSCognitoIdentityUserAttributeType(name: "email_verified", value: "true")
+        ]
+
+        AWSMobileClientTestBase
+            .userPoolsAdminClient
+            .adminUpdateUserAttributes(confirmEmailRequest)
+            .continueWith(block: { task in
+                XCTAssertNil(task.error)
+                XCTAssertNotNil(task.result)
+                return nil
+            })
+            .waitUntilFinished()
+
+        let forgotPasswordComplete = expectation(description: "forgotPasswordComplete")
+        AWSMobileClient.default().forgotPassword(username: username) { result, error in
+            defer {
+                forgotPasswordComplete.fulfill()
+            }
+
+            XCTAssertNil(error)
+
+            guard let forgotPasswordResult = result else {
+                XCTAssertNotNil(result)
+                return
+            }
+
+            XCTAssertEqual(forgotPasswordResult.forgotPasswordState, .confirmationCodeSent)
+        }
+
+        wait(for: [forgotPasswordComplete], timeout: AWSMobileClientCustomEndpointTest.networkRequestTimeout)
+    }
+
+    func testResendConfirmationCode() {
+        let username = "awsmobileclient-testResendConfirmationCode-\(UUID().uuidString)"
+        let userAttributes = ["email": AWSMobileClientTestBase.sharedEmail!]
+
+        let signUpComplete = expectation(description: "signUpComplete")
+        AWSMobileClient.default().signUp(
+            username: username,
+            password: AWSMobileClientTestBase.sharedPassword,
+            userAttributes: userAttributes
+        ) { result, error in
+            defer {
+                signUpComplete.fulfill()
+            }
+
+            guard error == nil else {
+                XCTAssertNil(error)
+                return
+            }
+
+            guard let result = result else {
+                XCTFail("result unexpectedly nil")
+                return
+            }
+
+            XCTAssertEqual(result.signUpConfirmationState, .unconfirmed)
+        }
+        waitForExpectations(timeout: AWSMobileClientTestBase.networkRequestTimeout)
+
+        let resendSignUpCodeComplete = expectation(description: "resendSignUpCodeComplete")
+        AWSMobileClient.default().resendSignUpCode(username: username) { result, error in
+            defer {
+                resendSignUpCodeComplete.fulfill()
+            }
+
+            guard error == nil else {
+                XCTAssertNil(error)
+                return
+            }
+
+            guard let result = result else {
+                XCTFail("result unexpectedly nil")
+                return
+            }
+
+            XCTAssertNotNil(result.codeDeliveryDetails)
+        }
+
+        waitForExpectations(timeout: AWSMobileClientTestBase.networkRequestTimeout)
+    }
+
+    func testRefreshToken() {
+        let username = "awsmobileclient-testRefreshToken-\(UUID().uuidString)"
+
+        signUpAndVerifyUser(username: username)
+
+        let signInComplete = expectation(description: "signInComplete")
+        AWSMobileClient.default().signIn(
+            username: username,
+            password: AWSMobileClientCustomEndpointTest.sharedPassword
+        ) { result, error in
+            defer {
+                signInComplete.fulfill()
+            }
+
+            XCTAssertNil(error)
+
+            guard let signInResult = result else {
+                XCTAssertNotNil(result)
+                return
+            }
+
+            XCTAssertEqual(signInResult.signInState, .signedIn)
+        }
+
+        wait(for: [signInComplete], timeout: AWSMobileClientCustomEndpointTest.networkRequestTimeout)
+
+        invalidateAccessToken(username: username)
+
+        let getTokensComplete = expectation(description: "getTokensComplete")
+        AWSMobileClient.default().getTokens { result, error in
+            defer {
+                getTokensComplete.fulfill()
+            }
+
+            guard error == nil else {
+                XCTAssertNil(error)
+                return
+            }
+
+            guard let tokens = result else {
+                XCTAssertNotNil(result)
+                return
+            }
+
+            XCTAssertNotNil(tokens.accessToken)
+        }
+
+        wait(for: [getTokensComplete], timeout: AWSMobileClientCustomEndpointTest.networkRequestTimeout)
+    }
+
+}

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/Info.plist
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientCredentialsTest.swift
@@ -364,7 +364,7 @@ class AWSMobileClientCredentialsTest: AWSMobileClientTestBase {
             }
         }
         // Now invalidate the session and then try to call getToken
-        self.invalidateSession(username: username_1)
+        self.invalidateRefreshToken(username: username_1)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         AWSMobileClient.default().getTokens { (token, error) in

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
@@ -243,7 +243,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
             }
         }
         wait(for: [tokenFetchExpectation], timeout: AWSMobileClientTestBase.networkRequestTimeout)
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
         
         let signOutExpectation = expectation(description: "signout was called")
         AWSMobileClient.default().addUserStateListener(self) { (userstate, info) in
@@ -309,7 +309,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
         }
 
         // Now invalidate the session and then try to call getToken
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         AWSMobileClient.default().getTokens { (token, error) in
@@ -361,7 +361,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
         }
 
         // Now invalidate the session and then try to call getToken
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         tokenFetchFailExpectation.expectedFulfillmentCount = 50
@@ -418,7 +418,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
         }
 
         // Now invalidate the session and then try to call getToken
-        invalidateSession(username: username)
+        invalidateRefreshToken(username: username)
 
         let tokenFetchFailExpectation = expectation(description: "Token fetch should complete")
         AWSMobileClient.default().getTokens { (token, error) in

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -218,15 +218,38 @@ class AWSMobileClientTestBase: XCTestCase {
             return nil
         }.waitUntilFinished()
     }
-    
-    func invalidateSession(username: String) {
-        let bundleID = Bundle.main.bundleIdentifier
-        let keychain = AWSUICKeyChainStore(service: "\(bundleID!).\(AWSCognitoIdentityUserPool.self)")
+
+    /// Removes the access token's expiration key from the keychain, which forces the SDK into the
+    /// "refresh token expired" flow
+    /// - Parameter username: the username for which to invalidate the token
+    func invalidateRefreshToken(username: String) {
+        let key = getTokenKeychainKey(for: username)
+        getKeychain().removeItem(forKey: key)
+    }
+
+    /// Sets access token's expiration date in the keychain to a past date, which forces the SDK into the
+    /// "access token expired" flow
+    /// - Parameter username: the username for which to invalidate the token
+    func invalidateAccessToken(username: String) {
+        let key = getTokenKeychainKey(for: username)
+        let pastDate = Date(timeIntervalSinceNow: -1)
+        let formattedDate = ISO8601DateFormatter().string(from: pastDate)
+        let dateData = formattedDate.data(using: .utf8)
+        getKeychain().setData(dateData, forKey: key)
+    }
+
+    private func getTokenKeychainKey(for username: String) -> String {
         let namespace = "\(AWSMobileClient.default().userPoolClient!.userPoolConfiguration.clientId).\(username)"
         let key = "\(namespace).tokenExpiration"
-        keychain.removeItem(forKey: key)
+        return key
     }
-    
+
+    private func getKeychain() -> AWSUICKeyChainStore {
+        let bundleID = Bundle.main.bundleIdentifier
+        let keychain = AWSUICKeyChainStore(service: "\(bundleID!).\(AWSCognitoIdentityUserPool.self)")
+        return keychain
+    }
+
     static func getAWSConfiguration() -> [String: Any] {
         let mobileClientConfig = AWSTestConfiguration.getIntegrationTestConfiguration(forPackageId: "mobileclient")
         let awsconfiguration = mobileClientConfig["awsconfiguration"] as! [String: Any]

--- a/AWSCore/Service/AWSService.h
+++ b/AWSCore/Service/AWSService.h
@@ -111,6 +111,11 @@ typedef NS_ENUM(NSInteger, AWSServiceErrorType) {
                       endpoint:(AWSEndpoint *)endpoint
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider;
 
+- (instancetype)initWithRegion:(AWSRegionType)regionType
+                      endpoint:(AWSEndpoint *)endpoint
+           credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
+           localTestingEnabled:(BOOL)localTestingEnabled;
+
 - (void)addUserAgentProductToken:(NSString *)productToken;
 
 @end

--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -122,36 +122,45 @@ static NSString *const AWSServiceConfigurationUnknown = @"Unknown";
                    serviceType:(AWSServiceType)serviceType
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
            localTestingEnabled:(BOOL)localTestingEnabled {
-    if(self = [self initWithRegion:regionType credentialsProvider:credentialsProvider]){
-        _localTestingEnabled = localTestingEnabled;
-        if(localTestingEnabled) {
-            _endpoint = [[AWSEndpoint alloc] initLocalEndpointWithRegion:regionType
-                                                                 service:serviceType
-                                                            useUnsafeURL:YES];
-        }
+    AWSEndpoint *endpoint;
+    if (localTestingEnabled) {
+        endpoint = [[AWSEndpoint alloc] initLocalEndpointWithRegion:regionType
+                                                            service:serviceType
+                                                       useUnsafeURL:YES];
     }
-    
-    return self;
+    return [self initWithRegion:regionType
+                       endpoint:endpoint
+            credentialsProvider:credentialsProvider
+            localTestingEnabled:localTestingEnabled];
 }
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
-    if (self = [super init]) {
-        _regionType = regionType;
-        _credentialsProvider = credentialsProvider;
-        _localTestingEnabled = NO;
-    }
-
-    return self;
+    return [self initWithRegion:regionType
+                       endpoint:nil
+            credentialsProvider:credentialsProvider
+            localTestingEnabled:NO];
 }
 
 - (instancetype)initWithRegion:(AWSRegionType)regionType
                       endpoint:(AWSEndpoint *)endpoint
            credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider {
-    if(self = [self initWithRegion:regionType credentialsProvider:credentialsProvider]){
+    return [self initWithRegion:regionType
+                       endpoint:endpoint
+            credentialsProvider:credentialsProvider
+            localTestingEnabled:NO];
+}
+
+- (instancetype)initWithRegion:(AWSRegionType)regionType
+                      endpoint:(AWSEndpoint *)endpoint
+           credentialsProvider:(id<AWSCredentialsProvider>)credentialsProvider
+           localTestingEnabled:(BOOL)localTestingEnabled {
+    if (self = [super init]) {
+        _regionType = regionType;
         _endpoint = endpoint;
+        _credentialsProvider = credentialsProvider;
+        _localTestingEnabled = localTestingEnabled;
     }
-    
     return self;
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### New Features
 
 - **AWSMobileClient**, **AWSCognitoIdentityProvider**
-  - AWSCognitoIdentityProvider now accepts an `Endpoint` configuration value that can be used to override the default endpoint of `cognito-idp.<region>.amazonaws.com`. (See (PR #3482)[https://github.com/aws-amplify/aws-sdk-ios/pull/3482].)
+  - AWSCognitoIdentityProvider now accepts an `Endpoint` configuration value that can be used to override the default endpoint of `cognito-idp.<region>.amazonaws.com`. (See [PR #3482](https://github.com/aws-amplify/aws-sdk-ios/pull/3482).)
 
     You can use this override value to specify the domain name of, for example, a CloudFront distribution fronted by a Web Application Firewall for DDOS protection on your Cognito User Pool account. The value of `Endpoint` should be a fully-qualified host name, not a URL. Example:
 


### PR DESCRIPTION
Reverts aws-amplify/aws-sdk-ios#3553

By reverting the revert PR, we are adding the following changes back in for the 2.24.0 minor version release:

As per changelog:

**AWSMobileClient**, **AWSCognitoIdentityProvider**
  - AWSCognitoIdentityProvider now accepts an `Endpoint` configuration value that can be used to override the default endpoint of `cognito-idp.<region>.amazonaws.com`. (See [PR #3482](https://github.com/aws-amplify/aws-sdk-ios/pull/3482).)

    You can use this override value to specify the domain name of, for example, a CloudFront distribution fronted by a Web Application Firewall for DDOS protection on your Cognito User Pool account. The value of `Endpoint` should be a fully-qualified host name, not a URL. Example:

    ```json
    "CognitoUserPool": {
      "Default": {
        "AppClientId": "xxx",
        "AppClientSecret": "xxx",
        "Endpoint": "d2XXXXXXXXXXXX.cloudfront.net",
        "PoolId": "xxxxx",
        "Region": "xx-xxx-1"
      }
    }
    ```
    > **WARNING** The Amplify CLI will overwrite customizations to the `awsconfiguration.json` and `amplifyconfiguration.json` files if you do an `amplify push` or `amplify pull`. You will need to manually re-apply the `Endpoint` customization if you use the CLI to modify your cloud backend.