### PR TITLE
fix: Return Swift optionals from Objective C methods that can return nil

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -1202,7 +1202,7 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 }
 
 -(NSDictionary *) claims {
-    NSDictionary * result = [NSDictionary dictionary];
+    NSDictionary * result = @{};
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){
         NSString * claims = pieces[1];

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -1202,7 +1202,7 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 }
 
 -(NSDictionary *) claims {
-    NSDictionary * result = nil;
+    NSDictionary * result = [NSDictionary dictionary];
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){
         NSString * claims = pieces[1];

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.h
@@ -77,8 +77,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Get the device id
+ 
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use deviceIdentifier instead.
+ @deprecated Use deviceIdentifier instead.
  */
-@property (nonatomic, readonly) NSString * deviceId;
+@property (nonatomic, readonly) NSString * deviceId DEPRECATED_MSG_ATTRIBUTE("Use deviceIdentifier instead.");
+
+/**
+ Get the device id
+ */
+@property (nonatomic, readonly, nullable) NSString * deviceIdentifier;
 
 /**
  Confirm a users' sign up with the confirmation code

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1701,7 +1701,12 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 
 - (NSString*) deviceId {
     AWSCognitoIdentityUserDeviceCredentials *deviceCredentials = [self getDeviceCredentials];
-    return deviceCredentials?deviceCredentials.deviceId:nil;
+    return deviceCredentials ? deviceCredentials.deviceId : nil;
+}
+
+- (NSString*) deviceIdentifier {
+    AWSCognitoIdentityUserDeviceCredentials *deviceCredentials = [self getDeviceCredentials];
+    return deviceCredentials ? deviceCredentials.deviceId : nil;
 }
 
 @end
@@ -1743,7 +1748,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 }
 
 -(NSDictionary<NSString *, id> *) tokenClaims {
-    NSDictionary * result = nil;
+    NSDictionary * result = [NSDictionary dictionary];
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){
         NSString * claims = pieces[1];

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1748,7 +1748,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 }
 
 -(NSDictionary<NSString *, id> *) tokenClaims {
-    NSDictionary * result = [NSDictionary dictionary];
+    NSDictionary * result = @{};
     NSArray *pieces = [self.tokenString componentsSeparatedByString:@"."];
     if(pieces.count > 2){
         NSString * claims = pieces[1];

--- a/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h
+++ b/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.h
@@ -14,7 +14,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSData (NSDataBigInteger)
 + (NSData*) aws_dataWithBigInteger:(AWSJKBigInteger *)bigInteger;
 + (NSData*) aws_dataWithSignedBigInteger:(AWSJKBigInteger *)bigInteger;
-+ (NSData*) aws_dataFromHexString:(NSString*)hexString;
+/*!
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use aws_dataFromHexidecimalString instead.
+ @deprecated Use aws_dataFromHexidecimalString instead.
+ */
++ (NSData*) aws_dataFromHexString:(NSString*)hexString DEPRECATED_MSG_ATTRIBUTE("Use aws_dataFromHexidecimalString instead.");
++ (nullable NSData*) aws_dataFromHexidecimalString:(NSString*)hexString;
 - (AWSJKBigInteger *)aws_toBigInt;
 void awsbigint_loadBigInt(void);
 @end

--- a/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m
+++ b/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m
@@ -160,4 +160,33 @@ AWSJKBigInteger *signedBigIntegerFromNSData(NSData* data) {
     return [NSData dataWithBytesNoCopy:output length:outputLen freeWhenDone:YES];
 }
 
++ (NSData*) aws_dataFromHexidecimalString:(NSString*)hexString {
+    hexString = [[hexString lowercaseString] stringByReplacingOccurrencesOfString:@"0x" withString:@""];
+    NSData *hexStrData = [hexString dataUsingEncoding:NSASCIIStringEncoding];
+    NSUInteger len = [hexStrData length];
+    if (len % 2 != 0) {
+        return nil;
+    }
+    
+    NSUInteger outputLen = len / 2;
+    if (outputLen == 0) {
+        return [NSData data];
+    }
+    uint8_t *output = malloc(sizeof(uint8_t) * outputLen);
+    if (output == NULL) {
+        // this situation is irrecoverable and we don't want to return something corrupted, so we raise an exception (avoiding NSAssert that may be disabled)
+        [NSException raise:@"NSInternalInconsistencyException" format:@"failed malloc" arguments:nil];
+        return nil;
+    }
+    
+    const char *hexBytes = (const char*)[hexStrData bytes];
+    for (NSUInteger i = 0, j=0; i < len && j < outputLen; i += 2, j++) {
+        unsigned res;
+        sscanf(hexBytes+i, "%2x", &res);
+        output[j] = (uint8_t) (res & 0xff);
+    }
+    
+    return [NSData dataWithBytesNoCopy:output length:outputLen freeWhenDone:YES];
+}
+
 @end

--- a/AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m
+++ b/AWSCognitoIdentityProviderASF/AWSCognitoIdentityProviderASF.m
@@ -23,7 +23,7 @@
 #ifdef DEBUG
     build = @"debug";
 #endif
-    return [AWSCognitoIdentityASF userContextData:  __IPHONE_OS_VERSION_MIN_REQUIRED
+    return [AWSCognitoIdentityASF userContextString:  __IPHONE_OS_VERSION_MIN_REQUIRED
                                             build:build userPoolId: userPoolId username:username deviceId:deviceId userPoolClientId:userPoolClientId];
 }
 

--- a/AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h
+++ b/AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.h
@@ -18,6 +18,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AWSCognitoIdentityASF : NSObject
-+ (NSString *)userContextData: (int) minTarget build: (NSString *) build userPoolId: (NSString*) userPoolId username: (NSString *) username deviceId: ( NSString * _Nullable ) deviceId userPoolClientId: (NSString *) userPoolClientId;
+/*!
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use userContextString instead.
+ @deprecated Use userContextString instead.
+ */
++ (NSString *)userContextData: (int) minTarget build: (NSString *) build userPoolId: (NSString*) userPoolId username: (NSString *) username deviceId: ( NSString * _Nullable ) deviceId userPoolClientId: (NSString *) userPoolClientId DEPRECATED_MSG_ATTRIBUTE("Use userContextString instead.");
+
++ (nullable NSString *)userContextString: (int) minTarget build: (NSString *) build userPoolId: (NSString*) userPoolId username: (NSString *) username deviceId: ( NSString * _Nullable ) deviceId userPoolClientId: (NSString *) userPoolClientId;
 @end
 NS_ASSUME_NONNULL_END

--- a/AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.m
+++ b/AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.m
@@ -143,6 +143,109 @@ static NSString *const AWSCognitoIdentityASFVersion= @"IOS20171114";
     return base64Encoded;
 }
 
