### PR TITLE
Fix: AWSS3TransferUtility.uploadFileUsingMultiPart fails if local file URL contains a space

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1278,7 +1278,7 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
                               partNumber:(long)partNumber
                               dataLength:(NSUInteger)dataLength
                                    error:(NSError **)error {
-    NSURL *fileURL = [NSURL URLWithString:fileName];
+    NSURL *fileURL = [NSURL fileURLWithPath: fileName isDirectory: false];
     NSUInteger offset = (partNumber - 1) * AWSS3TransferUtilityMultiPartSize;
 
     NSURL *partialFileURL = [self createPartialFile:fileURL offset:offset length:dataLength error:error];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - **CI/CD**
   - Fixes CocoaPods release step which reports `pod repo update` to run after AWSCore is pushed (See [PR #3961](https://github.com/aws-amplify/aws-sdk-ios/pull/3961))
 
+- **AWSS3**
+  - Fixed an issue with Multi Part uploads when uploading from a file URL that contains a space (See [PR #3956](https://github.com/aws-amplify/aws-sdk-ios/pull/3956))
+
 ## 2.26.7
 
 ### New features


### PR DESCRIPTION
*Issue #, if available:*

#3955 #3956

*Description of changes:*

Fix for multipart uploads with a space in the file path.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
