### PR TITLE
Update AWSDynamoDBObjectMapper.m

### DIFF
--- a/AWSDynamoDB/AWSDynamoDBObjectMapper.m
+++ b/AWSDynamoDB/AWSDynamoDBObjectMapper.m
@@ -586,7 +586,7 @@ completionHandler:completionHandler];
 // Internal class
 - (AWSTask<AWSDynamoDBPaginatedOutput *> *)query:(Class)resultClass
                                       queryInput:(AWSDynamoDBQueryInput *)queryInput {
-    return [[self.dynamoDB query:queryInput] continueWithSuccessBlock:^id(AWSTask *task) {
+    return [[self.dynamoDB query:queryInput] continueWithBlock:^id(AWSTask *task) {
         AWSDynamoDBQueryOutput *queryOutput = task.result;
 
         NSMutableArray *items = [NSMutableArray new];


### PR DESCRIPTION
Line 589:  The dynamoDB query requires continueWithBlock for proper error handling in the client; slow connections, proxy Wifi services, or no internet connectivity fails to respond when task uses "continueWithSuccessBlock".  Modification of code provides a more reliable solution - the modification was tested using a completionhandler.

*Issue #, if available:* The dynamoDB query requires continueWithBlock for proper error handling in the client; slow connections, proxy Wifi services, or no internet connectivity fails to respond when task uses "continueWithSuccessBlock".  Modification of code provides a more reliable solution - the modification was tested using a completionhandler.

*Description of changes:* Line 589: Change task continuation from "continueWithSuccessBlock" to ""continueWithBlock".   

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ x] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ x] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
