### PR TITLE
fix(IoT): Fixing identity not being created

### DIFF
--- a/AWSIoT/AWSIoTManager.m
+++ b/AWSIoT/AWSIoTManager.m
@@ -206,13 +206,13 @@ static BOOL _tagCertificateEnabled = NO;
 
                 SecKeyRef publicKeyRef = [AWSIoTKeychain getPublicKeyRef:publicTag];
                 SecKeyRef privateKeyRef = [AWSIoTKeychain getPrivateKeyRef:privateTag];
-                SecIdentityRef identityRef = [AWSIoTKeychain getIdentityRef:newPrivateTag certificateLabel:newCertTag];
+                SecIdentityRef identityRef = nil;
 
                 if ([AWSIoTKeychain deleteAsymmetricKeysWithPublicTag:publicTag privateTag:privateTag] &&
                     [AWSIoTKeychain addPrivateKeyRef:privateKeyRef tag:newPrivateTag] &&
                     [AWSIoTKeychain addPublicKeyRef:publicKeyRef tag:newPublicTag] &&
                     [AWSIoTKeychain addCertificateToKeychain:certificatePem tag:newCertTag] &&
-                    identityRef != nil) {
+                    (identityRef = [AWSIoTKeychain getIdentityRef:newPrivateTag certificateLabel:newCertTag])) {
                     AWSIoTCreateCertificateResponse* resp = [[AWSIoTCreateCertificateResponse alloc] init];
                     resp.certificateId = certificateId;
                     resp.certificatePem = certificatePem;


### PR DESCRIPTION
*Description of changes:*

This PR fixes an issue introduced in https://github.com/aws-amplify/aws-sdk-ios/pull/5185, in which an `SecIdentityRef` could not be created due to the private key and/or certificate not being previously added to the Keychain.

The integration tests are now passing: [run](https://github.com/aws-amplify/aws-sdk-ios/actions/runs/7821680123/job/21339176082)

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
