### PR TITLE
chore(S3): makes transferUtilityConfiguration public as read-only #3788

### DIFF
--- a/AWSS3/AWSS3TransferUtility.h
+++ b/AWSS3/AWSS3TransferUtility.h
@@ -58,6 +58,11 @@ FOUNDATION_EXPORT NSString *const AWSS3TransferUtilityURLSessionDidBecomeInvalid
 @property (readonly) AWSServiceConfiguration *configuration;
 
 /**
+ The transfer utility configuration.
+ */
+@property (readonly) AWSS3TransferUtilityConfiguration *transferUtilityConfiguration;
+
+/**
  Returns the singleton service client. If the singleton object does not exist, the SDK instantiates the default service client with `defaultServiceConfiguration` from `[AWSServiceManager defaultServiceManager]`. The reference to this object is maintained by the SDK, and you do not need to retain it manually.
 
  For example, set the default service configuration in `- application:didFinishLaunchingWithOptions:`

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1536,7 +1536,8 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
 
     [[[self.preSignedURLBuilder getPreSignedURL:request] continueWithBlock:^id(AWSTask *task) {
         error = task.error;
-        if ( error ) {
+        if (error) {
+            AWSDDLogError(@"Error: %@", error);
             return nil;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

#3788

*Description of changes:*

Makes `transferUtilityConfiguration` public as read-only so properties like `bucket` can be accessed.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
