### PR TITLE
fix(mobile-client): add missing userSub property to SignUpResult

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+SignUp.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+SignUp.swift
@@ -99,9 +99,13 @@ extension AWSMobileClient {
                         }
                     }
                     completionHandler(
-                        SignUpResult(signUpState: confirmedStatus!,
-                                     codeDeliveryDetails: codeDeliveryDetails),
-                        nil)
+                        SignUpResult(
+                            signUpState: confirmedStatus!,
+                            codeDeliveryDetails: codeDeliveryDetails,
+                            userSub: result.userSub
+                        ),
+                        nil
+                    )
                 }
                 return nil
             }
@@ -145,7 +149,7 @@ extension AWSMobileClient {
             if let error = task.error {
                 completionHandler(nil, AWSMobileClientError.makeMobileClientError(from: error))
             } else if let _ = task.result {
-                let signUpResult = SignUpResult(signUpState: .confirmed, codeDeliveryDetails: nil)
+                let signUpResult = SignUpResult(signUpState: .confirmed, codeDeliveryDetails: nil, userSub: nil)
                 completionHandler(signUpResult, nil)
             }
             return nil
@@ -186,7 +190,7 @@ extension AWSMobileClient {
                 if let deliveryDetails = result.codeDeliveryDetails {
                     codeDeliveryDetails = UserCodeDeliveryDetails.getUserCodeDeliveryDetails(deliveryDetails)
                 }
-                completionHandler(SignUpResult(signUpState: confirmedStatus, codeDeliveryDetails: codeDeliveryDetails), nil)
+                completionHandler(SignUpResult(signUpState: confirmedStatus, codeDeliveryDetails: codeDeliveryDetails, userSub: nil), nil)
             }
             return nil
         })

--- a/AWSAuthSDK/Sources/AWSMobileClient/Models/SignUpResult.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Models/SignUpResult.swift
@@ -18,9 +18,15 @@ import Foundation
 public struct SignUpResult {
     public let codeDeliveryDetails: UserCodeDeliveryDetails?
     public let signUpConfirmationState: SignUpConfirmationState
+    public let userSub: String?
 
-    internal init(signUpState: SignUpConfirmationState, codeDeliveryDetails: UserCodeDeliveryDetails?){
+    internal init(
+        signUpState: SignUpConfirmationState,
+        codeDeliveryDetails: UserCodeDeliveryDetails?,
+        userSub: String?
+    ) {
         self.codeDeliveryDetails = codeDeliveryDetails
         self.signUpConfirmationState = signUpState
+        self.userSub = userSub
     }
 }

--- a/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientTests/AWSMobileClientTestBase.swift
@@ -194,7 +194,7 @@ class AWSMobileClientTestBase: XCTestCase {
                 }
                 
                 XCTAssertTrue(signUpResult.signUpConfirmationState == signupState, "User is expected to be marked as \(signupState).")
-                
+                XCTAssertNotNil(signUpResult.userSub)
                 signUpExpectation.fulfill()
         }
         


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/1566

*Description of changes:*
Adds missing `userSub` property to SignUpResult in AWSMobileClient.

*Check points:*

- [x] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
