### PR TITLE
fix(cognito-identity): honor provided configuration headers

### DIFF
--- a/AWSCore/CognitoIdentity/AWSCognitoIdentityService.m
+++ b/AWSCore/CognitoIdentity/AWSCognitoIdentityService.m
@@ -231,8 +231,15 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 
         _configuration.baseURL = _configuration.endpoint.URL;
         _configuration.retryHandler = [[AWSCognitoIdentityRequestRetryHandler alloc] initWithMaximumRetryCount:_configuration.maxRetryCount];
-        _configuration.headers = @{@"Content-Type" : @"application/x-amz-json-1.1"}; 
-		
+
+        if (_configuration.headers == nil) {
+            _configuration.headers = @{@"Content-Type" : @"application/x-amz-json-1.1"};
+        } else {
+            NSMutableDictionary *headers = [[NSMutableDictionary alloc] initWithDictionary:_configuration.headers];
+            headers[@"Content-Type"] = @"application/x-amz-json-1.1";
+            _configuration.headers = headers;
+        }
+
         _networking = [[AWSNetworking alloc] initWithConfiguration:_configuration];
     }
     

--- a/AWSCoreUnitTests/AWSGeneralCognitoIdentityTests.m
+++ b/AWSCoreUnitTests/AWSGeneralCognitoIdentityTests.m
@@ -115,6 +115,15 @@ static id mockNetworking = nil;
     XCTAssertEqualObjects(cognitoIdentity.configuration.headers, expected, @"expected provided headers to be included in configuration object");
 }
 
+- (void)testCreateIdentityPoolNoSuppliedHeaders {
+    AWSServiceConfiguration *configuration = [AWSTestUtility getDefaultServiceConfiguration];
+    id key = @"test-without-headers";
+    [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration forKey:key];
+    AWSCognitoIdentity *cognitoIdentity = [AWSCognitoIdentity CognitoIdentityForKey:key];
+    NSDictionary *expected = @{@"Content-Type": @"application/x-amz-json-1.1"};
+    XCTAssertEqualObjects(cognitoIdentity.configuration.headers, expected, @"expected Content-Type header to be included");
+}
+
 - (void)testDeleteIdentities {
     NSString *key = @"testDeleteIdentities";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];

--- a/AWSCoreUnitTests/AWSGeneralCognitoIdentityTests.m
+++ b/AWSCoreUnitTests/AWSGeneralCognitoIdentityTests.m
@@ -105,6 +105,16 @@ static id mockNetworking = nil;
     [AWSCognitoIdentity removeCognitoIdentityForKey:key];
 }
 
+- (void)testCreateIdentityPoolWithSuppliedHeaders {
+    AWSServiceConfiguration *configuration = [AWSTestUtility getDefaultServiceConfiguration];
+    configuration.headers = @{@"foo": @"bar"};
+    id key = @"test-with-headers";
+    [AWSCognitoIdentity registerCognitoIdentityWithConfiguration:configuration forKey:key];
+    AWSCognitoIdentity *cognitoIdentity = [AWSCognitoIdentity CognitoIdentityForKey:key];
+    NSDictionary *expected = @{@"foo": @"bar", @"Content-Type": @"application/x-amz-json-1.1"};
+    XCTAssertEqualObjects(cognitoIdentity.configuration.headers, expected, @"expected provided headers to be included in configuration object");
+}
+
 - (void)testDeleteIdentities {
     NSString *key = @"testDeleteIdentities";
     AWSServiceConfiguration *configuration = [[AWSServiceConfiguration alloc] initWithRegion:AWSRegionUSEast1 credentialsProvider:nil];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- **CognitoIdentity**
+  - Don't overwrite AWSServiceConfiguration provided headers.
+
 ### Misc. Updates
 
 - Model updates for the following services


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/4302

*Description of changes:*
If headers are supplied via the `AWSServiceConfiguration` object, don't overwrite them.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
