### PR TITLE
feat(awscore): support for ap-southeast-3

### DIFF
--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -257,6 +257,7 @@ static NSString *const AWSRegionNameAPSoutheast1 = @"ap-southeast-1";
 static NSString *const AWSRegionNameAPNortheast1 = @"ap-northeast-1";
 static NSString *const AWSRegionNameAPNortheast2 = @"ap-northeast-2";
 static NSString *const AWSRegionNameAPSoutheast2 = @"ap-southeast-2";
+static NSString *const AWSRegionNameAPSoutheast3 = @"ap-southeast-3";
 static NSString *const AWSRegionNameAPSouth1 = @"ap-south-1";
 static NSString *const AWSRegionNameSAEast1 = @"sa-east-1";
 static NSString *const AWSRegionNameCNNorth1 = @"cn-north-1";
@@ -461,6 +462,8 @@ static NSString *const AWSServiceNameChimeSDKIdentity = @"chime";
             return AWSRegionNameAPSoutheast1;
         case AWSRegionAPSoutheast2:
             return AWSRegionNameAPSoutheast2;
+        case AWSRegionAPSoutheast3:
+            return AWSRegionNameAPSoutheast3;
         case AWSRegionAPNortheast1:
             return AWSRegionNameAPNortheast1;
         case AWSRegionAPNortheast2:

--- a/AWSCore/Service/AWSServiceEnum.h
+++ b/AWSCore/Service/AWSServiceEnum.h
@@ -72,6 +72,10 @@ typedef NS_ENUM(NSInteger, AWSRegionType) {
      */
     AWSRegionAPSoutheast2 NS_SWIFT_NAME(APSoutheast2),
     /**
+     * Asia Pacific (Jakarta)
+     */
+    AWSRegionAPSoutheast3 NS_SWIFT_NAME(APSoutheast3),
+    /**
      *  Asia Pacific (Mumbai)
      */
     AWSRegionAPSouth1 NS_SWIFT_NAME(APSouth1),

--- a/AWSCore/Utility/AWSCategory.m
+++ b/AWSCore/Utility/AWSCategory.m
@@ -515,6 +515,11 @@ static NSTimeInterval _clockskew = 0.0;
         || [self isEqualToString:@"ap-southeast-2"]) {
         return AWSRegionAPSoutheast2;
     }
+    if ([self isEqualToString:@"AWSRegionAPSoutheast3"]
+        || [self isEqualToString:@"APSoutheast3"]
+        || [self isEqualToString:@"ap-southeast-3"]) {
+        return AWSRegionAPSoutheast3;
+    }
     if ([self isEqualToString:@"AWSRegionAPSouth1"]
         || [self isEqualToString:@"APSouth1"]
         || [self isEqualToString:@"ap-south-1"]) {

--- a/AWSS3/AWSS3Model.h
+++ b/AWSS3/AWSS3Model.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSInteger, AWSS3BucketLocationConstraint) {
     AWSS3BucketLocationConstraintAPSouth1,
     AWSS3BucketLocationConstraintAPSoutheast1,
     AWSS3BucketLocationConstraintAPSoutheast2,
+    AWSS3BucketLocationConstraintAPSoutheast3,
     AWSS3BucketLocationConstraintCACentral1,
     AWSS3BucketLocationConstraintCNNorth1,
     AWSS3BucketLocationConstraintCNNorthwest1,

--- a/AWSS3/AWSS3Model.m
+++ b/AWSS3/AWSS3Model.m
@@ -1217,6 +1217,9 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
         if ([value caseInsensitiveCompare:@"ap-southeast-2"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintAPSoutheast2);
         }
+        if ([value caseInsensitiveCompare:@"ap-southeast-3"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintAPSoutheast3);
+        }
         if ([value caseInsensitiveCompare:@"ca-central-1"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintCACentral1);
         }
@@ -1289,6 +1292,8 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
                 return @"ap-southeast-1";
             case AWSS3BucketLocationConstraintAPSoutheast2:
                 return @"ap-southeast-2";
+            case AWSS3BucketLocationConstraintAPSoutheast3:
+                return @"ap-southeast-3";
             case AWSS3BucketLocationConstraintCACentral1:
                 return @"ca-central-1";
             case AWSS3BucketLocationConstraintCNNorth1:
@@ -2795,6 +2800,9 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
         if ([value caseInsensitiveCompare:@"ap-southeast-2"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintAPSoutheast2);
         }
+        if ([value caseInsensitiveCompare:@"ap-southeast-3"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintAPSoutheast3);
+        }
         if ([value caseInsensitiveCompare:@"ca-central-1"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintCACentral1);
         }
@@ -2867,6 +2875,8 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
                 return @"ap-southeast-1";
             case AWSS3BucketLocationConstraintAPSoutheast2:
                 return @"ap-southeast-2";
+            case AWSS3BucketLocationConstraintAPSoutheast3:
+                return @"ap-southeast-3";
             case AWSS3BucketLocationConstraintCACentral1:
                 return @"ca-central-1";
             case AWSS3BucketLocationConstraintCNNorth1:

--- a/AWSS3/AWSS3Resources.m
+++ b/AWSS3/AWSS3Resources.m
@@ -1372,6 +1372,7 @@
         \"ap-south-1\",\
         \"ap-southeast-1\",\
         \"ap-southeast-2\",\
+        \"ap-southeast-3\",\
         \"ca-central-1\",\
         \"cn-north-1\",\
         \"cn-northwest-1\",\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
--Features for next release
+### Features for next release
+### New features
+- **AWSCore**
+  - Support for `ap-southeast-3` - Asia Pacific (Jakarta)
 
 ## 2.26.4
 
-### Features for next release
+### Bug Fixes
 
 - **AWSIoT**
   - fix(AWSIoT): adds back Message type ([PR #3852](https://github.com/aws-amplify/aws-sdk-ios/pull/3852))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features for next release
 ### New features
 - **AWSCore**
-  - Support for `ap-southeast-3` - Asia Pacific (Jakarta)
+  - Support for `ap-southeast-3` - Asia Pacific (Jakarta) (see [AWS Regional Services List](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) for a list of services supported in the region)
 
 ## 2.26.4
 


### PR DESCRIPTION
*Description of changes:*
Added support for `ap-southeast-3` region

The following tests are failing as some services are not available in the new region yet:
- `AWSCognitoIdentityProviderTests`
- `AWSComprehendTests`
- `AWSCoreTests/AWSCognitoIdentityTests`
- `AWSIoTFreeRTOSOTATests`
- `AWSIoTTests`
- `AWSFirehoseTests`
- `AWSKinesisVideoTests`
- `AWSKinesisVideoArchivedMediaTests`
- `AWSLex`
- `AWSLocation`
- `AWSPinpointTests`
- `AWSPollyTests`
- `AWSRekognitionTests`
- `AWSSESTests`
- `AWSSimpleDBTests`
- `AWSTextractTests`
- `AWSTranscribeStreamingTests`
- `AWSTranslateTests`

**Note:**
`AWSS3Tests::testTransferAcceleration`, `AWSS3TransferUtilityTests::testMultiPartUploadTransferAcceleration` are currently failing as transfer acceleration isn't supported
`AWSLambdaTests `tests have been run using session credentials instead of Cognito credentials

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
