### PR TITLE
chore: Fixing AWSComprehend integration test

### DIFF
--- a/AWSComprehendTests/AWSComprehendTests.swift
+++ b/AWSComprehendTests/AWSComprehendTests.swift
@@ -138,7 +138,7 @@ class AWSComprehendTests: XCTestCase {
         let comprehendClient = AWSComprehend.default()
         let detectSentimentRequest = AWSComprehendDetectSentimentRequest()
         detectSentimentRequest!.languageCode = AWSComprehendLanguageCode.en
-        detectSentimentRequest!.text = "It is raining in Seattle"
+        detectSentimentRequest!.text = "I have no strong feelings one way or the other"
         
         comprehendClient.detectSentiment(detectSentimentRequest!).continueWith{ (task)-> Any? in
             if let error = task.error {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Misc. Updates
+- **AWSComprehend**
+  - Updating text used in the `testDetectSentimentNeutral` integration test.
 
 - Model updates for the following services
   - AWSChimeSDKIdentity


### PR DESCRIPTION
*Description of changes:*

FIxing `AWSComprehendTests.testDetectSentimentNeutral` by using the neutralest sentence of them all.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
