### PR TITLE
AWSS3TransferUtility: added MD5 content verification for multi-part uploads

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1534,6 +1534,12 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
     
     [transferUtilityMultiPartUploadTask.expression assignRequestParameters:request];
 
+    NSString *contentMD5 = nil;
+    if (transferUtilityMultiPartUploadTask.expression.useContentMD5) {
+        contentMD5 = [NSString aws_base64md5FromData: [NSData dataWithContentsOfFile: subTask.file]];
+        [request setContentMD5: contentMD5];
+    }
+
     [[[self.preSignedURLBuilder getPreSignedURL:request] continueWithBlock:^id(AWSTask *task) {
         error = task.error;
         if ( error ) {
@@ -1546,7 +1552,10 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
          urlRequest.HTTPMethod = @"PUT";
         [self filterAndAssignHeaders:transferUtilityMultiPartUploadTask.expression.requestHeaders
               getPresignedURLRequest:nil URLRequest: urlRequest];
-        [ urlRequest setValue:[self.configuration.userAgent stringByAppendingString:@" MultiPart"] forHTTPHeaderField:@"User-Agent"];
+        [urlRequest setValue:[self.configuration.userAgent stringByAppendingString:@" MultiPart"] forHTTPHeaderField:@"User-Agent"];
+        if (contentMD5 != nil) {
+            [urlRequest setValue:contentMD5 forHTTPHeaderField:@"Content-MD5"];
+        }
         NSURLSessionUploadTask *nsURLUploadTask = [self getURLSessionUploadTaskWithRequest:urlRequest
                                                                                   fromFile:[NSURL fileURLWithPath:subTask.file]
                                                                                      error:&error];

--- a/AWSS3/AWSS3TransferUtilityTasks.h
+++ b/AWSS3/AWSS3TransferUtilityTasks.h
@@ -329,6 +329,11 @@ typedef void (^AWSS3TransferUtilityMultiPartProgressBlock) (AWSS3TransferUtility
 @property (copy, nonatomic, nullable) AWSS3TransferUtilityMultiPartProgressBlock progressBlock;
 
 /**
+ If YES, generate and add `Content-MD5` headers to the chunk upload requests. If NO, don't (default).
+ */
+@property (nonatomic) BOOL useContentMD5;
+
+/**
  Set an additional request header to be included in the pre-signed URL.
  
  

--- a/AWSS3/AWSS3TransferUtilityTasks.m
+++ b/AWSS3/AWSS3TransferUtilityTasks.m
@@ -447,6 +447,7 @@
     if (self = [super init]) {
         _internalRequestHeaders = [NSMutableDictionary new];
         _internalRequestParameters = [NSMutableDictionary new];
+        _useContentMD5 = false;
     }
     return self;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
   - AWSEC2
   - AWSTranscribe
 
+- **AWSS3**
+	- Added option to use Content-MD5 for multipart uploads with AWSS3TransferUtility (`useContentMD5` in `AWSS3TransferUtilityMultiPartUploadExpression`)
+
 ## 2.24.1
 
 ### Bug fixes


### PR DESCRIPTION
*Issue #, if available:*
Multi-part uploads do not have the option to use content verification by MD5 hash, the way single-part uploads do.

*Description of changes:*
- Transfer Utility can now generate and add Content-MD5 headers for the part uploads.
- Added bool property to multipart upload expression to specify if Content-MD5 headers should be used.

*Check points:*

- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [ ] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
