### PR TITLE
chore: Revert "[bump version 2.32.0] (#4727)"

### DIFF
--- a/AWSAPIGateway.podspec
+++ b/AWSAPIGateway.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AWSAPIGateway'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
 
   s.source_files = 'AWSAPIGateway/*.{h,m}'
 end

--- a/AWSAPIGateway/AWSAPIGatewayClient.m
+++ b/AWSAPIGateway/AWSAPIGatewayClient.m
@@ -23,7 +23,7 @@ NSString *const AWSAPIGatewayErrorHTTPHeaderFieldsKey = @"HTTPHeaderFields";
 
 static NSString *const AWSAPIGatewayAPIKeyHeader = @"x-api-key";
 
-NSString *const AWSAPIGatewaySDKVersion = @"2.32.0";
+NSString *const AWSAPIGatewaySDKVersion = @"2.31.1";
 
 static int defaultChunkSize = 1024;
 

--- a/AWSAPIGateway/Info.plist
+++ b/AWSAPIGateway/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSAppleSignIn.podspec
+++ b/AWSAppleSignIn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSAppleSignIn'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
-  s.dependency 'AWSAuthCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
+  s.dependency 'AWSAuthCore', '2.31.1'
   s.source_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.{h,m}'
   s.public_header_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.h'
 end

--- a/AWSAuth.podspec
+++ b/AWSAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSAuth'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -14,23 +14,23 @@ Pod::Spec.new do |s|
    s.requires_arc = true
 
    s.subspec 'Core' do  |authcore|
-      authcore.dependency 'AWSAuthCore', '2.32.0'
+      authcore.dependency 'AWSAuthCore', '2.31.1'
    end
 
    s.subspec 'FacebookSignIn' do  |facebook|
-      facebook.dependency 'AWSFacebookSignIn', '2.32.0'
+      facebook.dependency 'AWSFacebookSignIn', '2.31.1'
    end
 
    s.subspec 'GoogleSignIn' do  |google|
-      google.dependency 'AWSGoogleSignIn', '2.32.0'
+      google.dependency 'AWSGoogleSignIn', '2.31.1'
    end
 
    s.subspec 'UserPoolsSignIn' do  |up|
-      up.dependency 'AWSUserPoolsSignIn', '2.32.0'
+      up.dependency 'AWSUserPoolsSignIn', '2.31.1'
    end
 
    s.subspec 'UI' do  |ui|
-      ui.dependency 'AWSAuthUI', '2.32.0'
+      ui.dependency 'AWSAuthUI', '2.31.1'
    end
 
 end

--- a/AWSAuthCore.podspec
+++ b/AWSAuthCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSAuthCore'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true
-   s.dependency 'AWSCore', '2.32.0'
+   s.dependency 'AWSCore', '2.31.1'
    s.source_files = 'AWSAuthSDK/Sources/AWSAuthCore/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSAuthCore/*.h'
  end

--- a/AWSAuthSDK/Sources/AWSAppleSignIn/Info.plist
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSAuthCore/Info.plist
+++ b/AWSAuthSDK/Sources/AWSAuthCore/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSAuthUI/Info.plist
+++ b/AWSAuthSDK/Sources/AWSAuthUI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSFacebookSignIn/Info.plist
+++ b/AWSAuthSDK/Sources/AWSFacebookSignIn/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSGoogleSignIn/Info.plist
+++ b/AWSAuthSDK/Sources/AWSGoogleSignIn/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSMobileClient/Info.plist
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSMobileClientXCF/Info.plist
+++ b/AWSAuthSDK/Sources/AWSMobileClientXCF/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/Info.plist
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/AWSAuthUI.podspec
+++ b/AWSAuthUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSAuthUI'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true
-   s.dependency 'AWSCore', '2.32.0'
-   s.dependency 'AWSAuthCore', '2.32.0'
+   s.dependency 'AWSCore', '2.31.1'
+   s.dependency 'AWSAuthCore', '2.31.1'
    s.source_files = 'AWSAuthSDK/Sources/AWSAuthUI/*.{h,m}', 'AWSAuthSDK/Sources/AWSAuthUI/**/*.{h,m}', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.h'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUI.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h'
    s.private_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h'

--- a/AWSAutoScaling.podspec
+++ b/AWSAutoScaling.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSAutoScaling'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSAutoScaling/*.{h,m}'
 end

--- a/AWSAutoScaling/AWSAutoScalingService.m
+++ b/AWSAutoScaling/AWSAutoScalingService.m
@@ -25,7 +25,7 @@
 #import "AWSAutoScalingResources.h"
 
 static NSString *const AWSInfoAutoScaling = @"AutoScaling";
-NSString *const AWSAutoScalingSDKVersion = @"2.32.0";
+NSString *const AWSAutoScalingSDKVersion = @"2.31.1";
 
 
 @interface AWSAutoScalingResponseSerializer : AWSXMLResponseSerializer

--- a/AWSAutoScaling/Info.plist
+++ b/AWSAutoScaling/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSChimeSDKIdentity.podspec
+++ b/AWSChimeSDKIdentity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSChimeSDKIdentity'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSChimeSDKIdentity/*.{h,m}'
 end

--- a/AWSChimeSDKIdentity/AWSChimeSDKIdentityService.m
+++ b/AWSChimeSDKIdentity/AWSChimeSDKIdentityService.m
@@ -25,7 +25,7 @@
 #import "AWSChimeSDKIdentityResources.h"
 
 static NSString *const AWSInfoChimeSDKIdentity = @"ChimeSDKIdentity";
-NSString *const AWSChimeSDKIdentitySDKVersion = @"2.32.0";
+NSString *const AWSChimeSDKIdentitySDKVersion = @"2.31.1";
 
 
 @interface AWSChimeSDKIdentityResponseSerializer : AWSJSONResponseSerializer

--- a/AWSChimeSDKIdentity/Info.plist
+++ b/AWSChimeSDKIdentity/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSChimeSDKMessaging.podspec
+++ b/AWSChimeSDKMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSChimeSDKMessaging'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSChimeSDKMessaging/*.{h,m}'
 end

