### PR TITLE
fix(AWSPinpoint): Fixing a deadlock when submitting events from multiple threads

### DIFF
--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -97,9 +97,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  An AWSPinpointEndpointProfile object with the specified context
+ @warning Calling this initializer from a non-main thread might result in a deadlock.
  @returns AWSPinpointEndpointProfile
  */
 - (instancetype)initWithContext:(AWSPinpointContext *) context;
+
+/**
+ An AWSPinpointEndpointProfile object with the specified context
+ @returns AWSPinpointEndpointProfile
+ */
+- (instancetype)initWithContext:(AWSPinpointContext *) context isRegisteredForRemoteNotifications:(BOOL) isRegisteredForRemoteNotifications;
 
 /**
  Adds an attribute to this AWSPinpointEndpointProfile with the specified key. Only 40 attributes/metrics

--- a/AWSPinpoint/AWSPinpointEndpointProfile.h
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.h
@@ -97,13 +97,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  An AWSPinpointEndpointProfile object with the specified context
- @warning Calling this initializer from a non-main thread might result in a deadlock.
- @returns AWSPinpointEndpointProfile
- */
-- (instancetype)initWithContext:(AWSPinpointContext *) context;
-
-/**
- An AWSPinpointEndpointProfile object with the specified context
  @returns AWSPinpointEndpointProfile
  */
 - (instancetype)initWithContext:(AWSPinpointContext *) context isRegisteredForRemoteNotifications:(BOOL) isRegisteredForRemoteNotifications;

--- a/AWSPinpoint/AWSPinpointNotificationManager.h
+++ b/AWSPinpoint/AWSPinpointNotificationManager.h
@@ -47,11 +47,11 @@ typedef NS_ENUM(NSInteger, AWSPinpointPushEvent) {
 };
 
 #pragma mark - Notification Helpers
-/**
- Returns a Boolean indicating whether the app is currently registered for remote notifications.
- @return BOOL YES if the app is registered for remote notifications and received its device token or NO if registration
- has not occurred, has failed, or has been denied by the user.
- */
+
+///
+/// Returns a Boolean indicating whether the app is currently registered for remote notifications.
+/// - Warning: Calling this method from a non-main thread might result in a deadlock if the main queue is blocked.
+/// - Returns: YES if the app is registered for remote notifications and received its device token or NO if registration has not occurred, has failed, or has been denied by the user.
 + (BOOL)isNotificationEnabled;
 
 #pragma mark - Interceptors

--- a/AWSPinpoint/AWSPinpointTargetingClient.h
+++ b/AWSPinpoint/AWSPinpointTargetingClient.h
@@ -21,11 +21,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AWSPinpointTargetingClient : NSObject
 
-/**
- * Returns the current endpoint.
- * @return (id<AWSPinpointEndpoint>)
- */
+///
+/// Returns the current endpoint.
+/// - Warning: Calling this method from a non-main thread might result in a deadlock if the main queue is blocked
+/// - Returns: An AWSPinpointEndpoint
 - (AWSPinpointEndpointProfile*) currentEndpointProfile;
+
+///
+/// Requests the current endpoint.
+/// - Parameter completion: a block that is called with the current endpoint
+- (void) currentEndpointProfileWithCompletion:(void (^_Nonnull)(AWSPinpointEndpointProfile *profile))completion;
 
 /**
  * Sends an update of the current endpoint

--- a/AWSPinpointUnitTests/AWSPinpointNSSecureCodingTests.m
+++ b/AWSPinpointUnitTests/AWSPinpointNSSecureCodingTests.m
@@ -21,6 +21,7 @@
 - (instancetype) initWithApplicationId:(NSString *)applicationId
                             endpointId:(NSString *)endpointId
                 applicationLevelOptOut:(BOOL)applicationLevelOptOut
+    isRegisteredForRemoteNotifications:(BOOL)isRegisteredForRemoteNotifications
                                  debug:(BOOL)debug
                           userDefaults:(NSUserDefaults *)userDefaults
                               keychain:(AWSUICKeyChainStore *)keychain;
@@ -55,6 +56,7 @@
     AWSPinpointEndpointProfile *profile = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"app-id-123"
                                                                                          endpointId:@"endpoint-id-123"
                                                                              applicationLevelOptOut:YES
+                                                                 isRegisteredForRemoteNotifications:YES
                                                                                               debug:YES
                                                                                        userDefaults:[NSUserDefaults standardUserDefaults] keychain:[AWSUICKeyChainStore keyChainStoreWithService: @"com.amazonaws.AWSPinpointContext"]];
 
@@ -82,6 +84,7 @@
     AWSPinpointEndpointProfile *profile = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"app-id-123"
                                                                                          endpointId:@"endpoint-id-123"
                                                                              applicationLevelOptOut:YES
+                                                                 isRegisteredForRemoteNotifications:YES
                                                                                               debug:YES
                                                                                        userDefaults:[NSUserDefaults standardUserDefaults] keychain:[AWSUICKeyChainStore keyChainStoreWithService: @"com.amazonaws.AWSPinpointContext"]];
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profile];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 # AWS Mobile SDK for iOS CHANGELOG
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSPinpoint**
+  - Fixed a deadlock that happened when `AWSPinpointAnalyticsClient.submitEvents` was called from different threads at the same time. (See [PR #4558](https://github.com/aws-amplify/aws-sdk-ios/pull/4558))
 
 ## 2.30.1
 


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/2419
- https://github.com/aws-amplify/aws-sdk-ios/issues/4551

*Description of changes:*

When `submitEvents` is called, part of the process is to grab the `currentEndpointProfile` because the `PutEvents` call to  **Pinpoint** requires it as an input.

Inside `AWSPinpointTargetingClient.currentEndpointProfile`, there's a call to `AWSPinpointNotificationManager.isNotificationEnabled`, which is necessary to determine if the endpoint is currently opted out of notifications or not. 

`isNotificationEnabled` is internally calling `UIApplication.isRegisteredForRemoteNotifications`, but because the latter **needs** to be called from the main queue, it's doing a `dispatch_sync(dispatch_get_main_queue())` if the current thread is not the main one.

This in isolation is not a problem, but it causes trouble when integrated to the whole event submission process, since we do a `@synchronized(self.lock)` right at the beginning. This will result in a deadlock:
- A background thread calls `submitEvents` and gets the lock
- The main queue calls `submitEvents` and waits to get the lock
- The background thread reaches the `isNotificationEnabled` code, so it attempts to `dispatch_sync` into the main queue
- Because the main queue is waiting for the lock to be released, it won't run.

The background thread is now blocked because it is waiting on the main queue to unblock, which un turn is waiting for the background thread to release the lock.

---

In order to fix this, I wanted to be the least disruptive possible since we are dealing with very old implementations.

 Since submitting events is already an async operation, I decided to just introduce a new `currentEndpointProfileWithCompletion:` method that won't block the main queue when it needs to grab `UIApplication.isRegisteredForRemoteNotifications`, and call this method instead internally.

I also decoupled `AWSPinpointEndpointProfile` from `AWSPinpointNotificationManager`, so now the `isRegisteredForRemoteNotifications` flag needs to be provided externally when creating the profile.

Finally, I added  **Warning** annotations to both `isNotificationEnabled` and `currentEndpointProfile` docs indicating that calling them from a non-main thread _might_ cause deadlocks if the main queue is blocked.


*Check points:*

- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
