### PR TITLE
replaces Brew with supported installer for AWS CLI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
 
   configure_aws:
     description: >-
-      Install aws cli and configure android aws release profile
+      Install aws cli and configure release profile
     steps:
       - run:
           name: Install AWS CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,10 @@ commands:
       Install aws cli and configure android aws release profile
     steps:
       - run:
-          name: Install AWS cli
+          name: Install AWS CLI
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install awscli
+            curl -O https://awscli.amazonaws.com/AWSCLIV2.pkg
+            sudo installer -pkg AWSCLIV2.pkg -target /
       - run:
           name: Configure AWS profiles
           command: |


### PR DESCRIPTION
https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-mac.html

*Issue #, if available:*

#3777

*Description of changes:*

Changes command to install AWS CLI from brew to the supported process for macOS.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [x] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
