### PR TITLE
fix: NSSecureCoding fix for decoding for AWSPinpointEndpointProfile

### DIFF
--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -355,7 +355,10 @@ NSString *DEBUG_CHANNEL_TYPE = @"APNS_SANDBOX";
         _effectiveDate = [decoder decodeInt64ForKey:@"effectiveDate"];
         _location = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileLocation class] forKey:@"location"];
         _demographic = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileDemographic class] forKey:@"demographic"];
-        _attributes = [decoder decodeObjectOfClass:[NSDictionary class] forKey:@"attributes"];
+
+        NSSet * attributesClasses = [NSSet setWithObjects:[NSDictionary class], [NSArray class], [NSString class], nil];
+        _attributes = [decoder decodeObjectOfClasses:attributesClasses forKey:@"attributes"];
+
         _metrics = [decoder decodeObjectOfClass:[NSDictionary class] forKey:@"metrics"];
         _user = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileUser class] forKey:@"user"];
     }

--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -359,7 +359,9 @@ NSString *DEBUG_CHANNEL_TYPE = @"APNS_SANDBOX";
         NSSet * attributesClasses = [NSSet setWithObjects:[NSDictionary class], [NSArray class], [NSString class], nil];
         _attributes = [decoder decodeObjectOfClasses:attributesClasses forKey:@"attributes"];
 
-        _metrics = [decoder decodeObjectOfClass:[NSDictionary class] forKey:@"metrics"];
+        NSSet * metricsClasses = [NSSet setWithObjects:[NSDictionary class], [NSArray class], [NSNumber class], nil];
+        _metrics = [decoder decodeObjectOfClasses:metricsClasses forKey:@"metrics"];
+
         _user = [decoder decodeObjectOfClass:[AWSPinpointEndpointProfileUser class] forKey:@"user"];
     }
     return self;

--- a/AWSPinpointTests/AWSPinpointEndpointProfileTests.m
+++ b/AWSPinpointTests/AWSPinpointEndpointProfileTests.m
@@ -1,0 +1,100 @@
+//
+// Copyright 2010-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "AWSTestUtility.h"
+#import "AWSPinpoint.h"
+#import "AWSPinpointEndpointProfile.h"
+
+@interface AWSPinpointEndpointProfileTests : XCTestCase
+
+@end
+
+@implementation AWSPinpointEndpointProfileTests
+
+- (void)testArchivingAndUnarchivingPinpointEndpointProfileWithoutAttributes {
+    if (@available(iOS 11, *)) {
+        AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
+
+        NSError * error = nil;
+        NSData * data = [NSKeyedArchiver archivedDataWithRootObject:profile1 requiringSecureCoding:YES error:&error];
+
+        XCTAssertNil(error);
+
+        AWSPinpointEndpointProfile * profile2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
+                                                                                   fromData:data
+                                                                                      error:&error];
+
+        XCTAssertNil(error);
+
+        XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
+        XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
+        XCTAssert([profile1.channelType isEqualToString:profile2.channelType]);
+    }
+}
+
+- (void)testArchivingAndUnarchivingPinpointEndpointProfileWithAttributes {
+    if (@available(iOS 11, *)) {
+        NSString * numbersKey = @"Numbers";
+        NSArray<NSString *> * numbers1 = @[@"1", @"2", @"3"];
+        AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
+        [profile1 addAttribute:numbers1 forKey:numbersKey];
+
+        NSLog(@"Attribute Keys: %@", profile1.allAttributes.allKeys);
+
+        NSError * error = nil;
+        NSData * data = [NSKeyedArchiver archivedDataWithRootObject:profile1 requiringSecureCoding:YES error:&error];
+
+        XCTAssertNil(error);
+
+        AWSPinpointEndpointProfile * profile2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
+                                                                                   fromData:data
+                                                                                      error:&error];
+
+        XCTAssertNil(error);
+
+        XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
+        XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
+        XCTAssert([profile1.channelType isEqualToString:profile2.channelType]);
+
+        NSArray<NSNumber *> * numbers2 = [profile2 attributeForKey:numbersKey];
+        XCTAssertNotNil(numbers2);
+    }
+}
+
+- (void)testUsingAWSNSCodingUtilitiesForPinpointEndpointProfile {
+    NSString * numbersKey = @"Numbers";
+    NSArray<NSString *> * numbers1 = @[@"1", @"2", @"3"];
+    AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
+    [profile1 addAttribute:numbers1 forKey:numbersKey];
+
+    NSError * error = nil;
+    NSData * data = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:profile1 requiringSecureCoding:YES error:&error];
+
+    XCTAssertNil(error);
+
+    AWSPinpointEndpointProfile * profile2 = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointEndpointProfile class] fromData:data error:&error];
+
+    XCTAssertNil(error);
+
+    XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
+    XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
+    XCTAssert([profile1.channelType isEqualToString:profile2.channelType]);
+
+    NSArray<NSNumber *> * numbers2 = [profile2 attributeForKey:numbersKey];
+    XCTAssertNotNil(numbers2);
+}
+
+@end

