### PR TITLE
chore: update build setting to link but not embed AWSCore in AWSCognitoIdentityProvider

### DIFF
--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -558,7 +558,6 @@
 		21C9132A2667D70F00233AF9 /* MockCredentialsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C913292667D70F00233AF9 /* MockCredentialsProvider.swift */; };
 		21E97D472558DBFF004C98D6 /* AsynchronousOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E97D462558DBFF004C98D6 /* AsynchronousOperation.swift */; };
 		5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
-		5C1590182755727C00F88085 /* AWSCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C1978DD2702364800F9C11E /* AWSLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1978DC2702364800F9C11E /* AWSLocationTests.swift */; };
 		6BE9D6AA25A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6A925A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift */; };
 		6BE9D74025A6D52100AB5C9A /* MQTTStatusCallBackWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D73F25A6D52100AB5C9A /* MQTTStatusCallBackWrapper.swift */; };
@@ -2715,17 +2714,6 @@
 				211FFC9326C2FBAE00F0DB75 /* AWSChimeSDKIdentity.framework in Embed Frameworks */,
 				2109E2CF254745210057043C /* AWSLocation.framework in Embed Frameworks */,
 				211FFCB526C2FF4700F0DB75 /* AWSChimeSDKMessaging.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5C15901B2755727D00F88085 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				5C1590182755727C00F88085 /* AWSCore.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10302,7 +10290,6 @@
 				EFDE85BD1FC5DD3D00D281A2 /* Sources */,
 				EFDE85C91FC5DD3D00D281A2 /* Frameworks */,
 				EFDE85DD1FC5DD3D00D281A2 /* Resources */,
-				5C15901B2755727D00F88085 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
*Description of changes:*
chore: update build setting to link but not embed AWSCore in AWSCognitoIdentityProvider

*Check points:*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] All unit tests pass
- [x] All integration tests pass
- ~~[ ] Updated CHANGELOG.md~~
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
