### PR TITLE
test(kms): add propagate period after createKey API

### DIFF
--- a/AWSKMSTests/AWSKMSTests.m
+++ b/AWSKMSTests/AWSKMSTests.m
@@ -37,6 +37,12 @@
     _sharedKeyMetadata = [self createKey];
     
     XCTAssertNotNil(_sharedKeyMetadata);
+
+    // wait for KMS to propagate changes. KMS APIs are eventually consistent.
+    // ref: https://docs.aws.amazon.com/kms/latest/developerguide/programming-eventual-consistency.html
+    XCTestExpectation *delay = [self expectationWithDescription:@"delay"];
+    [delay setInverted:YES];
+    [self waitForExpectations:@[delay] timeout:5];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- according to [aws doc](https://docs.aws.amazon.com/kms/latest/developerguide/programming-eventual-consistency.html), add propagate period after KMS `createKey` API.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