--- a/AWSPinpointTests/AWSPinpointEndpointProfileTests.m
+++ b/AWSPinpointTests/AWSPinpointEndpointProfileTests.m
@@ -34,14 +34,13 @@
         XCTAssertNil(error);
 
         AWSPinpointEndpointProfile * profile2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
-                                                                                   fromData:data
-                                                                                      error:&error];
+                                                                                  fromData:data
+                                                                                     error:&error];
 
         XCTAssertNil(error);
 
         XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
         XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
-        XCTAssert([profile1.channelType isEqualToString:profile2.channelType]);
     }
 }
 
@@ -52,29 +51,27 @@
         AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
         [profile1 addAttribute:numbers1 forKey:numbersKey];
 
-        NSLog(@"Attribute Keys: %@", profile1.allAttributes.allKeys);
-
         NSError * error = nil;
         NSData * data = [NSKeyedArchiver archivedDataWithRootObject:profile1 requiringSecureCoding:YES error:&error];
 
         XCTAssertNil(error);
 
         AWSPinpointEndpointProfile * profile2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
-                                                                                   fromData:data
-                                                                                      error:&error];
+                                                                                  fromData:data
+                                                                                     error:&error];
 
         XCTAssertNil(error);
 
         XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
         XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
-        XCTAssert([profile1.channelType isEqualToString:profile2.channelType]);
 
-        NSArray<NSNumber *> * numbers2 = [profile2 attributeForKey:numbersKey];
+        NSArray<NSString *> * numbers2 = [profile2 attributeForKey:numbersKey];
         XCTAssertNotNil(numbers2);
+        XCTAssertTrue([numbers1 isEqualToArray:numbers2]);
     }
 }
 
-- (void)testUsingAWSNSCodingUtilitiesForPinpointEndpointProfile {
+- (void)testUsingAWSNSCodingUtilitiesForPinpointEndpointProfileWithAttributes {
     NSString * numbersKey = @"Numbers";
     NSArray<NSString *> * numbers1 = @[@"1", @"2", @"3"];
     AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
@@ -91,10 +88,60 @@
 
     XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
     XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
-    XCTAssert([profile1.channelType isEqualToString:profile2.channelType]);
 
-    NSArray<NSNumber *> * numbers2 = [profile2 attributeForKey:numbersKey];
+    NSArray<NSString *> * numbers2 = [profile2 attributeForKey:numbersKey];
     XCTAssertNotNil(numbers2);
+    XCTAssertTrue([numbers1 isEqualToArray:numbers2]);
+}
+
+- (void)testArchivingAndUnarchivingPinpointEndpointProfileWithMetrics {
+    if (@available(iOS 11, *)) {
+        NSString * metricKey = @"Metric";
+        NSNumber * metric1 = @42;
+        AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
+        [profile1 addMetric:metric1 forKey:metricKey];
+
+        NSError * error = nil;
+        NSData * data = [NSKeyedArchiver archivedDataWithRootObject:profile1 requiringSecureCoding:YES error:&error];
+
+        XCTAssertNil(error);
+
+        AWSPinpointEndpointProfile * profile2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[AWSPinpointEndpointProfile class]
+                                                                                  fromData:data
+                                                                                     error:&error];
+
+        XCTAssertNil(error);
+
+        XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
+        XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
+
+        NSNumber * metric2 = [profile2 metricForKey:metricKey];
+        XCTAssertNotNil(metric2);
+        XCTAssertTrue([metric1 isEqualToNumber:metric2]);
+    }
+}
+
+- (void)testUsingAWSNSCodingUtilitiesForPinpointEndpointProfileWithMetrics {
+    NSString * metricKey = @"Metric";
+    NSNumber * metric1 = @42;
+    AWSPinpointEndpointProfile * profile1 = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"MyApp" endpointId:@"abc123"];
+    [profile1 addMetric:metric1 forKey:metricKey];
+
+    NSError * error = nil;
+    NSData * data = [AWSNSCodingUtilities versionSafeArchivedDataWithRootObject:profile1 requiringSecureCoding:YES error:&error];
+
+    XCTAssertNil(error);
+
+    AWSPinpointEndpointProfile * profile2 = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClass:[AWSPinpointEndpointProfile class] fromData:data error:&error];
+
+    XCTAssertNil(error);
+
+    XCTAssert([profile1.applicationId isEqualToString:profile2.applicationId]);
+    XCTAssert([profile1.endpointId isEqualToString:profile2.endpointId]);
+
+    NSNumber * metric2 = [profile2 metricForKey:metricKey];
+    XCTAssertNotNil(metric2);
+    XCTAssertTrue([metric1 isEqualToNumber:metric2]);
 }
 
 @end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		030CD859266053EB00B734C5 /* AWSPinpointEndpointProfileTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 030CD858266053EA00B734C5 /* AWSPinpointEndpointProfileTests.m */; };
 		173641DE1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 173641DC1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.h */; };
 		173641DF1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 173641DD1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.m */; };
 		174A59F01D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 174A59EF1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.m */; };
