### PR TITLE
chore: Change circle ci script to use Xcode 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ commands:
 jobs:
   build:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -272,7 +272,7 @@ jobs:
 
   build_test_host_apps:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -289,7 +289,7 @@ jobs:
 
   unit_test:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     parameters:
       project:
         default: "AWSiOSSDKv2.xcodeproj"
@@ -342,7 +342,7 @@ jobs:
 
   integ_test:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     parameters:
       project:
         default: "AWSiOSSDKv2.xcodeproj"
@@ -393,7 +393,7 @@ jobs:
 
   release_tag:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -428,7 +428,7 @@ jobs:
 
   release_carthage:
     macos:
-      xcode: "12.3.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -449,7 +449,7 @@ jobs:
 
   release_cocoapods:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -467,7 +467,7 @@ jobs:
 
   release_docs:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -497,7 +497,7 @@ jobs:
 
   add_doc_tag:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -511,7 +511,7 @@ jobs:
 
   bump_ios_sampleapp_version:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - set_environment_variables
@@ -530,7 +530,7 @@ jobs:
   
   release_xcframeworks:
     macos:
-      xcode: "12.3.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - checkout_with_cache
@@ -574,7 +574,7 @@ jobs:
 
   release_xcframeworks_combined:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     environment:
       TERM: xterm-256color
     steps:
@@ -618,7 +618,7 @@ jobs:
 
   bump_sdk_version:
     macos:
-      xcode: "12.1.0"
+      xcode: "13.0.0"
     steps:
       - skip_job_unless_required
       - set_environment_variables

--- a/AWSLocationUnitTests/AWSLocationTracker/AWSLocationTrackerTests.swift
+++ b/AWSLocationUnitTests/AWSLocationTracker/AWSLocationTrackerTests.swift
@@ -14,6 +14,7 @@
 //
 
 import XCTest
+import CoreLocation
 @testable import AWSLocation
 
 class AWSLocationTrackerTests: XCTestCase {

--- a/AWSLocationUnitTests/AWSLocationTracker/EmitLocationsOperationTests.swift
+++ b/AWSLocationUnitTests/AWSLocationTracker/EmitLocationsOperationTests.swift
@@ -14,6 +14,7 @@
 //
 
 import XCTest
+import CoreLocation
 @testable import AWSLocation
 
 class EmitLocationsOperationTests: XCTestCase {

--- a/AWSLocationUnitTests/AWSLocationTracker/Support/CLLocation+ExtensionTests.swift
+++ b/AWSLocationUnitTests/AWSLocationTracker/Support/CLLocation+ExtensionTests.swift
@@ -14,6 +14,7 @@
 //
 
 import XCTest
+import CoreLocation
 @testable import AWSLocation
 
 class CLLocation_ExtensionTests: XCTestCase {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## 2.26.1
 
--Features for next release
+### Misc. Updates
+
+- Support Xcode 13.0.0 for CircleCI build ([PR #3803](https://github.com/aws-amplify/aws-sdk-ios/pull/3803))
 
 ### Bug Fixes
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/aws-sdk-ios/issues/3795

*Description of changes:*

- CircleCI script uses Xcode 13.0.0
- Added missing import for AWSLocation test

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