--- a/AWSChimeSDKMessaging/AWSChimeSDKMessagingService.m
+++ b/AWSChimeSDKMessaging/AWSChimeSDKMessagingService.m
@@ -25,7 +25,7 @@
 #import "AWSChimeSDKMessagingResources.h"
 
 static NSString *const AWSInfoChimeSDKMessaging = @"ChimeSDKMessaging";
-NSString *const AWSChimeSDKMessagingSDKVersion = @"2.32.0";
+NSString *const AWSChimeSDKMessagingSDKVersion = @"2.31.1";
 
 
 @interface AWSChimeSDKMessagingResponseSerializer : AWSJSONResponseSerializer

--- a/AWSChimeSDKMessaging/Info.plist
+++ b/AWSChimeSDKMessaging/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSCloudWatch.podspec
+++ b/AWSCloudWatch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSCloudWatch'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSCloudWatch/*.{h,m}'
 end

--- a/AWSCloudWatch/AWSCloudWatchService.m
+++ b/AWSCloudWatch/AWSCloudWatchService.m
@@ -26,7 +26,7 @@
 #import "AWSCloudWatchResources.h"
 
 static NSString *const AWSInfoCloudWatch = @"CloudWatch";
-NSString *const AWSCloudWatchSDKVersion = @"2.32.0";
+NSString *const AWSCloudWatchSDKVersion = @"2.31.1";
 
 
 @interface AWSCloudWatchResponseSerializer : AWSXMLResponseSerializer

--- a/AWSCloudWatch/Info.plist
+++ b/AWSCloudWatch/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSCognitoAuth.podspec
+++ b/AWSCognitoAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSCognitoAuth'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Cognito Auth SDK for iOS'
 
   s.description  = 'Amazon Cognito Auth enables sign up and authentication of your end users via a hosted UI'
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
                      :tag => s.version}
   s.requires_arc = true
 
-  s.dependency 'AWSCore', '2.32.0'
-  s.dependency 'AWSCognitoIdentityProviderASF', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
+  s.dependency 'AWSCognitoIdentityProviderASF', '2.31.1'
 
   s.source_files = 'AWSCognitoAuth/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoAuth/*.h'

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -80,7 +80,7 @@ API_AVAILABLE(ios(13.0))
 
 @implementation AWSCognitoAuth
 
-NSString *const AWSCognitoAuthSDKVersion = @"2.32.0";
+NSString *const AWSCognitoAuthSDKVersion = @"2.31.1";
 
 
 static NSMutableDictionary *_instanceDictionary = nil;

--- a/AWSCognitoAuth/Info.plist
+++ b/AWSCognitoAuth/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSCognitoIdentityProvider.podspec
+++ b/AWSCognitoIdentityProvider.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSCognitoIdentityProvider'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Cognito Identity Provider SDK for iOS (Beta)'
 
   s.description  = 'Amazon Cognito Identity Provider enables sign up and authentication of your end users'
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
                      :tag => s.version}
   s.requires_arc = true
   s.frameworks   = 'Security', 'UIKit'
-  s.dependency 'AWSCore', '2.32.0'
-  s.dependency 'AWSCognitoIdentityProviderASF', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
+  s.dependency 'AWSCognitoIdentityProviderASF', '2.31.1'
 
   s.source_files = 'AWSCognitoIdentityProvider/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoIdentityProvider/*.h'

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityProviderService.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityProviderService.m
@@ -25,7 +25,7 @@
 #import "AWSCognitoIdentityProviderResources.h"
 
 static NSString *const AWSInfoCognitoIdentityProvider = @"CognitoIdentityProvider";
-NSString *const AWSCognitoIdentityProviderSDKVersion = @"2.32.0";
+NSString *const AWSCognitoIdentityProviderSDKVersion = @"2.31.1";
 
 
 @interface AWSCognitoIdentityProviderResponseSerializer : AWSJSONResponseSerializer

--- a/AWSCognitoIdentityProvider/Info.plist
+++ b/AWSCognitoIdentityProvider/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSCognitoIdentityProviderASF.podspec
+++ b/AWSCognitoIdentityProviderASF.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSCognitoIdentityProviderASF'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Cognito Identity Provider Advanced Security Features library (Beta)'
 
   s.description  = 'Amazon Cognito Identity Provider ASF provides the information necessary to support adaptive authentication'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.public_header_files = 'AWSCognitoIdentityProviderASF/*.h'
   s.source_files = 'AWSCognitoIdentityProviderASF/**/*.{h,m,c}'
   s.private_header_files = 'AWSCognitoIdentityProviderASF/Internal/*.h'

--- a/AWSCognitoIdentityProviderASF/Info.plist
+++ b/AWSCognitoIdentityProviderASF/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSComprehend.podspec
+++ b/AWSComprehend.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSComprehend'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSComprehend/*.{h,m}'
 end

--- a/AWSComprehend/AWSComprehendService.m
+++ b/AWSComprehend/AWSComprehendService.m
@@ -25,7 +25,7 @@
 #import "AWSComprehendResources.h"
 
 static NSString *const AWSInfoComprehend = @"Comprehend";
-NSString *const AWSComprehendSDKVersion = @"2.32.0";
+NSString *const AWSComprehendSDKVersion = @"2.31.1";
 
 
 @interface AWSComprehendResponseSerializer : AWSJSONResponseSerializer

--- a/AWSComprehend/Info.plist
+++ b/AWSComprehend/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSConnect.podspec
+++ b/AWSConnect.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSConnect'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSConnect/*.{h,m}'
 end

--- a/AWSConnect/AWSConnectService.m
+++ b/AWSConnect/AWSConnectService.m
@@ -25,7 +25,7 @@
 #import "AWSConnectResources.h"
 
 static NSString *const AWSInfoConnect = @"Connect";
-NSString *const AWSConnectSDKVersion = @"2.32.0";
+NSString *const AWSConnectSDKVersion = @"2.31.1";
 
 
 @interface AWSConnectResponseSerializer : AWSJSONResponseSerializer

--- a/AWSConnect/Info.plist
+++ b/AWSConnect/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSConnectParticipant.podspec
+++ b/AWSConnectParticipant.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSConnectParticipant'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSConnectParticipant/*.{h,m}'
 end

--- a/AWSConnectParticipant/AWSConnectParticipantService.m
+++ b/AWSConnectParticipant/AWSConnectParticipantService.m
@@ -25,7 +25,7 @@
 #import "AWSConnectParticipantResources.h"
 
 static NSString *const AWSInfoConnectParticipant = @"ConnectParticipant";
