### PR TITLE
fix(AWSCredentialsProvider): validate credentials have access-, secret-, sessionKey

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -111,7 +111,10 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     // Returns cached credentials when all of the following conditions are true:
     // 1. The cached credentials are not nil.
     // 2. The credentials do not expire within 10 minutes.
-    return ([self.expiration compare:[NSDate dateWithTimeIntervalSinceNow:10 * 60]] == NSOrderedDescending);
+    return (self.accessKey != nil &&
+            self.secretKey != nil &&
+            self.sessionKey != nil &&
+            [self.expiration compare:[NSDate dateWithTimeIntervalSinceNow:10 * 60]] == NSOrderedDescending);
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **AWSCore/AWSCredentialsProvider**
+    - Fixed an issue where `getAWSCredentials` thinks it has valid credentials despite them being potentially invalidated through a concurrent call to `invalidateCachedTemporaryCredentials`. (See [PR #4379](https://github.com/aws-amplify/aws-sdk-ios/pull/4379))
+
 ### Misc. Updates
 
 - Model updates for the following services


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-swift/issues/2527

*Description of changes:*
Adds validation of accessKey, secretKey, and sessionKey within `AWSCredentialsProvider`. This resolves an issue where `getAWSCredentials` thinks it has valid credentials despite them being potentially invalidated through a concurrent call to `invalidateCachedTemporaryCredentials`.

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
