### PR TITLE
fix(s3): adds autorelease pool around file creation for multipart uploads #4128

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1367,36 +1367,38 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
         return nil;
     }
     NSUInteger remaining = length;
-    NSData *data;
 
     while (remaining > 0) {
-        NSUInteger bufferSize = MIN(remaining, AWSS3TransferUtilityMultiPartSize);
+        @autoreleasepool {
+            NSData *data;
+            NSUInteger bufferSize = MIN(remaining, AWSS3TransferUtilityMultiPartSize);
 
-        // Read data
-        if (@available(iOS 13.0, *)) {
-            data = [readFileHandle readDataUpToLength:bufferSize error:error];
-        } else {
-            data = [readFileHandle readDataOfLength:bufferSize];
-        }
-        if (*error) {
-            break;
-        }
+            // Read data
+            if (@available(iOS 13.0, *)) {
+                data = [readFileHandle readDataUpToLength:bufferSize error:error];
+            } else {
+                data = [readFileHandle readDataOfLength:bufferSize];
+            }
+            if (*error) {
+                break;
+            }
 
-        // Write data
-        if (@available(iOS 13.0, *)) {
-            [writeFileHandle writeData:data error:error];
-        } else {
-            [writeFileHandle writeData:data];
+            // Write data
+            if (@available(iOS 13.0, *)) {
+                [writeFileHandle writeData:data error:error];
+            } else {
+                [writeFileHandle writeData:data];
+            }
+            if (*error) {
+                break;
+            }
+            remaining -= bufferSize;
+            data = nil;
         }
-        if (*error) {
-            break;
-        }
-        remaining -= bufferSize;
     }
 
     [readFileHandle closeFile];
     [writeFileHandle closeFile];
-    data = nil;
 
     if (*error) {
         AWSDDLogError(@"Error while creating temporary file for partial file: %@", fileURL);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 -Features for next release
 
+- **AWSS3**
+
+  - fix: Reduces memory use for multipart uploads with `@autoreleasepool` to prevent excessive memory allocation (See [PR #4129](https://github.com/aws-amplify/aws-sdk-ios/pull/4129))
+
+
 ## 2.27.8
 
 ### Bug Fixes


### PR DESCRIPTION
Found the memory spike happens just before uploading when partial files are created. It appears to hold onto the memory during the run loop so an `@autoreleasepool` was added to clear the memory in the loop so it does not add up.

*Issue #, if available:*

#4128

*Description of changes:*

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
