### PR TITLE
feat(Auth): Sign out with revoke token

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -550,7 +550,7 @@ extension AWSMobileClient {
         // If using hosted UI, we need to launch SFSafariVC/SFAuthSession/ASWebAuthenticationSession to invalidate token
         if federationProvider == .hostedUI {
             if options.invalidateTokens {
-                let _ = self.userpoolOpsHelper.currentActiveUser?.revokeToken().continueWith { (task) -> Any? in
+                revokeIfSessionIsRevocable { _ in
                     // Ensure UI actions are performed on the main thread since revoke token may be performed on a
                     // background thread.
                     DispatchQueue.main.async {
@@ -560,7 +560,6 @@ extension AWSMobileClient {
                             self.hostedUILegacySignOut(completionHandler: completionHandler)
                         }
                     }
-                    return nil
                 }
             }
             return
@@ -582,17 +581,33 @@ extension AWSMobileClient {
         }
         // If using userpools sign in (not global sign out or federated sign in), revoke the token before signing out
         if federationProvider == .userPools {
-            let _ = self.userpoolOpsHelper.currentActiveUser?.revokeToken().continueWith { (task) -> Any? in
-                // Regardless whether revoke token was successful or not, continue to sign out locally
+            revokeIfSessionIsRevocable { _ in
                 self.signOut()
                 completionHandler(nil)
-                return nil
             }
             return
         }
         // If signing in with federated sign in, perform local sign out
         signOut()
         completionHandler(nil)
+    }
+    
+    /// Returns if the session is not revocable, attempts to revoke the token if it is.
+    private func revokeIfSessionIsRevocable(completionHandler: @escaping ((Error?) -> Void)) {
+        guard let isSessionRevocable = self.userpoolOpsHelper.currentActiveUser?.isSessionRevocable,
+              isSessionRevocable else {
+            completionHandler(nil)
+            return
+        }
+        
+        let _ = self.userpoolOpsHelper.currentActiveUser?.revokeToken().continueWith { (task) -> Any? in
+            if let error = task.error {
+                completionHandler(AWSMobileClientError.makeMobileClientError(from: error))
+            } else if let _ = task.result {
+                completionHandler(nil)
+            }
+            return nil
+        }
     }
     
     private func hostedUISignOut(presentationAnchor: ASPresentationAnchor,

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -21,7 +21,23 @@ class AWSMobileClientTestBase: XCTestCase {
     static var identityPoolId: String!
     static var sharedPassword: String!
     
+    // Access token with just the "sub" claim
+    static var testAccessTokenWithSub: String = """
+        eyJraWQiOiJzU01EYmZyQ21pb3FrbEVRZFprNXl6UmszekxSTlo4aGlGMnlxdVFZbVM0PSIsImFsZyI6IlJTMjU2In0.\
+        eyJzdWIiOiI3YTQyNTFmMS04MmEyLTQxNzgtOWZhOS1mNmE3MTc1RCJ9.\
+        a
+        """
+    
+    // Access token with just the "origin_jti" claim
+    static var testAccessTokenWithOriginJTI: String = """
+        eyJraWQiOiIwTmxhQUhzbmtwQW5zbHBzUFhHWkJKcVJoR3E5WTkwckwweXpaWUV1OTJZPSIsImFsZyI6IlJTMjU2In0.\
+        eyJvcmlnaW5fanRpIjoiMzM2MWFkZDMtMDIwNS00NTY1LTk0MjQtMDQ3YWQ2N2Y0MjhmZWwifQ.\
+        a
+        """
+    
     override class func setUp() {
+        AWSDDLog.sharedInstance.logLevel = .verbose
+        AWSDDLog.add(AWSDDTTYLogger.sharedInstance)
         sharedEmail = AWSTestConfiguration.getIntegrationTestConfigurationValue(forPackageId: "mobileclient",
                                                                                 configKey: "email_address")
         sharedPassword = AWSTestConfiguration.getIntegrationTestConfigurationValue(forPackageId: "mobileclient",
@@ -242,6 +258,13 @@ class AWSMobileClientTestBase: XCTestCase {
         let formattedDate = ISO8601DateFormatter().string(from: pastDate)
         let dateData = formattedDate.data(using: .utf8)
         getKeychain().setData(dateData, forKey: key)
+    }
+    
+    func setAccessToken(for username: String,  using accessToken: String) {
+        let namespace = "\(AWSMobileClient.default().userPoolClient!.userPoolConfiguration.clientId).\(username)"
+        let key = "\(namespace).accessToken"
+        let data = accessToken.data(using: .utf8)
+        getKeychain().setData(data, forKey: key)
     }
 
     private func getTokenKeychainKey(for username: String) -> String {

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -220,6 +220,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)signOut;
 
 /**
+ Revoke all tokens for this user. Check Access Token for claims for validity to revoke tokens.
+ */
+- (AWSTask<AWSCognitoIdentityProviderRevokeTokenResponse *> *) revokeToken;
+
+/**
  Invalidate any active sessions with the service.  Last known user remains.
  */
 - (AWSTask<AWSCognitoIdentityUserGlobalSignOutResponse *> *) globalSignOut;

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -71,6 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, getter=isSignedIn) BOOL signedIn;
 
 /**
+ Determines whether this user's session is revocable. If the access token has "origin_jti" claim, then the revocation feature is enabled.
+*/
+@property (nonatomic, readonly, getter=isSessionRevocable) BOOL sessionRevocable;
+
+/**
  Get the device id
  */
 @property (nonatomic, readonly) NSString * deviceId;

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1489,7 +1489,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 }
 
 -(BOOL) isSessionRevocable {
-    __block NSString * keyChainNamespace = [self keyChainNamespaceClientId];
+    NSString * keyChainNamespace = [self keyChainNamespaceClientId];
     NSString * accessTokenKey = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserAccessToken];
     NSString * accessTokenString = self.pool.keychain[accessTokenKey];
     AWSCognitoIdentityUserSessionToken * accessToken = [[AWSCognitoIdentityUserSessionToken alloc] initWithToken:accessTokenString];
@@ -1497,7 +1497,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 }
 
 - (AWSTask<AWSCognitoIdentityProviderRevokeTokenResponse *> *) revokeToken {
-    __block NSString * keyChainNamespace = [self keyChainNamespaceClientId];
+    NSString * keyChainNamespace = [self keyChainNamespaceClientId];
     AWSCognitoIdentityProviderRevokeTokenRequest *request = [AWSCognitoIdentityProviderRevokeTokenRequest new];
     NSString * refreshToken = [self refreshTokenFromKeyChain:keyChainNamespace];
     request.token = refreshToken;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**AWSCognitoIdentityProvider**
1. Get the AccessToken from the keychain
2. Check if there is a `origin_jti` claim from the Access Token
3. Call revoke token with the refresh token, only if (2) contains the claim
4. Call (3) in an retry expoential back-off 

**AWSMobileClient sign out API**
- HostedUI Sign out API will call revoke token API before performing hosted ui sign out
- UserPool sign out API will call revoke the token. note: It does not care about the invalidateToken sign out option
- no changes to global sign out

**Behavior comparison**
- Android: https://github.com/aws-amplify/aws-sdk-android/pull/2415
- JS: https://github.com/aws-amplify/amplify-js/pull/8418

**Retryability**
In JS, the retry mechanism takes on a similar structure to AppSync's retry logic as
```
// pseudocode
Retryability {
   let baseTime = 100ms
   let maxTime = 5mins
   let jitter = 100ms
   func shouldRetry(statusCode: Int, totalBackOffTime: Int) {
       return statusCode == 5xx || 429 && totalBackoffTime < maxTime
   }
   func backoffAmount(retryCount) -> Double {
     return 2^retryCount * baseTime + jitterAmount()
   }
   private func jitterAmount() {
     return 100ms * random(0, 1)
   }
}
```

iOS also has built in retry logic at https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSCore/Serialization/AWSURLRequestRetryHandler.m#L53

**Cognito Notes**
[Cognito revoke token docs](https://docs.aws.amazon.com/cognito/latest/developerguide/token-revocation.html)
Checking revoke token functionality is enabled
With your cient id and user pool id (from `awsconfiguration.json` as `AppClientId` and `PoolId`)
```
aws cognito-idp describe-user-pool-client \
    --client-id xxxxxxxxxxxxxxxx \
    --user-pool-id [us-east-1_xxxxxx]
```
should display *EnableTokenRevocation* to true
```
{
    "UserPoolClient": {
        "UserPoolId": "us-east-1_xxx",
        "ClientName": "xxx",
        "ClientId": "xxx",
        "LastModifiedDate": "2021-06-30T12:36:36.347000-07:00",
        "CreationDate": "2021-06-23T10:29:40.936000-07:00",
        "RefreshTokenValidity": 30,
        "TokenValidityUnits": {},
        "AllowedOAuthFlowsUserPoolClient": false,
        "EnableTokenRevocation": true
    }
}
```
If it doesn't and you have an previous provision Cognito resource, enable using
```
aws cognito-idp update-user-pool-client \
    --client-id xxxxx \
    --user-pool-id [xx-xxxx-xxxx] \
    --enable-token-revocation \
```

- [ ] add additional check on asserting that token cannot be reused, ie. calling updateAttribtes or global sign out

**Testing:**
- [x] Update integration test provisioning with revoke token enable
- [x] re-run existing tests and new tests added which should have test coverage 
- [x] run integ test using pipeline: https://github.com/aws-amplify/aws-sdk-ios/pull/3679
- [x] Sample app testing: HostedUI
- [x] Sample app testing: User Pools
- [x] Sample app testing: Federated Sign in

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md (https://github.com/aws-amplify/aws-sdk-ios/pull/3680)
- [x] Documentation update for the change if required (https://github.com/aws-amplify/docs/pull/3379)
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