++ (NSString *) userContextString: (int) minTarget build: (NSString *) build userPoolId: (NSString*) userPoolId username: (NSString *) username deviceId: (NSString * _Nullable) deviceId userPoolClientId: (NSString *) userPoolClientId {
+    UIDevice *device = [UIDevice currentDevice];
+    NSBundle *bundle = [NSBundle mainBundle];
+    NSString *bundleIdentifier = [bundle bundleIdentifier];
+    NSString *buildVersion = [bundle objectForInfoDictionaryKey:(NSString*)kCFBundleVersionKey];
+    NSString *bundleVersion = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    CGRect bounds = [[UIScreen mainScreen] nativeBounds];
+    CGFloat screenWidth = bounds.size.width;
+    CGFloat screenHeight = bounds.size.height;
+    
+    NSDateFormatter *localTimeZoneFormatter = [NSDateFormatter new];
+    localTimeZoneFormatter.timeZone = [NSTimeZone localTimeZone];
+    localTimeZoneFormatter.dateFormat = @"Z";
+    NSString *localTimeZoneOffset = [localTimeZoneFormatter stringFromDate:[NSDate date]];
+    
+    NSString *hourOffset = [localTimeZoneOffset substringToIndex:[localTimeZoneOffset length] - 2];
+    NSString *minuteOffset = [localTimeZoneOffset substringFromIndex:[localTimeZoneOffset length] - 2];
+    NSString *timezoneOffset = [NSString stringWithFormat:@"%@:%@",hourOffset,minuteOffset];
+    NSString * locale = [[NSLocale preferredLanguages] objectAtIndex:0];
+    CTTelephonyNetworkInfo *networkInfo = [[CTTelephonyNetworkInfo alloc] init];
+    NSString * networkType = [networkInfo currentRadioAccessTechnology];
+    CTCarrier *cellularProvider = [networkInfo subscriberCellularProvider];
+    NSString *countryCode = cellularProvider.isoCountryCode;
+    BOOL hasSimCard = countryCode != nil;
+    NSString *carrier = [cellularProvider carrierName];
+    NSString *fingerprint = [NSString stringWithFormat:@"Apple/%@/%@/-:%@/-/-:-/%@",
+                             [AWSCognitoIdentityASF dashIfNil:[device model]],
+                             [AWSCognitoIdentityASF dashIfNil:[AWSCognitoIdentityASF deviceName]],
+                             [AWSCognitoIdentityASF dashIfNil:[device systemVersion]],
+                             [AWSCognitoIdentityASF dashIfNil:build]];
+    
+    
+    NSString * minTargetString = [NSString stringWithFormat:@"%i", minTarget];
+    
+    
+    
+    NSMutableDictionary * contextData= [NSMutableDictionary new];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppName value:bundleIdentifier];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppTargetSDK value: minTargetString];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppVersion value:[NSString stringWithFormat:@"%@-%@",bundleVersion,buildVersion]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityDeviceName value:[device name]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityPhoneType value:[AWSCognitoIdentityASF deviceName]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityThirdPartyDeviceId value:[device identifierForVendor].UUIDString];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityDeviceId value: ((deviceId == nil)? [device identifierForVendor].UUIDString : deviceId)]; //TODO
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityReleaseVersion value: [device systemVersion]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityPlatform value: [device systemName]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityBuildType value: build];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityTimezone value: timezoneOffset];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityDeviceHeight value: [NSString stringWithFormat:@"%.0f",screenHeight]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityDeviceWidth value: [NSString stringWithFormat:@"%.0f",screenWidth]];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityDeviceLanguage value: locale];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityCarrier value: carrier];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityNetworkType value: networkType];
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityHasSimCard value:hasSimCard?@"true":@"false"];
+    
+    [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityDeviceFingerprint value:fingerprint];
+    
+    if(username == nil){
+        username = @"unknown";
+    }
+    
+    NSDictionary * payload =  @{
+        @"contextData": contextData,
+        @"username":username,
+        @"userPoolId": userPoolId,
+        @"timestamp" : [NSString stringWithFormat:@"%lli", [@(floor([[NSDate date] timeIntervalSince1970] * 1000)) longLongValue]]
+    };
+    
+    
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:payload
+                                                       options:0
+                                                         error:&error];
+    if(error){
+        return nil;
+    }
+    
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    
+    NSDictionary * result = @{
+        @"payload": jsonString,
+        @"version": AWSCognitoIdentityASFVersion,
+        @"signature": [AWSCognitoIdentityASF calculateSecretHash: jsonString clientId:userPoolClientId]
+    };
+    
+    jsonData = [NSJSONSerialization dataWithJSONObject:result
+                                               options:0
+                                                 error:&error];
+    jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    
+    if(error){
+        return nil;
+    }
+    
+    NSData *data = [jsonString
+                    dataUsingEncoding:NSUTF8StringEncoding];
+    
+    // Get NSString from NSData object in Base64
+    NSString *base64Encoded = [data base64EncodedStringWithOptions:0];
+    
+    return base64Encoded;
+}
+
 
 + (NSString*) deviceName
 {

--- a/AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.m
+++ b/AWSCognitoIdentityProviderASF/Internal/AWSCognitoIdentityASF.m
@@ -4,6 +4,7 @@
 #import <CoreTelephony/CTCarrier.h>
 #import <sys/utsname.h>
 #import <CommonCrypto/CommonHMAC.h>
+#import <AWSCore/AWSCocoaLumberjack.h>
 
 @interface AWSCognitoIdentityASF()
 + (NSString *) dashIfNil: (NSString *) str;
@@ -74,8 +75,6 @@ static NSString *const AWSCognitoIdentityASFVersion= @"IOS20171114";
     
     NSString * minTargetString = [NSString stringWithFormat:@"%i", minTarget];
     
-    
-    
     NSMutableDictionary * contextData= [NSMutableDictionary new];
     [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppName value:bundleIdentifier];
     [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppTargetSDK value: minTargetString];
@@ -107,7 +106,6 @@ static NSString *const AWSCognitoIdentityASFVersion= @"IOS20171114";
                                 @"userPoolId": userPoolId,
                                 @"timestamp" : [NSString stringWithFormat:@"%lli", [@(floor([[NSDate date] timeIntervalSince1970] * 1000)) longLongValue]]
                                 };
