### PR TITLE
fix(AWSCognitoIdentityProviderASF): Add missing AWSCore dependency to AWSCognitoIdentityProviderASF for Cocoapods

### DIFF
--- a/AWSAppleSignIn.podspec
+++ b/AWSAppleSignIn.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
+  s.dependency 'AWSCore', '2.26.6'
   s.dependency 'AWSAuthCore', '2.26.6'
   s.source_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.{h,m}'
   s.public_header_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.h'
 end
-

--- a/AWSCognitoIdentityProviderASF.podspec
+++ b/AWSCognitoIdentityProviderASF.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
+  s.dependency 'AWSCore', '2.26.6'
   s.public_header_files = 'AWSCognitoIdentityProviderASF/*.h'
   s.source_files = 'AWSCognitoIdentityProviderASF/**/*.{h,m,c}'
   s.private_header_files = 'AWSCognitoIdentityProviderASF/Internal/*.h'

--- a/CircleciScripts/framework_list.py
+++ b/CircleciScripts/framework_list.py
@@ -10,7 +10,10 @@ grouped_frameworks = [
     # No dependencies
     ["AWSCore"],
     [
-        "AWSCognitoIdentityProviderASF",
+        # Depends only on AWSCore
+        "AWSCognitoIdentityProviderASF"
+    ],
+    [
         # Depends only on AWSCognitoIdentityProviderASF
         "AWSCognitoAuth",
         # Depends on AWSCore and AWSCognitoIdentityProviderASF

--- a/CircleciScripts/framework_list.py
+++ b/CircleciScripts/framework_list.py
@@ -8,8 +8,9 @@
 
 grouped_frameworks = [
     # No dependencies
-    ["AWSCore", "AWSCognitoIdentityProviderASF"],
+    ["AWSCore"],
     [
+        "AWSCognitoIdentityProviderASF",
         # Depends only on AWSCognitoIdentityProviderASF
         "AWSCognitoAuth",
         # Depends on AWSCore and AWSCognitoIdentityProviderASF


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Changes to `AWSCognitoIdentityProviderASF` resulted in it having a dependency on `AWSCore`. 
The `AWSCore` dependency wasn't included in the `AWSCognitoIdentityProviderASF.podspec` file for release `2.26.6`, which lead to a partial cocoapod release of the SDK frameworks. 

The cocoapod release process failed on `AWSCognitoIdentityProvider` due to its dependency on `AWSCognitoIdentityProviderASF` because `AWSCognitoIdentityProviderASF` currently has an invalid podspec (missing `AWSCore` dependency).

This PR adds the `AWSCore` dependency to the `AWSCognitoIdentityProviderASF.podspec` file. It was smoketested by locally compiling a project that includes the `AWSCognitoIdentityProviderASF` pod from this branch and instantiates a `AWSCognitoIdentityProviderASF()`.


*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
