### PR TITLE
fix(AWSAuthUI) Fix keyboard disappearance during sign in, fix black navigation bar

### DIFF
--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -110,30 +110,9 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
 
 #pragma mark - UIViewController
 
-
-- (void)keyboardDidShow:(NSNotification *)notification {
-    CGSize keyboardSize = ((NSValue *)[[notification userInfo]
-                                       valueForKey:UIKeyboardFrameBeginUserInfoKey]).CGRectValue.size;
-    
-    CGPoint buttonOrigin = self.signInButton.frame.origin;
-    CGRect visibleRect = self.view.frame;
-    
-    visibleRect.size.height -= keyboardSize.height;
-    
-    if (visibleRect.size.height < buttonOrigin.y) {
-        [self.view setFrame:CGRectMake(0,visibleRect.size.height - buttonOrigin.y, self.view.frame.size.width, self.view.frame.size.height)];
-    }
-}
-
-- (void)keyboardDidHide:(NSNotification *)notification {
-    [self.view setFrame:CGRectMake(0, NAVIGATION_BAR_HEIGHT ,self.view.frame.size.width,self.view.frame.size.height)];
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
     AWSDDLogDebug(@"Sign-In Loading...");
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
     
     // set up the navigation controller
     [self setUpNavigationController];

--- a/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
+++ b/AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.m
@@ -170,18 +170,6 @@ static NSInteger const SCALED_DOWN_LOGO_IMAGE_HEIGHT = 140;
     [AWSSignInManager sharedInstance].pendingSignIn = NO;
     [AWSSignInManager sharedInstance].pendingUsername = @"";
     [AWSSignInManager sharedInstance].pendingPassword = @"";
-    
-}
-
-// This is used to dismiss the keyboard, user just has to tap outside the
-// user name and password views and it will dismiss
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
-    UITouch *touch = [touches anyObject];
-    if (touch.phase == UITouchPhaseBegan) {
-        [self.view endEditing:YES];
-    }
-    
-    [super touchesBegan:touches withEvent:event];
 }
 
 #pragma mark - Utility Methods

--- a/AWSAuthSDK/Sources/AWSAuthUI/SignIn.storyboard
+++ b/AWSAuthSDK/Sources/AWSAuthUI/SignIn.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,8 +20,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BSJ-TI-rDy">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="BSJ-TI-rDy">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z0I-A0-G5E">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="542"/>

--- a/AWSAuthSDK/Sources/AWSAuthUI/SignIn.storyboard
+++ b/AWSAuthSDK/Sources/AWSAuthUI/SignIn.storyboard
@@ -11,7 +11,7 @@
         <!--Sign-In View Controller-->
         <scene sceneID="7j4-1z-nW1">
             <objects>
-                <viewController storyboardIdentifier="SignIn" title="Sign-In View Controller" id="xc1-Jg-Y5t" customClass="AWSSignInViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignIn" title="Sign-In View Controller" extendedLayoutIncludesOpaqueBars="YES" id="xc1-Jg-Y5t" customClass="AWSSignInViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="iDn-EW-gbn"/>
                         <viewControllerLayoutGuide type="bottom" id="oro-gg-Uv8"/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@
   - AWSSTS
   - AWSTranslate
 
+### Bug Fixes
+- **AWSAuthUI**
+  - Fix ability to hide keyboard in `AWSSignInViewController`, using `keyboardDismissMode`
+  - Fix black navigation bar in `AWSSignInViewController`, using view controllers option to 'Extend edges Under Opaque Bars'.  
+   [Issue #2321](https://github.com/aws-amplify/aws-sdk-ios/issues/2321)
+
 ## 2.33.0
 
 ### Misc. Updates


### PR DESCRIPTION
One of the issues, for black navigation bar: #2321 

*Description of changes:*

In AWSSignInViewController, code handling keyboard dismissal was added in 2017/2018. In the meantime, in a PR #4338  the content inside was wrapped in a ScrollView. This caused `touchesBegan` to not be triggered, and there was no way to dismiss the keyboard, which often covers sign in button, making it pretty hard to sign in.

This PR fixes this by removing not working `touchesBegan`, and instead using ScrollView's `keyboardDismissMode`, set to `drag`.

Also fixes black navigation bar in the same view, using suggestion from https://stackoverflow.com/a/50506540
Original issue, closed with only a workaround listed:
https://github.com/aws-amplify/aws-sdk-ios/issues/2321

Before:
https://github.com/aws-amplify/aws-sdk-ios/assets/3706309/792007db-f662-4bc8-a8bb-e66a7cbf6068

After:
https://github.com/aws-amplify/aws-sdk-ios/assets/3706309/0968f30a-6496-4483-89b0-28d33a7bf069

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
