### PR TITLE
(fix:S3): adds details to userInfo for NSError for TransferUtility

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1991,23 +1991,28 @@ didCompleteWithError:(NSError *)error {
         else {
             HTTPResponse = (NSHTTPURLResponse *) task.response;
             userInfo = [NSMutableDictionary dictionaryWithDictionary:[HTTPResponse allHeaderFields]];
+            userInfo[@"HTTPStatusCode"] = @(HTTPResponse.statusCode);
+            userInfo[NSLocalizedFailureReasonErrorKey] = [NSHTTPURLResponse localizedStringForStatusCode:HTTPResponse.statusCode];
         }
     
         if (!error) {
             if (HTTPResponse.statusCode / 100 == 3
                 && HTTPResponse.statusCode != 304) { // 304 Not Modified is a valid response.
+                userInfo[NSLocalizedDescriptionKey] = @"Redirection";
                 error = [NSError errorWithDomain:AWSS3TransferUtilityErrorDomain
                                             code:AWSS3TransferUtilityErrorRedirection
                                         userInfo:userInfo];
             }
             
             if (HTTPResponse.statusCode / 100 == 4) {
+                userInfo[NSLocalizedDescriptionKey] = @"Client Error";
                 error = [NSError errorWithDomain:AWSS3TransferUtilityErrorDomain
                                             code:AWSS3TransferUtilityErrorClientError
                                         userInfo:userInfo];
             }
             
             if (HTTPResponse.statusCode / 100 == 5) {
+                userInfo[NSLocalizedDescriptionKey] = @"Server Error";
                 error = [NSError errorWithDomain:AWSS3TransferUtilityErrorDomain
                                             code:AWSS3TransferUtilityErrorServerError
                                         userInfo:userInfo];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - **AWSS3**
 
+ - fix: adds details to userInfo for NSError for TransferUtility (See [PR #4115](https://github.com/aws-amplify/aws-sdk-ios/pull/4115))
+
+
   - fix: Reduces memory use for multipart uploads with `@autoreleasepool` to prevent excessive memory allocation (See [PR #4129](https://github.com/aws-amplify/aws-sdk-ios/pull/4129))
 
 
@@ -13,7 +16,7 @@
 
 ### Bug Fixes
 
-- **Pinpoint**
+- **AWSPinpoint**
   - fix: Updates Pinpoint to allow for push events for received and opened (See [PR #4105](https://github.com/aws-amplify/aws-sdk-ios/pull/4105))
 
 ### Misc. Updates


### PR DESCRIPTION
*Issue #, if available:*

#4114 

*Description of changes:*

Adds localized description and reason to `userInfo` dictionary for NSError returned by TransferUtility.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
