### PR TITLE
test: Make AWSTranslate test case insensitive

### DIFF
--- a/AWSTranslateTests/AWSTranslateTests.swift
+++ b/AWSTranslateTests/AWSTranslateTests.swift
@@ -44,7 +44,7 @@ class AWSTranslateTests: XCTestCase {
             XCTAssertNotNil(response.translatedText)
             
             if let translatedText = response.translatedText {
-                XCTAssertEqual(translatedText, "Hola Mundo")
+                XCTAssertEqual(translatedText.lowercased(), "hola mundo")
             }
             expectation.fulfill()
         }


### PR DESCRIPTION
*Description of changes:*

Fixes casing error in AWSTranslate test: https://app.circleci.com/pipelines/github/aws-amplify/aws-sdk-ios/4832/workflows/6d61f4c8-0335-4661-bccf-83a28bc6df1f

*Check points:*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] All unit tests pass
- [x] All integration tests pass
- ~~[ ] Updated CHANGELOG.md~~
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
