### PR TITLE
chore: Allowing PRs from ModelUpdates to run integration tests.

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -6,7 +6,7 @@ on:
       identifier:
         required: true
         type: string
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -67,6 +67,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Configure AWS Credentials

--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref_name }}
           persist-credentials: false
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Description of changes:*

This changes the Integration Tests workflow's trigger back to `pull_request_target`, because otherwise PRs coming from the forks that **awsmobilesdk** use to upgrade models will fail.

In order to actually test the changes from the PR, i've explicitly added the PR's SHA to checkout. This is safe because we're still validating that the Integration Tests can only run if they originate by members/owners or the **awsmobilesdk** account.

For non-PR runs (i.e. on a release), we just checkout the branch (as before)

For community contributions PRs, the integration tests will be skipped. We still need to find a way to run those

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
