### PR TITLE
fix(IoT): priority inversion runtime warning

### DIFF
--- a/AWSIoT/Internal/SocketRocket/AWSSRWebSocket.m
+++ b/AWSIoT/Internal/SocketRocket/AWSSRWebSocket.m
@@ -1844,6 +1844,7 @@ static NSRunLoop *networkRunLoop = nil;
     dispatch_once(&onceToken, ^{
         networkThread = [[_SRRunLoopThread alloc] init];
         networkThread.name = @"com.squareup.SocketRocket.NetworkThread";
+        networkThread.qualityOfService = NSQualityOfServiceUserInitiated;
         [networkThread start];
         networkRunLoop = networkThread.runLoop;
     });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # AWS Mobile SDK for iOS CHANGELOG
 ## Unreleased
 
--Features for next release
+- **AWSIoT**
+    - Fixed a potential point of priority inversion, resolving new Xcode 14 threat performance warning.
 
 ## 2.30.2
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-sdk-ios/issues/4360

*Description of changes:*
Explicitly sets the `qualityOfService` of the `networkThread` to `NSQualityOfServiceUserInitiated` to prevent priority inversion.

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
