### PR TITLE
test: fix flaky KMS test cases

### DIFF
--- a/AWSKMSTests/AWSKMSTests.m
+++ b/AWSKMSTests/AWSKMSTests.m
@@ -54,17 +54,18 @@
     createRequest.origin = AWSKMSOriginTypeAwsKms;
     
     __block AWSKMSKeyMetadata *keyMetadata = nil;
-    
-    [[[self.kms createKey:createRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSCreateKeyResponse *> * _Nonnull t) {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"key is created"];
+    [[self.kms createKey:createRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSCreateKeyResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
         
         AWSKMSCreateKeyResponse *response = t.result;
         keyMetadata = response.keyMetadata;
-        
+        [expectation fulfill];
         return nil;
-    }] waitUntilFinished];
-    
+    }];
+
+    [self waitForExpectations:@[expectation] timeout:10];
     return keyMetadata;
 }
 
@@ -85,26 +86,31 @@
     AWSKMSCreateAliasRequest *createAliasRequest = [AWSKMSCreateAliasRequest new];
     createAliasRequest.targetKeyId = self.sharedKeyMetadata.keyId;
     createAliasRequest.aliasName = [NSString stringWithFormat:@"alias/testKey%@", self.sharedKeyMetadata.keyId];
-    
-    [[[self.kms createAlias:createAliasRequest] continueWithBlock:^id _Nullable(AWSTask * _Nonnull t) {
+
+    XCTestExpectation *operationFinished = [self expectationWithDescription:@"createAlias operation finished"];
+    [[self.kms createAlias:createAliasRequest] continueWithBlock:^id _Nullable(AWSTask * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
-        
+        [operationFinished fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+
+    [self waitForExpectations:@[operationFinished] timeout:10];
 }
 
 - (void)testDeleteKey {
     AWSKMSScheduleKeyDeletionRequest *deleteRequest = [AWSKMSScheduleKeyDeletionRequest new];
     deleteRequest.keyId = self.sharedKeyMetadata.keyId;
     deleteRequest.pendingWindowInDays = [NSNumber numberWithInt:7];
-    
-    [[[self.kms scheduleKeyDeletion:deleteRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSScheduleKeyDeletionResponse *> * _Nonnull t) {
+
+    XCTestExpectation *operationFinished = [self expectationWithDescription:@"scheduleKeyDeletion operation finished"];
+    [[self.kms scheduleKeyDeletion:deleteRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSScheduleKeyDeletionResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
-        
+        [operationFinished fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+    [self waitForExpectations:@[operationFinished] timeout:10];
 }
 
 
@@ -112,59 +118,70 @@
     AWSKMSScheduleKeyDeletionRequest *deleteRequest = [AWSKMSScheduleKeyDeletionRequest new];
     deleteRequest.keyId = self.sharedKeyMetadata.keyId;
     deleteRequest.pendingWindowInDays = [NSNumber numberWithInt:7];
-    
-    [[[self.kms scheduleKeyDeletion:deleteRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSScheduleKeyDeletionResponse *> * _Nonnull t) {
+
+    XCTestExpectation *scheduleKeyDeletion = [self expectationWithDescription:@"scheduleKeyDeletion operation finished"];
+    [[self.kms scheduleKeyDeletion:deleteRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSScheduleKeyDeletionResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
-        
+        [scheduleKeyDeletion fulfill];
         return nil;
-    }] waitUntilFinished];
-    
+    }];
+    [self waitForExpectations:@[scheduleKeyDeletion] timeout:10];
+
+
+    XCTestExpectation *cancelKeyDeletion = [self expectationWithDescription:@"cancelKeyDeletion operation finished"];
     AWSKMSCancelKeyDeletionRequest *cancelDeleteRequest = [AWSKMSCancelKeyDeletionRequest new];
     cancelDeleteRequest.keyId = self.sharedKeyMetadata.keyId;
     
-    [[[self.kms cancelKeyDeletion:cancelDeleteRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSCancelKeyDeletionResponse *> * _Nonnull t) {
+    [[self.kms cancelKeyDeletion:cancelDeleteRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSCancelKeyDeletionResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
-        
+        [cancelKeyDeletion fulfill];
         return nil;
-    }] waitUntilFinished];
-    
+    }];
+    [self waitForExpectations:@[cancelKeyDeletion] timeout:10];
+
+    XCTestExpectation *describeKey = [self expectationWithDescription:@"describeKey operation finished"];
     AWSKMSDescribeKeyRequest *describeRequest = [AWSKMSDescribeKeyRequest new];
     describeRequest.keyId = self.sharedKeyMetadata.keyId;
     
-    [[[self.kms describeKey:describeRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSDescribeKeyResponse *> * _Nonnull t) {
+    [[self.kms describeKey:describeRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSDescribeKeyResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
         
         XCTAssertTrue([[NSNumber numberWithInt:0] isEqualToNumber:t.result.keyMetadata.enabled]);
-        
+        [describeKey fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+    [self waitForExpectations:@[describeKey] timeout:10];
 }
 
 - (void)testDescribeKey {
     AWSKMSDescribeKeyRequest *describeRequest = [AWSKMSDescribeKeyRequest new];
     describeRequest.keyId = self.sharedKeyMetadata.keyId;
-    
-    [[[self.kms describeKey:describeRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSDescribeKeyResponse *> * _Nonnull t) {
+
+    XCTestExpectation *describeKey = [self expectationWithDescription:@"describeKey operation finished"];
+    [[self.kms describeKey:describeRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSDescribeKeyResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
-        
+        [describeKey fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+    [self waitForExpectations:@[describeKey] timeout:10];
 }
 
 - (void)testDisableKeyRotation {
     AWSKMSDisableKeyRotationRequest *disableRotationRequest = [AWSKMSDisableKeyRotationRequest new];
     disableRotationRequest.keyId = self.sharedKeyMetadata.keyId;
-    
-    [[[self.kms disableKeyRotation:disableRotationRequest] continueWithBlock:^id _Nullable(AWSTask * _Nonnull t) {
+
+    XCTestExpectation *operationFinished = [self expectationWithDescription:@"disableKeyRotation operation finished"];
+    [[self.kms disableKeyRotation:disableRotationRequest] continueWithBlock:^id _Nullable(AWSTask * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
-        
+        [operationFinished fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+    [self waitForExpectations:@[operationFinished] timeout:10];
 }
 
 -(void)testEncryptDecrypt {
@@ -174,8 +191,8 @@
     encryptRequest.keyId = self.sharedKeyMetadata.keyId;
     
     __block NSData *encryptedData = nil; // Set inside encrypt block
-    
-    [[[self.kms encrypt:encryptRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSEncryptResponse *> * _Nonnull t) {
+    XCTestExpectation *encrypt = [self expectationWithDescription:@"encrypt operation finished"];
+    [[self.kms encrypt:encryptRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSEncryptResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
         
@@ -185,21 +202,25 @@
         
         NSString *keyIdEnding = [NSString stringWithFormat:@"/%@", self.sharedKeyMetadata.keyId];
         XCTAssertTrue([response.keyId hasSuffix:keyIdEnding]);
+        [encrypt fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+    [self waitForExpectations:@[encrypt] timeout:10];
     
     AWSKMSDecryptRequest * decryptRequest = [AWSKMSDecryptRequest new];
     decryptRequest.ciphertextBlob = encryptedData;
-    
-    [[[self.kms decrypt:decryptRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSDecryptResponse *> * _Nonnull t) {
+    XCTestExpectation *decrypt = [self expectationWithDescription:@"decrypt operation finished"];
+    [[self.kms decrypt:decryptRequest] continueWithBlock:^id _Nullable(AWSTask<AWSKMSDecryptResponse *> * _Nonnull t) {
         XCTAssertNil(t.error);
         XCTAssertNotNil(t.result);
         
         NSString *decryptedString = [[NSString alloc] initWithData:t.result.plaintext encoding:NSUTF8StringEncoding];
         XCTAssertNotNil(decryptedString);
         XCTAssertTrue([decryptedString isEqualToString:text]);
+        [decrypt fulfill];
         return nil;
-    }] waitUntilFinished];
+    }];
+    [self waitForExpectations:@[decrypt] timeout:10];
 }
 
 @end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- update the test case to use expecations rather than NSLock to wait for async result. As NSLock is only blocking the execution thread and the AWSTask is dispatched on the global queue, which may not really blocking the test executing thread.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
