### PR TITLE
fix(auth): LoginMap key to use the cognito keyword

### DIFF
--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUserPool.m
@@ -294,7 +294,9 @@ static NSString *const AWSPinpointContextKeychainUniqueIdKey = @"com.amazonaws.A
 
 #pragma mark identity provider
 - (NSString *) identityProviderName {
-    return [NSString stringWithFormat:@"%@/%@", self.client.configuration.endpoint.hostName, self.userPoolConfiguration.poolId];
+    return [NSString stringWithFormat:@"cognito-idp.%@.amazonaws.com/%@",
+            [AWSEndpoint regionNameFromType:self.client.configuration.endpoint.regionType],
+            self.userPoolConfiguration.poolId];
 }
 
 - (AWSTask<NSString*>*) token {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-amplify/aws-sdk-ios/issues/4153

*Description of changes:*
ProviderName used in the loginMaps should follow the format  `cognito-idp.<region>.amazonaws.com/<YOUR_USER_POOL_ID>` as mentioned [here](https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetId.html#CognitoIdentity-GetId-request-Logins), this fix is to make the logic work when using custom endpoint.

Maps the same behavior from Android.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