-NSString *const AWSConnectParticipantSDKVersion = @"2.32.0";
+NSString *const AWSConnectParticipantSDKVersion = @"2.31.1";
 
 
 @interface AWSConnectParticipantResponseSerializer : AWSJSONResponseSerializer

--- a/AWSConnectParticipant/Info.plist
+++ b/AWSConnectParticipant/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AWSCore'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'

--- a/AWSCore/Info.plist
+++ b/AWSCore/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -21,7 +21,7 @@
 #import "AWSCocoaLumberjack.h"
 #import "AWSCategory.h"
 
-NSString *const AWSiOSSDKVersion = @"2.32.0";
+NSString *const AWSiOSSDKVersion = @"2.31.1";
 NSString *const AWSServiceErrorDomain = @"com.amazonaws.AWSServiceErrorDomain";
 
 static NSString *const AWSServiceConfigurationUnknown = @"Unknown";

--- a/AWSDynamoDB.podspec
+++ b/AWSDynamoDB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSDynamoDB'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSDynamoDB/*.{h,m}'
 end

--- a/AWSDynamoDB/AWSDynamoDBService.m
+++ b/AWSDynamoDB/AWSDynamoDBService.m
@@ -26,7 +26,7 @@
 #import "AWSDynamoDBRequestRetryHandler.h"
 
 static NSString *const AWSInfoDynamoDB = @"DynamoDB";
-NSString *const AWSDynamoDBSDKVersion = @"2.32.0";
+NSString *const AWSDynamoDBSDKVersion = @"2.31.1";
 
 
 @interface AWSDynamoDBResponseSerializer : AWSJSONResponseSerializer

--- a/AWSDynamoDB/Info.plist
+++ b/AWSDynamoDB/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSEC2.podspec
+++ b/AWSEC2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSEC2'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSEC2/*.{h,m}'
 end

--- a/AWSEC2/AWSEC2Service.m
+++ b/AWSEC2/AWSEC2Service.m
@@ -26,7 +26,7 @@
 #import "AWSEC2Serializer.h"
 
 static NSString *const AWSInfoEC2 = @"EC2";
-NSString *const AWSEC2SDKVersion = @"2.32.0";
+NSString *const AWSEC2SDKVersion = @"2.31.1";
 
 
 @interface AWSEC2ResponseSerializer : AWSXMLResponseSerializer

--- a/AWSEC2/Info.plist
+++ b/AWSEC2/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSElasticLoadBalancing.podspec
+++ b/AWSElasticLoadBalancing.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSElasticLoadBalancing'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSElasticLoadBalancing/*.{h,m}'
 end

--- a/AWSElasticLoadBalancing/AWSElasticLoadBalancingService.m
+++ b/AWSElasticLoadBalancing/AWSElasticLoadBalancingService.m
@@ -25,7 +25,7 @@
 #import "AWSElasticLoadBalancingResources.h"
 
 static NSString *const AWSInfoElasticLoadBalancing = @"ElasticLoadBalancing";
-NSString *const AWSElasticLoadBalancingSDKVersion = @"2.32.0";
+NSString *const AWSElasticLoadBalancingSDKVersion = @"2.31.1";
 
 
 @interface AWSElasticLoadBalancingResponseSerializer : AWSXMLResponseSerializer

--- a/AWSElasticLoadBalancing/Info.plist
+++ b/AWSElasticLoadBalancing/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSFacebookSignIn.podspec
+++ b/AWSFacebookSignIn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSFacebookSignIn'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true
-   s.dependency 'AWSAuthCore', '2.32.0'
-   s.dependency 'AWSCore', '2.32.0'
+   s.dependency 'AWSAuthCore', '2.31.1'
+   s.dependency 'AWSCore', '2.31.1'
    s.dependency 'FBSDKLoginKit', '9.0'
    s.dependency 'FBSDKCoreKit', '9.0'
 

--- a/AWSGoogleSignIn.podspec
+++ b/AWSGoogleSignIn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSGoogleSignIn'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true
-   s.dependency 'AWSAuthCore', '2.32.0'
-   s.dependency 'AWSCore', '2.32.0'
+   s.dependency 'AWSAuthCore', '2.31.1'
+   s.dependency 'AWSCore', '2.31.1'
    s.source_files = 'AWSAuthSDK/Sources/AWSGoogleSignIn/*.{h,m}', 'AWSAuthSDK/Dependencies/GoogleHeaders/*.h'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSGoogleSignIn/*.h'
    s.private_header_files = 'AWSAuthSDK/Dependencies/GoogleHeaders/*.h'

--- a/AWSIoT.podspec
+++ b/AWSIoT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSIoT'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSIoT/*.{h,m}', 'AWSIoT/**/*.{h,m}'
   s.private_header_files = 'AWSIoT/Internal/*.h'
 end

--- a/AWSIoT/AWSIoTDataService.m
+++ b/AWSIoT/AWSIoTDataService.m
@@ -25,7 +25,7 @@
 #import "AWSIoTDataResources.h"
 
 static NSString *const AWSInfoIoTData = @"IoTData";
-NSString *const AWSIoTDataSDKVersion = @"2.32.0";
+NSString *const AWSIoTDataSDKVersion = @"2.31.1";
 
 
 @interface AWSIoTDataResponseSerializer : AWSJSONResponseSerializer

--- a/AWSIoT/AWSIoTService.m
+++ b/AWSIoT/AWSIoTService.m
@@ -25,7 +25,7 @@
 #import "AWSIoTResources.h"
 
 static NSString *const AWSInfoIoT = @"IoT";
-NSString *const AWSIoTSDKVersion = @"2.32.0";
+NSString *const AWSIoTSDKVersion = @"2.31.1";
 
 
 @interface AWSIoTResponseSerializer : AWSJSONResponseSerializer

--- a/AWSIoT/Info.plist
+++ b/AWSIoT/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSKMS.podspec
+++ b/AWSKMS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSKMS'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSKMS/*.{h,m}'
 end

--- a/AWSKMS/AWSKMSService.m
+++ b/AWSKMS/AWSKMSService.m
@@ -25,7 +25,7 @@
 #import "AWSKMSResources.h"
 
 static NSString *const AWSInfoKMS = @"KMS";
