### PR TITLE
fix(IoT): Adding completion callbacks for `registerWithShadow` and `unregisterFromShadow` methods

### DIFF
--- a/AWSIoT/AWSIoTDataManager.h
+++ b/AWSIoT/AWSIoTDataManager.h
@@ -809,6 +809,33 @@ shadowOperationTimeoutSeconds: double, device shadow operation timeout (default 
               eventCallback:(void(^)(NSString *name, AWSIoTShadowOperationType operation, AWSIoTShadowOperationStatusType status, NSString *clientToken, NSData *payload))callback;
 
 /**
+ Register for updates on a device shadow
+
+ @param name The device shadow to register for updates on.
+
+ @param options A dictionary with device shadow registration options.  The options are:
+
+enableDebugging: BOOL, set to YES to enable additional console debugging (default NO)
+enableVersioning: BOOL, set to NO to disable versioning (default YES)
+enableForeignStateUpdateNotifications: BOOL, set to YES to enable foreign state updates (default NO)
+enableStaleDiscards: BOOL, set to NO to disable discarding stale updates (default YES)
+enableIgnoreDeltas: BOOL, set to YES to disable delta updates (default NO)
+QoS: AWSIoTMQTTQoS (default AWSIoTMQTTQoSMessageDeliveryAttemptedAtMostOnce)
+shadowOperationTimeoutSeconds: double, device shadow operation timeout (default 10.0)
+
+ @param callback The function to call when updates are received for the device shadow.
+
+ @param completionCallback The function to call when the operation is completed.
+
+ @return Boolean value indicating success or failure.
+
+ */
+- (BOOL) registerWithShadow:(NSString *)name
+                    options:(NSDictionary<NSString *, NSNumber *> * _Nullable)options
+              eventCallback:(void(^)(NSString *name, AWSIoTShadowOperationType operation, AWSIoTShadowOperationStatusType status, NSString *clientToken, NSData *payload))callback
+         completionCallback:(void(^)(void))completionCallback;
+
+/**
  Unregister from updates on a device shadow
  
  @param name The device shadow to unregister from updates on.
@@ -817,6 +844,19 @@ shadowOperationTimeoutSeconds: double, device shadow operation timeout (default 
  
  */
 - (BOOL) unregisterFromShadow:(NSString *)name;
+
+/**
+ Unregister from updates on a device shadow
+
+ @param name The device shadow to unregister from updates on.
+
+ @param completionCallback The function to call when the operation is completed.
+
+ @return Boolean value indicating success or failure.
+
+ */
+- (BOOL) unregisterFromShadow:(NSString *)name
+           completionCallback:(void(^)(void))completionCallback;
 
 /**
  Update a device shadow

--- a/AWSIoT/AWSIoTDataManager.m
+++ b/AWSIoT/AWSIoTDataManager.m
@@ -912,22 +912,39 @@ static NSString * const AWSIoTShadowOperationStatusTypeStrings[] = {
  */
 - (BOOL)handleSubscriptionsForShadow:(NSString *)name
                             callback:(AWSIoTMQTTExtendedNewMessageBlock)callback {
+    return [self handleSubscriptionsForShadow:name callback:callback completionHandler:nil];
+}
+
+- (BOOL)handleSubscriptionsForShadow:(NSString *)name
+                            callback:(AWSIoTMQTTExtendedNewMessageBlock)callback
+                  completionHandler:(void(^)(void))completionHandler {
     BOOL rc = NO;
     AWSIoTDataShadow *shadow = (AWSIoTDataShadow *)[self.shadows objectForKey:name];
     
     if (shadow != nil) {
+        __block NSUInteger remainingTopics = [shadow.topics count];
+        AWSIoTMQTTAckBlock ackCallback = NULL;
+        if (completionHandler) {
+            ackCallback = ^void {
+                remainingTopics--;
+                if (remainingTopics == 0) {
+                    completionHandler();
+                }
+            };
+        }
+
         for (int i = 0; i < [shadow.topics count]; i++) {
             if (callback != nil) {
                 if (shadow.enableDebugging == YES) {
                     AWSDDLogInfo(@"subscribing on %@", (NSString *)shadow.topics[i]);
                 }
-                [self subscribeToTopic:shadow.topics[i] QoS:shadow.qos extendedCallback:callback];
+                [self subscribeToTopic:shadow.topics[i] QoS:shadow.qos extendedCallback:callback ackCallback:ackCallback];
             }
             else {
                 if (shadow.enableDebugging == YES) {
                     AWSDDLogInfo(@"unsubscribing from %@", (NSString *)shadow.topics[i]);
                 }
-                [self unsubscribeTopic:shadow.topics[i]];
+                [self unsubscribeTopic:shadow.topics[i] ackCallback:ackCallback];
             }
         }
         rc = YES;
@@ -1208,6 +1225,20 @@ static void (^shadowMqttMessageHandler)(NSObject *mqttClient, NSString *topic, N
 - (BOOL) registerWithShadow:(NSString *)name
                     options:(NSDictionary *)options
               eventCallback:(void(^)(NSString *name, AWSIoTShadowOperationType operation, AWSIoTShadowOperationStatusType status, NSString *clientToken, NSData *payload))callback {
+    return [self registerWithShadow:name options:options eventCallback:callback completionHandler:nil];
+}
+
+- (BOOL) registerWithShadow:(NSString *)name
+                    options:(NSDictionary *)options
+              eventCallback:(void(^)(NSString *name, AWSIoTShadowOperationType operation, AWSIoTShadowOperationStatusType status, NSString *clientToken, NSData *payload))callback
+         completionCallback:(void(^)(void))completionCallback {
+    return [self registerWithShadow:name options:options eventCallback:callback completionHandler:completionCallback];
+}
+
+- (BOOL) registerWithShadow:(NSString *)name
+                    options:(NSDictionary *)options
+              eventCallback:(void(^)(NSString *name, AWSIoTShadowOperationType operation, AWSIoTShadowOperationStatusType status, NSString *clientToken, NSData *payload))callback
+          completionHandler:(nullable void(^)(void))completionHandler {
     BOOL rc = YES;
     
     AWSIoTDataShadow *shadow = [self.shadows objectForKey:name];
@@ -1291,7 +1322,8 @@ static void (^shadowMqttMessageHandler)(NSObject *mqttClient, NSString *topic, N
             // Persistently subscribe to the special topics for this shadow.
             //
             rc = [self handleSubscriptionsForShadow:shadow.name
-                                           callback:shadowMqttMessageHandler];
+                                           callback:shadowMqttMessageHandler
+                                  completionHandler:completionHandler];
 
             if( rc == NO ){
                 AWSDDLogError(@"unable to subscribe to shadow topics for (%@)", name);
@@ -1308,13 +1340,23 @@ static void (^shadowMqttMessageHandler)(NSObject *mqttClient, NSString *topic, N
 }
 
 - (BOOL) unregisterFromShadow:(NSString *)name {
+    return [self unregisterFromShadow:name completionHandler:nil];
+}
+
+- (BOOL) unregisterFromShadow:(NSString *)name
+           completionCallback:(void (^)(void))completionCallback {
+    return [self unregisterFromShadow:name completionHandler:completionCallback];
+}
+
+- (BOOL) unregisterFromShadow:(NSString *)name
+            completionHandler:(nullable void (^)(void))completionHandler {
     BOOL rc = NO;
     
     AWSIoTDataShadow *shadow = [self.shadows objectForKey:name];
     
     if (shadow != nil) {
         // Unsubscribe from all topics associated with this shadow.
-        rc = [self handleSubscriptionsForShadow:shadow.name callback:nil];
+        rc = [self handleSubscriptionsForShadow:shadow.name callback:nil completionHandler:completionHandler];
 
         //invalidate the timer as the shadow is being unregistered.
         [shadow.timer invalidate];

--- a/AWSIoTTests/AWSIoTDataManagerTests.swift
+++ b/AWSIoTTests/AWSIoTDataManagerTests.swift
@@ -284,6 +284,41 @@ class AWSIoTDataManagerTests: XCTestCase {
 
     }
 
+    func testRegisterAndUnregisterWithShadow_withCompletionCallbacks_shouldInvokeCallbacks() {
+        let connectExpectation = expectation(description: "connect expectation")
+        let iotDataManager = AWSIoTDataManager(forKey: "iot-data-manager-broker1")
+        iotDataManager.connect(
+            withClientId: UUID().uuidString,
+            cleanSession: true,
+            certificateId: UserDefaults.standard.string(forKey: "TestCertBroker1")!,
+            statusCallback: { status in
+                if case .connected = status {
+                    connectExpectation.fulfill()
+                }
+            }
+        )
+        wait(for: [connectExpectation], timeout: 30)
+
+        let registerExpectation = expectation(description: "registerWithShadow expectation")
+        iotDataManager.register(
+            withShadow: "iot-shadow",
+            eventCallback: { _, _, _, _, _ in },
+            completionCallback: {
+                registerExpectation.fulfill()
+            }
+        )
+        wait(for: [registerExpectation], timeout: 5)
+
+        let unregisterExpectation = expectation(description: "unregisterFromShadow expectation")
+        iotDataManager.unregister(
+            fromShadow: "iot-shadow",
+            completionCallback: {
+                unregisterExpectation.fulfill()
+            }
+        )
+        wait(for: [unregisterExpectation], timeout: 5)
+    }
+
     func testPublishWithoutConnect() {
         let iotDataManager:AWSIoTDataManager = AWSIoTDataManager(forKey: "iot-data-manager-broker-test-without-connect")
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/1159

**Description of changes:**

This PR adds the following methods to `AWSIoTDataManager`:
  - `registerWithShadow:options:eventCallback:completionCallback:`
  - `unregisterFromShadow:completionCallback:`

They are basically just overloading the existing ones with the addition of the `completionCallback` argument, which is invoked when the subscription to all topics is done.

The reasoning behind this is to provide a way for consumers to know when the subscription is actually done and they can get the shadow (see the referenced issue for more information).

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
