### PR TITLE
fix(AWSTranscribeStreaming): fix URL creation for CN regions

### DIFF
--- a/AWSTranscribeStreaming/AWSTranscribeStreamingService.m
+++ b/AWSTranscribeStreaming/AWSTranscribeStreamingService.m
@@ -334,6 +334,11 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         
         components.host = [NSString stringWithFormat:@"transcribestreaming.%@.amazonaws.com",
                            self.configuration.endpoint.regionName];
+
+        // need to add ".cn" at end of URL if it is in China Region
+        if ([self.configuration.endpoint.regionName hasPrefix:@"cn"]) {
+            components.host = [components.host stringByAppendingString:@".cn"];
+        }
         
         components.port = @(8443);
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **AWSTranscribeStreaming**
+  - Fixed assigning of host for CN regions in AWSTranscribeStreaming
+
 ### Bug Fixes
 - **AWSAuthUI**
   - Fixed spacing and color issues in `AWSSignInViewController` when displaying social providers.


### PR DESCRIPTION
*Description of changes:*
Fixing assigning of host for CN regions in AWSTranscribeStreaming

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