-NSString *const AWSKMSSDKVersion = @"2.32.0";
+NSString *const AWSKMSSDKVersion = @"2.31.1";
 
 
 @interface AWSKMSResponseSerializer : AWSJSONResponseSerializer

--- a/AWSKMS/Info.plist
+++ b/AWSKMS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSKinesis.podspec
+++ b/AWSKinesis.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSKinesis'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSKinesis/*.{h,m}', 'AWSKinesis/**/*.{h,m}'
   s.private_header_files = 'AWSKinesis/Internal/*.h'
 end

--- a/AWSKinesis/AWSFirehoseService.m
+++ b/AWSKinesis/AWSFirehoseService.m
@@ -26,7 +26,7 @@
 #import "AWSFirehoseSerializer.h"
 
 static NSString *const AWSInfoFirehose = @"Firehose";
-NSString *const AWSFirehoseSDKVersion = @"2.32.0";
+NSString *const AWSFirehoseSDKVersion = @"2.31.1";
 
 
 @interface AWSFirehoseResponseSerializer : AWSJSONResponseSerializer

--- a/AWSKinesis/AWSKinesisService.m
+++ b/AWSKinesis/AWSKinesisService.m
@@ -28,7 +28,7 @@
 #import "AWSKinesisSerializer.h"
 
 static NSString *const AWSInfoKinesis = @"Kinesis";
-NSString *const AWSKinesisSDKVersion = @"2.32.0";
+NSString *const AWSKinesisSDKVersion = @"2.31.1";
 
 
 @interface AWSKinesisResponseSerializer : AWSJSONResponseSerializer

--- a/AWSKinesis/Info.plist
+++ b/AWSKinesis/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSKinesisVideo.podspec
+++ b/AWSKinesisVideo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSKinesisVideo'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSKinesisVideo/*.{h,m}'
 end

--- a/AWSKinesisVideo/AWSKinesisVideoService.m
+++ b/AWSKinesisVideo/AWSKinesisVideoService.m
@@ -25,7 +25,7 @@
 #import "AWSKinesisVideoResources.h"
 
 static NSString *const AWSInfoKinesisVideo = @"KinesisVideo";
-NSString *const AWSKinesisVideoSDKVersion = @"2.32.0";
+NSString *const AWSKinesisVideoSDKVersion = @"2.31.1";
 
 
 @interface AWSKinesisVideoResponseSerializer : AWSJSONResponseSerializer

--- a/AWSKinesisVideo/Info.plist
+++ b/AWSKinesisVideo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSKinesisVideoArchivedMedia.podspec
+++ b/AWSKinesisVideoArchivedMedia.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSKinesisVideoArchivedMedia'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSKinesisVideoArchivedMedia/*.{h,m}'
 end

--- a/AWSKinesisVideoArchivedMedia/AWSKinesisVideoArchivedMediaService.m
+++ b/AWSKinesisVideoArchivedMedia/AWSKinesisVideoArchivedMediaService.m
@@ -25,7 +25,7 @@
 #import "AWSKinesisVideoArchivedMediaResources.h"
 
 static NSString *const AWSInfoKinesisVideoArchivedMedia = @"KinesisVideoArchivedMedia";
-NSString *const AWSKinesisVideoArchivedMediaSDKVersion = @"2.32.0";
+NSString *const AWSKinesisVideoArchivedMediaSDKVersion = @"2.31.1";
 
 
 @interface AWSKinesisVideoArchivedMediaResponseSerializer : AWSJSONResponseSerializer

--- a/AWSKinesisVideoArchivedMedia/Info.plist
+++ b/AWSKinesisVideoArchivedMedia/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSKinesisVideoSignaling.podspec
+++ b/AWSKinesisVideoSignaling.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSKinesisVideoSignaling'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSKinesisVideoSignaling/*.{h,m}'
 end

--- a/AWSKinesisVideoSignaling/AWSKinesisVideoSignalingService.m
+++ b/AWSKinesisVideoSignaling/AWSKinesisVideoSignalingService.m
@@ -25,7 +25,7 @@
 #import "AWSKinesisVideoSignalingResources.h"
 
 static NSString *const AWSInfoKinesisVideoSignaling = @"KinesisVideoSignaling";
-NSString *const AWSKinesisVideoSignalingSDKVersion = @"2.32.0";
+NSString *const AWSKinesisVideoSignalingSDKVersion = @"2.31.1";
 
 
 @interface AWSKinesisVideoSignalingResponseSerializer : AWSJSONResponseSerializer

--- a/AWSKinesisVideoSignaling/Info.plist
+++ b/AWSKinesisVideoSignaling/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSKinesisVideoWebRTCStorage.podspec
+++ b/AWSKinesisVideoWebRTCStorage.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSKinesisVideoWebRTCStorage'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSKinesisVideoWebRTCStorage/*.{h,m}'
 end

--- a/AWSLambda.podspec
+++ b/AWSLambda.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSLambda'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSLambda/*.{h,m}'
 end

--- a/AWSLambda/AWSLambdaService.m
+++ b/AWSLambda/AWSLambdaService.m
@@ -26,7 +26,7 @@
 #import "AWSLambdaRequestRetryHandler.h"
 
 static NSString *const AWSInfoLambda = @"Lambda";
-NSString *const AWSLambdaSDKVersion = @"2.32.0";
+NSString *const AWSLambdaSDKVersion = @"2.31.1";
 
 
 @interface AWSLambdaResponseSerializer : AWSJSONResponseSerializer

--- a/AWSLambda/Info.plist
+++ b/AWSLambda/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSLex.podspec
+++ b/AWSLex.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSLex'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSLex/*.{h,m}', 'AWSLex/Bluefront/include/*.h'
   s.public_header_files = 'AWSLex/*.h'
   s.private_header_files = 'AWSLex/Bluefront/include/*.h'

--- a/AWSLex/AWSLexInteractionKit.m
+++ b/AWSLex/AWSLexInteractionKit.m
@@ -22,7 +22,7 @@
 #import <AVFoundation/AVFoundation.h>
 
 NSString *const AWSInfoInteractionKit = @"LexInteractionKit";
