### PR TITLE
fix(AWSAuthCore): rename private selector to avoid naming collision

### DIFF
--- a/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/AWSAppleSignInProvider.m
@@ -84,7 +84,7 @@ static NSString *const AWSInfoAppleIdentifier = @"AppleSignIn";
     // There is no apple api to logout
 }
 
-- (void)reloadSession {
+- (void)reloadSignedInSession {
     [self appleLogin];
 }
 

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSSignInManager.m
@@ -132,7 +132,7 @@ static AWSIdentityManager *identityManager;
         }
     }
     
-    [self.potentialSignInProvider reloadSession];
+    [self.potentialSignInProvider reloadSignedInSession];
     
     if (self.potentialSignInProvider == nil) {
         [self completeLogin];

--- a/AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h
+++ b/AWSAuthSDK/Sources/AWSAuthCore/AWSSignInProvider.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, AWSIdentityManagerAuthState) {
  The handler method for managing the session reload for the Sign-In Provider.
  The completionHandler will bubble back errors to the developers.
  */
-- (void)reloadSession;
+- (void)reloadSignedInSession;
 
 @end
 

--- a/AWSAuthSDK/Sources/AWSFacebookSignIn/AWSFacebookSignInProvider.m
+++ b/AWSAuthSDK/Sources/AWSFacebookSignIn/AWSFacebookSignInProvider.m
@@ -114,7 +114,7 @@ static NSString* const AWSInfoFacebookSignInIdentifier = @"FacebookSignIn";
     return NO;
 }
 
-- (void)reloadSession {
+- (void)reloadSignedInSession {
     Class fbSDKAccessToken = NSClassFromString(@"FBSDKAccessToken");
     if (fbSDKAccessToken) {
         if([fbSDKAccessToken currentAccessToken]) {

--- a/AWSAuthSDK/Sources/AWSGoogleSignIn/AWSGoogleSignInProvider.m
+++ b/AWSAuthSDK/Sources/AWSGoogleSignIn/AWSGoogleSignInProvider.m
@@ -179,7 +179,7 @@ static NSString *const AWSInfoGoogleClientId = @"ClientId-iOS";
     return [self.signInClient hasPreviousSignIn];
 }
 
-- (void)reloadSession {
+- (void)reloadSignedInSession {
     if ([self isLoggedIn]) {
         [self signInSilently];
     }

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/AWSCognitoUserPoolsSignInProvider.m
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/AWSCognitoUserPoolsSignInProvider.m
@@ -99,7 +99,7 @@ cognitoIdentityUserPoolAppClientSecret:(NSString *)cognitoIdentityUserPoolAppCli
     return [pool.currentUser isSignedIn];
 }
 
-- (void)reloadSession {
+- (void)reloadSignedInSession {
     if ([self isLoggedIn]) {
         [self completeLogin];
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-ios/issues/4314
*Description of changes:*
* Rename `reloadSession` to `reloadSignedInSession` to avoid name collision with Apple's private selectors
*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
