### PR TITLE
chore: Tweaking testing workflows

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -6,7 +6,7 @@ on:
       identifier:
         required: true
         type: string
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -19,7 +19,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validation:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request || (github.event.pull_request.user.login == 'awsmobilesdk' || contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)) }}
+    steps:
+      - run: echo "Integration Tests can be run"
   integration-test:
+    needs: [validation]
     name: Integration Test
     environment: IntegrationTest
     strategy:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,6 +22,7 @@ jobs:
   unit-test:
     name: Unit Test
     strategy:
+      fail-fast: false
       matrix:
         scheme:
           - AWSAPIGateway


### PR DESCRIPTION
*Description of changes:*
This PR changes the `pull_request_target` trigger to `pull_request` in the Integration Tests workflow so they can test the proposed changes, but adds a validation to only allow them to run if the PR comes from a **MEMBER** or **OWNER** of this organization, or from the **awsmobilesdk** bot.

Additionally, this also disables `fail-fast` on the Unit Tests workflow, so that if one of them fail the others are not immediately cancelled.


*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
