### PR TITLE
fix: HostedUI show signIn webUI when session expired

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -105,6 +105,27 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  */
 + (void)removeCognitoAuthForKey:(NSString *)key;
 
+/**
+ Launches the signin UI and updates the session after the user logs in. Current user data is cleared
+ @param vc Presentation view controller to display the hosted UI signIn
+ @param completion completion block to invoke on completion
+ */
+- (void)launchSignInWithViewController:(UIViewController *) vc
+            completion:(nullable AWSCognitoAuthGetSessionBlock) completion;
+
+/**
+ Launches the signin UI and updates the session after the user logs in. Current user data is cleared
+ @param anchor Presentation anchor to display the hosted UI signIn
+ @param completion completion block to invoke on completion
+ */
+- (void)launchSignInWithWebUI:(nonnull ASPresentationAnchor) anchor
+                   completion:(nullable AWSCognitoAuthGetSessionBlock) completion API_AVAILABLE(ios(13));
+
+/**
+ Get a session with id, access and refresh tokens.
+ @param anchor Presentation anchor to display the hosted UI on if needed during sign in.
+ @param completion completion block to invoke on completion
+ */
 - (void)getSessionWithWebUI:(nonnull ASPresentationAnchor) anchor
                  completion:(nullable AWSCognitoAuthGetSessionBlock) completion API_AVAILABLE(ios(13));
 

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -106,7 +106,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
 + (void)removeCognitoAuthForKey:(NSString *)key;
 
 /**
- Launches the signin UI and updates the session after the user logs in. Current user data is cleared
+ Launches the signin UI and updates the session after the user logs in.
  @param vc Presentation view controller to display the hosted UI signIn
  @param completion completion block to invoke on completion
  */
@@ -114,7 +114,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
             completion:(nullable AWSCognitoAuthGetSessionBlock) completion;
 
 /**
- Launches the signin UI and updates the session after the user logs in. Current user data is cleared
+ Launches the signin UI and updates the session after the user logs in.
  @param anchor Presentation anchor to display the hosted UI signIn
  @param completion completion block to invoke on completion
  */

--- a/AWSCognitoAuth/AWSCognitoAuth.h
+++ b/AWSCognitoAuth/AWSCognitoAuth.h
@@ -111,7 +111,7 @@ typedef void (^AWSCognitoAuthSignOutBlock)(NSError * _Nullable error);
  @param completion completion block to invoke on completion
  */
 - (void)launchSignInWithViewController:(UIViewController *) vc
-            completion:(nullable AWSCognitoAuthGetSessionBlock) completion;
+                            completion:(nullable AWSCognitoAuthGetSessionBlock) completion;
 
 /**
  Launches the signin UI and updates the session after the user logs in.

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -220,7 +220,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
             completion:(nullable AWSCognitoAuthGetSessionBlock) completion {
 
     __block __weak NSOperation *weakGetSessionOperation;
-    NSOperation *getSessionOperation =  [NSBlockOperation blockOperationWithBlock:^{
+    NSOperation *getSessionOperation = [NSBlockOperation blockOperationWithBlock:^{
         self.presentationAnchor = nil;
         [self prepareForSignIn:vc completion:completion];
         [self launchSignInVC:vc];
@@ -236,7 +236,7 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
                    completion:(nullable AWSCognitoAuthGetSessionBlock) completion {
     
     __block __weak NSOperation *weakGetSessionOperation;
-    NSOperation *getSessionOperation =  [NSBlockOperation blockOperationWithBlock:^{
+    NSOperation *getSessionOperation = [NSBlockOperation blockOperationWithBlock:^{
         self.presentationAnchor = anchor;
         [self prepareForSignIn:nil completion:completion];
         [self launchSignInVC:nil];

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -217,36 +217,29 @@ static NSString * AWSCognitoAuthAsfDeviceId = @"asf.device.id";
 }
 
 - (void)launchSignInWithViewController:(UIViewController *) vc
-            completion:(nullable AWSCognitoAuthGetSessionBlock) completion {
-
-    __block __weak NSOperation *weakGetSessionOperation;
-    NSOperation *getSessionOperation = [NSBlockOperation blockOperationWithBlock:^{
-        self.presentationAnchor = nil;
-        [self prepareForSignIn:vc completion:completion];
-        [self launchSignInVC:vc];
-        if(weakGetSessionOperation.isCancelled){
-            [self dismissSafariViewControllerAndCompleteGetSession:nil error:self.getSessionError];
-        }
-    }];
-    weakGetSessionOperation = getSessionOperation;
-    [self.getSessionQueue addOperation:getSessionOperation];
+                            completion:(nullable AWSCognitoAuthGetSessionBlock) completion {
+    [self launchUsing:nil uiViewController:vc completion:completion];
 }
 
 - (void)launchSignInWithWebUI:(nonnull ASPresentationAnchor) anchor
                    completion:(nullable AWSCognitoAuthGetSessionBlock) completion {
-    
+    [self launchUsing:anchor uiViewController:nil completion:completion];
+}
+
+- (void)launchUsing:(nullable ASPresentationAnchor) anchor
+   uiViewController:(nullable UIViewController *) vc
+         completion:(nullable AWSCognitoAuthGetSessionBlock) completion {
     __block __weak NSOperation *weakGetSessionOperation;
     NSOperation *getSessionOperation = [NSBlockOperation blockOperationWithBlock:^{
         self.presentationAnchor = anchor;
-        [self prepareForSignIn:nil completion:completion];
-        [self launchSignInVC:nil];
+        [self prepareForSignIn:vc completion:completion];
         if(weakGetSessionOperation.isCancelled){
             [self dismissSafariViewControllerAndCompleteGetSession:nil error:self.getSessionError];
         }
+        [self launchSignInVC:vc];
     }];
     weakGetSessionOperation = getSessionOperation;
     [self.getSessionQueue addOperation:getSessionOperation];
-    
 }
 
 #pragma mark get session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+- **AWSMobileClient**
+  - Fix hostedUI signIn when the refresh token is expired ([PR #3565](https://github.com/aws-amplify/aws-sdk-ios/pull/3565))
+  
 ### Misc. Updates
 
 - Model updates for the following services


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/1204

*Description of changes:*

AWSCognitoAuth is the low level SDK that used to show the hostedUI. Internally it invokes getSessionInternal to present the hostedUI. This same api is also used to refresh tokens when expired. The bug occurs due to the double responsibility of this function. The error flow is:

1. AWSCognitoAuth returns session expired notification
2. Developer tries to signIn by calling AWSMobileClient.showSignIn
3. AWSMobileClient.showSignIn internally calls getSession in AWSCognitoAuth
4. getSession finds that there is already a user present and proceeds to get the tokens
5. getSession finds that the access token is expired and finds that the refresh token is present 
6. getSession doesnot know the refresh token is expired, it tries to refresh the tokens using the refresh token
7. Refresh token api returns an error and this is send back to the developer.


*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
