### PR TITLE
chore: improving notifications workflows [skip ci]

### DIFF
--- a/.github/workflows/notify_issue_comment.yml
+++ b/.github/workflows/notify_issue_comment.yml
@@ -18,7 +18,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    if: ${{ !github.event.issue.pull_request && !contains(fromJSON('["palpatim", "brennanMKE", "lawmicha", "harsh62", "thisisabhash", "ameter", "royjit", "atierian", "ukhan-amazon", "ruisebas", "phantumcode"]'), github.event.comment.user.login) }}
+    # Exclude comments in PRs and comments made from maintainers
+    if: ${{ !github.event.issue.pull_request && !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -27,7 +28,7 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_COMMENT_WEBHOOK_URL }}
           COMMENT: ${{toJson(github.event.comment.body)}}
-          USER: ${{github.event.issue.user.login}}
+          USER: ${{github.event.comment.user.login}}
           COMMENT_URL: ${{github.event.comment.html_url}}
         shell: bash
         run: echo $COMMENT | sed "s/\\\n/. /g; s/\\\r//g; s/[^a-zA-Z0-9 &().,:]//g" | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"comment":"{}", "commentUrl":"'$COMMENT_URL'", "user":"'$USER'"}'

--- a/.github/workflows/notify_new_issue.yml
+++ b/.github/workflows/notify_new_issue.yml
@@ -18,6 +18,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Exclude issues opened by maintainers
+    if: ${{ !contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association) }}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Runs a single command using the runners shell

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           VERSION: $${{github.event.release.html_url}}
-          REPO_URL: ${{github.event.repository.html_url}}
+          REPO_NAME: ${{github.event.repository.name}}
           ACTION_NAME: ${{github.event.action}}
         shell: bash
-        run: echo $VERSION | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"action":"'$ACTION_NAME'", "repo":"'$REPO_URL'", "version":"{}"}'
+        run: echo $VERSION | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"action":"'$ACTION_NAME'", "repo":"'$REPO_NAME'", "version":"{}"}'

--- a/.github/workflows/notify_release.yml
+++ b/.github/workflows/notify_release.yml
@@ -4,9 +4,9 @@ name: Notify AWS SDK iOS Release
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on release created (draft) or released (stable) events but only for the main branch
+  # Triggers the workflow on released events
   release:
-    types: [created, released]
+    types: [released]
 
 # Limit the GITHUB_TOKEN permissions
 permissions: {}


### PR DESCRIPTION
**Description of changes:**

Same as https://github.com/aws-amplify/amplify-swift/pull/3269 and https://github.com/aws-amplify/amplify-swift/pull/3273, updating the notifications workflows to:
- Filter by `author_association` instead of hardcoding aliases, for both comments and issues
- Notify the comment author instead of the issue author
- Remove notifications for draft releases, they are just spammy
- Sends the name of the repo instead of the URL when notifying releases.

**Check points:**

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
