### PR TITLE
fix: Add privacy manifest

### DIFF
--- a/AWSAPIGateway.podspec
+++ b/AWSAPIGateway.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '2.33.10'
 
   s.source_files = 'AWSAPIGateway/*.{h,m}'
+  s.resource_bundle = { 'AWSAPIGateway' => ['AWSAPIGateway/PrivacyInfo.xcprivacy']}
 end

--- a/AWSAPIGateway/PrivacyInfo.xcprivacy
+++ b/AWSAPIGateway/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAPIGateway/PrivacyInfo.xcprivacy
+++ b/AWSAPIGateway/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAppleSignIn.podspec
+++ b/AWSAppleSignIn.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSAuthCore', '2.33.10'
   s.source_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.{h,m}'
   s.public_header_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.h'
+  s.resource_bundle = { 'AWSAppleSignIn' => ['AWSAppleSignIn/PrivacyInfo.xcprivacy']}
 end

--- a/AWSAuthCore.podspec
+++ b/AWSAuthCore.podspec
@@ -15,5 +15,6 @@ Pod::Spec.new do |s|
    s.dependency 'AWSCore', '2.33.10'
    s.source_files = 'AWSAuthSDK/Sources/AWSAuthCore/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSAuthCore/*.h'
+   s.resource_bundle = { 'AWSAuthCore' => ['AWSAuthCore/PrivacyInfo.xcprivacy']}
  end
  

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -125,6 +125,13 @@
 		17D61FA7216BBC59009B2B9C /* AWSMobileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D61FA6216BBC59009B2B9C /* AWSMobileClient.swift */; };
 		17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1786CA4D1F2BEDB8003421FF /* Images.xcassets */; };
 		17F4F75121F6B0750068B553 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */; };
+		214609902B88FA8B002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609142B88FA8B002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609922B88FABA002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609912B88FABA002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609942B88FAD9002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609932B88FAD9002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609962B88FAFF002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609952B88FAFF002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609982B88FB0F002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609972B88FB0F002FCE7B /* PrivacyInfo.xcprivacy */; };
+		2146099A2B88FB2D002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609992B88FB2D002FCE7B /* PrivacyInfo.xcprivacy */; };
+		2146099C2B88FB46002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146099B2B88FB46002FCE7B /* PrivacyInfo.xcprivacy */; };
 		5C3324972773F43400F2C47B /* AWSMobileClientDeleteUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3324962773F43400F2C47B /* AWSMobileClientDeleteUserTests.swift */; };
 		68B1317829A95E6400E3B3BC /* WeakHashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B1317729A95E6400E3B3BC /* WeakHashTable.swift */; };
 		68B1317929A95E6400E3B3BC /* WeakHashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B1317729A95E6400E3B3BC /* WeakHashTable.swift */; };
@@ -483,6 +490,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = B5FC69001FAFA1AA004790CB;
 			remoteInfo = AWSMobileClient;
+		};
+		2146098C2B88FA8B002FCE7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 48885FBC2A0C1F440012EEB7;
+			remoteInfo = AWSKinesisVideoWebRTCStorage;
+		};
+		2146098E2B88FA8B002FCE7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B55D56BD1F44EC3F005A0E56 /* AWSiOSSDKv2.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 48885FCB2A0C1FB30012EEB7;
+			remoteInfo = AWSKinesisVideoWebRTCStorageUnitTests;
 		};
 		5C33250D2773F43500F2C47B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1502,6 +1523,13 @@
 		17D61FA6216BBC59009B2B9C /* AWSMobileClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClient.swift; sourceTree = "<group>"; };
 		17F4F74E21F6B0750068B553 /* AWSCognitoAuth+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSCognitoAuth+Extensions.h"; sourceTree = "<group>"; };
 		17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSCognitoAuth+Extensions.m"; sourceTree = "<group>"; };
+		214609142B88FA8B002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609912B88FABA002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609932B88FAD9002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609952B88FAFF002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609972B88FB0F002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609992B88FB2D002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2146099B2B88FB46002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		5C3324962773F43400F2C47B /* AWSMobileClientDeleteUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSMobileClientDeleteUserTests.swift; sourceTree = "<group>"; };
 		68B1317729A95E6400E3B3BC /* WeakHashTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakHashTable.swift; sourceTree = "<group>"; };
 		6BB7BF2E23E5E8FB0026E789 /* AWSMobileClient-Mixed-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSMobileClient-Mixed-Swift.h"; sourceTree = "<group>"; };
@@ -1896,6 +1924,7 @@
 		1750D0081F2D4DFA006D915E /* AWSUserPoolsSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				2146099B2B88FB46002FCE7B /* PrivacyInfo.xcprivacy */,
 				1750D00F1F2D4E23006D915E /* AWSCognitoUserPoolsSignInProvider.h */,
 				1750D0101F2D4E23006D915E /* AWSCognitoUserPoolsSignInProvider.m */,
 				B5170D2E1F44F091008FD811 /* AWSUserPoolsSignIn.h */,
@@ -1992,6 +2021,7 @@
 		1786CA351F2BED3C003421FF /* AWSGoogleSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				214609972B88FB0F002FCE7B /* PrivacyInfo.xcprivacy */,
 				B5170CD51F44EF0E008FD811 /* AWSGoogleSignIn.h */,
 				1786CA491F2BEDB8003421FF /* AWSGoogleSignInButton.h */,
 				1786CA4A1F2BEDB8003421FF /* AWSGoogleSignInButton.m */,
@@ -2006,6 +2036,7 @@
 		1786CA421F2BED46003421FF /* AWSFacebookSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				214609952B88FAFF002FCE7B /* PrivacyInfo.xcprivacy */,
 				1786CA431F2BED46003421FF /* AWSFacebookSignIn.h */,
 				1786CA531F2BEDDD003421FF /* AWSFacebookSignInButton.h */,
 				1786CA541F2BEDDD003421FF /* AWSFacebookSignInButton.m */,
