### PR TITLE
chore(ci): archive and build non-base frameworks concurrently

### DIFF
--- a/CircleciScripts/create_xcframeworks.py
+++ b/CircleciScripts/create_xcframeworks.py
@@ -2,6 +2,7 @@ import os
 import sys
 import shutil
 
+from multiprocessing import Pool
 from framework_list import xcframeworks
 from functions import log, run_command
 
@@ -62,25 +63,21 @@ def map_framework_to_project(framework_list):
             framework_map[framework] = "AWSiOSSDKv2.xcodeproj"
     return framework_map
 
-project_dir = os.getcwd()
-log(f"Creating XCFrameworks in {project_dir}")
-framework_map = map_framework_to_project(xcframeworks)
-
-# Archive all the frameworks.
-for framework in xcframeworks:
+def archive(framework):
     xcframework = f"{XCFRAMEWORK_PATH}{framework}.xcframework"
 
     if os.path.exists(xcframework):
         log(f"skipping {framework}...")
-        continue
-    
+        return
+
     log(f"Creating archives for {framework}")
 
     create_archive(framework=framework, project_file=framework_map[framework], build_for_device=True)
     create_archive(framework=framework, project_file=framework_map[framework], build_for_device=False)
 
-# Create XCFramework using the archived frameworks.
-for framework in xcframeworks:
+framework_map = map_framework_to_project(xcframeworks)
+
+def create_xc_framework(framework):
     ios_device_framework = f"{IOS_DEVICE_ARCHIVE_PATH}{framework}.xcarchive/Products/Library/Frameworks/{framework}.framework"
     ios_device_debug_symbols = f"{IOS_DEVICE_ARCHIVE_PATH}{framework}.xcarchive/dSYMs/{framework}.framework.dSYM"
     ios_simulator_framework = f"{IOS_SIMULATOR_ARCHIVE_PATH}{framework}.xcarchive/Products/Library/Frameworks/{framework}.framework"
@@ -112,7 +109,41 @@ for framework in xcframeworks:
             log(f"Could not create XCFramework: {framework} output: {out}; error: {err}")
             sys.exit(exit_code)
 
-if os.path.exists(IOS_DEVICE_ARCHIVE_PATH):
-    shutil.rmtree(IOS_DEVICE_ARCHIVE_PATH)
-if os.path.exists(IOS_SIMULATOR_ARCHIVE_PATH):
-    shutil.rmtree(IOS_SIMULATOR_ARCHIVE_PATH)
+def process_frameworks(process, base_frameworks, remaining_frameworks, pool):
+    for base_framework in base_frameworks:
+        process(base_framework)
+
+    with pool:
+        pool.map(process, remaining_frameworks)
+
+if __name__ == '__main__':
+    project_dir = os.getcwd()
+    log(f"Creating XCFrameworks in {project_dir}")
+
+    # These base_frameworks must be built first and serially.
+    # Other frameworks are dependant on these base_frameworks,
+    # and the build scripts will fail if they're not archived /
+    # created in the proper order.
+    # *** This may need to be updated when dependencies change ***
+    base_frameworks = xcframeworks[:5]
+
+    # The remaining_frameworks are archived and built concurrently
+    # because they are dependent only on base_frameworks.
+    remaining_frameworks = xcframeworks[5:]
+
+    # To build the remaining_frameworks concurrently, we're using
+    # a Pool(). By omitting an explicit input into the Pool constructor
+    # we're allowing it to decide an appropriate amount of processes to run.
+    archive_pool = Pool()
+
+    # First let's archive everything.
+    process_frameworks(archive, base_frameworks, remaining_frameworks, archive_pool)
+
+    create_frameworks_pool = Pool()
+    # Next let's create the xcframeworks.
+    process_frameworks(create_xc_framework, base_frameworks, remaining_frameworks, create_frameworks_pool)
+
+    if os.path.exists(IOS_DEVICE_ARCHIVE_PATH):
+        shutil.rmtree(IOS_DEVICE_ARCHIVE_PATH)
+    if os.path.exists(IOS_SIMULATOR_ARCHIVE_PATH):
+        shutil.rmtree(IOS_SIMULATOR_ARCHIVE_PATH)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Currently, as part of the CI release process, all frameworks are archived and built serially. This generally takes a little over an hour to complete. Some frameworks have dependencies on others; in these cases order is important. This change builds base frameworks (i.e. frameworks that other frameworks have dependencies on) first and serially. Once those base frameworks are complete, the remaining frameworks are built concurrently. This speeds up the archive and build process in the `create_xcframeworks.py` script from > 1 hour to approximately 10 minutes. 

It's called out in the code documentation, but worth noting again here in the PR. Changes to the dependency graph of the frameworks will most likely require changes to the `base_frameworks` and `remaining_frameworks` definitions. 
```python
    # These base_frameworks must be built first and serially.
    # Other frameworks are dependant on these base_frameworks,
    # and the build scripts will fail if they're not archived /
    # created in the proper order.
    # *** This may need to be updated when dependencies change ***
    base_frameworks = xcframeworks[:5]

    # The remaining_frameworks are archived and built concurrently
    # because they are dependent only on base_frameworks.
    remaining_frameworks = xcframeworks[5:]
```

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [ ] ~All unit tests pass~
- [ ] ~All integration tests pass~
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
