### PR TITLE
fix(AWSMobileClient): Fixing duplicated callbacks when getToken fails

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/DeviceOperations.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/DeviceOperations.swift
@@ -24,6 +24,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(nil, error)
+                return
             }
             self.mobileClient?.userpoolOpsHelper.currentActiveUser!.listDevices(Int32(limit), paginationToken: paginationToken).continueWith { (task) -> Any? in
                 if let error = task.error {
@@ -57,6 +58,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(nil, error)
+                return
             }
             self.mobileClient!.userpoolOpsHelper.currentActiveUser!.updateDeviceStatus(deviceId, remembered: remembered).continueWith { (task) -> Any? in
                 if let error = task.error {
@@ -78,6 +80,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(nil, error)
+                return
             }
             self.mobileClient!.userpoolOpsHelper.currentActiveUser!.updateDeviceStatus(remembered).continueWith { (task) -> Any? in
                 if let error = task.error {
@@ -100,6 +103,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(nil, error)
+                return
             }
             self.mobileClient!.userpoolOpsHelper.currentActiveUser!.getDevice(deviceId).continueWith { (task) -> Any? in
                 if let error = task.error {
@@ -120,6 +124,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(nil, error)
+                return
             }
             self.mobileClient!.userpoolOpsHelper.currentActiveUser!.getDevice().continueWith { (task) -> Any? in
                 if let error = task.error {
@@ -142,6 +147,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(error)
+                return
             }
             self.mobileClient!.userpoolOpsHelper.currentActiveUser!.forgetDevice(deviceId).continueWith { (task) -> Any? in
                 if let error = task.error {
@@ -162,6 +168,7 @@ public class DeviceOperations {
         mobileClient?.getTokens{ _, error in
             if let error = error {
                 completionHandler(error)
+                return
             }
             self.mobileClient!.userpoolOpsHelper.currentActiveUser!.forgetDevice().continueWith { (task) -> Any? in
                 if let error = task.error {


### PR DESCRIPTION
*Description of changes:*
Follow up to https://github.com/aws-amplify/aws-sdk-ios/pull/4215: Adding a `return` break after invoking the callback with a `getTokens` error, to avoid duplicate callbacks.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