-    
     
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:payload
@@ -177,8 +175,6 @@ static NSString *const AWSCognitoIdentityASFVersion= @"IOS20171114";
     
     NSString * minTargetString = [NSString stringWithFormat:@"%i", minTarget];
     
-    
-    
     NSMutableDictionary * contextData= [NSMutableDictionary new];
     [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppName value:bundleIdentifier];
     [AWSCognitoIdentityASF addIfNotNil: contextData key:AWSCognitoIdentityAppTargetSDK value: minTargetString];
@@ -211,12 +207,12 @@ static NSString *const AWSCognitoIdentityASFVersion= @"IOS20171114";
         @"timestamp" : [NSString stringWithFormat:@"%lli", [@(floor([[NSDate date] timeIntervalSince1970] * 1000)) longLongValue]]
     };
     
-    
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:payload
                                                        options:0
                                                          error:&error];
     if(error){
+        AWSDDLogError(@"Failed to parse JSON user context: %@", error);
         return nil;
     }
     

--- a/AWSCore/Authentication/AWSSignature.h
+++ b/AWSCore/Authentication/AWSSignature.h
@@ -27,7 +27,13 @@ FOUNDATION_EXPORT NSString * _Nonnull const AWSSignatureV4Terminator;
 
 + (NSData * _Nonnull)sha256HMacWithData:(NSData * _Nullable)data withKey:(NSData * _Nonnull)key;
 + (NSString * _Nonnull)hashString:(NSString * _Nullable)stringToHash;
