### PR TITLE
fix(IoT): Fixing auto reconnection not working properly.

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -384,7 +384,7 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
     @synchronized(self) {
         if (self.streamsThread && !self.streamsThread.isCancelled) {
             AWSDDLogVerbose(@"Issued Cancel on thread [%@]", self.streamsThread);
-            [self.streamsThread cancel];
+            [self.streamsThread cancelAndDisconnect:self.userDidIssueDisconnect];
         }
         self.streamsThread = [[AWSIoTStreamThread alloc] initWithSession:self.session
                                                       decoderInputStream:inputStream
@@ -637,7 +637,7 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
     self.connectionAgeInSeconds = 0;
 
     //Cancel the current streams thread
-    [self.streamsThread cancel];
+    [self.streamsThread cancelAndDisconnect:YES];
 
     __weak AWSIoTMQTTClient *weakSelf = self;
     self.streamsThread.onStop = ^{
@@ -1230,7 +1230,7 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
     @synchronized(self) {
         if (self.streamsThread && !self.streamsThread.isCancelled) {
             AWSDDLogVerbose(@"Issued Cancel on thread [%@]", self.streamsThread);
-            [self.streamsThread cancel];
+            [self.streamsThread cancelAndDisconnect:self.userDidIssueDisconnect];
         }
 
         self.streamsThread = [[AWSIoTStreamThread alloc] initWithSession:self.session

--- a/AWSIoT/Internal/AWSIoTStreamThread.h
+++ b/AWSIoT/Internal/AWSIoTStreamThread.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
             decoderInputStream:(nonnull NSInputStream *)decoderInputStream
            encoderOutputStream:(nonnull NSOutputStream *)decoderOutputStream
                   outputStream:(nullable NSOutputStream *)outputStream;
+
+- (void)cancelAndDisconnect:(BOOL)shouldDisconnect;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - **AWSS3TransferUtility**
   - Adding support for path-style access requests
 
+### Bug Fixes
+
+- **AWSIoT**
+  - Fixing auto reconnection not working properly
+
 ## 2.33.9
 
 ### Bug Fixes


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5198
 
**Description of changes:**

This PR addresses an issue introduced in the refactor made on https://github.com/aws-amplify/aws-sdk-ios/pull/5185.
When a reconnection happens, neither the session nor the streams are recreated (i.e. the existing ones are reused), so the `AWSIoTStreamThread` should **not** close them when it gets cancelled because of a reconnection.

I've solved this issue by creating a new `cancelAndDisconnect:` method that can be invoked with the proper flag when creating a new thread, i.e. `self.userDidIssueDisconnect`. A reconnection then would keep all the streams open and continue to receive updates.

**Check points:**

- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [X] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
