### PR TITLE
fix: AWSLocation Blob deserialization

### DIFF
--- a/AWSCore/Serialization/AWSSerialization.m
+++ b/AWSCore/Serialization/AWSSerialization.m
@@ -1414,7 +1414,8 @@ NSString *const AWSJSONParserErrorDomain = @"com.amazonaws.AWSJSONParserErrorDom
         if ((rules[@"members"][isPayloadData][@"streaming"]) ||
                 ([shapeName isEqual:@"JsonDocument"]) ||
                 ([shapeName isEqual:@"BlobStream"]) ||
-                ([shapeName isEqual:@"BodyBlob"])) {
+                ([shapeName isEqual:@"BodyBlob"]) ||
+                ([shapeName isEqual:@"Blob"])) {
             parsedData[isPayloadData] = data;
             if (error) *error = nil;
             return parsedData;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **AWSMobileClient (HostedUI)**
   - Fixed an issue Base64-decoding claims containing non-ASCII characters ([PR #3533](https://github.com/aws-amplify/aws-sdk-ios/pull/3533)). Thanks, [@NivisUnder7](https://github.com/NivisUnder7)!
+- **AWSLocation**
+  - AWSLocation Blob deserialization ([PR #3651](https://github.com/aws-amplify/aws-sdk-ios/pull/3651))
 
 ### Misc. Updates
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fixes the deserialization of response objects for 
- GetMapGlyphsResponse
- GetMapSpritesResponse
- GetMapStyleDescriptorResponse
- GetMapTileResponse

"Blob" is a shape defined as the primitive type "blob" (https://awslabs.github.io/smithy/spec/core.html#shapes) and so we should be treating it as a data like the other hardcoded shapes

Testing done: AWSLocation dependency, calling GetMapStyleDescriptor and accessing the blob field

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
