### PR TITLE
fix: imports for private headers were not found (#3568)

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 #import <AWSCore/AWSCore.h>
 #import "AWSIoTDataManager.h"
-#import <AWSIoT/AWSSRWebSocket.h>
+#import "AWSSRWebSocket.h"
 #import "AWSIoTMQTTTypes.h"
 
 @interface AWSIoTMQTTTopicModel : NSObject

--- a/AWSIoT/Internal/AWSIoTMQTTClient.h
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 #import <AWSCore/AWSCore.h>
 #import "AWSIoTDataManager.h"
-#import "AWSSRWebSocket.h"
+#import <AWSIoT/AWSSRWebSocket.h>
 #import "AWSIoTMQTTTypes.h"
 
 @interface AWSIoTMQTTTopicModel : NSObject

--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -17,7 +17,7 @@
 
 #import "AWSIoTMQTTClient.h"
 #import "AWSMQTTSession.h"
-#import "AWSSRWebSocket.h"
+#import <AWSIoT/AWSSRWebSocket.h>
 #import "AWSIoTWebSocketOutputStream.h"
 #import "AWSIoTKeychain.h"
 

--- a/AWSIoT/Internal/AWSIoTWebSocketOutputStream.h
+++ b/AWSIoT/Internal/AWSIoTWebSocketOutputStream.h
@@ -17,7 +17,7 @@
 #define AWSIoTWebSocketOutputStream_h
 
 #import <Foundation/Foundation.h>
-#import "AWSSRWebSocket.h"
+#import <AWSIoT/AWSSRWebSocket.h>
 
 @interface AWSIoTWebSocketOutputStream : NSOutputStream
 

--- a/AWSIoT/Internal/AWSIoTWebSocketOutputStream.m
+++ b/AWSIoT/Internal/AWSIoTWebSocketOutputStream.m
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import "AWSCocoaLumberjack.h"
 #import "AWSIoTWebSocketOutputStream.h"
-#import "AWSSRWebSocket.h"
+#import <AWSIoT/AWSSRWebSocket.h>
 
 @interface AWSIoTWebSocketOutputStreamFactory()
 

--- a/AWSTranscribeStreaming/Internal/AWSSRWebSocketAdaptor.h
+++ b/AWSTranscribeStreaming/Internal/AWSSRWebSocketAdaptor.h
@@ -14,7 +14,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "AWSSRWebSocket.h"
+#import <AWSTranscribeStreaming/AWSSRWebSocket.h>
 #import "AWSTranscribeStreamingClientDelegate.h"
 #import "AWSTranscribeStreamingWebSocketProvider.h"
 #import "AWSSRWebSocketDelegateAdaptor.h"

--- a/AWSTranscribeStreaming/Internal/AWSSRWebSocketDelegateAdaptor.h
+++ b/AWSTranscribeStreaming/Internal/AWSSRWebSocketDelegateAdaptor.h
@@ -14,8 +14,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "AWSSRWebSocket.h"
-#import "AWSTranscribeStreamingClientDelegate.h"
+#import <AWSTranscribeStreaming/AWSSRWebSocket.h>
+#import <AWSTranscribeStreaming/AWSTranscribeStreamingClientDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+- **AWSTranssribing**
+  - Fixed build issue due to import statements. [PR #3655](https://github.com/aws-amplify/aws-sdk-ios/pull/3655)
 - **AWSMobileClient (HostedUI)**
   - Fixed an issue Base64-decoding claims containing non-ASCII characters ([PR #3533](https://github.com/aws-amplify/aws-sdk-ios/pull/3533)). Thanks, [@NivisUnder7](https://github.com/NivisUnder7)!
 - **AWSLocation**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- **AWSTranssribing**
+- **AWSTransscribing**
   - Fixed build issue due to import statements. [PR #3655](https://github.com/aws-amplify/aws-sdk-ios/pull/3655)
 - **AWSMobileClient (HostedUI)**
   - Fixed an issue Base64-decoding claims containing non-ASCII characters ([PR #3533](https://github.com/aws-amplify/aws-sdk-ios/pull/3533)). Thanks, [@NivisUnder7](https://github.com/NivisUnder7)!


### PR DESCRIPTION
*Issue #, if available:*

#3568 

*Description of changes:*

There were 2 import statements which were not finding the headers which are placed in the framework structure and the imports being used are meant for local search paths, not frameworks.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
