### PR TITLE
fix(mobile-client): make AWSMobileClientError message getter public

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/Models/AWSMobileClientError.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Models/AWSMobileClientError.swift
@@ -64,7 +64,7 @@ public enum AWSMobileClientError: Error {
 
 extension AWSMobileClientError {
     /// Underlying error message of `AWSMobileClientError`
-    var message: String {
+    public var message: String {
         switch self {
         case .aliasExists(let message),
              .badRequest(let message),


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/2024

*Description of changes:*
Adds public access control to the `message` getter on `AWSMobileClientError`.

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [ ] ~All integration tests pass~
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
