### PR TITLE
fix(pinpoint): update event max attributes limit and value limit

### DIFF
--- a/AWSPinpoint/AWSPinpointEvent.m
+++ b/AWSPinpoint/AWSPinpointEvent.m
@@ -19,9 +19,9 @@
 #import "AWSPinpointDateUtils.h"
 #import "AWSPinpointSessionClient.h"
 
-static int const MAX_NUM_OF_METRICS_AND_ATTRIBUTES = 50;
+static int const MAX_NUM_OF_METRICS_AND_ATTRIBUTES = 40;
 static int const MAX_EVENT_TYPE_ATTRIBUTE_METRIC_KEY_LENGTH = 50;
-static int const MAX_EVENT_ATTRIBUTE_VALUE_LENGTH = 1000;
+static int const MAX_EVENT_ATTRIBUTE_VALUE_LENGTH = 200;
 
 NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventErrorDomain";
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **AWSAuthUI**
   - Fixed `AWSAuthUIViewController` not being able to display its contents on landscape orientation (See [PR #4338](https://github.com/aws-amplify/aws-sdk-ios/pull/4338))
 
+- **AWSPinpoint**
+  - Update Pinpoint Event max attributes limit and attribute value limit (See [PR #4348](https://github.com/aws-amplify/aws-sdk-ios/pull/4348))
+
 ## 2.28.0
 
 ### Bug Fixes


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2471
*Description of changes:*
Updating pinpoint event max attributes limit and value length to match [Pinpoint documentation](https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html#quotas-events)
Check points: (check or cross out if not relevant)

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [x] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
