### PR TITLE
feat(Auth): Sign Out with revoke token functionality

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientExtensions.swift
@@ -573,8 +573,12 @@ extension AWSMobileClient {
             }
             return
         }
-        signOut()
-        completionHandler(nil)
+        let _ = self.userpoolOpsHelper.currentActiveUser?.revokeToken().continueWith { (task) -> Any? in
+            // Regardless whether revoke token was successful or not, continue to sign out locally
+            self.signOut()
+            completionHandler(nil)
+            return nil
+        }
     }
     
     private func hostedUISignOut(presentationAnchor: ASPresentationAnchor,

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -220,6 +220,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)signOut;
 
 /**
+ Revoke all tokens for this user.
+ */
+- (AWSTask<AWSCognitoIdentityProviderRevokeTokenResponse *> *) revokeToken;
+
+/**
  Invalidate any active sessions with the service.  Last known user remains.
  */
 - (AWSTask<AWSCognitoIdentityUserGlobalSignOutResponse *> *) globalSignOut;

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1488,6 +1488,28 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     return refreshToken != nil;
 }
 
+- (AWSTask<AWSCognitoIdentityProviderRevokeTokenResponse *> *) revokeToken {
+    __block NSString * keyChainNamespace = [self keyChainNamespaceClientId];
+    NSString * idTokenString = [self keyChainKey:keyChainNamespace key:AWSCognitoIdentityUserIdToken];
+    AWSCognitoIdentityUserSessionToken * idToken = [[AWSCognitoIdentityUserSessionToken alloc] initWithToken:idTokenString];
+    
+    if ([idToken.tokenClaims objectForKey:@"jti"] == nil) {
+        AWSDDLogVerbose(@"ID Token does not contain `jti` claim. Skip revoking tokens.");
+        return [AWSTask taskWithResult:nil];
+    }
+    
+    AWSCognitoIdentityProviderRevokeTokenRequest *request = [AWSCognitoIdentityProviderRevokeTokenRequest new];
+    NSString * refreshToken = [self refreshTokenFromKeyChain:keyChainNamespace];
+    request.token = refreshToken;
+    request.clientId = self.pool.userPoolConfiguration.clientId;
+    request.clientSecret = self.pool.userPoolConfiguration.clientSecret;
+    
+    return [[self.pool.client revokeToken:request] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityProviderRevokeTokenResponse *> * _Nonnull task) {
+        AWSDDLogVerbose(@"Revoke token completed.");
+        return task;
+    }];
+}
+
 - (AWSTask<AWSCognitoIdentityUserGlobalSignOutResponse *> *) globalSignOut {
     AWSCognitoIdentityProviderGlobalSignOutRequest *request = [AWSCognitoIdentityProviderGlobalSignOutRequest new];
     return [[self getSession] continueWithSuccessBlock:^id _Nullable(AWSTask<AWSCognitoIdentityUserSession *> * _Nonnull task) {


### PR DESCRIPTION
*Issue #, if available:*
This PR depends on revoke token function from https://github.com/aws-amplify/aws-sdk-ios/pull/3638

*Description of changes:*
If sign out with userpool, attempt to revoke the token

**Q: Any changes to HostedUI sign out?**

There should not be since calling HostedUI sign out also revokes the token. 

**Q: Any changes to global sign out?**

There should not be since calling global sign out API also revokes the token.

**Q: Should there be a flag to toggle this functionality?**

Not sure, should revokeToken be the default behavior. The `invalidateToken` in SignOutOptions is used for HostedUI flow, not related to revoking tokens for user pool sign out.

**Q: Should sign out API have a callback to indicate revoke token intent?**

See https://github.com/aws-amplify/amplify-js/pull/8418/files#r652987225

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