-NSString *const AWSInteractionKitSDKVersion = @"2.32.0";
+NSString *const AWSInteractionKitSDKVersion = @"2.31.1";
 NSString *const AWSInternalLexInteractionKit = @"LexInteractionKitClient";
 NSString *const AWSLexInteractionKitUserAgent = @"interactionkit";
 NSString *const AWSLexInteractionKitErrorDomain = @"com.amazonaws.AWSLexInteractionKitErrorDomain";

--- a/AWSLex/AWSLexService.m
+++ b/AWSLex/AWSLexService.m
@@ -27,7 +27,7 @@
 #import "AWSLexSignature.h"
 
 static NSString *const AWSInfoLex = @"Lex";
-NSString *const AWSLexSDKVersion = @"2.32.0";
+NSString *const AWSLexSDKVersion = @"2.31.1";
 
 
 @interface AWSLexResponseSerializer : AWSJSONResponseSerializer

--- a/AWSLex/Info.plist
+++ b/AWSLex/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSLocation.podspec
+++ b/AWSLocation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSLocation'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSLocation/*.{h,m}', 'AWSLocation/AWSLocationTracker/**/*.swift'
 end

--- a/AWSLocation/AWSLocationService.m
+++ b/AWSLocation/AWSLocationService.m
@@ -25,7 +25,7 @@
 #import "AWSLocationResources.h"
 
 static NSString *const AWSInfoLocation = @"Location";
-NSString *const AWSLocationSDKVersion = @"2.32.0";
+NSString *const AWSLocationSDKVersion = @"2.31.1";
 
 
 @interface AWSLocationResponseSerializer : AWSJSONResponseSerializer

--- a/AWSLocation/Info.plist
+++ b/AWSLocation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSLocationXCF/Info.plist
+++ b/AWSLocationXCF/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSLogs.podspec
+++ b/AWSLogs.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSLogs'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSLogs/*.{h,m}'
 end

--- a/AWSLogs/AWSLogsService.m
+++ b/AWSLogs/AWSLogsService.m
@@ -25,7 +25,7 @@
 #import "AWSLogsResources.h"
 
 static NSString *const AWSInfoLogs = @"Logs";
-NSString *const AWSLogsSDKVersion = @"2.32.0";
+NSString *const AWSLogsSDKVersion = @"2.31.1";
 
 
 @interface AWSLogsResponseSerializer : AWSJSONResponseSerializer

--- a/AWSLogs/Info.plist
+++ b/AWSLogs/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSMachineLearning.podspec
+++ b/AWSMachineLearning.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSMachineLearning'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSMachineLearning/*.{h,m}'
 end

--- a/AWSMachineLearning/AWSMachineLearningService.m
+++ b/AWSMachineLearning/AWSMachineLearningService.m
@@ -26,7 +26,7 @@
 #import "AWSMachineLearningResources.h"
 
 static NSString *const AWSInfoMachineLearning = @"MachineLearning";
-NSString *const AWSMachineLearningSDKVersion = @"2.32.0";
+NSString *const AWSMachineLearningSDKVersion = @"2.31.1";
 
 
 @interface AWSMachineLearningResponseSerializer : AWSJSONResponseSerializer

--- a/AWSMachineLearning/Info.plist
+++ b/AWSMachineLearning/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSMobileClient.podspec
+++ b/AWSMobileClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSMobileClient'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -13,14 +13,14 @@ Pod::Spec.new do |s|
                       :tag => s.version}
    s.requires_arc = true
 
-   s.dependency 'AWSAuthCore', '2.32.0'
-   s.dependency 'AWSCognitoIdentityProvider', '2.32.0'
+   s.dependency 'AWSAuthCore', '2.31.1'
+   s.dependency 'AWSCognitoIdentityProvider', '2.31.1'
 
    # Include transitive dependencies to help CocoaPods resolve deeply nested
    # dependency graphs; without this we get sporadic failures compiling when a
    # project relies on AWSMobileClient
-   s.dependency 'AWSCore', '2.32.0'
-   s.dependency 'AWSCognitoIdentityProviderASF', '2.32.0'
+   s.dependency 'AWSCore', '2.31.1'
+   s.dependency 'AWSCognitoIdentityProviderASF', '2.31.1'
 
    s.source_files = 'AWSAuthSDK/Sources/AWSMobileClient/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/**/*.swift', 'AWSCognitoAuth/**/*.{h,m,c}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h', 'AWSCognitoAuth/*.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h'

--- a/AWSPinpoint.podspec
+++ b/AWSPinpoint.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSPinpoint'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSPinpoint/*.{h,m}', 'AWSPinpoint/**/*.{h,m}'
   s.private_header_files = 'AWSPinpoint/Internal/*.h'
 end

--- a/AWSPinpoint/AWSPinpointTargeting/AWSPinpointTargetingService.m
+++ b/AWSPinpoint/AWSPinpointTargeting/AWSPinpointTargetingService.m
@@ -25,7 +25,7 @@
 #import "AWSPinpointTargetingResources.h"
 
 static NSString *const AWSInfoPinpointTargeting = @"PinpointTargeting";
-NSString *const AWSPinpointTargetingSDKVersion = @"2.32.0";
+NSString *const AWSPinpointTargetingSDKVersion = @"2.31.1";
 
 
 @interface AWSPinpointTargetingResponseSerializer : AWSJSONResponseSerializer

--- a/AWSPinpoint/Info.plist
+++ b/AWSPinpoint/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSPolly.podspec
+++ b/AWSPolly.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSPolly'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSPolly/*.{h,m}'
 end

--- a/AWSPolly/AWSPollyService.m
+++ b/AWSPolly/AWSPollyService.m
@@ -25,7 +25,7 @@
 #import "AWSPollyResources.h"
 
 static NSString *const AWSInfoPolly = @"Polly";
-NSString *const AWSPollySDKVersion = @"2.32.0";
+NSString *const AWSPollySDKVersion = @"2.31.1";
 
 
 @interface AWSPollyResponseSerializer : AWSJSONResponseSerializer

--- a/AWSPolly/AWSPollySynthesizeSpeechURLBuilder.m
+++ b/AWSPolly/AWSPollySynthesizeSpeechURLBuilder.m
@@ -16,7 +16,7 @@
 #import "AWSPollySynthesizeSpeechURLBuilder.h"
 
 static NSString *const AWSInfoPollySynthesizeSpeechURLBuilder = @"PollySynthesizeSpeechUrlBuilder";
