### PR TITLE
fix:(AWSMobileClient) prevent user from cancelling signout after account deletion with hosted UI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - **AWSMobileClient**
+  - Prevent user from cancelling signout after account deletion with hosted UI. (See [PR #3965](https://github.com/aws-amplify/aws-sdk-ios/pull/3965))
   - Fix issue that caused access token to be revoked when user canceled hosted UI signout. (See [PR #3964](https://github.com/aws-amplify/aws-sdk-ios/pull/3964))
 
 - **CI/CD**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -Features for next release
 
+### Breaking Changes
+
+- **AWSMobileClient**
+  - **Breaking Change** Remove the option to not signout when deleting a user.
 ### Bug Fixes
 
 - **AWSMobileClient**


### PR DESCRIPTION
*Description of changes:*
Prevents user from cancelling signout after account deletion with hosted UI.  Because the user's account no longer exists, it is not necessary to launch a web session to invalidate the login cookie.  Instead, it performs a global signout, revokes access tokens, and signs out locally.

*Check points:*

- ~~[ ] Added new tests to cover change, if needed~~
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- ~~[ ] Documentation update for the change if required~~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
