### PR TITLE
Fix: AWSS3TransferUtility.uploadFileUsingMultiPart fails if local file URL contains a space

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1278,7 +1278,7 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
                               partNumber:(long)partNumber
                               dataLength:(NSUInteger)dataLength
                                    error:(NSError **)error {
-    NSURL *fileURL = [NSURL URLWithString:fileName];
+    NSURL *fileURL = [NSURL fileURLWithPath: fileName isDirectory: false];
     NSUInteger offset = (partNumber - 1) * AWSS3TransferUtilityMultiPartSize;
 
     NSURL *partialFileURL = [self createPartialFile:fileURL offset:offset length:dataLength error:error];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -Features for next release
 
+### Bug Fixes
+- **AWSS3**
+  - Fixed an issue with Multi Part uploads when uploading from a file URL that contains a space (See [PR #3956](https://github.com/aws-amplify/aws-sdk-ios/pull/3956))
+
 ## 2.26.7
 
 ### New features


### PR DESCRIPTION
*Issue #, if available:* #3955

*Description of changes:*

#3955 contains a nice write up of the resolved issue. In short, multi part uploads from local files would fail immediately if the location of the local path contained a space. This is due to an incorrect initialisation of a `NSURL` where `URLWithString` was used instead of the recommended `fileURLWithPath`.

While a test already exists to check this situation, it only tests single part uploads, not multipart. While this issue is only prevalent to Multi Part uploads.

This PR:
* Fixes the described issue
* Adds a test for Multi Part upload from a fileUrl with a space

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
