### PR TITLE
fix: Return non nil credentials back from CredentialsProvider

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.h
+++ b/AWSCore/Authentication/AWSCredentialsProvider.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, AWSCognitoCredentialsProviderErrorType) {
 /**
  An AWS credentials container class.
  */
-@interface AWSCredentials : NSObject
+@interface AWSCredentials : NSObject <NSCopying>
 
 /**
  Access Key component of credentials.


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/amplify-ios/issues/1501

*Description of changes:* 
In `AWSCredentialsProvider` class `self.credentials` gets the credentials values directly from the keychain. So these value can change underneath while we try to access it. This change holds on to a copy of the credentials and returns them to use to make sure that a valid result is returned.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
