### PR TITLE
chore: Reorder release tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1401,7 +1401,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
-      - build_xcframeworks:
+      - release_tag:
           requires:
             - build
           filters:
@@ -1409,8 +1409,15 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
+      - build_xcframeworks:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^[0-9]+.[0-9]+.[0-9]+$/
       - release_xcframeworks:
           requires:
+            - release_tag
             - build_xcframeworks
           filters:
             branches:
@@ -1420,12 +1427,6 @@ workflows:
       - release_xcframeworks_combined:
           requires:
             - release_xcframeworks
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^[0-9]+.[0-9]+.[0-9]+$/
-      - release_tag:
           filters:
             branches:
               ignore: /.*/
@@ -1450,7 +1451,7 @@ workflows:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
       - release_cocoapods:
           requires:
-            - add_doc_tag
+            - release_tag
           filters:
             branches:
               ignore: /.*/
@@ -1459,7 +1460,6 @@ workflows:
       - release_carthage:
           requires:
             - build_xcframeworks
-            - add_doc_tag
           filters:
             branches:
               ignore: /.*/
@@ -1467,8 +1467,6 @@ workflows:
               only: /^[0-9]+.[0-9]+.[0-9]+$/
       - bump_ios_sampleapp_version:
           requires:
-            - release_tag
-            - release_xcframeworks_combined
             - release_cocoapods
           filters:
             branches:


### PR DESCRIPTION
*Description of changes:*

Reorders the steps in the CI/CD release to start CocoaPods earlier. Generally, I tried to normalize the release flow so that documentation proceeds independently from publishing artifacts to Carthage, CocoaPods, SPM, etc. Once a release is tagged in GH, it should be a pretty rare occurrence to have to make code changes to get the release to successfully publish binary artifacts for distribution.

Unfortunately I'm unable to visualize the new workflow. It validates with `circleci config validate`, so I'm at least sure I didn't fat-finger a name or refer to a non-existent dependency.

*Check points:*

- [ ] ~~Added new tests to cover change, if needed~~
- [ ] ~~All unit tests pass~~
- [ ] ~~All integration tests pass~~
- [ ] ~~Updated CHANGELOG.md~~
- [ ] ~~Documentation update for the change if required~~
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