-static NSString *const AWSPollySDKVersion = @"2.32.0";
+static NSString *const AWSPollySDKVersion = @"2.31.1";
 
 NSString *const AWSPollySynthesizeSpeechURLBuilderErrorDomain = @"com.amazonaws.AWSPollySynthesizeSpeechURLBuilderErrorDomain";
 NSString *const AWSPollyPresignedUrlPath = @"v1/speech";

--- a/AWSPolly/Info.plist
+++ b/AWSPolly/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSRekognition.podspec
+++ b/AWSRekognition.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSRekognition'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSRekognition/*.{h,m}'
 end

--- a/AWSRekognition/AWSRekognitionService.m
+++ b/AWSRekognition/AWSRekognitionService.m
@@ -25,7 +25,7 @@
 #import "AWSRekognitionResources.h"
 
 static NSString *const AWSInfoRekognition = @"Rekognition";
-NSString *const AWSRekognitionSDKVersion = @"2.32.0";
+NSString *const AWSRekognitionSDKVersion = @"2.31.1";
 
 
 @interface AWSRekognitionResponseSerializer : AWSJSONResponseSerializer

--- a/AWSRekognition/Info.plist
+++ b/AWSRekognition/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSS3.podspec
+++ b/AWSS3.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSS3'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSS3/*.{h,m}'
 end

--- a/AWSS3/AWSS3PreSignedURL.m
+++ b/AWSS3/AWSS3PreSignedURL.m
@@ -26,7 +26,7 @@ NSString *const AWSS3PresignedURLErrorDomain = @"com.amazonaws.AWSS3PresignedURL
 static NSString *const AWSS3PreSignedURLBuilderAcceleratedEndpoint = @"s3-accelerate.amazonaws.com";
 
 static NSString *const AWSInfoS3PreSignedURLBuilder = @"S3PreSignedURLBuilder";
-static NSString *const AWSS3PreSignedURLBuilderSDKVersion = @"2.32.0";
+static NSString *const AWSS3PreSignedURLBuilderSDKVersion = @"2.31.1";
 
 @interface AWSS3PreSignedURLBuilder()
 

--- a/AWSS3/AWSS3Service.m
+++ b/AWSS3/AWSS3Service.m
@@ -27,7 +27,7 @@
 #import "AWSS3Serializer.h"
 
 static NSString *const AWSInfoS3 = @"S3";
-NSString *const AWSS3SDKVersion = @"2.32.0";
+NSString *const AWSS3SDKVersion = @"2.31.1";
 
 
 

--- a/AWSS3/Info.plist
+++ b/AWSS3/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSSES.podspec
+++ b/AWSSES.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSSES'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSSES/*.{h,m}'
 end

--- a/AWSSES/AWSSESService.m
+++ b/AWSSES/AWSSESService.m
@@ -25,7 +25,7 @@
 #import "AWSSESResources.h"
 
 static NSString *const AWSInfoSES = @"SES";
-NSString *const AWSSESSDKVersion = @"2.32.0";
+NSString *const AWSSESSDKVersion = @"2.31.1";
 
 
 @interface AWSSESResponseSerializer : AWSXMLResponseSerializer

--- a/AWSSES/Info.plist
+++ b/AWSSES/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSSNS.podspec
+++ b/AWSSNS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSSNS'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSSNS/*.{h,m}'
 end

--- a/AWSSNS/AWSSNSService.m
+++ b/AWSSNS/AWSSNSService.m
@@ -25,7 +25,7 @@
 #import "AWSSNSResources.h"
 
 static NSString *const AWSInfoSNS = @"SNS";
-NSString *const AWSSNSSDKVersion = @"2.32.0";
+NSString *const AWSSNSSDKVersion = @"2.31.1";
 
 
 @interface AWSSNSResponseSerializer : AWSXMLResponseSerializer

--- a/AWSSNS/Info.plist
+++ b/AWSSNS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSSQS.podspec
+++ b/AWSSQS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSSQS'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSSQS/*.{h,m}'
 end

--- a/AWSSQS/AWSSQSService.m
+++ b/AWSSQS/AWSSQSService.m
@@ -25,7 +25,7 @@
 #import "AWSSQSResources.h"
 
 static NSString *const AWSInfoSQS = @"SQS";
-NSString *const AWSSQSSDKVersion = @"2.32.0";
+NSString *const AWSSQSSDKVersion = @"2.31.1";
 
 
 @interface AWSSQSResponseSerializer : AWSXMLResponseSerializer

--- a/AWSSQS/Info.plist
+++ b/AWSSQS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSSageMakerRuntime.podspec
+++ b/AWSSageMakerRuntime.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSSageMakerRuntime'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSSageMakerRuntime/*.{h,m}'
 end

--- a/AWSSageMakerRuntime/AWSSageMakerRuntimeService.m
+++ b/AWSSageMakerRuntime/AWSSageMakerRuntimeService.m
@@ -25,7 +25,7 @@
 #import "AWSSageMakerRuntimeResources.h"
 
 static NSString *const AWSInfoSageMakerRuntime = @"SageMakerRuntime";
-NSString *const AWSSageMakerRuntimeSDKVersion = @"2.32.0";
+NSString *const AWSSageMakerRuntimeSDKVersion = @"2.31.1";
 
 
 @interface AWSSageMakerRuntimeResponseSerializer : AWSJSONResponseSerializer

--- a/AWSSageMakerRuntime/Info.plist
+++ b/AWSSageMakerRuntime/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSSimpleDB.podspec
+++ b/AWSSimpleDB.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSSimpleDB'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSSimpleDB/*.{h,m}'
 end

--- a/AWSSimpleDB/AWSSimpleDBService.m
+++ b/AWSSimpleDB/AWSSimpleDBService.m
@@ -25,7 +25,7 @@
 #import "AWSSimpleDBResources.h"
 
 static NSString *const AWSInfoSimpleDB = @"SimpleDB";
-NSString *const AWSSimpleDBSDKVersion = @"2.32.0";
+NSString *const AWSSimpleDBSDKVersion = @"2.31.1";
 
 
 @interface AWSSimpleDBResponseSerializer : AWSXMLResponseSerializer