@@ -2586,6 +2587,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		030CD858266053EA00B734C5 /* AWSPinpointEndpointProfileTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSPinpointEndpointProfileTests.m; sourceTree = "<group>"; };
 		173641DC1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSLambdaRequestRetryHandler.h; sourceTree = "<group>"; };
 		173641DD1ECBBABC00512239 /* AWSLambdaRequestRetryHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSLambdaRequestRetryHandler.m; sourceTree = "<group>"; };
 		174A59EE1D89D7DB008C7D52 /* AWSLambdaMicroserviceClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSLambdaMicroserviceClient.h; sourceTree = "<group>"; };
@@ -5173,6 +5175,7 @@
 				18798FFD1DEFCB8800BC419B /* AWSPinpointAnalyticsClientTests.m */,
 				FA6978C721FA63D40092C8F3 /* AWSPinpointBackgroundBehaviorTests.m */,
 				18798FFF1DEFCB8800BC419B /* AWSPinpointContextTests.m */,
+				030CD858266053EA00B734C5 /* AWSPinpointEndpointProfileTests.m */,
 				FA64FA9A23AAAC1000B29182 /* AWSPinpointEventRecorderBatchTests.m */,
 				FA64FA9F23AAB17100B29182 /* AWSPinpointEventRecorderTestBase.h */,
 				FA64FA9D23AAB16000B29182 /* AWSPinpointEventRecorderTestBase.m */,
@@ -11542,6 +11545,7 @@
 				18798FFC1DEFCB4000BC419B /* AWSTestUtility.m in Sources */,
 				187990051DEFCB8800BC419B /* AWSPinpointContextTests.m in Sources */,
 				18798F8D1DEF9EAA00BC419B /* AWSPinpointTests.m in Sources */,
+				030CD859266053EB00B734C5 /* AWSPinpointEndpointProfileTests.m in Sources */,
 				187990071DEFCB8800BC419B /* AWSPinpointSessionClientTests.m in Sources */,
 				FA64FA9E23AAB16000B29182 /* AWSPinpointEventRecorderTestBase.m in Sources */,
 				FA64FA9B23AAAC1000B29182 /* AWSPinpointEventRecorderBatchTests.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - AWSEC2
   - AWSTranscribe
 
+- Fix for decoding AWSPinpointEndpointProfile when it includes attributes ([PR #3601](https://github.com/aws-amplify/aws-sdk-ios/pull/3601))
+
 ## 2.24.1
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
+### Bug fixes
+- Fix for decoding AWSPinpointEndpointProfile when it includes attributes ([PR #3601](https://github.com/aws-amplify/aws-sdk-ios/pull/3601))
+
 ### Misc. Updates
 
 - Model updates for the following services
   - AWSEC2
   - AWSTranscribe
-
-- Fix for decoding AWSPinpointEndpointProfile when it includes attributes ([PR #3601](https://github.com/aws-amplify/aws-sdk-ios/pull/3601))
 
 ## 2.24.1
 


### PR DESCRIPTION


*Issue #, if available:*

#3600 

*Description of changes:*

Uses decoder function appropriate for the nested types involved with the property.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
