### PR TITLE
fix(s3): cleanup file cache after mpu task is cancelled

### DIFF
--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -1157,7 +1157,8 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
     transferUtilityMultiPartUploadTask.retryCount = 0;
     transferUtilityMultiPartUploadTask.temporaryFileCreated = temporaryFileCreated;
     transferUtilityMultiPartUploadTask.status = AWSS3TransferUtilityTransferStatusInProgress;
-    
+    transferUtilityMultiPartUploadTask.cachedFileURL = fileURL;
+
     //Get the size of the file and calculate the number of parts.
     NSError *nsError = nil;
     NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[fileURL path]

--- a/AWSS3/AWSS3TransferUtilityTasks.m
+++ b/AWSS3/AWSS3TransferUtilityTasks.m
@@ -153,6 +153,15 @@
     }
 
     [AWSS3TransferUtilityDatabaseHelper deleteTransferRequestFromDB:self.transferID databaseQueue:self.databaseQueue];
+
+    NSString *path = self.cachedFileURL.path;
+    if (path && [[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        NSError *error = nil;
+        [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+        if (error) {
+            AWSDDLogError(@"Error deleting file[%@]: [%@]", path, error);
+        }
+    }
 }
 
 - (void)resume {

--- a/AWSS3/AWSS3TransferUtility_private.h
+++ b/AWSS3/AWSS3TransferUtility_private.h
@@ -53,6 +53,7 @@
 @property (copy) NSString * uploadID;
 @property BOOL cancelled;
 @property BOOL temporaryFileCreated;
+@property NSURL *cachedFileURL;
 @property NSMutableDictionary <NSNumber *, AWSS3TransferUtilityUploadSubTask *> *waitingPartsDictionary;
 @property (strong, nonatomic) NSMutableSet <AWSS3TransferUtilityUploadSubTask *> *completedPartsSet;
 @property (strong, nonatomic) NSMutableDictionary <NSNumber *, AWSS3TransferUtilityUploadSubTask *> *inProgressPartsDictionary;


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-amplify/aws-sdk-ios/issues/1576

*Description of changes:*

If a `AWSS3TransferUtilityMultiPartUploadTask` is cancelled by the caller, there's no use keeping the cached file around.
According to the [File System Programming Guide](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW1), the /Library/Caches directory is rarely purged by the system:
> Your app is generally responsible for managing the contents of this directory and for adding and deleting files as needed. 
> ...
> In iOS 5.0 and later, the system may delete the Caches directory on rare occasions when the system is very low on disk space. This will never occur while an app is running. However, be aware that restoring from backup is not necessarily the only condition under which the Caches directory can be erased.


*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [x] All unit tests pass
- [x] All integration tests pass
- [ ] ~Updated CHANGELOG.md~
- [ ] ~Documentation update for the change if required~
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
