### PR TITLE
Fix for failed build due private headers not being found

### DIFF
--- a/AWSTranscribeStreaming/Internal/AWSSRWebSocketDelegateAdaptor.h
+++ b/AWSTranscribeStreaming/Internal/AWSSRWebSocketDelegateAdaptor.h
@@ -14,8 +14,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "AWSSRWebSocket.h"
-#import "AWSTranscribeStreamingClientDelegate.h"
+#import <AWSTranscribeStreaming/AWSSRWebSocket.h>
+#import <AWSTranscribeStreaming/AWSTranscribeStreamingClientDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/CircleciScripts/create_xcframeworks.py
+++ b/CircleciScripts/create_xcframeworks.py
@@ -4,6 +4,8 @@ import sys
 from framework_list import frameworks
 from functions import log, run_command
 
+PWD = os.getcwd()
+
 EXCLUDE_FROM_XCFRAMEWORK = [
     # This isn't a real framework
     "AWSiOSSDKv2",
@@ -13,9 +15,9 @@ EXCLUDE_FROM_XCFRAMEWORK = [
     "AWSMobileClient",
 ]
 
-IOS_DEVICE_ARCHIVE_PATH = "./xcframeworks/output/iOS/"
-IOS_SIMULATOR_ARCHIVE_PATH = "./xcframeworks/output/Simulator/"
-XCFRAMEWORK_PATH = "./xcframeworks/output/XCF/"
+IOS_DEVICE_ARCHIVE_PATH = f"{PWD}/xcframeworks/output/iOS/"
+IOS_SIMULATOR_ARCHIVE_PATH = f"{PWD}/xcframeworks/output/Simulator/"
+XCFRAMEWORK_PATH = f"{PWD}/xcframeworks/output/XCF/"
 
 def is_framework_included(framework):
     return framework not in EXCLUDE_FROM_XCFRAMEWORK
@@ -86,15 +88,21 @@ for framework in filtered_frameworks:
 # Create XCFramework using the archived frameworks.
 for framework in filtered_frameworks:
     ios_device_framework = f"{IOS_DEVICE_ARCHIVE_PATH}{framework}.xcarchive/Products/Library/Frameworks/{framework}.framework"
+    ios_device_debug_symbols = f"{IOS_DEVICE_ARCHIVE_PATH}{framework}.xcarchive/dSYMs/{framework}.framework.dSYM"
     ios_simulator_framework = f"{IOS_SIMULATOR_ARCHIVE_PATH}{framework}.xcarchive/Products/Library/Frameworks/{framework}.framework"
+    ios_simulator_debug_symbols = f"{IOS_SIMULATOR_ARCHIVE_PATH}{framework}.xcarchive/dSYMs/{framework}.framework.dSYM"
     xcframework = f"{XCFRAMEWORK_PATH}{framework}.xcframework"
     cmd = [
             "xcodebuild",
             "-create-xcframework",
             "-framework",
             ios_device_framework,
+            "-debug-symbols",
+            ios_device_debug_symbols,
              "-framework",
             ios_simulator_framework,
+            "-debug-symbols",
+            ios_simulator_debug_symbols,
             "-output",
             xcframework
         ] 


### PR DESCRIPTION
*Issue #, if available:*

#3568 

*Description of changes:*

There were 2 import statements which were not finding the headers which are placed in the framework structure and the imports being used are meant for local search paths, not frameworks.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
