### PR TITLE
feat(TransferUtility) Adding support for path-style access requests.

### DIFF
--- a/AWSS3/AWSS3Model.h
+++ b/AWSS3/AWSS3Model.h
@@ -43,6 +43,11 @@ typedef NS_ENUM(NSInteger, AWSS3BucketAccelerateStatus) {
     AWSS3BucketAccelerateStatusSuspended,
 };
 
+typedef NS_ENUM(NSInteger, AWSS3BucketAccessStyle) {
+    AWSS3BucketAccessStyleVirtualHosted,
+    AWSS3BucketAccessStylePath
+};
+
 typedef NS_ENUM(NSInteger, AWSS3BucketCannedACL) {
     AWSS3BucketCannedACLUnknown,
     AWSS3BucketCannedACLPrivate,

--- a/AWSS3/AWSS3PreSignedURL.h
+++ b/AWSS3/AWSS3PreSignedURL.h
@@ -14,6 +14,7 @@
 //
 
 #import <AWSCore/AWSCore.h>
+#import "AWSS3Model.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,6 +43,7 @@ typedef NS_ENUM(NSInteger, AWSS3PresignedURLErrorType) {
     AWSS3PresignedURLErrorInvalidRequestParameters,
     AWSS3PresignedURLErrorInvalidBucketName,
     AWSS3PresignedURLErrorInvalidBucketNameForAccelerateModeEnabled,
+    AWSS3PresignedURLErrorInvalidAccessStyleForAccelerateModeEnabled,
 };
 
 @class AWSS3GetPreSignedURLRequest;
