### PR TITLE
fix(s3): set taskIdentifier attribute to nonatomic in transferutilitytask_private

### DIFF
--- a/AWSS3/AWSS3TransferUtility_private.h
+++ b/AWSS3/AWSS3TransferUtility_private.h
@@ -20,7 +20,7 @@
 @interface AWSS3TransferUtilityTask()
 
 @property (strong, nonatomic) NSURLSessionTask *sessionTask;
-@property (readwrite) NSUInteger taskIdentifier;
+@property (nonatomic, readwrite) NSUInteger taskIdentifier;
 @property (strong, nonatomic) NSString *transferID;
 @property (strong, nonatomic) NSString *bucket;
 @property (strong, nonatomic) NSString *key;


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/4284

*Description of changes:*
Adds `nonatomic` property attribute to `taskIdentifier` to resolve warning around custom getter with synthesized property in AWSS3TransferUtilityTask.

*Check points:*
- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
