### PR TITLE
test(auth): Fix intermittent failing test in AWSMobileClient

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSAsyncOperations/GetTokensUserPool/FetchUserPoolTokensOperation+States.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSAsyncOperations/GetTokensUserPool/FetchUserPoolTokensOperation+States.swift
@@ -161,3 +161,50 @@ extension FetchUserPoolTokensOperation.TokenFetchError: Equatable {
         }
     }
 }
+
+extension FetchUserPoolTokensOperation.TokenFetchState: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        switch self {
+
+        case .notStarted:
+            return "notStarted"
+        case .fetching:
+            return "fetching"
+        case .waitingForSignIn:
+            return "waitingForSignIn"
+        case .releasedSignInWait:
+            return "releasedSignInWait"
+        case .fetched:
+            return "fetched"
+        case .error(let error):
+            return "error \(error)"
+        }
+    }
+}
+
+extension FetchUserPoolTokensOperation.TokenFetchEvent: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        switch self {
+        case .cancelled:
+            return "cancelled"
+        case .startOperation:
+            return "startOperation"
+        case .tokenFetched:
+            return "tokenFetched"
+        case .tokenExpired:
+            return "tokenExpired"
+        case .serviceError(let error):
+            return "serviceError \(error)"
+        case .signedIn:
+            return "signedIn"
+        case .signedOut:
+            return "signedOut"
+        case .releaseWait:
+            return "releaseWait"
+        case .noUserFound:
+            return "noUserFound"
+        }
+    }
+}

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+Tokens.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+Tokens.swift
@@ -40,7 +40,6 @@ extension AWSMobileClient {
             }
             tokenOperations.append(operation)
             tokenFetchOperationQueue.addOperation(operation)
-
         case .hostedUI:
             AWSMobileClientLogging.verbose("Invoking hostedUI getTokens")
             let operation = FetchUserPoolTokensOperation(

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomAuthTests/AWSMobileClientCustomAuthTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomAuthTests/AWSMobileClientCustomAuthTests.swift
@@ -327,7 +327,7 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
     /// - When:
     ///    - I call signOut after receiving signedOutUserPoolsTokenInvalid
     /// - Then:
-    ///    - The waiting getTokens call should complete with an .unableToSignIn error.
+    ///    - The waiting getTokens call should complete with an  error.
     ///
     func testSignOutOnSessionExpiry() {
         XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Should be in signOut state")
@@ -363,10 +363,15 @@ class AWSMobileClientCustomAuthTests: AWSMobileClientTestBase {
             defer {
                 tokenFetchFailExpectation.fulfill()
             }
-            guard let error = error as? AWSMobileClientError,
-                case .unableToSignIn = error else {
+            guard let error = error as? AWSMobileClientError else {
                 XCTFail("Should receive an unable to signIn error")
                 return
+            }
+            switch error {
+            case .notSignedIn, .unableToSignIn:
+                break;
+            default:
+                XCTFail("Error should be either of notSignedIn or unableToSigIn but received \(error)")
             }
         }
         wait(for: [tokenFetchFailExpectation], timeout: 20)

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientSignInTests.swift
@@ -463,7 +463,7 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
     /// - When:
     ///    - I call signOut after receiving signedOutUserPoolsTokenInvalid
     /// - Then:
-    ///    - The waiting getTokens call should complete with an .unableToSignIn error.
+    ///    - The waiting getTokens call should complete with an error.
     ///
     func testSignOutOnSessionExpiry() {
         XCTAssertFalse(AWSMobileClient.default().isSignedIn, "Should be in signOut state")
@@ -499,10 +499,15 @@ class AWSMobileClientSignInTests: AWSMobileClientTestBase {
             defer {
                 tokenFetchFailExpectation.fulfill()
             }
-            guard let error = error as? AWSMobileClientError,
-                case .unableToSignIn = error else {
+            guard let error = error as? AWSMobileClientError else {
                 XCTFail("Should receive an unable to signIn error")
                 return
+            }
+            switch error {
+            case .notSignedIn, .unableToSignIn:
+                break;
+            default:
+                XCTFail("Error should be either of notSignedIn or unableToSigIn but received \(error)")
             }
         }
         wait(for: [tokenFetchFailExpectation], timeout: AWSMobileClientTestBase.networkRequestTimeout)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 - **AWSMobileClient**
-  - Fixes concurrent execution of fetch AWS Credentials just after signIn
+  - fix(awsmobileclient): Makes fetch aws credentials serial with the rest of the calls. (See [PR #4202](https://github.com/aws-amplify/aws-sdk-ios/pull/4202))
 
 ### Misc. Updates
 
@@ -13,6 +13,11 @@
   - AWSLambda
   - AWSIoT
   - AWSEC2
+  - AWSPolly
+  - AWSElasticLoadBalancingv2
+  - AWSTranslate
+  - AWSSTS
+  - AWSRekognition
   - AWSKMS
   - AWSComprehend
   - AWSCloudWatchLogs


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* We cannot predict the returned error in case there are multiple getToken in progress and we call signOut. It can be either unAbleToSignIn or notSignedIn.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
