### PR TITLE
fix(CI/CD): updates CocoaPods repo after AWSCore is released (#3960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 -Features for next release
 
+### Bug Fixes
+
+- **CI/CD**
+  - Fixes CocoaPods release step which reports `pod repo update` to run after AWSCore is pushed (See [PR #3961](https://github.com/aws-amplify/aws-sdk-ios/pull/3961))
+
 ## 2.26.7
 
 ### New features

--- a/CircleciScripts/cocoapods_release.py
+++ b/CircleciScripts/cocoapods_release.py
@@ -25,4 +25,14 @@ for framework in frameworks:
         log(f"Could not publish {framework}: output: {out}; error: {err}")
         sys.exit(exit_code)
 
+    if framework == "AWSCore":
+        log(f"pod repo update after {framework}")
+        (exit_code, out, err) = run_command(
+            ["pod", "repo", "update"],
+            keepalive_interval=300,
+            timeout=3600,
+        )
+        if exit_code != 0:
+            log(f"Failed to update CocoaPods repo'; output={out}, error={err}")
+
 sys.exit(0)


### PR DESCRIPTION
*Issue #, if available:*

#3960

*Description of changes:*

Runs `pod update repo` after `AWSCore` is released so that all other packages which depend on it are able to resolve.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