@@ -2261,6 +2292,7 @@
 		B49C891024B387C3009739FC /* AWSAppleSignIn */ = {
 			isa = PBXGroup;
 			children = (
+				214609142B88FA8B002FCE7B /* PrivacyInfo.xcprivacy */,
 				B49C891124B387C3009739FC /* AWSAppleSignIn.h */,
 				B49C891324B387C3009739FC /* AWSAppleSignInButton.h */,
 				B49C891624B387C3009739FC /* AWSAppleSignInButton.m */,
@@ -2341,6 +2373,7 @@
 		B5345D101F366AFA009C1041 /* AWSAuthUI */ = {
 			isa = PBXGroup;
 			children = (
+				214609932B88FAD9002FCE7B /* PrivacyInfo.xcprivacy */,
 				B5345D741F366E4A009C1041 /* AWSAuthUI.h */,
 				B5150A531F3BF00F00AC8D08 /* AWSAuthUIConfiguration.h */,
 				B5150AB11F3BF03D00AC8D08 /* AWSAuthUIConfiguration.m */,
@@ -2477,6 +2510,8 @@
 				5C3325142773F43500F2C47B /* AWSChimeSDKMessaging.framework */,
 				5C3325162773F43500F2C47B /* AWSChimeSDKMessagingTests.xctest */,
 				5C3325182773F43500F2C47B /* AWSChimeSDKMessagingUnitTests.xctest */,
+				2146098D2B88FA8B002FCE7B /* AWSKinesisVideoWebRTCStorage.framework */,
+				2146098F2B88FA8B002FCE7B /* AWSKinesisVideoWebRTCStorageUnitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2484,6 +2519,7 @@
 		B5C564B61F2B2302004FF3CF /* AWSAuthCore */ = {
 			isa = PBXGroup;
 			children = (
+				214609912B88FABA002FCE7B /* PrivacyInfo.xcprivacy */,
 				B5C564901F2B2162004FF3CF /* AWSAuthCore.h */,
 				B9AC6318234F00FA00A713A5 /* AWSAuthUIHelper.h */,
 				B9AC6317234F00F900A713A5 /* AWSAuthUIHelper.m */,
@@ -2503,6 +2539,7 @@
 		B5FC69021FAFA1AA004790CB /* AWSMobileClient */ = {
 			isa = PBXGroup;
 			children = (
+				214609992B88FB2D002FCE7B /* PrivacyInfo.xcprivacy */,
 				B5FC69041FAFA1AA004790CB /* Info.plist */,
 				170AD35221921764004E1E88 /* AWSMobileClient.h */,
 				B402D00725815C550020B83B /* AWSMobileClientXCF.h */,
@@ -3157,6 +3194,20 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		2146098D2B88FA8B002FCE7B /* AWSKinesisVideoWebRTCStorage.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = AWSKinesisVideoWebRTCStorage.framework;
+			remoteRef = 2146098C2B88FA8B002FCE7B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		2146098F2B88FA8B002FCE7B /* AWSKinesisVideoWebRTCStorageUnitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = AWSKinesisVideoWebRTCStorageUnitTests.xctest;
+			remoteRef = 2146098E2B88FA8B002FCE7B /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		5C33250E2773F43500F2C47B /* AWSChimeSDKIdentity.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -4068,6 +4119,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2146099A2B88FB2D002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
+				2146099C2B88FB46002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
+				214609942B88FAD9002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
+				214609922B88FABA002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
+				214609962B88FAFF002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
+				214609982B88FB0F002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
+				214609902B88FA8B002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AWSAuthSDK/Sources/AWSMobileClient/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSMobileClient/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSMobileClient/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSMobileClient/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy
+++ b/AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy
@@ -3,20 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array/>
 </dict>

--- a/AWSAuthUI.podspec
+++ b/AWSAuthUI.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
    s.source_files = 'AWSAuthSDK/Sources/AWSAuthUI/*.{h,m}', 'AWSAuthSDK/Sources/AWSAuthUI/**/*.{h,m}', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSUserPoolsUIHelper.h'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUI.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIViewController.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSAuthUIConfiguration.h'
    s.private_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableCell.h', 'AWSAuthSDK/Sources/AWSAuthUI/AWSSignInViewController.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSTableInputCell.h', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/AWSFormTableDelegate.h'
-   s.resource_bundles = { 'AWSAuthUI' => ['AWSAuthSDK/Sources/AWSAuthUI/*.{storyboard}', 'AWSAuthSDK/Sources/AWSAuthUI/Images.xcassets'] }
+   s.resource_bundles = { 'AWSAuthUI' => ['AWSAuthSDK/Sources/AWSAuthUI/*.{storyboard}', 'AWSAuthSDK/Sources/AWSAuthUI/Images.xcassets', 'AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy'] }
  end

--- a/AWSAutoScaling.podspec
+++ b/AWSAutoScaling.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSAutoScaling/*.{h,m}'
+  s.resource_bundle = { 'AWSAutoScaling' => ['AWSAutoScaling/PrivacyInfo.xcprivacy']}
 end

--- a/AWSAutoScaling/PrivacyInfo.xcprivacy
+++ b/AWSAutoScaling/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSAutoScaling/PrivacyInfo.xcprivacy
+++ b/AWSAutoScaling/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSChimeSDKIdentity.podspec
+++ b/AWSChimeSDKIdentity.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSChimeSDKIdentity/*.{h,m}'
+  s.resource_bundle = { 'AWSChimeSDKIdentity' => ['AWSChimeSDKIdentity/PrivacyInfo.xcprivacy']}
 end

--- a/AWSChimeSDKIdentity/PrivacyInfo.xcprivacy
+++ b/AWSChimeSDKIdentity/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSChimeSDKIdentity/PrivacyInfo.xcprivacy
+++ b/AWSChimeSDKIdentity/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSChimeSDKMessaging.podspec
+++ b/AWSChimeSDKMessaging.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSChimeSDKMessaging/*.{h,m}'
+  s.resource_bundle = { 'AWSChimeSDKMessaging' => ['AWSChimeSDKMessaging/PrivacyInfo.xcprivacy']}
 end

--- a/AWSChimeSDKMessaging/PrivacyInfo.xcprivacy
+++ b/AWSChimeSDKMessaging/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSChimeSDKMessaging/PrivacyInfo.xcprivacy
+++ b/AWSChimeSDKMessaging/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSCloudWatch.podspec
+++ b/AWSCloudWatch.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSCloudWatch/*.{h,m}'
+  s.resource_bundle = { 'AWSCloudWatch' => ['AWSCloudWatch/PrivacyInfo.xcprivacy']}
 end

--- a/AWSCloudWatch/PrivacyInfo.xcprivacy
+++ b/AWSCloudWatch/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSCloudWatch/PrivacyInfo.xcprivacy
+++ b/AWSCloudWatch/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSCognitoAuth.podspec
+++ b/AWSCognitoAuth.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.source_files = 'AWSCognitoAuth/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoAuth/*.h'
   s.private_header_files = 'AWSCognitoAuth/Internal/*.h'
+  s.resource_bundle = { 'AWSCognitoAuth' => ['AWSCognitoAuth/PrivacyInfo.xcprivacy']}
 end

--- a/AWSCognitoAuth/PrivacyInfo.xcprivacy
+++ b/AWSCognitoAuth/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSCognitoAuth/PrivacyInfo.xcprivacy
+++ b/AWSCognitoAuth/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSCognitoIdentityProvider.podspec
+++ b/AWSCognitoIdentityProvider.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.source_files = 'AWSCognitoIdentityProvider/**/*.{h,m,c}'
   s.public_header_files = 'AWSCognitoIdentityProvider/*.h'
   s.private_header_files = 'AWSCognitoIdentityProvider/Internal/*.h'
+  s.resource_bundle = { 'AWSCognitoIdentityProvider' => ['AWSCognitoIdentityProvider/PrivacyInfo.xcprivacy']}
 end

--- a/AWSCognitoIdentityProvider/PrivacyInfo.xcprivacy
+++ b/AWSCognitoIdentityProvider/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSCognitoIdentityProvider/PrivacyInfo.xcprivacy
+++ b/AWSCognitoIdentityProvider/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSCognitoIdentityProviderASF.podspec
+++ b/AWSCognitoIdentityProviderASF.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.public_header_files = 'AWSCognitoIdentityProviderASF/*.h'
   s.source_files = 'AWSCognitoIdentityProviderASF/**/*.{h,m,c}'
   s.private_header_files = 'AWSCognitoIdentityProviderASF/Internal/*.h'
+  s.resource_bundle = { 'AWSCognitoIdentityProviderASF' => ['AWSCognitoIdentityProviderASF/PrivacyInfo.xcprivacy']}
 end

--- a/AWSCognitoIdentityProviderASF/PrivacyInfo.xcprivacy
+++ b/AWSCognitoIdentityProviderASF/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSCognitoIdentityProviderASF/PrivacyInfo.xcprivacy
+++ b/AWSCognitoIdentityProviderASF/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSComprehend.podspec
+++ b/AWSComprehend.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSComprehend/*.{h,m}'
+  s.resource_bundle = { 'AWSComprehend' => ['AWSComprehend/PrivacyInfo.xcprivacy']}
 end

--- a/AWSComprehend/PrivacyInfo.xcprivacy
+++ b/AWSComprehend/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSComprehend/PrivacyInfo.xcprivacy
+++ b/AWSComprehend/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSConnect.podspec
+++ b/AWSConnect.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSConnect/*.{h,m}'
+  s.resource_bundle = { 'AWSConnect' => ['AWSConnect/PrivacyInfo.xcprivacy']}
 end

--- a/AWSConnect/PrivacyInfo.xcprivacy
+++ b/AWSConnect/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSConnect/PrivacyInfo.xcprivacy
+++ b/AWSConnect/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSConnectParticipant.podspec
+++ b/AWSConnectParticipant.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSConnectParticipant/*.{h,m}'
+  s.resource_bundle = { 'AWSConnectParticipant' => ['AWSConnectParticipant/PrivacyInfo.xcprivacy']}
 end

--- a/AWSConnectParticipant/PrivacyInfo.xcprivacy
+++ b/AWSConnectParticipant/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSConnectParticipant/PrivacyInfo.xcprivacy
+++ b/AWSConnectParticipant/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -20,4 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}'
   s.private_header_files = 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h', 'AWSCore/Fabric/*.h', 'AWSCore/Mantle/extobjc/*.h', 'AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h'
+  s.resource_bundle = { 'AWSCore' => ['AWSCore/PrivacyInfo.xcprivacy']}
 end

--- a/AWSCore/PrivacyInfo.xcprivacy
+++ b/AWSCore/PrivacyInfo.xcprivacy
@@ -18,6 +18,15 @@
 		</dict>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/AWSCore/PrivacyInfo.xcprivacy
+++ b/AWSCore/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSCore/PrivacyInfo.xcprivacy
+++ b/AWSCore/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSDynamoDB.podspec
+++ b/AWSDynamoDB.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSDynamoDB/*.{h,m}'
+  s.resource_bundle = { 'AWSDynamoDB' => ['AWSDynamoDB/PrivacyInfo.xcprivacy']}
 end

--- a/AWSDynamoDB/PrivacyInfo.xcprivacy
+++ b/AWSDynamoDB/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSDynamoDB/PrivacyInfo.xcprivacy
+++ b/AWSDynamoDB/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSEC2.podspec
+++ b/AWSEC2.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSEC2/*.{h,m}'
+  s.resource_bundle = { 'AWSEC2' => ['AWSEC2/PrivacyInfo.xcprivacy']}
 end

--- a/AWSEC2/PrivacyInfo.xcprivacy
+++ b/AWSEC2/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSEC2/PrivacyInfo.xcprivacy
+++ b/AWSEC2/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSElasticLoadBalancing.podspec
+++ b/AWSElasticLoadBalancing.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSElasticLoadBalancing/*.{h,m}'
+  s.resource_bundle = { 'AWSElasticLoadBalancing' => ['AWSElasticLoadBalancing/PrivacyInfo.xcprivacy']}
 end

--- a/AWSElasticLoadBalancing/PrivacyInfo.xcprivacy
+++ b/AWSElasticLoadBalancing/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSElasticLoadBalancing/PrivacyInfo.xcprivacy
+++ b/AWSElasticLoadBalancing/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSFacebookSignIn.podspec
+++ b/AWSFacebookSignIn.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
 
    s.source_files = 'AWSAuthSDK/Sources/AWSFacebookSignIn/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSFacebookSignIn/*.h'
-   s.resource_bundle = {  'AWSFacebookSignIn' => 'AWSAuthSDK/Sources/AWSFacebookSignIn/Images.xcassets' }
+   s.resource_bundle = {  'AWSFacebookSignIn' => ['AWSAuthSDK/Sources/AWSFacebookSignIn/Images.xcassets', 'AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy'] }
  end

--- a/AWSGoogleSignIn.podspec
+++ b/AWSGoogleSignIn.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
    s.source_files = 'AWSAuthSDK/Sources/AWSGoogleSignIn/*.{h,m}', 'AWSAuthSDK/Dependencies/GoogleHeaders/*.h'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSGoogleSignIn/*.h'
    s.private_header_files = 'AWSAuthSDK/Dependencies/GoogleHeaders/*.h'
-   s.resource_bundle = {  'AWSGoogleSignIn' => 'AWSAuthSDK/Sources/AWSGoogleSignIn/Images.xcassets' }
+   s.resource_bundle = {  'AWSGoogleSignIn' => ['AWSAuthSDK/Sources/AWSGoogleSignIn/Images.xcassets','AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy']  }
  end

--- a/AWSIoT.podspec
+++ b/AWSIoT.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSIoT/*.{h,m}', 'AWSIoT/**/*.{h,m}'
   s.private_header_files = 'AWSIoT/Internal/*.h'
+  s.resource_bundle = { 'AWSIoT' => ['AWSIoT/PrivacyInfo.xcprivacy']}
 end

--- a/AWSIoT/PrivacyInfo.xcprivacy
+++ b/AWSIoT/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSIoT/PrivacyInfo.xcprivacy
+++ b/AWSIoT/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSKMS.podspec
+++ b/AWSKMS.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSKMS/*.{h,m}'
+  s.resource_bundle = { 'AWSKMS' => ['AWSKMS/PrivacyInfo.xcprivacy']}
 end

--- a/AWSKMS/PrivacyInfo.xcprivacy
+++ b/AWSKMS/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSKMS/PrivacyInfo.xcprivacy
+++ b/AWSKMS/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSKinesis.podspec
+++ b/AWSKinesis.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSKinesis/*.{h,m}', 'AWSKinesis/**/*.{h,m}'
   s.private_header_files = 'AWSKinesis/Internal/*.h'
+  s.resource_bundle = { 'AWSKinesis' => ['AWSKinesis/PrivacyInfo.xcprivacy']}
 end

--- a/AWSKinesis/PrivacyInfo.xcprivacy
+++ b/AWSKinesis/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSKinesis/PrivacyInfo.xcprivacy
+++ b/AWSKinesis/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSKinesisVideo.podspec
+++ b/AWSKinesisVideo.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSKinesisVideo/*.{h,m}'
+  s.resource_bundle = { 'AWSKinesisVideo' => ['AWSKinesisVideo/PrivacyInfo.xcprivacy']}
 end

--- a/AWSKinesisVideo/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideo/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSKinesisVideo/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideo/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSKinesisVideoArchivedMedia.podspec
+++ b/AWSKinesisVideoArchivedMedia.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSKinesisVideoArchivedMedia/*.{h,m}'
+  s.resource_bundle = { 'AWSKinesisVideoArchivedMedia' => ['AWSKinesisVideoArchivedMedia/PrivacyInfo.xcprivacy']}
 end

--- a/AWSKinesisVideoArchivedMedia/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideoArchivedMedia/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSKinesisVideoArchivedMedia/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideoArchivedMedia/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSKinesisVideoSignaling.podspec
+++ b/AWSKinesisVideoSignaling.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSKinesisVideoSignaling/*.{h,m}'
+  s.resource_bundle = { 'AWSKinesisVideoSignaling' => ['AWSKinesisVideoSignaling/PrivacyInfo.xcprivacy']}
 end

--- a/AWSKinesisVideoSignaling/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideoSignaling/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSKinesisVideoSignaling/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideoSignaling/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSKinesisVideoWebRTCStorage.podspec
+++ b/AWSKinesisVideoWebRTCStorage.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSKinesisVideoWebRTCStorage/*.{h,m}'
+  s.resource_bundle = { 'AWSKinesisVideoWebRTCStorage' => ['AWSKinesisVideoWebRTCStorage/PrivacyInfo.xcprivacy']}
 end

--- a/AWSKinesisVideoWebRTCStorage/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideoWebRTCStorage/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSKinesisVideoWebRTCStorage/PrivacyInfo.xcprivacy
+++ b/AWSKinesisVideoWebRTCStorage/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSLambda.podspec
+++ b/AWSLambda.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSLambda/*.{h,m}'
+  s.resource_bundle = { 'AWSLambda' => ['AWSLambda/PrivacyInfo.xcprivacy']}
 end

--- a/AWSLambda/PrivacyInfo.xcprivacy
+++ b/AWSLambda/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSLambda/PrivacyInfo.xcprivacy
+++ b/AWSLambda/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSLex.podspec
+++ b/AWSLex.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.private_header_files = 'AWSLex/Bluefront/include/*.h'
   s.preserve_paths = 'AWSLex/Bluefront/include/*'
   s.vendored_libraries = 'AWSLex/Bluefront/libBlueAudioSourceiOS.a'
-  s.resource_bundle = { 'AWSLex' => 'AWSLex/Media.xcassets' }
+  s.resource_bundle = { 'AWSLex' => ['AWSLex/Media.xcassets', 'AWSLex/PrivacyInfo.xcprivacy'] }
   
   # Exclude arm64 when building for simulator on Xcode 12+
   s.pod_target_xcconfig = {'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}

--- a/AWSLex/PrivacyInfo.xcprivacy
+++ b/AWSLex/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSLex/PrivacyInfo.xcprivacy
+++ b/AWSLex/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSLocation.podspec
+++ b/AWSLocation.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSLocation/*.{h,m}', 'AWSLocation/AWSLocationTracker/**/*.swift'
+  s.resource_bundle = { 'AWSLocation' => ['AWSLocation/PrivacyInfo.xcprivacy']}
 end

--- a/AWSLocation/PrivacyInfo.xcprivacy
+++ b/AWSLocation/PrivacyInfo.xcprivacy
@@ -18,6 +18,15 @@
 		</dict>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/AWSLocation/PrivacyInfo.xcprivacy
+++ b/AWSLocation/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSLocation/PrivacyInfo.xcprivacy
+++ b/AWSLocation/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSLogs.podspec
+++ b/AWSLogs.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSLogs/*.{h,m}'
+  s.resource_bundle = { 'AWSLogs' => ['AWSLogs/PrivacyInfo.xcprivacy']}
 end

--- a/AWSLogs/PrivacyInfo.xcprivacy
+++ b/AWSLogs/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSLogs/PrivacyInfo.xcprivacy
+++ b/AWSLogs/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSMachineLearning.podspec
+++ b/AWSMachineLearning.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSMachineLearning/*.{h,m}'
+  s.resource_bundle = { 'AWSMachineLearning' => ['AWSMachineLearning/PrivacyInfo.xcprivacy']}
 end

--- a/AWSMachineLearning/PrivacyInfo.xcprivacy
+++ b/AWSMachineLearning/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSMachineLearning/PrivacyInfo.xcprivacy
+++ b/AWSMachineLearning/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSMobileClient.podspec
+++ b/AWSMobileClient.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
 
    s.source_files = 'AWSAuthSDK/Sources/AWSMobileClient/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/*.{h,m}', 'AWSAuthSDK/Sources/AWSMobileClient/**/*.swift', 'AWSCognitoAuth/**/*.{h,m,c}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h', 'AWSCognitoAuth/*.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoCredentialsProvider+Extension.h', 'AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoIdentityUserPool+Extension.h'
+   s.resource_bundle = { 'AWSMobileClient' => ['AWSAuthSDK/Sources/AWSMobileClient/PrivacyInfo.xcprivacy']}
  end

--- a/AWSPinpoint.podspec
+++ b/AWSPinpoint.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSPinpoint/*.{h,m}', 'AWSPinpoint/**/*.{h,m}'
   s.private_header_files = 'AWSPinpoint/Internal/*.h'
+  s.resource_bundle = { 'AWSPinpoint' => ['AWSPinpoint/PrivacyInfo.xcprivacy']}
 end

--- a/AWSPinpoint/PrivacyInfo.xcprivacy
+++ b/AWSPinpoint/PrivacyInfo.xcprivacy
@@ -18,6 +18,15 @@
 		</dict>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/AWSPinpoint/PrivacyInfo.xcprivacy
+++ b/AWSPinpoint/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSPinpoint/PrivacyInfo.xcprivacy
+++ b/AWSPinpoint/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSPolly.podspec
+++ b/AWSPolly.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSPolly/*.{h,m}'
+  s.resource_bundle = { 'AWSPolly' => ['AWSPolly/PrivacyInfo.xcprivacy']}
 end

--- a/AWSPolly/PrivacyInfo.xcprivacy
+++ b/AWSPolly/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSPolly/PrivacyInfo.xcprivacy
+++ b/AWSPolly/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSRekognition.podspec
+++ b/AWSRekognition.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSRekognition/*.{h,m}'
+  s.resource_bundle = { 'AWSRekognition' => ['AWSRekognition/PrivacyInfo.xcprivacy']}
 end

--- a/AWSRekognition/PrivacyInfo.xcprivacy
+++ b/AWSRekognition/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSRekognition/PrivacyInfo.xcprivacy
+++ b/AWSRekognition/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSS3.podspec
+++ b/AWSS3.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSS3/*.{h,m}'
+  s.resource_bundle = { 'AWSS3' => ['AWSS3/PrivacyInfo.xcprivacy']}
 end

--- a/AWSS3/PrivacyInfo.xcprivacy
+++ b/AWSS3/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSS3/PrivacyInfo.xcprivacy
+++ b/AWSS3/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSSES.podspec
+++ b/AWSSES.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSSES/*.{h,m}'
+  s.resource_bundle = { 'AWSSES' => ['AWSSES/PrivacyInfo.xcprivacy']}
 end

--- a/AWSSES/PrivacyInfo.xcprivacy
+++ b/AWSSES/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSSES/PrivacyInfo.xcprivacy
+++ b/AWSSES/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSSNS.podspec
+++ b/AWSSNS.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSSNS/*.{h,m}'
+  s.resource_bundle = { 'AWSSNS' => ['AWSSNS/PrivacyInfo.xcprivacy']}
 end

--- a/AWSSNS/PrivacyInfo.xcprivacy
+++ b/AWSSNS/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSSNS/PrivacyInfo.xcprivacy
+++ b/AWSSNS/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSSQS.podspec
+++ b/AWSSQS.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSSQS/*.{h,m}'
+  s.resource_bundle = { 'AWSSQS' => ['AWSSQS/PrivacyInfo.xcprivacy']}
 end

--- a/AWSSQS/PrivacyInfo.xcprivacy
+++ b/AWSSQS/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSSQS/PrivacyInfo.xcprivacy
+++ b/AWSSQS/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSSageMakerRuntime.podspec
+++ b/AWSSageMakerRuntime.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSSageMakerRuntime/*.{h,m}'
+  s.resource_bundle = { 'AWSSageMakerRuntime' => ['AWSSageMakerRuntime/PrivacyInfo.xcprivacy']}
 end

--- a/AWSSageMakerRuntime/PrivacyInfo.xcprivacy
+++ b/AWSSageMakerRuntime/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSSageMakerRuntime/PrivacyInfo.xcprivacy
+++ b/AWSSageMakerRuntime/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSSimpleDB.podspec
+++ b/AWSSimpleDB.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSSimpleDB/*.{h,m}'
+  s.resource_bundle = { 'AWSSimpleDB' => ['AWSSimpleDB/PrivacyInfo.xcprivacy']}
 end

--- a/AWSSimpleDB/PrivacyInfo.xcprivacy
+++ b/AWSSimpleDB/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSSimpleDB/PrivacyInfo.xcprivacy
+++ b/AWSSimpleDB/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSTextract.podspec
+++ b/AWSTextract.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSTextract/*.{h,m}'
+  s.resource_bundle = { 'AWSTextract' => ['AWSTextract/PrivacyInfo.xcprivacy']}
 end

--- a/AWSTextract/PrivacyInfo.xcprivacy
+++ b/AWSTextract/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSTextract/PrivacyInfo.xcprivacy
+++ b/AWSTextract/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSTranscribe.podspec
+++ b/AWSTranscribe.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSTranscribe/*.{h,m}'
+  s.resource_bundle = { 'AWSTranscribe' => ['AWSTranscribe/PrivacyInfo.xcprivacy']}
 end

--- a/AWSTranscribe/PrivacyInfo.xcprivacy
+++ b/AWSTranscribe/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSTranscribe/PrivacyInfo.xcprivacy
+++ b/AWSTranscribe/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSTranscribeStreaming.podspec
+++ b/AWSTranscribeStreaming.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSTranscribeStreaming/*.{h,m}', 'AWSTranscribeStreaming/**/*.{h,m}', 'AWSIoT/Internal/SocketRocket/*.{h,m}'
   s.private_header_files = 'AWSTranscribeStreaming/Internal/*.h', 'AWSIoT/Internal/SocketRocket/*.h'
+  s.resource_bundle = { 'AWSTranscribeStreaming' => ['AWSTranscribeStreaming/PrivacyInfo.xcprivacy']}
 end

--- a/AWSTranscribeStreaming/PrivacyInfo.xcprivacy
+++ b/AWSTranscribeStreaming/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSTranscribeStreaming/PrivacyInfo.xcprivacy
+++ b/AWSTranscribeStreaming/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSTranslate.podspec
+++ b/AWSTranslate.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'AWSCore', '2.33.10'
   s.source_files = 'AWSTranslate/*.{h,m}'
+  s.resource_bundle = { 'AWSTranslate' => ['AWSTranslate/PrivacyInfo.xcprivacy']}
 end

--- a/AWSTranslate/PrivacyInfo.xcprivacy
+++ b/AWSTranslate/PrivacyInfo.xcprivacy
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/AWSTranslate/PrivacyInfo.xcprivacy
+++ b/AWSTranslate/PrivacyInfo.xcprivacy
@@ -13,7 +13,6 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>

--- a/AWSUserPoolsSignIn.podspec
+++ b/AWSUserPoolsSignIn.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
    s.source_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/**/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/*.{h}'
    s.private_header_files = 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/UserPoolsUI/*.{h}'
-   s.resource_bundles = { 'AWSUserPoolsSignIn' => ['AWSAuthSDK/Sources/AWSUserPoolsSignIn/**/*.{storyboard}'] }
+   s.resource_bundles = { 'AWSUserPoolsSignIn' => ['AWSAuthSDK/Sources/AWSUserPoolsSignIn/**/*.{storyboard}', 'AWSAuthSDK/Sources/AWSUserPoolsSignIn/PrivacyInfo.xcprivacy'] }
  end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -507,6 +507,44 @@
 		211FFD0D26C30DCF00F0DB75 /* AWSGeneralChimeSDKMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 211FFD0B26C30DCE00F0DB75 /* AWSGeneralChimeSDKMessagingTests.m */; };
 		211FFD1026C30E5800F0DB75 /* AWSGeneralChimeSDKIdentityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 211FFD0E26C30E5700F0DB75 /* AWSGeneralChimeSDKIdentityTests.m */; };
 		211FFD1126C30E5800F0DB75 /* AWSChimeSDKIdentityNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 211FFD0F26C30E5700F0DB75 /* AWSChimeSDKIdentityNSSecureCodingTests.m */; };
+		214608C82B88F2EA002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608C72B88F2EA002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608CA2B88F301002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608C92B88F301002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608CC2B88F30D002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608CB2B88F30D002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608CE2B88F318002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608CD2B88F318002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608D02B88F324002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608CF2B88F324002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608D22B88F32C002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608D12B88F32C002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608D42B88F344002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608D32B88F343002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608D62B88F350002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608D52B88F350002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608D82B88F35A002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608D72B88F35A002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608DA2B88F363002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608D92B88F363002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608DC2B88F37D002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608DB2B88F37D002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608DE2B88F387002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608DD2B88F387002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608E02B88F390002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608DF2B88F390002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608E22B88F39A002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608E12B88F39A002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608E42B88F3A5002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608E32B88F3A5002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608E62B88F3B2002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608E52B88F3B2002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608E82B88F3BB002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608E72B88F3BB002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608EA2B88F3C7002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608E92B88F3C7002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608EC2B88F3D3002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608EB2B88F3D3002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608EE2B88F3DE002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608ED2B88F3DE002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608F02B88F3E8002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608EF2B88F3E8002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608F22B88F3F3002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608F12B88F3F3002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608F42B88F3FF002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608F32B88F3FF002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608F62B88F40B002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608F52B88F40B002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608F82B88F416002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608F72B88F416002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608FA2B88F422002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608F92B88F421002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608FC2B88F42B002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608FB2B88F42B002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214608FE2B88F436002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608FD2B88F436002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609002B88F447002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608FF2B88F446002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609022B88F450002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609012B88F450002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609042B88F45A002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609032B88F45A002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609062B88F465002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609052B88F465002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609082B88F46F002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609072B88F46F002FCE7B /* PrivacyInfo.xcprivacy */; };
+		2146090A2B88F47A002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609092B88F47A002FCE7B /* PrivacyInfo.xcprivacy */; };
+		2146090C2B88F485002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146090B2B88F485002FCE7B /* PrivacyInfo.xcprivacy */; };
+		2146090E2B88F493002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146090D2B88F493002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609102B88F4A2002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146090F2B88F4A2002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609122B88F4B0002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609112B88F4B0002FCE7B /* PrivacyInfo.xcprivacy */; };
 		21607DE425547FB00012FE96 /* AWSLocationTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21607DE325547FB00012FE96 /* AWSLocationTrackerTests.swift */; };
 		217100032551B09100FAB22F /* TrackingListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217100022551B09100FAB22F /* TrackingListener.swift */; };
 		2171007D2551B0AD00FAB22F /* TrackingPublishedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171007C2551B0AD00FAB22F /* TrackingPublishedEvent.swift */; };
