### PR TITLE
fix(SQS): integ test fail with QueueDoesNotExist error

### DIFF
--- a/AWSSQSTests/AWSSQSTests.m
+++ b/AWSSQSTests/AWSSQSTests.m
@@ -74,11 +74,11 @@
     attributesRequest.queueUrl = @""; //queueURL is empty
     
     [[[sqs getQueueAttributes:attributesRequest] continueWithBlock:^id(AWSTask *task) {
-        XCTAssertNotNil(task.error, @"expected InvalidAddress Error but got nil");
+        XCTAssertNotNil(task.error, @"expected AWSSQSErrorQueueDoesNotExist Error but got nil");
         XCTAssertEqualObjects(task.error.domain, AWSSQSErrorDomain);
-        XCTAssertEqual(task.error.code, AWSSQSErrorUnknown);
-        XCTAssertTrue([@"InvalidAddress" isEqualToString:task.error.userInfo[@"Code"]]);
-        XCTAssertTrue([@"The address  is not valid for this endpoint." isEqualToString:task.error.userInfo[@"Message"]]);
+        XCTAssertEqual(task.error.code, AWSSQSErrorQueueDoesNotExist);
+        XCTAssertTrue([@"AWS.SimpleQueueService.NonExistentQueue" isEqualToString:task.error.userInfo[@"Code"]]);
+        XCTAssertTrue([@"The specified queue does not exist for this wsdl version." isEqualToString:task.error.userInfo[@"Message"]]);
         return nil;
     }] waitUntilFinished];
 }


### PR DESCRIPTION
*Issue #, if available:*
```
SQS integration tests are failing: testGetQueueAttributesRequestFailure

((task.error.code) equal to (AWSSQSErrorUnknown)) failed: ("12") is not equal to ("0")
AWSSQSTests/AWSSQSTests.m:79

(([@"InvalidAddress" isEqualToString:task.error.userInfo[@"Code"]]) is true) failed
AWSSQSTests/AWSSQSTests.m:80

(([@"The address  is not valid for this endpoint." isEqualToString:task.error.userInfo[@"Message"]]) is true) failed
AWSSQSTests/AWSSQSTests.m:81
```

*Description of changes:*
Error code 12 corresponds to `AWSSQSErrorQueueDoesNotExist` which indicates that there was a change from the SQS service on what they return on this failure case. I've seen service teams change their error handling scenarios before and isn't a breaking for the customer as none of the interfaces changed. In this case, it broke our test since we hardcode to what we think is the expected error when an invalid request parameter is passed in. This change decides to keep the test as is and just update to what the error we are now receiving. Alternatively we could just make sure an error is returned and skip checking deeper or remove this test all together. 


*Reference*
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