--- a/AWSSimpleDB/Info.plist
+++ b/AWSSimpleDB/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSTextract.podspec
+++ b/AWSTextract.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSTextract'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSTextract/*.{h,m}'
 end

--- a/AWSTextract/AWSTextractService.m
+++ b/AWSTextract/AWSTextractService.m
@@ -25,7 +25,7 @@
 #import "AWSTextractResources.h"
 
 static NSString *const AWSInfoTextract = @"Textract";
-NSString *const AWSTextractSDKVersion = @"2.32.0";
+NSString *const AWSTextractSDKVersion = @"2.31.1";
 
 
 @interface AWSTextractResponseSerializer : AWSJSONResponseSerializer

--- a/AWSTextract/Info.plist
+++ b/AWSTextract/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSTranscribe.podspec
+++ b/AWSTranscribe.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSTranscribe'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSTranscribe/*.{h,m}'
 end

--- a/AWSTranscribe/AWSTranscribeService.m
+++ b/AWSTranscribe/AWSTranscribeService.m
@@ -25,7 +25,7 @@
 #import "AWSTranscribeResources.h"
 
 static NSString *const AWSInfoTranscribe = @"Transcribe";
-NSString *const AWSTranscribeSDKVersion = @"2.32.0";
+NSString *const AWSTranscribeSDKVersion = @"2.31.1";
 
 
 @interface AWSTranscribeResponseSerializer : AWSJSONResponseSerializer

--- a/AWSTranscribe/Info.plist
+++ b/AWSTranscribe/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSTranscribeStreaming.podspec
+++ b/AWSTranscribeStreaming.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSTranscribeStreaming'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSTranscribeStreaming/*.{h,m}', 'AWSTranscribeStreaming/**/*.{h,m}', 'AWSIoT/Internal/SocketRocket/*.{h,m}'
   s.private_header_files = 'AWSTranscribeStreaming/Internal/*.h', 'AWSIoT/Internal/SocketRocket/*.h'
 end

--- a/AWSTranscribeStreaming/AWSTranscribeStreamingService.m
+++ b/AWSTranscribeStreaming/AWSTranscribeStreamingService.m
@@ -33,7 +33,7 @@
 NSString *const AWSTranscribeStreamingClientErrorDomain = @"com.amazonaws.AWSTranscribeStreamingClientErrorDomain";
 
 static NSString *const AWSInfoTranscribeStreaming = @"TranscribeStreaming";
-NSString *const AWSTranscribeStreamingSDKVersion = @"2.32.0";
+NSString *const AWSTranscribeStreamingSDKVersion = @"2.31.1";
 
 @interface AWSTranscribeStreamingResponseSerializer : AWSJSONResponseSerializer
 

--- a/AWSTranscribeStreaming/Info.plist
+++ b/AWSTranscribeStreaming/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSTranslate.podspec
+++ b/AWSTranslate.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'AWSTranslate'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true
-  s.dependency 'AWSCore', '2.32.0'
+  s.dependency 'AWSCore', '2.31.1'
   s.source_files = 'AWSTranslate/*.{h,m}'
 end

--- a/AWSTranslate/AWSTranslateService.m
+++ b/AWSTranslate/AWSTranslateService.m
@@ -25,7 +25,7 @@
 #import "AWSTranslateResources.h"
 
 static NSString *const AWSInfoTranslate = @"Translate";
-NSString *const AWSTranslateSDKVersion = @"2.32.0";
+NSString *const AWSTranslateSDKVersion = @"2.31.1";
 
 
 @interface AWSTranslateResponseSerializer : AWSJSONResponseSerializer

--- a/AWSTranslate/Info.plist
+++ b/AWSTranslate/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.32.0</string>
+	<string>2.31.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/AWSUserPoolsSignIn.podspec
+++ b/AWSUserPoolsSignIn.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name         = 'AWSUserPoolsSignIn'
-   s.version      = '2.32.0'
+   s.version      = '2.31.1'
    s.summary      = 'Amazon Web Services SDK for iOS.'
  
    s.description  = 'The AWS SDK for iOS provides a library, code samples, and documentation for developers to build connected mobile applications using AWS.'