-+ (NSData * _Nonnull)hash:(NSData * _Nullable)dataToHash;
+/*!
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use hashData instead.
+ @deprecated Use hashData instead.
+ */
++ (NSData * _Nonnull)hash:(NSData * _Nullable)dataToHash DEPRECATED_MSG_ATTRIBUTE("Use hashData instead.");
++ (NSData * _Nullable)hashData:(NSData * _Nullable)dataToHash;
 + (NSString * _Nonnull)hexEncode:(NSString * _Nullable)string;
 + (NSString * _Nullable)HMACSign:(NSData * _Nullable)data withKey:(NSString * _Nonnull)key usingAlgorithm:(uint32_t)algorithm;
 

--- a/AWSCore/Service/AWSClientContext.m
+++ b/AWSCore/Service/AWSClientContext.m
@@ -113,6 +113,7 @@ static NSString *const AWSClientContextKeychainInstallationIdKey = @"com.amazona
                                                          error:&error];
     if (!JSONData) {
         AWSDDLogError(@"Failed to serialize JSON Data. [%@]", error);
+        return nil;
     }
 
     return [[NSString alloc] initWithData:JSONData

--- a/AWSPinpoint/AWSPinpointService.m
+++ b/AWSPinpoint/AWSPinpointService.m
@@ -153,7 +153,7 @@ static AWSSynchronizedMutableDictionary *_pinpointForAppNamespace = nil;
         }
         
         if (configuration.enableAutoSessionRecording) {
-            [_pinpointContext.sessionClient startSession];
+            [_pinpointContext.sessionClient startPinpointSession];
         }
         
         AWSDDLogInfo(@"Pinpoint SDK Initialization successfully completed.");