@@ -213,6 +215,15 @@ typedef NS_ENUM(NSInteger, AWSS3PresignedURLErrorType) {
  The name of the bucket
  */
 @property (nonatomic, strong) NSString *bucket;
+
+/**
+ The preferred access style for the bucket. The default is `AWSS3BucketAccessStyleVirtualHosted`.
+ 
+ Virtual-hosted-style requests require that the bucket name must be DNS-compliant and must not contain periods `(".")`.
+ 
+ If virtual-hosted-style access is set as preferred but the bucket name does not meet these conditions, path-style access will be used instead.
+ */
+@property (nonatomic, assign) AWSS3BucketAccessStyle preferredAccessStyle;
 
 /**
  The name of the S3 object

--- a/AWSS3/AWSS3PreSignedURL.m
+++ b/AWSS3/AWSS3PreSignedURL.m
@@ -206,12 +206,23 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
                                                           userInfo:@{NSLocalizedDescriptionKey: @"S3 bucket can not be nil or empty"}]];
         }
 
-        // Validates the buket name for transfer acceleration.
-        if (isAccelerateModeEnabled && ![bucketName aws_isVirtualHostedStyleCompliant]) {
-            return [AWSTask taskWithError:[NSError errorWithDomain:AWSS3PresignedURLErrorDomain
-                                                              code:AWSS3PresignedURLErrorInvalidBucketNameForAccelerateModeEnabled
-                                                          userInfo:@{
-                                                                     NSLocalizedDescriptionKey: @"For your bucket to work with transfer acceleration, the bucket name must conform to DNS naming requirements and must not contain periods."}]];
+        // validate values for transfer acceleration.
+        if (isAccelerateModeEnabled) {
+            // validate the bucket name
+            if (![bucketName aws_isVirtualHostedStyleCompliant]) {
+                return [AWSTask taskWithError:[NSError errorWithDomain:AWSS3PresignedURLErrorDomain
+                                                                  code:AWSS3PresignedURLErrorInvalidBucketNameForAccelerateModeEnabled
+                                                              userInfo:@{
+                                                                         NSLocalizedDescriptionKey: @"For your bucket to work with transfer acceleration, the bucket name must conform to DNS naming requirements and must not contain periods."}]];
+            }
+            
+            // validate the preferred access style
+            if (getPreSignedURLRequest.preferredAccessStyle == AWSS3BucketAccessStylePath) {
+                return [AWSTask taskWithError:[NSError errorWithDomain:AWSS3PresignedURLErrorDomain
+                                                                  code:AWSS3PresignedURLErrorInvalidAccessStyleForAccelerateModeEnabled
+                                                              userInfo:@{
+                                                                         NSLocalizedDescriptionKey: @"Transfer Acceleration is only supported on virtual-hosted style requests."}]];
+            }
         }
 
         //validate keyName
@@ -262,7 +273,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         //generate baseURL String (use virtualHostStyle if possible)
         //base url is not url encoded.
         NSString *keyPath = nil;
-        if (bucketName == nil || [bucketName aws_isVirtualHostedStyleCompliant]) {
+        if (bucketName == nil || [self shouldUseVirtualHostStyleForRequest:getPreSignedURLRequest]) {
             keyPath = (keyName == nil ? @"" : [NSString stringWithFormat:@"%@", [keyName aws_stringWithURLEncodingPath]]);
         } else {
             keyPath = (keyName == nil ? [NSString stringWithFormat:@"%@", bucketName] : [NSString stringWithFormat:@"%@/%@", bucketName, [keyName aws_stringWithURLEncodingPath]]);
@@ -272,7 +283,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
         NSString *host = nil;
         if (!self.configuration.localTestingEnabled &&
             bucketName &&
-            [bucketName aws_isVirtualHostedStyleCompliant]) {
+            [self shouldUseVirtualHostStyleForRequest:getPreSignedURLRequest]) {
             if (isAccelerateModeEnabled) {
                 host = [NSString stringWithFormat:@"%@.%@", bucketName, AWSS3PreSignedURLBuilderAcceleratedEndpoint];
             } else {
@@ -315,6 +326,21 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
     }];
 }
 
+- (BOOL)shouldUseVirtualHostStyleForRequest:(AWSS3GetPreSignedURLRequest *)getPreSignedURLRequest  {
+    if (getPreSignedURLRequest.preferredAccessStyle == AWSS3BucketAccessStylePath) {
+        AWSDDLogVerbose(@"Using path-style access because it is set as preferred access style");
+        return NO;
+    }
+
+    if ([getPreSignedURLRequest.bucket aws_isVirtualHostedStyleCompliant]) {
+        AWSDDLogVerbose(@"Using virtual-hosted-style access because bucket is compliant");
+        return YES;
+    }
+
+    AWSDDLogVerbose(@"Using path-style access because bucket is not virtual-hosted-style compliant");
+    return NO;
+}
+
 @end
 
 @implementation AWSS3GetPreSignedURLRequest
@@ -322,6 +348,7 @@ static AWSSynchronizedMutableDictionary *_serviceClients = nil;
 - (instancetype)init {
     if ( self = [super init] ) {
         _accelerateModeEnabled = NO;
+        _preferredAccessStyle = AWSS3BucketAccessStyleVirtualHosted;
         _minimumCredentialsExpirationInterval = 50 * 60;
         _internalRequestParameters = [NSMutableDictionary<NSString *, NSString *> new];
         _internalRequestHeaders = [NSMutableDictionary<NSString *, NSString *> new];

--- a/AWSS3/AWSS3TransferUtility.h
+++ b/AWSS3/AWSS3TransferUtility.h
@@ -696,6 +696,15 @@ handleEventsForBackgroundURLSession:(NSString *)identifier
 
 @property NSInteger timeoutIntervalForResource;
 
+/**
+ The preferred access style for the bucket. The default is `AWSS3BucketAccessStyleVirtualHosted`.
+ 
+ Virtual-hosted-style requests require that the bucket name must be DNS-compliant and must not contain periods `(".")`.
+ 
+ If virtual-hosted-style access is set as preferred but the bucket name does not meet these conditions, path-style access will be used instead.
+ */
+@property (nonatomic, assign) AWSS3BucketAccessStyle preferredAccessStyle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWSS3/AWSS3TransferUtility.m
+++ b/AWSS3/AWSS3TransferUtility.m
@@ -942,6 +942,7 @@ static AWSS3TransferUtility *_defaultS3TransferUtility = nil;
     AWSDDLogDebug(@"Value of timeoutIntervalForResource is %ld", (long)_transferUtilityConfiguration.timeoutIntervalForResource);
     getPreSignedURLRequest.minimumCredentialsExpirationInterval = _transferUtilityConfiguration.timeoutIntervalForResource;
     getPreSignedURLRequest.accelerateModeEnabled = self.transferUtilityConfiguration.isAccelerateModeEnabled;
+    getPreSignedURLRequest.preferredAccessStyle = self.transferUtilityConfiguration.preferredAccessStyle;
     
     [transferUtilityUploadTask.expression assignRequestHeaders:getPreSignedURLRequest];
     [transferUtilityUploadTask.expression assignRequestParameters:getPreSignedURLRequest];
@@ -1450,6 +1451,7 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
     request.expires = [NSDate dateWithTimeIntervalSinceNow:_transferUtilityConfiguration.timeoutIntervalForResource];
     request.minimumCredentialsExpirationInterval = _transferUtilityConfiguration.timeoutIntervalForResource;
     request.accelerateModeEnabled = self.transferUtilityConfiguration.isAccelerateModeEnabled;
+    request.preferredAccessStyle = self.transferUtilityConfiguration.preferredAccessStyle;
     [self filterAndAssignHeaders:transferUtilityMultiPartUploadTask.expression.requestHeaders getPresignedURLRequest:request
                       URLRequest:nil];
     
@@ -1662,6 +1664,7 @@ internalDictionaryToAddSubTaskTo: (NSMutableDictionary *) internalDictionaryToAd
     getPreSignedURLRequest.expires = [NSDate dateWithTimeIntervalSinceNow:_transferUtilityConfiguration.timeoutIntervalForResource];
     getPreSignedURLRequest.minimumCredentialsExpirationInterval = _transferUtilityConfiguration.timeoutIntervalForResource;
     getPreSignedURLRequest.accelerateModeEnabled = self.transferUtilityConfiguration.isAccelerateModeEnabled;
+    getPreSignedURLRequest.preferredAccessStyle = self.transferUtilityConfiguration.preferredAccessStyle;
     
     [transferUtilityDownloadTask.expression assignRequestHeaders:getPreSignedURLRequest];
     [transferUtilityDownloadTask.expression assignRequestParameters:getPreSignedURLRequest];
@@ -2593,6 +2596,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         _retryLimit = 0;
         _multiPartConcurrencyLimit = @(AWSS3TransferUtilityMultiPartDefaultConcurrencyLimit);
         _timeoutIntervalForResource = AWSS3TransferUtilityTimeoutIntervalForResource;
+        _preferredAccessStyle = AWSS3BucketAccessStyleVirtualHosted;
     }
     return self;
 }