@@ -12,9 +12,9 @@ Pod::Spec.new do |s|
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true
-   s.dependency 'AWSCognitoIdentityProvider', '2.32.0'
-   s.dependency 'AWSAuthCore', '2.32.0'
-   s.dependency 'AWSCore', '2.32.0'
+   s.dependency 'AWSCognitoIdentityProvider', '2.31.1'
+   s.dependency 'AWSAuthCore', '2.31.1'
+   s.dependency 'AWSCore', '2.31.1'
    s.source_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/**/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/*.{h}'
    s.private_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/*.{h}'

--- a/AWSiOSSDKv2.podspec
+++ b/AWSiOSSDKv2.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'AWSiOSSDKv2'
-  s.version      = '2.32.0'
+  s.version      = '2.31.1'
   s.summary      = 'Amazon Web Services SDK for iOS.'
 
   s.deprecated = true
@@ -18,135 +18,135 @@ Pod::Spec.new do |s|
 
   # Used by many of the service-api subspecs
   s.subspec 'AWSCognitoIdentityProvider' do |sub|
-    sub.dependency 'AWSCognitoIdentityProvider', '2.32.0'
+    sub.dependency 'AWSCognitoIdentityProvider', '2.31.1'
   end
 
   # Used by all service-api subspecs
   s.subspec 'AWSCore' do |sub|
-    sub.dependency 'AWSCore', '2.32.0'
+    sub.dependency 'AWSCore', '2.31.1'
   end
 
   # Service-api subspecs
   s.subspec 'AWSAPIGateway' do |sub|
-    sub.dependency 'AWSAPIGateway', '2.32.0'
+    sub.dependency 'AWSAPIGateway', '2.31.1'
   end
 
   s.subspec 'AutoScaling' do |sub|
-    sub.dependency 'AWSAutoScaling', '2.32.0'
+    sub.dependency 'AWSAutoScaling', '2.31.1'
   end
 
   s.subspec 'CloudWatch' do |sub|
-    sub.dependency 'AWSCloudWatch', '2.32.0'
+    sub.dependency 'AWSCloudWatch', '2.31.1'
   end
 
   s.subspec 'AWSComprehend' do |sub|
-    sub.dependency 'AWSComprehend', '2.32.0'
+    sub.dependency 'AWSComprehend', '2.31.1'
   end
 
   s.subspec 'AWSConnect' do |sub|
-    sub.dependency 'AWSConnect', '2.32.0'
+    sub.dependency 'AWSConnect', '2.31.1'
   end
 
   s.subspec 'AWSConnectParticipant' do |sub|
-    sub.dependency 'AWSConnectParticipant', '2.32.0'
+    sub.dependency 'AWSConnectParticipant', '2.31.1'
   end
 
   s.subspec 'DynamoDB' do |sub|
-    sub.dependency 'AWSDynamoDB', '2.32.0'
+    sub.dependency 'AWSDynamoDB', '2.31.1'
   end
 
   s.subspec 'EC2' do |sub|
-    sub.dependency 'AWSEC2', '2.32.0'
+    sub.dependency 'AWSEC2', '2.31.1'
   end
 
   s.subspec 'ElasticLoadBalancing' do |sub|
-    sub.dependency 'AWSElasticLoadBalancing', '2.32.0'
+    sub.dependency 'AWSElasticLoadBalancing', '2.31.1'
   end
 
   s.subspec 'AWSIoT' do |sub|
-    sub.dependency 'AWSIoT', '2.32.0'
+    sub.dependency 'AWSIoT', '2.31.1'
   end
 
   s.subspec 'AWSKMS' do |sub|
-    sub.dependency 'AWSKMS', '2.32.0'
+    sub.dependency 'AWSKMS', '2.31.1'
   end
 
   s.subspec 'Kinesis' do |sub|
-    sub.dependency 'AWSKinesis', '2.32.0'
+    sub.dependency 'AWSKinesis', '2.31.1'
   end
 
   # KinesisVideo not released as part of AWSiOSSDKv2
   # KinesisVideoArchivedMedia not released as part of AWSiOSSDKv2
 
   s.subspec 'KinesisVideoSignaling' do |sub|
-    sub.dependency 'AWSKinesisVideoSignaling', '2.32.0'
+    sub.dependency 'AWSKinesisVideoSignaling', '2.31.1'
   end
 
   s.subspec 'AWSLambda' do |sub|
-    sub.dependency 'AWSLambda', '2.32.0'
+    sub.dependency 'AWSLambda', '2.31.1'
   end
 
   s.subspec 'AWSLex' do |sub|
-    sub.dependency 'AWSLex', '2.32.0'
+    sub.dependency 'AWSLex', '2.31.1'
   end
 
   s.subspec 'AWSLogs' do |sub|
-    sub.dependency 'AWSLogs', '2.32.0'
+    sub.dependency 'AWSLogs', '2.31.1'
   end
 
   s.subspec 'AWSMachineLearning' do |sub|
-    sub.dependency 'AWSMachineLearning', '2.32.0'
+    sub.dependency 'AWSMachineLearning', '2.31.1'
   end
 
   s.subspec 'Pinpoint' do |sub|
-    sub.dependency 'AWSPinpoint', '2.32.0'
+    sub.dependency 'AWSPinpoint', '2.31.1'
   end
 
   s.subspec 'AWSPolly' do |sub|
-    sub.dependency 'AWSPolly', '2.32.0'
+    sub.dependency 'AWSPolly', '2.31.1'
   end
 
   s.subspec 'AWSRekognition' do |sub|
-    sub.dependency 'AWSRekognition', '2.32.0'
+    sub.dependency 'AWSRekognition', '2.31.1'
   end
 
   s.subspec 'AWSS3' do |sub|
-    sub.dependency 'AWSS3', '2.32.0'
+    sub.dependency 'AWSS3', '2.31.1'
   end
 
   s.subspec 'AWSSES' do |sub|
-    sub.dependency 'AWSSES', '2.32.0'
+    sub.dependency 'AWSSES', '2.31.1'
   end
 
   s.subspec 'AWSSNS' do |sub|
-    sub.dependency 'AWSSNS', '2.32.0'
+    sub.dependency 'AWSSNS', '2.31.1'
   end
 
   s.subspec 'AWSSQS' do |sub|
-    sub.dependency 'AWSSQS', '2.32.0'
+    sub.dependency 'AWSSQS', '2.31.1'
   end
   
   s.subspec 'AWSSageMakerRuntime' do |sub|
-    sub.dependency 'AWSSageMakerRuntime', '2.32.0'
+    sub.dependency 'AWSSageMakerRuntime', '2.31.1'
   end
 
   s.subspec 'AWSSimpleDB' do |sub|
-    sub.dependency 'AWSSimpleDB', '2.32.0'
+    sub.dependency 'AWSSimpleDB', '2.31.1'
   end
 
   s.subspec 'AWSTextract' do |sub|
-    sub.dependency 'AWSTextract', '2.32.0'
+    sub.dependency 'AWSTextract', '2.31.1'
   end
   
   s.subspec 'AWSTranscribe' do |sub|
-    sub.dependency 'AWSTranscribe', '2.32.0'
+    sub.dependency 'AWSTranscribe', '2.31.1'
   end
 
   # note that AWSTranscribeStreaming requires iOS 9.0 or higher, and is
   # therefore not included as a subspec
 
   s.subspec 'AWSTranslate' do |sub|
-    sub.dependency 'AWSTranslate', '2.32.0'
+    sub.dependency 'AWSTranslate', '2.31.1'
   end
   
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
--Features for next release
-
-## 2.32.0
-
 ### Misc. Updates
 
 - Model updates for the following services

--- a/CircleciScripts/generate_documentation.sh
+++ b/CircleciScripts/generate_documentation.sh
@@ -6,7 +6,7 @@
 
 set -x
 
-SDK_VERSION="2.32.0"
+SDK_VERSION="2.31.1"
 
 GITHUB_DOC_ROOT=https://aws-amplify.github.io
 GITHUB_SOURCE_ROOT=https://github.com/aws-amplify/aws-sdk-ios


### PR DESCRIPTION
Reverting the 2.32.0 release due to new framework not able to build correctly. 

*Issue #, if available:*

*Description of changes:*

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