--- a/AWSPinpoint/AWSPinpointSessionClient.h
+++ b/AWSPinpoint/AWSPinpointSessionClient.h
@@ -63,15 +63,52 @@ typedef __nullable id(^AWSPinpointTimeoutBlock)(AWSTask *task);
  If a session is currently active then that session is stopped and a new session started.
  
  @return AWSTask - task.result contains the start event.
+ 
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use startPinpointSession instead.
+ @deprecated Use startPinpointSession instead.
  */
-- (AWSTask*)startSession;
+- (AWSTask*)startSession DEPRECATED_MSG_ATTRIBUTE("Use startPinpointSession instead.");
+
+/**
+ Starts the session by recording an event of type "_session.start"
+ If a session is currently active then that session is stopped and a new session started.
+ 
+ @return AWSTask - task.result contains the start event.
+ */
+- (nullable AWSTask*)startPinpointSession;
+
+/**
+ Stops the session by recording an event of type "_session.stop"
+ 
+ @return AWSTask - task.result contains the stop event.
+ 
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use stopPinpointSession instead.
+ @deprecated Use stopPinpointSession instead.
+ */
+- (AWSTask*)stopSession DEPRECATED_MSG_ATTRIBUTE("Use stopPinpointSession instead.");
 
 /**
  Stops the session by recording an event of type "_session.stop"
  
  @return AWSTask - task.result contains the stop event.
  */
-- (AWSTask*)stopSession;
+- (nullable AWSTask*)stopPinpointSession;
+
+/**
+ Pauses the session by recording an event of type "_session.pause"
+ @param timeoutEnabled If this is enabled then the session will timeout after 5 seconds and a session stop will be recorded. (Session timeout is configurable in AWSPinpointConfiguration)
+ @param timeoutCompletionBlock The block that will be executed after timeout has completed and submission of events has occurred, task.result will contain events that were submitted.
+ 
+ @return AWSTask - task.result contains the pause event.
+ 
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use pausePinpointSessionWithTimeoutEnabled instead.
+ @deprecated Use pausePinpointSessionWithTimeoutEnabled instead.
+ */
+- (AWSTask*)pauseSessionWithTimeoutEnabled:(BOOL) timeoutEnabled
+                    timeoutCompletionBlock:(nullable AWSPinpointTimeoutBlock) timeoutCompletionBlock DEPRECATED_MSG_ATTRIBUTE("Use pausePinpointSessionWithTimeoutEnabled instead.");
 
 /**
  Pauses the session by recording an event of type "_session.pause"
@@ -80,7 +117,7 @@ typedef __nullable id(^AWSPinpointTimeoutBlock)(AWSTask *task);
  
  @return AWSTask - task.result contains the pause event.
  */
-- (AWSTask*)pauseSessionWithTimeoutEnabled:(BOOL) timeoutEnabled
+- (nullable AWSTask*)pausePinpointSessionWithTimeoutEnabled:(BOOL) timeoutEnabled
                     timeoutCompletionBlock:(nullable AWSPinpointTimeoutBlock) timeoutCompletionBlock;
 
 /**
@@ -89,9 +126,21 @@ typedef __nullable id(^AWSPinpointTimeoutBlock)(AWSTask *task);
  If the timeout of 5 seconds has passed, then the current session is stopped and a new session started. (Session timeout if configurable in AWSPinpointConfiguration)
  
  @return AWSTask - task.result contains the resume event.
+ 
+ @warning This function is deprecated and will be removed in an upcoming minor
+ version of the SDK. You should use resumePinpointSession instead.
+ @deprecated Use resumePinpointSession instead.
  */
-- (AWSTask*)resumeSession;
+- (AWSTask*)resumeSession DEPRECATED_MSG_ATTRIBUTE("Use resumePinpointSession instead.");
 
+/**
+ Resumes the session by recording an event of type "_session.resume"
+ If no session is active then a new session is started.
+ If the timeout of 5 seconds has passed, then the current session is stopped and a new session started. (Session timeout if configurable in AWSPinpointConfiguration)
+ 
+ @return AWSTask - task.result contains the resume event.
+ */
+- (nullable AWSTask*)resumePinpointSession;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -228,10 +228,7 @@ NSObject *sessionLock;
             AWSDDLogError(@"Pinpoint Analytics is disabled.");
             return nil;
         }
