### PR TITLE
fix(AWSPinpoint): Connectivity errors should be retried indefinitely

### DIFF
--- a/AWSCore/Utility/AWSNSCodingUtilities.m
+++ b/AWSCore/Utility/AWSNSCodingUtilities.m
@@ -87,6 +87,8 @@
 
     if (@available(iOS 11, *)) {
         NSSet *allowableClasses = [[NSSet alloc] initWithObjects:[NSMutableString class],
+                                   [NSNumber class],
+                                   [NSString class],
                                    [NSDictionary class],
                                    nil];
         NSDictionary *immutableDict = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClasses:allowableClasses

--- a/AWSPinpoint/AWSPinpointEvent.h
+++ b/AWSPinpoint/AWSPinpointEvent.h
@@ -15,6 +15,15 @@
 
 #import <Foundation/Foundation.h>
 
+/// The maximum number of attributes that can be added to an event.
+extern const NSInteger AWSPinpointEventMaxNumberOfAttributes;
+/// The maximum number of metrics that can be added to an event.
+extern const NSInteger AWSPinpointEventMaxNumberOfMetrics;
+/// The maximum length that an attribute or metric key can have.
+extern const NSInteger AWSPinpointEventMaxAttributeAndMetricKeyLength;
+/// The maximum length that an attribute value can have.
+extern const NSInteger AWSPinpointEventMaxAttributeValueLength;
+
 typedef uint64_t UTCTimeMillis;
 
 @class AWSPinpointContext, AWSPinpointSession;

--- a/AWSPinpoint/AWSPinpointEvent.h
+++ b/AWSPinpoint/AWSPinpointEvent.h
@@ -78,8 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
                          session:(AWSPinpointSession*) session;
 
 /**
- Adds an attribute to this AWSPinpointEvent with the specified key. Only 50 attributes/metrics.
- are allowed to be added to an AWSPinpointEvent. If 50 attributes/metrics already exist on this AWSPinpointEvent, the call is ignored.
+ Adds an attribute to this AWSPinpointEvent with the specified key. Only 40 attributes.
+ are allowed to be added to an AWSPinpointEvent. If 40 attributes already exist on this AWSPinpointEvent, the call is ignored.
  
  @param theValue The value of the attribute. The value will be truncated if it exceeds 200 characters.
  @param theKey The key of the attribute. The key will be truncated if it exceeds 50 characters.
@@ -88,8 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
               forKey:(NSString *)theKey;
 
 /**
- Adds a metric to this AWSPinpointEvent with the specified key. Only 50 attributes/metrics.
- are allowed to be added to an AWSPinpointEvent. If 50 attribute/metrics already exist on this AWSPinpointEvent, the call is ignored.
+ Adds a metric to this AWSPinpointEvent with the specified key. Only 40 metrics.
+ are allowed to be added to an AWSPinpointEvent. If 40 metrics already exist on this AWSPinpointEvent, the call is ignored.
  
  @param theValue The value of the metric.
  @param theKey The key of the metric. The key will be truncated if it exceeds 50 characters.

--- a/AWSPinpoint/AWSPinpointEvent.m
+++ b/AWSPinpoint/AWSPinpointEvent.m
@@ -31,7 +31,6 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
 @property (nonatomic, readwrite) AWSPinpointSession *session;
 @property (nonatomic, readwrite) NSMutableDictionary *attributes;
 @property (nonatomic, readwrite) NSMutableDictionary *metrics;
-@property (atomic, readonly) int currentNumOfAttributesAndMetrics;
 
 @end
 
@@ -67,10 +66,6 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
         _metrics = metrics;
     }
     return self;
-}
-
-- (int) currentNumOfAttributesAndMetrics {
-    return (int)self.attributes.count + (int)self.metrics.count;
 }
 
 - (NSMutableDictionary*) attributes {
@@ -115,12 +110,12 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
     if(!theKey) return;
     
     @synchronized(self.attributes) {
-        if(self.currentNumOfAttributesAndMetrics < MAX_NUM_OF_METRICS_AND_ATTRIBUTES) {
+        if(self.attributes.count <= MAX_NUM_OF_METRICS_AND_ATTRIBUTES) {
             NSString* trimmedKey = [AWSPinpointEvent trimKey:theKey forType:@"attribute"];
             NSString* trimmedValued = [AWSPinpointEvent trimValue:theValue];
             [self.attributes setValue:trimmedValued forKey:trimmedKey];
         } else {
-            AWSDDLogWarn(@"Max number of attributes/metrics reached, dropping attribute with key: %@", theKey);
+            AWSDDLogWarn(@"Max number of attributes reached, dropping attribute with key: %@", theKey);
         }
     }
 }
@@ -160,11 +155,11 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
     }
     
     @synchronized(self.metrics) {
-        if(self.currentNumOfAttributesAndMetrics < MAX_NUM_OF_METRICS_AND_ATTRIBUTES) {
+        if(self.metrics.count <= MAX_NUM_OF_METRICS_AND_ATTRIBUTES) {
             NSString* trimmedKey = [AWSPinpointEvent trimKey:theKey forType:@"attribute"];
             [self.metrics setValue:theValue forKey:trimmedKey];
         } else {
-            AWSDDLogWarn(@"Max number of attributes/metrics reached, dropping metric with key: %@", theKey);
+            AWSDDLogWarn(@"Max number of metrics reached, dropping metric with key: %@", theKey);
         }
     }
 }

--- a/AWSPinpoint/AWSPinpointEvent.m
+++ b/AWSPinpoint/AWSPinpointEvent.m
@@ -19,9 +19,10 @@
 #import "AWSPinpointDateUtils.h"
 #import "AWSPinpointSessionClient.h"
 
-static int const MAX_NUM_OF_METRICS_AND_ATTRIBUTES = 40;
-static int const MAX_EVENT_TYPE_ATTRIBUTE_METRIC_KEY_LENGTH = 50;
-static int const MAX_EVENT_ATTRIBUTE_VALUE_LENGTH = 200;
+const NSInteger AWSPinpointEventMaxNumberOfAttributes = 40;
+const NSInteger AWSPinpointEventMaxNumberOfMetrics = 40;
+const NSInteger AWSPinpointEventMaxAttributeAndMetricKeyLength = 50;
+const NSInteger AWSPinpointEventMaxAttributeValueLength = 200;
 
 NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventErrorDomain";
 
@@ -110,7 +111,7 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
     if(!theKey) return;
     
     @synchronized(self.attributes) {
-        if(self.attributes.count <= MAX_NUM_OF_METRICS_AND_ATTRIBUTES) {
+        if(self.attributes.count < AWSPinpointEventMaxNumberOfAttributes) {
             NSString* trimmedKey = [AWSPinpointEvent trimKey:theKey forType:@"attribute"];
             NSString* trimmedValued = [AWSPinpointEvent trimValue:theValue];
             [self.attributes setValue:trimmedValued forKey:trimmedKey];
@@ -155,8 +156,8 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
     }
     
     @synchronized(self.metrics) {
-        if(self.metrics.count <= MAX_NUM_OF_METRICS_AND_ATTRIBUTES) {
-            NSString* trimmedKey = [AWSPinpointEvent trimKey:theKey forType:@"attribute"];
+        if(self.metrics.count < AWSPinpointEventMaxNumberOfMetrics) {
+            NSString* trimmedKey = [AWSPinpointEvent trimKey:theKey forType:@"metric"];
             [self.metrics setValue:theValue forKey:trimmedKey];
         } else {
             AWSDDLogWarn(@"Max number of metrics reached, dropping metric with key: %@", theKey);
@@ -185,9 +186,9 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
 + (NSString*)trimKey:(NSString*)theKey
              forType:(NSString*)theType {
     NSString* trimmedKey = [AWSPinpointStringUtils clipString:theKey
-                                                   toMaxChars:MAX_EVENT_TYPE_ATTRIBUTE_METRIC_KEY_LENGTH andAppendEllipses:NO];
+                                                   toMaxChars:AWSPinpointEventMaxAttributeAndMetricKeyLength andAppendEllipses:NO];
     if(trimmedKey.length < theKey.length) {
-        AWSDDLogWarn(@"The %@ key has been trimmed to a length of %0d characters", theType, MAX_EVENT_TYPE_ATTRIBUTE_METRIC_KEY_LENGTH);
+        AWSDDLogWarn(@"The %@ key has been trimmed to a length of %0d characters", theType, AWSPinpointEventMaxAttributeAndMetricKeyLength);
     }
     
     return trimmedKey;
@@ -195,9 +196,9 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
 
 + (NSString*)trimValue:(NSString*)theValue {
     NSString* trimmedValue = [AWSPinpointStringUtils clipString:theValue
-                                                     toMaxChars:MAX_EVENT_ATTRIBUTE_VALUE_LENGTH andAppendEllipses:NO];
+                                                     toMaxChars:AWSPinpointEventMaxAttributeValueLength andAppendEllipses:NO];
     if(trimmedValue.length < theValue.length) {
-        AWSDDLogWarn( @"The attribute value has been trimmed to a length of %0d characters", MAX_EVENT_ATTRIBUTE_VALUE_LENGTH);
+        AWSDDLogWarn( @"The attribute value has been trimmed to a length of %0d characters", AWSPinpointEventMaxAttributeValueLength);
     }
     
     return trimmedValue;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 
 - **AWSPinpoint** (See [PR #4348](https://github.com/aws-amplify/aws-sdk-ios/pull/4348) and [PR #4357](https://github.com/aws-amplify/aws-sdk-ios/pull/4357))
   - Updated events max attributes/metrics limit and attribute value limit to align with what the Pinpoint service expects.
-  - Events that failed to submit due to connectivity errors are now retryable indefinitely, i.e. their retryCount won't be increased. 
+  - Events that failed to submit due to connectivity errors are now considered to be retryable indefinitely, i.e. their retry counter won't be increased. 
   - Removed warnings with `NSKeyedUnarchiver`.
 
 ### Misc. Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,4 @@
----
 
-MOVE THIS SECTION TO THE CORRECT LOCATION
-
-### Misc. Updates
-
-- Model updates for the following services
 ---AWSCognitoIdentityProvider
 ---
 
@@ -13,19 +7,6 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 ### Misc. Updates
 
 - Model updates for the following services
----AWSDynamoDB
----AWSComprehend
----AWSLocation
----AWSPolly
----AWSEC2
----AWSTranslate
----AWSConnect
----AWSChimeSDKMessaging
----AWSSageMakerRuntime
----AWSEC2
----AWSConnect
----AWSElasticLoadBalancingv2
-
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
@@ -35,8 +16,26 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
 - **AWSAuthUI**
   - Fixed `AWSAuthUIViewController` not being able to display its contents on landscape orientation (See [PR #4338](https://github.com/aws-amplify/aws-sdk-ios/pull/4338))
 
-- **AWSPinpoint**
-  - Update Pinpoint Event max attributes limit and attribute value limit (See [PR #4348](https://github.com/aws-amplify/aws-sdk-ios/pull/4348))
+- **AWSPinpoint** (See [PR #4348](https://github.com/aws-amplify/aws-sdk-ios/pull/4348) and [PR #4357](https://github.com/aws-amplify/aws-sdk-ios/pull/4357))
+  - Updated events max attributes/metrics limit and attribute value limit to align with what the Pinpoint service expects.
+  - Events that failed to submit due to connectivity errors are now retryable indefinitely, i.e. their retryCount won't be increased. 
+  - Removed warnings with `NSKeyedUnarchiver`.
+
+### Misc. Updates
+
+- Model updates for the following services
+ - AWSDynamoDB
+ - AWSComprehend
+ - AWSLocation
+ - AWSPolly
+ - AWSEC2
+ - AWSTranslate
+ - AWSConnect
+ - AWSChimeSDKMessaging
+ - AWSSageMakerRuntime
+ - AWSEC2
+ - AWSConnect
+ - AWSElasticLoadBalancingv2
 
 ## 2.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,3 @@
-
----AWSCognitoIdentityProvider
----
-
-MOVE THIS SECTION TO THE CORRECT LOCATION
-
-### Misc. Updates
-
-- Model updates for the following services
 # AWS Mobile SDK for iOS CHANGELOG
 
 ## Unreleased
@@ -36,6 +27,7 @@ MOVE THIS SECTION TO THE CORRECT LOCATION
  - AWSEC2
  - AWSConnect
  - AWSElasticLoadBalancingv2
+ - AWSCognitoIdentityProvider
 
 ## 2.28.0
 


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/4356
- https://github.com/aws-amplify/amplify-swift/issues/2401
- https://github.com/aws-amplify/amplify-swift/issues/2471

*Description of changes:*
  - Checking for attributes and metrics limits independently from each other, as Pinpoint does allow to have up to 40 metrics and 40 attributes.
  - Events that failed to submit due to connectivity errors are now considered to be retryable indefinitely, i.e. their `retryCount` won't be increased. 
  - Removed warnings with `NSKeyedUnarchiver` due to missing allowed classes.

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [X] All unit tests pass
- [ ] ~All integration tests pass~
- [X] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
