### PR TITLE
ci: update clone gh-pages branch script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,6 +503,7 @@ jobs:
           name: Copy documents
           command: |
             git config --local user.name "AWS"
+            git remote set-branches --add origin 'gh-pages'
             git fetch --depth 1 origin gh-pages
             git checkout gh-pages
             rm -rf docs/reference
@@ -527,6 +528,7 @@ jobs:
           name: Add documentation tags to gh-pages
           command: |
             git config --local user.name "AWS"
+            git remote set-branches --add origin 'gh-pages'
             git fetch --depth 1 origin gh-pages
             git checkout gh-pages
             git tag -a ${CIRCLE_TAG}_api_docs -m "Add documentation tags to version ${CIRCLE_TAG}"


### PR DESCRIPTION
*Issue #, if available:*

`gh-pages` cloning script failed because it is not added as a remote branch.

*Description of changes:*

- add commend for adding `gh-pages` as a remote branch

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