@@ -2604,6 +2608,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     configuration.retryLimit = self.retryLimit;
     configuration.multiPartConcurrencyLimit = self.multiPartConcurrencyLimit;
     configuration.timeoutIntervalForResource = self.timeoutIntervalForResource;
+    configuration.preferredAccessStyle = self.preferredAccessStyle;
     return configuration;
 }
 

--- a/AWSS3UnitTests/AWSS3PreSignedURLBuilderUnitTests.swift
+++ b/AWSS3UnitTests/AWSS3PreSignedURLBuilderUnitTests.swift
@@ -117,7 +117,7 @@ final class AWSS3PreSignedURLBuilderUnitTests: XCTestCase {
 
     /// Given: a `AWSS3GetPreSignedURLRequest` with `preferredAccessStyle` set to `.virtualHosted` and a `bucketName` that is not compliant.
     /// When: `AWSS3PreSignedURLBuilder.getPresignedURL(_:)` is invoked
-    /// Then: The generated request uses Virtual-Hosted style to create the URL.
+    /// Then: The generated request uses path style to create the URL.
     func testPreferredAccessStyle_withVirtualHostedStyle_andInvalidBucket() {
         let request = createRequest(
             bucket: "invalid_virtual_hosted_bucket_name",

--- a/AWSS3UnitTests/AWSS3PreSignedURLBuilderUnitTests.swift
+++ b/AWSS3UnitTests/AWSS3PreSignedURLBuilderUnitTests.swift
@@ -1,0 +1,163 @@
+//
+// Copyright 2010-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+import XCTest
+import AWSS3
+
+final class AWSS3PreSignedURLBuilderUnitTests: XCTestCase {
+    override func setUp() {
+        AWSS3PreSignedURLBuilder.register(
+            with: .init(
+                region: .USEast1,
+                credentialsProvider: self
+            ),
+            forKey: "AWSS3PreSignedURLBuilderUnitTests"
+        )
+    }
+
+    private var builder: AWSS3PreSignedURLBuilder {
+        AWSS3PreSignedURLBuilder.s3PreSignedURLBuilder(
+            forKey: "AWSS3PreSignedURLBuilderUnitTests"
+        )
+    }
+
+    private func createRequest(
+        bucket: String,
+        key: String,
+        preferredAccessStyle: AWSS3BucketAccessStyle
+    ) -> AWSS3GetPreSignedURLRequest {
+        let request = AWSS3GetPreSignedURLRequest()
+        request.bucket = bucket
+        request.key = key
+        request.httpMethod = .GET
+        request.expires = Date().addingTimeInterval(3600)
+        request.preferredAccessStyle = preferredAccessStyle
+        return request
+    }
+
+    /// Given: a `AWSS3GetPreSignedURLRequest` with `preferredAccessStyle` set to `.path`
+    /// When: `AWSS3PreSignedURLBuilder.getPresignedURL(_:)` is invoked
+    /// Then: The generated request uses path style to create the URL.
+    func testPreferredAccessStyle_withPathStyle() {
+        let request = createRequest(
+            bucket: "pathbucket",
+            key: "PathKey",
+            preferredAccessStyle: .path
+        )
+
+        let expectation = expectation(description: "getPresignedURL")
+        builder.getPreSignedURL(request).continueWith { task in
+            defer {
+                expectation.fulfill()
+            }
+
+            XCTAssertNil(task.error)
+            guard let presignedURL = task.result as? URL else {
+                XCTFail("Expected result")
+                return
+            }
+
+            guard let components = URLComponents(url: presignedURL, resolvingAgainstBaseURL: true) else {
+                XCTFail("Unable to retrieve components")
+                return
+            }
+
+            XCTAssertEqual(components.host, "s3.us-east-1.amazonaws.com")
+            XCTAssertEqual(components.path, "/pathbucket/PathKey")
+            return nil
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    /// Given: a `AWSS3GetPreSignedURLRequest` with `preferredAccessStyle` set to `.virtualHosted` and a `bucketName` that is compliant.
+    /// When: `AWSS3PreSignedURLBuilder.getPresignedURL(_:)` is invoked
+    /// Then: The generated request uses Virtual-Hosted style to create the URL.
+    func testPreferredAccessStyle_withVirtualHostedStyle() {
+        let request = createRequest(
+            bucket: "virtualhostedbucket",
+            key: "virtualHostedKey",
+            preferredAccessStyle: .virtualHosted
+        )
+
+        let expectation = expectation(description: "getPresignedURL")
+        builder.getPreSignedURL(request).continueWith { task in
+            defer {
+                expectation.fulfill()
+            }
+
+            XCTAssertNil(task.error)
+            guard let presignedURL = task.result as? URL else {
+                XCTFail("Expected result")
+                return
+            }
+
+            guard let components = URLComponents(url: presignedURL, resolvingAgainstBaseURL: true) else {
+                XCTFail("Unable to retrieve components")
+                return
+            }
+
+            XCTAssertEqual(components.host, "virtualhostedbucket.s3.us-east-1.amazonaws.com")
+            XCTAssertEqual(components.path, "/virtualHostedKey")
+            return nil
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    /// Given: a `AWSS3GetPreSignedURLRequest` with `preferredAccessStyle` set to `.virtualHosted` and a `bucketName` that is not compliant.
+    /// When: `AWSS3PreSignedURLBuilder.getPresignedURL(_:)` is invoked
+    /// Then: The generated request uses Virtual-Hosted style to create the URL.
+    func testPreferredAccessStyle_withVirtualHostedStyle_andInvalidBucket() {
+        let request = createRequest(
+            bucket: "invalid_virtual_hosted_bucket_name",
+            key: "virtualHostedKey",
+            preferredAccessStyle: .virtualHosted
+        )
+
+        let expectation = expectation(description: "getPresignedURL")
+        builder.getPreSignedURL(request).continueWith { task in
+            defer {
+                expectation.fulfill()
+            }
+            XCTAssertNil(task.error)
+            guard let presignedURL = task.result as? URL else {
+                XCTFail("Expected result")
+                return
+            }
+
+            guard let components = URLComponents(url: presignedURL, resolvingAgainstBaseURL: true) else {
+                XCTFail("Unable to retrieve components")
+                return
+            }
+
+            XCTAssertEqual(components.host, "s3.us-east-1.amazonaws.com")
+            XCTAssertEqual(components.path, "/invalid_virtual_hosted_bucket_name/virtualHostedKey")
+            return nil
+        }
+        waitForExpectations(timeout: 1)
+    }
+}
+
+extension AWSS3PreSignedURLBuilderUnitTests: AWSCredentialsProvider {
+    func credentials() -> AWSTask<AWSCredentials> {
+        return AWSTask(result: .init(
+            accessKey: "accessKey",
+            secretKey: "secretKey",
+            sessionKey: "sessionKey",
+            expiration: nil)
+        )
+    }
+    
+    func invalidateCachedTemporaryCredentials() {}
+}

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -581,6 +581,7 @@
 		5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		5C1978DD2702364800F9C11E /* AWSLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1978DC2702364800F9C11E /* AWSLocationTests.swift */; };
 		5C71F33F295672B8001183A4 /* guten_tag.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5C71F33E295672B8001183A4 /* guten_tag.wav */; };
+		6883619E2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */; };
 		688361A12B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */; };
 		68EE1A6C2B713D8100B7CF41 /* AWSIoTStreamThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 68EE1A6B2B713D8100B7CF41 /* AWSIoTStreamThread.h */; };
 		68EE1A6E2B713D8900B7CF41 /* AWSIoTStreamThread.m in Sources */ = {isa = PBXBuildFile; fileRef = 68EE1A6D2B713D8900B7CF41 /* AWSIoTStreamThread.m */; };
@@ -3144,6 +3145,7 @@
 		5C1978DB2702364800F9C11E /* AWSLocationTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSLocationTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5C1978DC2702364800F9C11E /* AWSLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLocationTests.swift; sourceTree = "<group>"; };
 		5C71F33E295672B8001183A4 /* guten_tag.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = guten_tag.wav; sourceTree = "<group>"; };
+		6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PreSignedURLBuilderUnitTests.swift; sourceTree = "<group>"; };
 		688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThreadTests.m; sourceTree = "<group>"; };
 		68EE1A6B2B713D8100B7CF41 /* AWSIoTStreamThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSIoTStreamThread.h; sourceTree = "<group>"; };
 		68EE1A6D2B713D8900B7CF41 /* AWSIoTStreamThread.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThread.m; sourceTree = "<group>"; };
@@ -6843,6 +6845,7 @@
 				B47FAF4222C577CE00014548 /* AWSS3TransferUtilityUnitTests.m */,
 				030087CD26CDA0E9002A9DFA /* AWSS3TransferUtilityEnumerateBlocksTests.swift */,
 				034785B126FB0C3600E8882C /* AWSS3TransferUtilityCreatePartialFileTests.swift */,
+				6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */,
 			);
 			path = AWSS3UnitTests;
 			sourceTree = "<group>";
@@ -13043,6 +13046,7 @@
 				034785B226FB0C3600E8882C /* AWSS3TransferUtilityCreatePartialFileTests.swift in Sources */,
 				030087CE26CDA0E9002A9DFA /* AWSS3TransferUtilityEnumerateBlocksTests.swift in Sources */,
 				FAB5E5DA253A6416002ECF1D /* AWSS3NSSecureCodingTests.m in Sources */,
+				6883619E2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift in Sources */,
 				CE5604F21C6BCAA000B4E00B /* AWSTestUtility.m in Sources */,
 				B47FAF4322C577CE00014548 /* AWSS3TransferUtilityUnitTests.m in Sources */,
 			);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### New features
+
+- **AWSS3TransferUtility**
+  - Adding support for path-style access requests
 
 ## 2.33.9
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5023

**Description of changes:**

This PR adds support for [path-style access requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) to the **AWSTransferUtility**, by introducing a new `preferredAccessStyle` property to **AWSTransferUtilityConfiguration**.

This property defaults to virtual-hosted-style access, so there's no change in behaviour. To to use path-style, you can do this:
```swift
let name = //...
let serviceConfiguration = //...
let transferUtilityConfiguration = AWSS3TransferUtilityConfiguration()
transferUtilityConfiguration.preferredAccessStyle = .path

AWSS3TransferUtility.register(
    with: serviceConfiguration,
    transferUtilityConfiguration: transferUtilityConfiguration,
    forKey: name
)
```

**Note**: This feature is supported by [Android](https://github.com/aws-amplify/aws-sdk-android/blob/main/aws-android-sdk-s3/src/main/java/com/amazonaws/services/s3/S3ClientOptions.java#L120) and [JavaScript](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property)


**Check points:**
- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
