### PR TITLE
fix(AWSS3): Fixing the integration tests for AWSS3

### DIFF
--- a/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
+++ b/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
@@ -1280,7 +1280,7 @@ static long unsigned testObjectSize = 10000;
             XCTAssertTrue([task.result isKindOfClass:[AWSS3PutObjectOutput class]],@"The response object is not a class of [%@], got: %@", NSStringFromClass([AWSS3PutObjectOutput class]),[task.result description]);
             AWSS3PutObjectOutput *putObjectOutput = task.result;
             XCTAssertNotNil(putObjectOutput.ETag);
-            XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionUnknown);
+            XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionAES256);
             return nil;
 
         }] waitUntilFinished];

--- a/AWSS3Tests/AWSS3Tests.m
+++ b/AWSS3Tests/AWSS3Tests.m
@@ -493,7 +493,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         XCTAssertTrue([task.result isKindOfClass:[AWSS3PutObjectOutput class]],@"The response object is not a class of [%@], got: %@", NSStringFromClass([AWSS3PutObjectOutput class]),[task.result description]);
         AWSS3PutObjectOutput *putObjectOutput = task.result;
         XCTAssertNotNil(putObjectOutput.ETag);
-        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionUnknown);
+        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionAES256);
         return nil;
         
     }] waitUntilFinished];
@@ -617,7 +617,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         XCTAssertTrue([task.result isKindOfClass:[AWSS3PutObjectOutput class]], @"The response object is not a class of [%@], got: %@", NSStringFromClass([AWSS3PutObjectOutput class]), [task.result description]);
         AWSS3PutObjectOutput *putObjectOutput = task.result;
         XCTAssertNotNil(putObjectOutput.ETag);
-        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionUnknown);
+        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionAES256);
 
         AWSS3HeadObjectRequest *headObjectRequest = [AWSS3HeadObjectRequest new];
         headObjectRequest.bucket = testBucketNameGeneral;
@@ -949,7 +949,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         XCTAssertTrue([task.result isKindOfClass:[AWSS3PutObjectOutput class]],@"The response object is not a class of [%@], got: %@", NSStringFromClass([AWSS3PutObjectOutput class]),[task.result description]);
         AWSS3PutObjectOutput *putObjectOutput = task.result;
         XCTAssertNotNil(putObjectOutput.ETag);
-        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionUnknown);
+        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionAES256);
         return nil;
 
     }] waitUntilFinished];
@@ -1222,7 +1222,7 @@ static NSMutableArray<NSString *> *testBucketsCreated;
         XCTAssertTrue([task.result isKindOfClass:[AWSS3PutObjectOutput class]],@"The response object is not a class of [%@], got: %@", NSStringFromClass([AWSS3PutObjectOutput class]),[task.result description]);
         AWSS3PutObjectOutput *putObjectOutput = task.result;
         XCTAssertNotNil(putObjectOutput.ETag);
-        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionUnknown);
+        XCTAssertEqual(putObjectOutput.serverSideEncryption, AWSS3ServerSideEncryptionAES256);
         return nil;
 
     }] waitUntilFinished];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 - **AWSMobileClient**
     - Add validation for the initial state of AWSMobileClient (See [PR #4547](https://github.com/aws-amplify/aws-sdk-ios/pull/4547))
+
+- **AWSS3**
+    - Fixing the integration tests (See [PR #4592](https://github.com/aws-amplify/aws-sdk-ios/pull/4592))
     
 - Model updates for the following services
   - AWSEC2


### PR DESCRIPTION
*Description of changes:*

AWSS3 now passes the correct default encryption being used for objects. 

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