-         if (_session) {
-             [self endCurrentSession];
-         }
-         return [self startNewSession];
+        if (_session) {
             [self endCurrentSession];
             return [self startNewSession];
         } else {

--- a/AWSPinpoint/AWSPinpointSessionClient.m
+++ b/AWSPinpoint/AWSPinpointSessionClient.m
@@ -228,7 +228,10 @@ NSObject *sessionLock;
             AWSDDLogError(@"Pinpoint Analytics is disabled.");
             return nil;
         }
-        if (_session) {
+         if (_session) {
+             [self endCurrentSession];
+         }
+         return [self startNewSession];
             [self endCurrentSession];
             return [self startNewSession];
         } else {

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -557,6 +557,8 @@
 		21C913272667CD4B00233AF9 /* AWSServiceConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C913262667CD4B00233AF9 /* AWSServiceConfigurationTests.swift */; };
 		21C9132A2667D70F00233AF9 /* MockCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C913292667D70F00233AF9 /* MockCredentialsProvider.swift */; };
 		21E97D472558DBFF004C98D6 /* AsynchronousOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E97D462558DBFF004C98D6 /* AsynchronousOperation.swift */; };
+		5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
+		5C1590182755727C00F88085 /* AWSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C1978DD2702364800F9C11E /* AWSLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1978DC2702364800F9C11E /* AWSLocationTests.swift */; };
 		6BE9D6AA25A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6A925A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift */; };
 		6BE9D74025A6D52100AB5C9A /* MQTTStatusCallBackWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73F25A6D52100AB5C9A /* MQTTStatusCallBackWrapper.swift */; };
@@ -1637,6 +1639,13 @@
 			remoteGlobalIDString = 211FFC7C26C2FBAC00F0DB75;
 			remoteInfo = AWSChimeSDKIdentity;
 		};
+		5C1590192755727C00F88085 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE0D41541C6A66A9006B91B5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE0D416C1C6A66E5006B91B5;
+			remoteInfo = AWSCore;
+		};
 		CE9DEA251C6A7E5B0060793F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CE0D41541C6A66A9006B91B5 /* Project object */;
@@ -2706,6 +2715,17 @@
 				211FFC9326C2FBAE00F0DB75 /* AWSChimeSDKIdentity.framework in Embed Frameworks */,
 				2109E2CF254745210057043C /* AWSLocation.framework in Embed Frameworks */,
 				211FFCB526C2FF4700F0DB75 /* AWSChimeSDKMessaging.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5C15901B2755727D00F88085 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				5C1590182755727C00F88085 /* AWSCore.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4996,6 +5016,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10281,10 +10302,12 @@
 				EFDE85BD1FC5DD3D00D281A2 /* Sources */,
 				EFDE85C91FC5DD3D00D281A2 /* Frameworks */,
 				EFDE85DD1FC5DD3D00D281A2 /* Resources */,
+				5C15901B2755727D00F88085 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				5C15901A2755727C00F88085 /* PBXTargetDependency */,
 			);
 			name = AWSCognitoIdentityProviderASF;
 			productName = AWSCognitoSignIn;
@@ -13445,6 +13468,11 @@
 			isa = PBXTargetDependency;
 			target = 211FFC7C26C2FBAC00F0DB75 /* AWSChimeSDKIdentity */;
 			targetProxy = 211FFCF326C306E000F0DB75 /* PBXContainerItemProxy */;
+		};
+		5C15901A2755727C00F88085 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE0D416C1C6A66E5006B91B5 /* AWSCore */;
+			targetProxy = 5C1590192755727C00F88085 /* PBXContainerItemProxy */;
 		};
 		CE9DEA261C6A7E5B0060793F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+- Return Swift optionals from Objective C methods that can return nil
 
 ## 2.26.5
 


### PR DESCRIPTION
*Issue #:*
3646

*Description of changes:*
Return Swift optionals from Objective C methods that can return nil by marking the return values nullable.  To avoid a breaking change, new methods were created and annotated nullable, and existing methods with return values incorrectly annotated nonnull were marked deprecated.

*Check points:*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] ~~Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
