### PR TITLE
ci: support check out pr from other repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ commands:
           path: artifacts
 
   shallow_checkout:
-    # Workaround for https://discuss.circleci.com/t/checkout-fails-on-git-tags-when-git-directory-is-already-present/22437/5
+    # Workaround for https://github.com/guitarrapc/git-shallow-clone-orb/blob/main/src/commands/checkout.yml
     steps:
       - run:
           name: Checkout code shallow to working directory
@@ -252,16 +252,25 @@ commands:
             echo "Using SSH Config Dir '$SSH_CONFIG_DIR'"
             mkdir -p $SSH_CONFIG_DIR
             echo -e 'github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\n' >> "$SSH_CONFIG_DIR/known_hosts"
+            chmod 0600 $SSH_CONFIG_DIR/known_hosts
+
             mkdir -p $CIRCLE_WORKING_DIRECTORY
-            git clone --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" $CIRCLE_WORKING_DIRECTORY
+            git clone --depth 1 "$CIRCLE_REPOSITORY_URL" $CIRCLE_WORKING_DIRECTORY
             cd $CIRCLE_WORKING_DIRECTORY
 
-      - run:
-          name: Fetch tag from origin if present
-          command: |
-            if [ -n "$CIRCLE_TAG" ] ; then
-              git fetch --force origin "refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+            if [ -n "$CIRCLE_TAG" ]; then
+              echo 'Fetch tag'
+              git fetch --depth 1 --force origin "+refs/tags/${CIRCLE_TAG}:refs/tags/${CIRCLE_TAG}"
+            elif [[ $(echo $CIRCLE_PULL_REQUEST | grep -E "${CIRCLE_BRANCH}$") ]]; then
+              echo 'Fetch pull request'
+              git fetch --depth 1 --force origin "$CIRCLE_BRANCH/head:remotes/origin/$CIRCLE_BRANCH"
+            else
+              echo 'Fetch branch'
+              git fetch --depth 1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
+
+            echo "Checking out the CI HEAD"
+            git reset --hard "$CIRCLE_SHA1"
 
 jobs:
   build:


### PR DESCRIPTION
*Issue #, if available:*
The new shallow checkout doesn't support PR that created from a different repo.

*Description of changes:*
- With reference from https://github.com/guitarrapc/git-shallow-clone-orb/blob/main/src/commands/checkout.yml
  - add steps to fetch history for different type of refs (tag, branch, pr)

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [X] All unit tests pass
- [X] All integration tests pass
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
