### PR TITLE
Trying to fix EXC_BAD_ACCESS in AWSPinpointEventRecorder

### DIFF
--- a/AWSPinpoint/AWSPinpointEventRecorder.m
+++ b/AWSPinpoint/AWSPinpointEventRecorder.m
@@ -1063,8 +1063,8 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                                               @"id" : eventID
                                                               }];
                             if (!result) {
-                                AWSDDLogError(@"SQLite error. [%@]", db.lastError);
-                                *error = db.lastError;
+                                *error = [db.lastError copy];
+                                AWSDDLogError(@"SQLite error. [%@]", *error);
                             }
                         }];
                     }
@@ -1080,8 +1080,8 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                                               @"id" : eventID
                                                               }];
                             if (!result) {
-                                AWSDDLogError(@"SQLite error. [%@]", db.lastError);
-                                *error = db.lastError;
+                                *error = [db.lastError copy];
+                                AWSDDLogError(@"SQLite error. [%@]", *error);
                             }
                         }];
                     }
@@ -1116,8 +1116,8 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                                           @"id" : eventID
                                                           }];
                         if (!result) {
-                            AWSDDLogError(@"SQLite error. [%@]", db.lastError);
-                            *error = db.lastError;
+                            *error = [db.lastError copy];
+                            AWSDDLogError(@"SQLite error. [%@]", *error);
                         }
                     }];
                 }
@@ -1129,8 +1129,8 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                                           @"id" : eventID
                                                           }];
                         if (!result) {
-                            AWSDDLogError(@"SQLite error. [%@]", db.lastError);
-                            *error = db.lastError;
+                            *error = [db.lastError copy];
+                            AWSDDLogError(@"SQLite error. [%@]", *error);
                         }
                     }];
                 }
@@ -1143,8 +1143,8 @@ NSString *const FAILURE_REASON = @"NSLocalizedFailureReason";
                                                           @"id" : eventID
                                                           }];
                         if (!result) {
-                            AWSDDLogError(@"SQLite error. [%@]", db.lastError);
-                            *error = db.lastError;
+                            *error = [db.lastError copy];
+                            AWSDDLogError(@"SQLite error. [%@]", *error);
                         }
                     }];
                 }


### PR DESCRIPTION

*Issue #, if available: 4721

https://github.com/aws-amplify/aws-sdk-ios/issues/4721

*Description of changes:

You can read the bug for more details but TLDR, if the app is locked and the app is configured to protect data (ie NSFileProtectionComplete), then updating the database fails (as expected). Calling db.lastError fails when called twice consecutively.

Although I couldn't fully understand why we cannot call db.lastError twice in a row, I was able to make changes to my local pod instance to prevent the error from happening by making adjustments to the code so we are only calling db.lastError once. 

Initially, I didn't have logic to copy the error but that somehow still ended up with EXC_BAD_ACCESS occurring so that is why I added the logic to copy.

Apologies if there's better way to fix, objective c is not a language I work with very much. 

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