@@ -3100,6 +3138,44 @@
 		211FFD0B26C30DCE00F0DB75 /* AWSGeneralChimeSDKMessagingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralChimeSDKMessagingTests.m; sourceTree = "<group>"; };
 		211FFD0E26C30E5700F0DB75 /* AWSGeneralChimeSDKIdentityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralChimeSDKIdentityTests.m; sourceTree = "<group>"; };
 		211FFD0F26C30E5700F0DB75 /* AWSChimeSDKIdentityNSSecureCodingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSChimeSDKIdentityNSSecureCodingTests.m; sourceTree = "<group>"; };
+		214608C72B88F2EA002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608C92B88F301002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608CB2B88F30D002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608CD2B88F318002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608CF2B88F324002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608D12B88F32C002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608D32B88F343002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608D52B88F350002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608D72B88F35A002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608D92B88F363002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608DB2B88F37D002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608DD2B88F387002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608DF2B88F390002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608E12B88F39A002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608E32B88F3A5002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608E52B88F3B2002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608E72B88F3BB002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608E92B88F3C7002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608EB2B88F3D3002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608ED2B88F3DE002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608EF2B88F3E8002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608F12B88F3F3002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608F32B88F3FF002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608F52B88F40B002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608F72B88F416002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608F92B88F421002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608FB2B88F42B002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608FD2B88F436002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214608FF2B88F446002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609012B88F450002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609032B88F45A002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609052B88F465002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609072B88F46F002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609092B88F47A002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2146090B2B88F485002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2146090D2B88F493002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2146090F2B88F4A2002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		214609112B88F4B0002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		21607DE325547FB00012FE96 /* AWSLocationTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLocationTrackerTests.swift; sourceTree = "<group>"; };
 		21607F4F255480080012FE96 /* AWSLocationUnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSLocationUnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		217100022551B09100FAB22F /* TrackingListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingListener.swift; sourceTree = "<group>"; };
@@ -5201,6 +5277,7 @@
 		1778554420F9A72800D083BB /* AWSKinesisVideo */ = {
 			isa = PBXGroup;
 			children = (
+				214608E72B88F3BB002FCE7B /* PrivacyInfo.xcprivacy */,
 				177855A620F9A90900D083BB /* AWSKinesisVideoModel.h */,
 				177855A920F9A90900D083BB /* AWSKinesisVideoModel.m */,
 				177855AA20F9A90A00D083BB /* AWSKinesisVideoResources.h */,
@@ -5216,6 +5293,7 @@
 		1778556920F9A7CE00D083BB /* AWSKinesisVideoArchivedMedia */ = {
 			isa = PBXGroup;
 			children = (
+				214608E92B88F3C7002FCE7B /* PrivacyInfo.xcprivacy */,
 				177855B620F9A91A00D083BB /* AWSKinesisVideoArchivedMediaModel.h */,
 				177855B520F9A91A00D083BB /* AWSKinesisVideoArchivedMediaModel.m */,
 				177855B720F9A91A00D083BB /* AWSKinesisVideoArchivedMediaResources.h */,
@@ -5271,6 +5349,7 @@
 		178A800D22AF7DA600B167D6 /* AWSTranscribeStreaming */ = {
 			isa = PBXGroup;
 			children = (
+				2146090F2B88F4A2002FCE7B /* PrivacyInfo.xcprivacy */,
 				FA53332222D40A3300BD88AF /* Internal */,
 				178A800E22AF7DA600B167D6 /* AWSTranscribeStreaming.h */,
 				FA09EEA322D63786007EA360 /* AWSTranscribeStreamingClientDelegate.h */,
@@ -5313,6 +5392,7 @@
 		17E6B437209BB7A80079B286 /* AWSTranscribe */ = {
 			isa = PBXGroup;
 			children = (
+				2146090D2B88F493002FCE7B /* PrivacyInfo.xcprivacy */,
 				17E6B438209BB7A80079B286 /* AWSTranscribe.h */,
 				17E6B472209BBCB60079B286 /* AWSTranscribeModel.h */,
 				17E6B46D209BBCB50079B286 /* AWSTranscribeModel.m */,
@@ -5372,6 +5452,7 @@
 		181270C21E8EB53A00174785 /* AWSLogs */ = {
 			isa = PBXGroup;
 			children = (
+				214608F52B88F40B002FCE7B /* PrivacyInfo.xcprivacy */,
 				181270C31E8EB53A00174785 /* AWSLogs.h */,
 				181270DF1E8EB78900174785 /* AWSLogsModel.h */,
 				181270E01E8EB78900174785 /* AWSLogsModel.m */,
@@ -5445,6 +5526,7 @@
 		185111CC1D78F03B0009F5C3 /* AWSLex */ = {
 			isa = PBXGroup;
 			children = (
+				214608F12B88F3F3002FCE7B /* PrivacyInfo.xcprivacy */,
 				B52FBE911F17414A000F0C00 /* Media.xcassets */,
 				18F938B11DE5148E00034221 /* AWSLex.h */,
 				18F938B21DE5148E00034221 /* AWSLexInteractionKit.h */,
@@ -5501,6 +5583,7 @@
 		18798F7F1DEF9EA900BC419B /* AWSPinpoint */ = {
 			isa = PBXGroup;
 			children = (
+				214608F92B88F421002FCE7B /* PrivacyInfo.xcprivacy */,
 				18798FA41DEF9F2B00BC419B /* AWSPinpoint.h */,
 				18798FAD1DEF9F2B00BC419B /* AWSPinpointAnalyticsClient.h */,
 				18798FAE1DEF9F2B00BC419B /* AWSPinpointAnalyticsClient.m */,
@@ -5588,6 +5671,7 @@
 		188321031DFF11B8003FBE9F /* AWSRekognition */ = {
 			isa = PBXGroup;
 			children = (
+				214608FD2B88F436002FCE7B /* PrivacyInfo.xcprivacy */,
 				188321191DFF1FD5003FBE9F /* AWSRekognition.h */,
 				1883211A1DFF1FD5003FBE9F /* AWSRekognitionModel.h */,
 				1883211B1DFF1FD5003FBE9F /* AWSRekognitionModel.m */,
@@ -5613,6 +5697,7 @@
 		18E2F5621DED307500BD4608 /* AWSPolly */ = {
 			isa = PBXGroup;
 			children = (
+				214608FB2B88F42B002FCE7B /* PrivacyInfo.xcprivacy */,
 				18E2F5781DED30C500BD4608 /* AWSPolly.h */,
 				18E2F5791DED30C500BD4608 /* AWSPollyModel.h */,
 				18E2F57A1DED30C500BD4608 /* AWSPollyModel.m */,
@@ -5661,6 +5746,7 @@
 		2109E2BA254745210057043C /* AWSLocation */ = {
 			isa = PBXGroup;
 			children = (
+				214608F32B88F3FF002FCE7B /* PrivacyInfo.xcprivacy */,
 				2109E4C2254754E00057043C /* AWSLocation.h */,
 				2109E4C6254754E10057043C /* AWSLocationModel.h */,
 				2109E4C4254754E00057043C /* AWSLocationModel.m */,
@@ -5699,6 +5785,7 @@
 		211166F72399C24900902FC1 /* AWSKinesisVideoSignaling */ = {
 			isa = PBXGroup;
 			children = (
+				214608EB2B88F3D3002FCE7B /* PrivacyInfo.xcprivacy */,
 				211167162399C5BB00902FC1 /* AWSKinesisVideoSignaling.h */,
 				211167182399C5BC00902FC1 /* AWSKinesisVideoSignalingModel.h */,
 				2111671A2399C5BC00902FC1 /* AWSKinesisVideoSignalingModel.m */,
@@ -5734,6 +5821,7 @@
 		211FFC7E26C2FBAD00F0DB75 /* AWSChimeSDKIdentity */ = {
 			isa = PBXGroup;
 			children = (
+				214608CD2B88F318002FCE7B /* PrivacyInfo.xcprivacy */,
 				211FFCBE26C3017400F0DB75 /* AWSChimeSDKIdentityModel.h */,
 				211FFCC326C3017500F0DB75 /* AWSChimeSDKIdentityModel.m */,
 				211FFCC026C3017400F0DB75 /* AWSChimeSDKIdentityResources.h */,
@@ -5759,6 +5847,7 @@
 		211FFCA026C2FF4600F0DB75 /* AWSChimeSDKMessaging */ = {
 			isa = PBXGroup;
 			children = (
+				214608CF2B88F324002FCE7B /* PrivacyInfo.xcprivacy */,
 				211FFCA126C2FF4600F0DB75 /* AWSChimeSDKMessaging.h */,
 				211FFCCF26C3022500F0DB75 /* AWSChimeSDKMessagingModel.h */,
 				211FFCCE26C3022500F0DB75 /* AWSChimeSDKMessagingModel.m */,
@@ -5913,6 +6002,7 @@
 		48885FAE2A0C1F170012EEB7 /* AWSKinesisVideoWebRTCStorage */ = {
 			isa = PBXGroup;
 			children = (
+				214608C72B88F2EA002FCE7B /* PrivacyInfo.xcprivacy */,
 				48885FAF2A0C1F170012EEB7 /* AWSKinesisVideoWebRTCStorage.h */,
 				48885FB02A0C1F170012EEB7 /* AWSKinesisVideoWebRTCStorageService.h */,
 				48885FB12A0C1F170012EEB7 /* AWSKinesisVideoWebRTCStorageModel.m */,
@@ -5928,6 +6018,7 @@
 		9A7ACC2120B0E85000DDBEC1 /* AWSTranslate */ = {
 			isa = PBXGroup;
 			children = (
+				214609112B88F4B0002FCE7B /* PrivacyInfo.xcprivacy */,
 				9A7ACC6420B10DCB00DDBEC1 /* AWSTranslate.h */,
 				9A7ACC4320B0E9EF00DDBEC1 /* AWSTranslateModel.h */,
 				9A7ACC3E20B0E9EE00DDBEC1 /* AWSTranslateModel.m */,
@@ -5953,6 +6044,7 @@
 		9A7ACC6C20B110DE00DDBEC1 /* AWSComprehend */ = {
 			isa = PBXGroup;
 			children = (
+				214608D52B88F350002FCE7B /* PrivacyInfo.xcprivacy */,
 				9A7ACC8C20B1113F00DDBEC1 /* AWSComprehend.h */,
 				9A7ACC8E20B1113F00DDBEC1 /* AWSComprehendModel.h */,
 				9A7ACC8B20B1113F00DDBEC1 /* AWSComprehendModel.m */,
@@ -6010,6 +6102,7 @@
 		B4A4DFF622B4201400379396 /* AWSSageMakerRuntime */ = {
 			isa = PBXGroup;
 			children = (
+				214609012B88F450002FCE7B /* PrivacyInfo.xcprivacy */,
 				B4A4E02122B4229200379396 /* AWSSageMakerRuntime.h */,
 				B4A4E01622B4212A00379396 /* AWSSageMakerRuntimeModel.h */,
 				B4A4E01922B4212A00379396 /* AWSSageMakerRuntimeModel.m */,
@@ -6043,6 +6136,7 @@
 		B4D61CB023285D16007E7A12 /* AWSConnectParticipant */ = {
 			isa = PBXGroup;
 			children = (
+				214608D92B88F363002FCE7B /* PrivacyInfo.xcprivacy */,
 				B4D61CCD23285DF3007E7A12 /* AWSConnectParticipant.h */,
 				B4D61CCF23285DF4007E7A12 /* AWSConnectParticipantModel.h */,
 				B4D61CD323285DF5007E7A12 /* AWSConnectParticipantModel.m */,
@@ -6087,6 +6181,7 @@
 		B5C01AF522EB7EFE000F2877 /* AWSTextract */ = {
 			isa = PBXGroup;
 			children = (
+				2146090B2B88F485002FCE7B /* PrivacyInfo.xcprivacy */,
 				B434294022F0FA0D00567E83 /* AWSTextract.h */,
 				B5C01B1622EB7F74000F2877 /* AWSTextractModel.h */,
 				B5C01B1422EB7F72000F2877 /* AWSTextractModel.m */,
@@ -6113,6 +6208,7 @@
 		B5DD450522C9B17C003871AE /* AWSConnect */ = {
 			isa = PBXGroup;
 			children = (
+				214608D72B88F35A002FCE7B /* PrivacyInfo.xcprivacy */,
 				B5DD452322C9B1B7003871AE /* AWSConnectModel.h */,
 				B5DD452422C9B1B7003871AE /* AWSConnectModel.m */,
 				B5DD452522C9B1B7003871AE /* AWSConnectResources.h */,
@@ -6407,6 +6503,7 @@
 		CE0D416E1C6A66E5006B91B5 /* AWSCore */ = {
 			isa = PBXGroup;
 			children = (
+				214608DB2B88F37D002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE0D416F1C6A66E5006B91B5 /* AWSCore.h */,
 				CE0D41711C6A66E5006B91B5 /* Info.plist */,
 				CE0D41841C6A673E006B91B5 /* Authentication */,
@@ -6910,6 +7007,7 @@
 		CE9DE5351C6A72960060793F /* AWSAutoScaling */ = {
 			isa = PBXGroup;
 			children = (
+				214608CB2B88F30D002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE5361C6A72960060793F /* AWSAutoScaling.h */,
 				CE9DE54B1C6A72FE0060793F /* AWSAutoScalingModel.h */,
 				CE9DE54C1C6A72FE0060793F /* AWSAutoScalingModel.m */,
@@ -6934,6 +7032,7 @@
 		CE9DE5711C6A763E0060793F /* AWSDynamoDB */ = {
 			isa = PBXGroup;
 			children = (
+				214608DD2B88F387002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE5721C6A763E0060793F /* AWSDynamoDB.h */,
 				CE9DE58A1C6A76E70060793F /* AWSDynamoDBModel.h */,
 				CE9DE58B1C6A76E70060793F /* AWSDynamoDBModel.m */,
@@ -6967,6 +7066,7 @@
 		CE9DE5AD1C6A77880060793F /* AWSEC2 */ = {
 			isa = PBXGroup;
 			children = (
+				214608DF2B88F390002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE5AE1C6A77880060793F /* AWSEC2.h */,
 				CE9DE5C41C6A77CD0060793F /* AWSEC2Model.h */,
 				CE9DE5C51C6A77CD0060793F /* AWSEC2Model.m */,
@@ -6993,6 +7093,7 @@
 		CE9DE5DD1C6A78200060793F /* AWSElasticLoadBalancing */ = {
 			isa = PBXGroup;
 			children = (
+				214608E12B88F39A002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE5DE1C6A78200060793F /* AWSElasticLoadBalancing.h */,
 				CE9DE5F41C6A78500060793F /* AWSElasticLoadBalancingModel.h */,
 				CE9DE5F51C6A78500060793F /* AWSElasticLoadBalancingModel.m */,
@@ -7017,6 +7118,7 @@
 		CE9DE60D1C6A78A60060793F /* AWSIoT */ = {
 			isa = PBXGroup;
 			children = (
+				214608E32B88F3A5002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE60E1C6A78A60060793F /* AWSIoT.h */,
 				CE9DE6241C6A78D70060793F /* AWSIoTData.h */,
 				CE9DE6251C6A78D70060793F /* AWSIoTDataManager.h */,
@@ -7115,6 +7217,7 @@
 		CE9DE6881C6A79460060793F /* AWSKinesis */ = {
 			isa = PBXGroup;
 			children = (
+				214608E52B88F3B2002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE69F1C6A79990060793F /* AWSAbstractKinesisRecorder.h */,
 				CE9DE6A01C6A79990060793F /* AWSAbstractKinesisRecorder.m */,
 				CE9DE6A11C6A79990060793F /* AWSFirehose.h */,
@@ -7158,6 +7261,7 @@
 		CE9DE6DA1C6A79DF0060793F /* AWSLambda */ = {
 			isa = PBXGroup;
 			children = (
+				214608EF2B88F3E8002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE6DB1C6A79DF0060793F /* AWSLambda.h */,
 				CE9DE6F11C6A7A260060793F /* AWSLambdaInvoker.h */,
 				CE9DE6F21C6A7A260060793F /* AWSLambdaInvoker.m */,
@@ -7187,6 +7291,7 @@
 		CE9DE7101C6A7A680060793F /* AWSMachineLearning */ = {
 			isa = PBXGroup;
 			children = (
+				214608F72B88F416002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE7111C6A7A680060793F /* AWSMachineLearning.h */,
 				CE9DE7261C6A7A9E0060793F /* AWSMachineLearningModel.h */,
 				CE9DE7271C6A7A9E0060793F /* AWSMachineLearningModel.m */,
@@ -7202,6 +7307,7 @@
 		CE9DE9BE1C6A7C2D0060793F /* AWSS3 */ = {
 			isa = PBXGroup;
 			children = (
+				214608FF2B88F446002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE9BF1C6A7C2D0060793F /* AWSS3.h */,
 				03B83FB42729C3AE004D5426 /* AWSS3TransferUtility_private.h */,
 				03D33F2526C5E492006DDCEB /* AWSS3CreateMultipartUploadRequest+RequestHeaders.h */,
@@ -7255,6 +7361,7 @@
 		CE9DE9FE1C6A7DFF0060793F /* AWSSES */ = {
 			isa = PBXGroup;
 			children = (
+				214609032B88F45A002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DE9FF1C6A7DFF0060793F /* AWSSES.h */,
 				CE9DEA151C6A7E330060793F /* AWSSESModel.h */,
 				CE9DEA161C6A7E330060793F /* AWSSESModel.m */,
@@ -7279,6 +7386,7 @@
 		CE9DEA2E1C6A7E710060793F /* AWSSimpleDB */ = {
 			isa = PBXGroup;
 			children = (
+				214609052B88F465002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DEA2F1C6A7E710060793F /* AWSSimpleDB.h */,
 				CE9DEA451C6A7EA20060793F /* AWSSimpleDBModel.h */,
 				CE9DEA461C6A7EA20060793F /* AWSSimpleDBModel.m */,
@@ -7303,6 +7411,7 @@
 		CE9DEA5E1C6A7EE30060793F /* AWSSNS */ = {
 			isa = PBXGroup;
 			children = (
+				214609072B88F46F002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DEA5F1C6A7EE30060793F /* AWSSNS.h */,
 				CE9DEA751C6A7F110060793F /* AWSSNSModel.h */,
 				CE9DEA761C6A7F110060793F /* AWSSNSModel.m */,
@@ -7327,6 +7436,7 @@
 		CE9DEA8E1C6A7F460060793F /* AWSSQS */ = {
 			isa = PBXGroup;
 			children = (
+				214609092B88F47A002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DEA8F1C6A7F460060793F /* AWSSQS.h */,
 				CE9DEAA51C6A7F810060793F /* AWSSQSModel.h */,
 				CE9DEAA61C6A7F810060793F /* AWSSQSModel.m */,
@@ -7351,6 +7461,7 @@
 		CE9DEB1F1C6A81160060793F /* AWSAPIGateway */ = {
 			isa = PBXGroup;
 			children = (
+				214608C92B88F301002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DEB201C6A81160060793F /* AWSAPIGateway.h */,
 				175C92571D8904B4001A145F /* AWSAPIGatewayModel.h */,
 				175C92551D89049F001A145F /* AWSAPIGatewayModel.m */,
@@ -7378,6 +7489,7 @@
 		CE9DEB611C6A9F3D0060793F /* AWSCloudWatch */ = {
 			isa = PBXGroup;
 			children = (
+				214608D12B88F32C002FCE7B /* PrivacyInfo.xcprivacy */,
 				CE9DEB621C6A9F3D0060793F /* AWSCloudWatch.h */,
 				CE9DEB781C6A9F8A0060793F /* AWSCloudWatchModel.h */,
 				CE9DEB791C6A9F8A0060793F /* AWSCloudWatchModel.m */,
@@ -7402,6 +7514,7 @@
 		CEA316991C93A0EA002A9F58 /* AWSCognitoIdentityProvider */ = {
 			isa = PBXGroup;
 			children = (
+				214608D32B88F343002FCE7B /* PrivacyInfo.xcprivacy */,
 				EF1D80031CBC924D007AC243 /* AWSCognitoIdentityProvider.h */,
 				EFDF14BF1C9929AE002CCFE2 /* AWSCognitoIdentityUser.h */,
 				EFDF147A1C98A79C002CCFE2 /* AWSCognitoIdentityUserPool.h */,
@@ -7476,6 +7589,7 @@
 		E4E1DA1F1E5F4E690080F769 /* AWSKMS */ = {
 			isa = PBXGroup;
 			children = (
+				214608ED2B88F3DE002FCE7B /* PrivacyInfo.xcprivacy */,
 				E4E1DA201E5F4E690080F769 /* AWSKMS.h */,
 				E4E1DA351E5F4EF40080F769 /* AWSKMSModel.h */,
 				E4E1DA361E5F4EF40080F769 /* AWSKMSResources.h */,
@@ -11262,6 +11376,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608E82B88F3BB002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11269,6 +11384,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608EA2B88F3C7002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11304,6 +11420,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609102B88F4A2002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11328,6 +11445,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2146090E2B88F493002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11352,6 +11470,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608F62B88F40B002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11366,6 +11485,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608F22B88F3F3002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 				B4B8C61325ACC1270054E723 /* AWSLexConfig.xcconfig in Resources */,
 				B52FBE921F17414A000F0C00 /* Media.xcassets in Resources */,
 			);
@@ -11382,6 +11502,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608FA2B88F422002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11403,6 +11524,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608FE2B88F436002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11417,6 +11539,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608FC2B88F42B002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11445,6 +11568,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608F42B88F3FF002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11466,6 +11590,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608EC2B88F3D3002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11487,6 +11612,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608CE2B88F318002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11501,6 +11627,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608D02B88F324002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11536,6 +11663,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608C82B88F2EA002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11550,6 +11678,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609122B88F4B0002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11564,6 +11693,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608D62B88F350002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11603,6 +11733,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609022B88F450002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11617,6 +11748,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608DA2B88F363002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11645,6 +11777,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2146090C2B88F485002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11660,6 +11793,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608D82B88F35A002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11681,6 +11815,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608DC2B88F37D002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 				EFE40B801CC5BDEF0045D710 /* strip-frameworks.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -11821,6 +11956,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608CC2B88F30D002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11835,6 +11971,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608DE2B88F387002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11849,6 +11986,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608E02B88F390002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11865,6 +12003,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608E22B88F39A002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11879,6 +12018,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608E42B88F3A5002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11894,6 +12034,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608E62B88F3B2002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11908,6 +12049,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608F02B88F3E8002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11922,6 +12064,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608F82B88F416002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11929,6 +12072,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609002B88F447002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11943,6 +12087,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609042B88F45A002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11957,6 +12102,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609062B88F465002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11971,6 +12117,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609082B88F46F002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11985,6 +12132,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2146090A2B88F47A002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11999,6 +12147,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608CA2B88F301002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12013,6 +12162,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608D22B88F32C002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12027,6 +12177,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608D42B88F344002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12048,6 +12199,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214608EE2B88F3DE002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -545,6 +545,8 @@
 		2146090E2B88F493002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146090D2B88F493002FCE7B /* PrivacyInfo.xcprivacy */; };
 		214609102B88F4A2002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146090F2B88F4A2002FCE7B /* PrivacyInfo.xcprivacy */; };
 		214609122B88F4B0002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609112B88F4B0002FCE7B /* PrivacyInfo.xcprivacy */; };
+		2146099E2B88FC4F002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146099D2B88FC4F002FCE7B /* PrivacyInfo.xcprivacy */; };
+		214609A02B88FC95002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146099F2B88FC95002FCE7B /* PrivacyInfo.xcprivacy */; };
 		21607DE425547FB00012FE96 /* AWSLocationTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21607DE325547FB00012FE96 /* AWSLocationTrackerTests.swift */; };
 		217100032551B09100FAB22F /* TrackingListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217100022551B09100FAB22F /* TrackingListener.swift */; };
 		2171007D2551B0AD00FAB22F /* TrackingPublishedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171007C2551B0AD00FAB22F /* TrackingPublishedEvent.swift */; };
@@ -3176,6 +3178,8 @@
 		2146090D2B88F493002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2146090F2B88F4A2002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		214609112B88F4B0002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2146099D2B88FC4F002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2146099F2B88FC95002FCE7B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		21607DE325547FB00012FE96 /* AWSLocationTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLocationTrackerTests.swift; sourceTree = "<group>"; };
 		21607F4F255480080012FE96 /* AWSLocationUnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSLocationUnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		217100022551B09100FAB22F /* TrackingListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingListener.swift; sourceTree = "<group>"; };
@@ -7670,6 +7674,7 @@
 		EFDE85AE1ED203D9008841EC /* AWSCognitoAuth */ = {
 			isa = PBXGroup;
 			children = (
+				2146099D2B88FC4F002FCE7B /* PrivacyInfo.xcprivacy */,
 				EFDE85AF1ED203D9008841EC /* AWSCognitoAuth.h */,
 				EFDE85B01ED203D9008841EC /* AWSCognitoAuth.m */,
 				EFDE85B11ED203D9008841EC /* Info.plist */,
@@ -7690,6 +7695,7 @@
 		EFDE85B91FC5DC8C00D281A2 /* AWSCognitoIdentityProviderASF */ = {
 			isa = PBXGroup;
 			children = (
+				2146099F2B88FC95002FCE7B /* PrivacyInfo.xcprivacy */,
 				EFDE85FF1FC656F900D281A2 /* Internal */,
 				EFDE85E81FC5E7F000D281A2 /* AWSCognitoIdentityProviderASF.h */,
 				EFDE85FD1FC6535E00D281A2 /* AWSCognitoIdentityProviderASF.m */,
@@ -12221,6 +12227,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				214609A02B88FC95002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -12228,6 +12235,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2146099E2B88FC4F002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 				EF22118A1ED75A0400F432F7 /* LICENSE in Resources */,
 				EF22118B1ED75A0400F432F7 /* README.md in Resources */,
 			);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The privacy manifest file is added to the target’s root directory, and added to the target membership to bundle it with the xcframeworks. The podspec files have been updated to include the privacy manifest in the `resouce_bundle`.

**Verifying xcframeworks**: After building xcframeworks with `CircleciScripts/create_xcframeworks.py`, we can see that the file is included in the framework package, and consuming it from a sample app shows that the file is picked up, ie.

<img width="1428" alt="Pasted Graphic" src="https://github.com/aws-amplify/aws-sdk-ios/assets/1365977/0cc216a1-6249-473d-bf00-4b13fb693565">

(Privacy Manifest report generated from archiving the sample app -> right click on archive -> Generate Privacy Report. Same as Xcode -> Window -> Organizer)

**Verifying pod installation** with local pods ` pod '[PodName]', :path => '~/aws-amplify/aws-sdk-ios'`

The user agent information contains the Amplify version, OS name and version which corresponds to Other Data types (https://docs.amplify.aws/swift/sdk/info/overview/#other-data).

Similar to the privacy manifest in Amplify https://github.com/aws-amplify/amplify-swift/pull/3531 

> In the current version of the privacy manifest format, there isn't a way to specify in more detail the type of "other data type", which is why I have opened a question in the Apple Developer Forums to ask about this: https://developer.apple.com/forums/thread/743559

> Tracking is set to false, despite the current version of our docs shows tracking is true for certain data types, however I have a separate proposal based on my understanding of AppTrackingTransparency Framework that defines what tracking is. We may wait for that proposal to finalize on the Tracking value for the data types listed here (either set NSPrivacyCollectedDataTypeTracking to true or leave it as false).


**1. Collected Data Type clarifications**

There are two projects in the SDK, `AWSiOSSDKv2.xcodeproj` contains AWSCore and most of the clients. `AWSAuthSDK/AWSAuthSDK.xcodeproj` contains AWSMobileClient and most of the UI components (AWSAppleSignIn, AWSFacebookSignIn, etc).

Any target that uses the user agent will be collecting "Other data types" such as OS name, version, locale. This includes all of the service client targets, which will leverage the [baseUserAgent](https://github.com/aws-amplify/aws-sdk-ios/blob/a8bc220252533855f2bec76f5468cd9889dbd573/AWSCore/Service/AWSService.m#L167) from AWSCore. This includes high level clients like AWSMobileClient, and excludes UI components.

**2. Required reason API**

UserDefaults
- AWSPinpoint https://github.com/aws-amplify/aws-sdk-ios/blob/a8bc220252533855f2bec76f5468cd9889dbd573/AWSPinpoint/AWSPinpointConfiguration.m#L52
- AWSLocation https://github.com/aws-amplify/aws-sdk-ios/blob/a8bc220252533855f2bec76f5468cd9889dbd573/AWSLocation/AWSLocationTracker/AWSLocationTracker.swift#L143

NSFileCreationDate / NSFileModificationDate

- AWSCore AWSSDDFileLogger https://github.com/aws-amplify/aws-sdk-ios/blob/a8bc220252533855f2bec76f5468cd9889dbd573/AWSCore/Logging/AWSDDFileLogger.m#L1135
- https://github.com/aws-amplify/aws-sdk-ios/blob/a8bc220252533855f2bec76f5468cd9889dbd573/AWSCore/Logging/AWSDDFileLogger.m#L1127

 C617.1 Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.

This is true if `AWSDDFileLogger` is used



*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
