### PR TITLE
chore: Fix AWSLex build to exclude arm64

### DIFF
--- a/AWSLex.podspec
+++ b/AWSLex.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.vendored_libraries = 'AWSLex/Bluefront/libBlueAudioSourceiOS.a'
   s.resource_bundle = { 'AWSLex' => 'AWSLex/Media.xcassets' }
   
-  # Exclude arm64 when building for simulator on Xcode 12
-  s.pod_target_xcconfig = {'EXCLUDED_ARCHS[sdk=iphonesimulator14*]' => 'arm64'}
+  # Exclude arm64 when building for simulator on Xcode 12+
+  s.pod_target_xcconfig = {'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
 
 end

--- a/XcodeConfiguration/AWSLexConfig.xcconfig
+++ b/XcodeConfiguration/AWSLexConfig.xcconfig
@@ -13,13 +13,12 @@
 // permissions and limitations under the License.
 //
 
-// Add arm64 to EXCLUDED_ARCHS for iOS simulator version 14
+// Add arm64 to EXCLUDED_ARCHS for iOS simulator version 14+
 // This is to temporarily fix issues with Xcode 12, since Xcode 12 supports Apple Silicon Macs using arm64,
 // but most libraries currently haven't been built with arm64 support for simulator. AWSLex internally uses
 // libBlueAudioSourceiOS static library which do not have support for arm64 simulator
 //
 // NOTE: EXCLUDED_ARCHS is a new feature of Xcode 12. https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#Build-System
 // Nevertheless, it appears that while Xcode 11 does not support this feature, it notices the build setting and does
-// weird things as a result, breaking the build on Xcode 11. To keep using Xcode 11, we found that we can
-// use 14* instead of *. also we can just comment this line out.
-EXCLUDED_ARCHS[sdk=iphonesimulator14*] = arm64
+// weird things as a result, breaking the build on Xcode 11. To keep using Xcode 11, we can just comment this line out.
+EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64


### PR DESCRIPTION
*Issue #, if available:* AWSLex internally depend on third party libraries that are not build for arm64. So we are temporary not supporting arm64 for AWSLex. This PR fixes an issue where AWSLex does not build for Xcode13.

*Description of changes:*

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
