### PR TITLE
feat(AWSCore): Upgrading CocoaLumberjack to version 3.4.8

### DIFF
--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.libraries    = 'z', 'sqlite3'
   s.requires_arc = true
 
-  s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}'
+  s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}', 'AWSCore/Logging/Extensions/*.swift'
   s.private_header_files = 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h', 'AWSCore/Fabric/*.h', 'AWSCore/Mantle/extobjc/*.h', 'AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h'
 end

--- a/AWSCore/Logging/AWSCLIColor.h
+++ b/AWSCore/Logging/AWSCLIColor.h
@@ -1,0 +1,54 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class represents an NSColor replacement for CLI projects that don't link with AppKit
+ **/
+@interface AWSCLIColor : NSObject
+
+/**
+ *  Convenience method for creating a `AWSCLIColor` instance from RGBA params
+ *
+ *  @param red   red channel, between 0 and 1
+ *  @param green green channel, between 0 and 1
+ *  @param blue  blue channel, between 0 and 1
+ *  @param alpha alpha channel, between 0 and 1
+ */
++ (instancetype)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
+
+/**
+ *  Get the RGBA components from a `AWSCLIColor`
+ *
+ *  @param red   red channel, between 0 and 1
+ *  @param green green channel, between 0 and 1
+ *  @param blue  blue channel, between 0 and 1
+ *  @param alpha alpha channel, between 0 and 1
+ */
+- (void)getRed:(nullable CGFloat *)red green:(nullable CGFloat *)green blue:(nullable CGFloat *)blue alpha:(nullable CGFloat *)alpha NS_SWIFT_NAME(get(red:green:blue:alpha:));
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/AWSCore/Logging/AWSCLIColor.m
+++ b/AWSCore/Logging/AWSCLIColor.m
@@ -1,0 +1,57 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+
+#import "AWSCLIColor.h"
+
+@interface AWSCLIColor () {
+    CGFloat _red, _green, _blue, _alpha;
+}
+
+@end
+
+
+@implementation AWSCLIColor
+
++ (instancetype)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha {
+    __auto_type color = [CLIColor new];
+    color->_red     = red;
+    color->_green   = green;
+    color->_blue    = blue;
+    color->_alpha   = alpha;
+    return color;
+}
+
+- (void)getRed:(CGFloat *)red green:(CGFloat *)green blue:(CGFloat *)blue alpha:(CGFloat *)alpha {
+    if (red) {
+        *red    = _red;
+    }
+    if (green) {
+        *green  = _green;
+    }
+    if (blue) {
+        *blue   = _blue;
+    }
+    if (alpha) {
+        *alpha  = _alpha;
+    }
+}
+
+@end
+
+#endif

--- a/AWSCore/Logging/AWSCocoaLumberjack.h
+++ b/AWSCore/Logging/AWSCocoaLumberjack.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -76,12 +76,24 @@
 #import "AWSDDASLLogCapture.h"
 
 // Loggers
+#import "AWSDDLoggerNames.h"
+
 #import "AWSDDTTYLogger.h"
 #import "AWSDDASLLogger.h"
 #import "AWSDDFileLogger.h"
 #import "AWSDDOSLogger.h"
 
+// Extensions
+#import "AWSDDContextFilterLogFormatter.h"
+#import "AWSDDContextFilterLogFormatter+Deprecated.h"
+#import "AWSDDDispatchQueueLogFormatter.h"
+#import "AWSDDMultiFormatter.h"
+#import "AWSDDFileLogger+Buffering.h"
+
 // CLI
-#if __has_include("CLIColor.h") && TARGET_OS_OSX
-#import "CLIColor.h"
-#endif
+#import "AWSCLIColor.h"
+
+// etc
+#import "AWSDDAbstractDatabaseLogger.h"
+#import "AWSDDLog+LOGV.h"
+#import "AWSDDLegacyMacros.h"

--- a/AWSCore/Logging/AWSDDASLLogger.h
+++ b/AWSCore/Logging/AWSDDASLLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -22,6 +22,8 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Custom key set on messages sent to ASL
 extern const char* const kAWSDDASLKeyAWSDDLog;
 
@@ -41,6 +43,7 @@ extern const char* const kAWSDDASLAWSDDLogValue;
  * However, if you instead choose to use file logging (for faster performance),
  * you may choose to use a file logger and a tty logger.
  **/
+API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
 @interface AWSDDASLLogger : AWSDDAbstractLogger <AWSDDLogger>
 
 /**
@@ -48,7 +51,7 @@ extern const char* const kAWSDDASLAWSDDLogValue;
  *
  *  @return the shared instance
  */
-@property (class, readonly, strong) AWSDDASLLogger *sharedInstance;
+@property (nonatomic, class, readonly, strong) AWSDDASLLogger *sharedInstance;
 
 // Inherited from AWSDDAbstractLogger
 
@@ -56,3 +59,5 @@ extern const char* const kAWSDDASLAWSDDLogValue;
 // - (void)setLogFormatter:(id <AWSDDLogFormatter>)formatter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDAbstractDatabaseLogger.h
+++ b/AWSCore/Logging/AWSDDAbstractDatabaseLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -20,6 +20,8 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This class provides an abstract implementation of a database logger.
  *
@@ -28,7 +30,7 @@
  * and override the methods in the implementation file that are prefixed with "db_".
  **/
 @interface AWSDDAbstractDatabaseLogger : AWSDDAbstractLogger {
-    
+
 @protected
     NSUInteger _saveThreshold;
     NSTimeInterval _saveInterval;
@@ -36,7 +38,7 @@
     NSTimeInterval _deleteInterval;
     BOOL _deleteOnEverySave;
     
-    BOOL _saveTimerSuspended;
+    NSInteger _saveTimerSuspended;
     NSUInteger _unsavedCount;
     dispatch_time_t _unsavedTime;
     dispatch_source_t _saveTimer;
@@ -121,3 +123,5 @@
 - (void)deleteOldLogEntries;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDAssertMacros.h
+++ b/AWSCore/Logging/AWSDDAssertMacros.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -14,13 +14,17 @@
 //   prior written permission of Deusty, LLC.
 
 /**
- * NSAsset replacement that will output a log message even when assertions are disabled.
+ * NSAssert replacement that will output a log message even when assertions are disabled.
  **/
 #define AWSDDAssert(condition, frmt, ...)                                                \
         if (!(condition)) {                                                           \
             NSString *description = [NSString stringWithFormat:frmt, ## __VA_ARGS__]; \
             AWSDDLogError(@"%@", description);                                           \
-            NSAssert(NO, description);                                                \
+            NSAssert(NO, @"%@", description);                                         \
         }
-#define AWSDDAssertCondition(condition) AWSDDAssert(condition, @"Condition not satisfied: %s", #condition)
+#define AWSDDAssertCondition(condition) AWSDDAssert(condition, @"Condition not satisfied: %@", @(#condition))
 
+/**
+ * Analog to `AWSDDAssertionFailure` from AWSDDAssert.swift for use in Objective C
+ */
+#define AWSDDAssertionFailure(frmt, ...) AWSDDAssert(NO, frmt, ##__VA_ARGS__)

--- a/AWSCore/Logging/AWSDDLegacyMacros.h
+++ b/AWSCore/Logging/AWSDDLegacyMacros.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -20,8 +20,12 @@
  **/
 #if AWSDD_LEGACY_MACROS
 
-#warning CocoaLumberjack 1.9.x legacy macros enabled. \
+#warning AWSCocoaLumberjack 1.9.x legacy macros enabled. \
 Disable legacy macros by importing AWSCocoaLumberjack.h or AWSDDLogMacros.h instead of AWSDDLog.h or add `#define AWSDD_LEGACY_MACROS 0` before importing AWSDDLog.h.
+
+#ifndef LOG_LEVEL_DEF
+    #define LOG_LEVEL_DEF [AWSDDLog sharedInstance].logLevel
+#endif
 
 #define LOG_FLAG_ERROR    AWSDDLogFlagError
 #define LOG_FLAG_WARN     AWSDDLogFlagWarning
@@ -57,7 +61,7 @@ Disable legacy macros by importing AWSCocoaLumberjack.h or AWSDDLogMacros.h inst
                format : (frmt), ## __VA_ARGS__]
 
 #define AWSDD_LOG_MAYBE(async, lvl, flg, ctx, fnct, frmt, ...)                       \
-        do { if(lvl & flg) AWSDD_LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if((lvl & flg) != 0) AWSDD_LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_OBJC_MAYBE(async, lvl, flg, ctx, frmt, ...) \
         AWSDD_LOG_MAYBE(async, lvl, flg, ctx, __PRETTY_FUNCTION__, frmt, ## __VA_ARGS__)

--- a/AWSCore/Logging/AWSDDLog+LOGV.h
+++ b/AWSCore/Logging/AWSDDLog+LOGV.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -21,6 +21,13 @@
 #import "AWSDDLog.h"
 
 /**
+ * The constant/variable/method responsible for controlling the current log level.
+ **/
+#ifndef LOG_LEVEL_DEF
+    #define LOG_LEVEL_DEF [AWSDDLog sharedInstance].logLevel
+#endif
+
+/**
  * Whether async should be used by log messages, excluding error messages that are always sent sync.
  **/
 #ifndef LOG_ASYNC_ENABLED
@@ -31,17 +38,17 @@
  * This is the single macro that all other macros below compile into.
  * This big multiline macro makes all the other macros easier to read.
  **/
-#define LOGV_MACRO(isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, avalist) \
-        [AWSDDLog log : isAsynchronous                                     \
-             level : lvl                                                \
-              flag : flg                                                \
-           context : ctx                                                \
-              file : __FILE__                                           \
-          function : fnct                                               \
-              line : __LINE__                                           \
-               tag : atag                                               \
-            format : frmt                                               \
-              args : avalist]
+#define LOGV_MACRO(isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, avalist)    \
+        [AWSDDLog log : isAsynchronous                                          \
+                level : lvl                                                     \
+                 flag : flg                                                     \
+              context : ctx                                                     \
+                 file : __FILE__                                                \
+             function : fnct                                                    \
+                 line : __LINE__                                                \
+                  tag : atag                                                    \
+               format : frmt                                                    \
+                 args : avalist]
 
 /**
  * Define version of the macro that only execute if the log level is above the threshold.
@@ -73,4 +80,3 @@
 #define AWSDDLogVInfo(frmt, avalist)    LOGV_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, avalist)
 #define AWSDDLogVDebug(frmt, avalist)   LOGV_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, avalist)
 #define AWSDDLogVVerbose(frmt, avalist) LOGV_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, avalist)
-

--- a/AWSCore/Logging/AWSDDLog.h
+++ b/AWSCore/Logging/AWSDDLog.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -15,6 +15,23 @@
 
 #import <Foundation/Foundation.h>
 
+// The Swift Package integration has no support for the legacy macros.
+#if __has_include(<AWSDDLegacyMacros.h>)
+    // Enable 1.9.x legacy macros if imported directly and it's not a swift package build.
+    #ifndef AWSDD_LEGACY_MACROS
+        #define AWSDD_LEGACY_MACROS 1
+    #endif
+    // AWSDD_LEGACY_MACROS is checked in the file itself
+    #import <AWSDDLegacyMacros.h>
+#endif
+
+#ifndef AWSDD_LEGACY_MESSAGE_TAG
+    #define AWSDD_LEGACY_MESSAGE_TAG 1
+#endif
+
+// Names of loggers.
+#import "AWSDDLoggerNames.h"
+
 #if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong
 #else
@@ -25,6 +42,8 @@
 @class AWSDDLoggerInformation;
 @protocol AWSDDLogger;
 @protocol AWSDDLogFormatter;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Define the standard options.
@@ -98,22 +117,22 @@ typedef NS_OPTIONS(NSUInteger, AWSDDLogFlag){
      *  0...00001 AWSDDLogFlagError
      */
     AWSDDLogFlagError      = (1 << 0),
-    
+
     /**
      *  0...00010 AWSDDLogFlagWarning
      */
     AWSDDLogFlagWarning    = (1 << 1),
-    
+
     /**
      *  0...00100 AWSDDLogFlagInfo
      */
     AWSDDLogFlagInfo       = (1 << 2),
-    
+
     /**
      *  0...01000 AWSDDLogFlagDebug
      */
     AWSDDLogFlagDebug      = (1 << 3),
-    
+
     /**
      *  0...10000 AWSDDLogFlagVerbose
      */
@@ -128,39 +147,37 @@ typedef NS_ENUM(NSUInteger, AWSDDLogLevel){
      *  No logs
      */
     AWSDDLogLevelOff       = 0,
-    
+
     /**
      *  Error logs only
      */
     AWSDDLogLevelError     = (AWSDDLogFlagError),
-    
+
     /**
      *  Error and warning logs
      */
     AWSDDLogLevelWarning   = (AWSDDLogLevelError   | AWSDDLogFlagWarning),
-    
+
     /**
      *  Error, warning and info logs
      */
     AWSDDLogLevelInfo      = (AWSDDLogLevelWarning | AWSDDLogFlagInfo),
-    
+
     /**
      *  Error, warning, info and debug logs
      */
     AWSDDLogLevelDebug     = (AWSDDLogLevelInfo    | AWSDDLogFlagDebug),
-    
+
     /**
      *  Error, warning, info, debug and verbose logs
      */
     AWSDDLogLevelVerbose   = (AWSDDLogLevelDebug   | AWSDDLogFlagVerbose),
-    
+
     /**
      *  All logs (1...11111)
      */
     AWSDDLogLevelAll       = NSUIntegerMax
 };
-
-NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Extracts just the file name, no path or extension
@@ -170,21 +187,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return the file name
  */
-NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
-
-/**
- * The THIS_FILE macro gives you an NSString of the file name.
- * For simplicity and clarity, the file name does not include the full path or file extension.
- *
- * For example: AWSDDLogWarn(@"%@: Unable to find thingy", THIS_FILE) -> @"MyViewController: Unable to find thingy"
- **/
-#ifndef THIS_FILE
-    #define THIS_FILE         (AWSDDExtractFileNameWithoutExtension(__FILE__, NO))
-#endif
+FOUNDATION_EXTERN NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 
 /**
  * The AWS_THIS_FILE macro gives you an NSString of the file name.
- * Provided for convenience in case of name conflicts of the THIS_FILE macro with CocoaLumberjack.
+ * For simplicity and clarity, the file name does not include the full path or file extension.
  *
  * For example: AWSDDLogWarn(@"%@: Unable to find thingy", AWS_THIS_FILE) -> @"MyViewController: Unable to find thingy"
  **/
@@ -200,6 +207,20 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  **/
 #define THIS_METHOD       NSStringFromSelector(_cmd)
 
+/**
+ * Makes a declaration "Sendable" in Swift (if supported by the compiler).
+ */
+#ifndef AWSDD_SENDABLE
+#ifdef __has_attribute
+#if __has_attribute(swift_attr)
+#define AWSDD_SENDABLE __attribute__((swift_attr("@Sendable")))
+#endif
+#endif
+#endif
+#ifndef AWSDD_SENDABLE
+#define AWSDD_SENDABLE
+#endif
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
@@ -209,6 +230,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  *  The main class, exposes all logging mechanisms, loggers, ...
  *  For most of the users, this class is hidden behind the logging functions like `AWSDDLogInfo`
  */
+AWSDD_SENDABLE
 @interface AWSDDLog : NSObject
 
 /**
@@ -218,7 +240,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 @property (class, nonatomic, strong, readonly) AWSDDLog *sharedInstance;
 
 /**
- * Log level setting.
+ * Log level setting.
  */
 @property (nonatomic, assign) AWSDDLogLevel logLevel;
 
@@ -249,9 +271,9 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format, ... NS_FORMAT_FUNCTION(9,10);
 
 /**
@@ -275,9 +297,9 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format, ... NS_FORMAT_FUNCTION(9,10);
 
 /**
@@ -302,9 +324,9 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format
        args:(va_list)argList NS_SWIFT_NAME(log(asynchronous:level:flag:context:file:function:line:tag:format:arguments:));
 
@@ -330,16 +352,16 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format
        args:(va_list)argList NS_SWIFT_NAME(log(asynchronous:level:flag:context:file:function:line:tag:format:arguments:));
 
 /**
  * Logging Primitive.
  *
- * This method can be used if you manualy prepared AWSDDLogMessage.
+ * This method can be used if you manually prepared AWSDDLogMessage.
  *
  *  @param asynchronous YES if the logging is done async, NO if you want to force sync
  *  @param logMessage   the log message stored in a `AWSDDLogMessage` model object
@@ -350,7 +372,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 /**
  * Logging Primitive.
  *
- * This method can be used if you manualy prepared AWSDDLogMessage.
+ * This method can be used if you manually prepared AWSDDLogMessage.
  *
  *  @param asynchronous YES if the logging is done async, NO if you want to force sync
  *  @param logMessage   the log message stored in a `AWSDDLogMessage` model object
@@ -583,7 +605,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  * If no formatter is set, the logger simply logs the message as it is given in logMessage,
  * or it may use its own built in formatting style.
  **/
-@property (nonatomic, strong) id <AWSDDLogFormatter> logFormatter;
+@property (nonatomic, strong, nullable) id <AWSDDLogFormatter> logFormatter;
 
 @optional
 
@@ -614,16 +636,16 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 - (void)didAddLoggerInQueue:(dispatch_queue_t)queue;
 
 /**
- *  See the above description for `didAddLoger`
+ *  See the above description for `didAddLogger`
  */
 - (void)willRemoveLogger;
 
 /**
  * Some loggers may buffer IO for optimization purposes.
- * For example, a database logger may only save occasionaly as the disk IO is slow.
+ * For example, a database logger may only save occasionally as the disk IO is slow.
  * In such loggers, this method should be implemented to flush any pending IO.
  *
- * This allows invocations of AWSDDLog's flushLog method to be propogated to loggers that need it.
+ * This allows invocations of AWSDDLog's flushLog method to be propagated to loggers that need it.
  *
  * Note that AWSDDLog's flushLog method is invoked automatically when the application quits,
  * and it may be also invoked manually by the developer prior to application crashes, or other such reasons.
@@ -643,7 +665,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  * The created queue will receive its name from this method.
  * This may be helpful for debugging or profiling reasons.
  **/
-@property (nonatomic, readonly) NSString *loggerName;
+@property (copy, nonatomic, readonly) AWSDDLoggerName loggerName;
 
 @end
 
@@ -668,7 +690,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  * The formatter may also optionally filter the log message by returning nil,
  * in which case the logger will not log the message.
  **/
-- (NSString * __nullable)formatLogMessage:(AWSDDLogMessage *)logMessage NS_SWIFT_NAME(format(message:));
+- (nullable NSString *)formatLogMessage:(AWSDDLogMessage *)logMessage NS_SWIFT_NAME(format(message:));
 
 @optional
 
@@ -678,7 +700,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  *
  * This is primarily for thread-safety.
  * If a formatter is explicitly not thread-safe, it may wish to throw an exception if added to multiple loggers.
- * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter),
+ * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter with 10.0 behavior),
  * it could possibly use these hooks to switch to thread-safe versions of the code.
  **/
 - (void)didAddToLogger:(id <AWSDDLogger>)logger;
@@ -689,7 +711,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  *
  * This is primarily for thread-safety.
  * If a formatter is explicitly not thread-safe, it may wish to throw an exception if added to multiple loggers.
- * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter),
+ * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter with 10.0 behavior),
  * it could possibly use these hooks to switch to thread-safe versions of the code or use dispatch_set_specific()
 .* to add its own specific values.
  **/
@@ -709,7 +731,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 /**
  *  This protocol describes a dynamic logging component
  */
-@protocol AWSDDRegisteredDynamicLogging
+@protocol AWSDRegisteredDynamicLogging
 
 /**
  * Implement these methods to allow a file's log level to be managed from a central location.
@@ -768,11 +790,13 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
  * The `AWSDDLogMessage` class encapsulates information about the log message.
  * If you write custom loggers or formatters, you will be dealing with objects of this class.
  **/
+AWSDD_SENDABLE
 @interface AWSDDLogMessage : NSObject <NSCopying>
 {
     // Direct accessors to be used only for performance
     @public
     NSString *_message;
+    NSString *_messageFormat;
     AWSDDLogLevel _level;
     AWSDDLogFlag _flag;
     NSInteger _context;
@@ -780,12 +804,16 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
     NSString *_fileName;
     NSString *_function;
     NSUInteger _line;
-    id _tag;
+#if AWSDD_LEGACY_MESSAGE_TAG
+    id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));
+#endif
+    id _representedObject;
     AWSDDLogMessageOptions _options;
-    NSDate *_timestamp;
+    NSDate * _timestamp;
     NSString *_threadID;
     NSString *_threadName;
     NSString *_queueLabel;
+    NSUInteger _qos;
 }
 
 /**
@@ -807,6 +835,64 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
  * so it makes sense to optimize and skip the unnecessary allocations.
  * However, if you need them to be copied you may use the options parameter to specify this.
  *
+ *  @param messageFormat   the message format
+ *  @param message  the formatted message
+ *  @param level     the log level
+ *  @param flag      the log flag
+ *  @param context   the context (if any is defined)
+ *  @param file      the current file
+ *  @param function  the current function
+ *  @param line      the current code line
+ *  @param tag       potential tag
+ *  @param options   a bitmask which supports AWSDDLogMessageCopyFile and AWSDDLogMessageCopyFunction.
+ *  @param timestamp the log timestamp
+ *
+ *  @return a new instance of a log message model object
+ */
+- (instancetype)initWithFormat:(NSString *)messageFormat
+                     formatted:(NSString *)message
+                         level:(AWSDDLogLevel)level
+                          flag:(AWSDDLogFlag)flag
+                       context:(NSInteger)context
+                          file:(NSString *)file
+                      function:(nullable NSString *)function
+                          line:(NSUInteger)line
+                           tag:(nullable id)tag
+                       options:(AWSDDLogMessageOptions)options
+                     timestamp:(nullable NSDate *)timestamp NS_DESIGNATED_INITIALIZER;
+
+/**
+ *     Convenience initializer taking a `va_list` as arguments to create the formatted message.
+ *
+ *  @param messageFormat   the message format
+ *  @param messageArgs   the message arguments.
+ *  @param level     the log level
+ *  @param flag      the log flag
+ *  @param context   the context (if any is defined)
+ *  @param file      the current file
+ *  @param function  the current function
+ *  @param line      the current code line
+ *  @param tag       potential tag
+ *  @param options   a bitmask which supports AWSDDLogMessageCopyFile and AWSDDLogMessageCopyFunction.
+ *  @param timestamp the log timestamp
+ *
+ *  @return a new instance of a log message model object
+ */
+- (instancetype)initWithFormat:(NSString *)messageFormat
+                          args:(va_list)messageArgs
+                         level:(AWSDDLogLevel)level
+                          flag:(AWSDDLogFlag)flag
+                       context:(NSInteger)context
+                          file:(NSString *)file
+                      function:(nullable NSString *)function
+                          line:(NSUInteger)line
+                           tag:(nullable id)tag
+                       options:(AWSDDLogMessageOptions)options
+                     timestamp:(nullable NSDate *)timestamp;
+
+/**
+ *  Deprecated initialier. See initWithFormat:args:formatted:level:flag:context:file:function:line:tag:options:timestamp:.
+ *
  *  @param message   the message
  *  @param level     the log level
  *  @param flag      the log flag
@@ -825,33 +911,42 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
                            flag:(AWSDDLogFlag)flag
                         context:(NSInteger)context
                            file:(NSString *)file
-                       function:(NSString * __nullable)function
+                       function:(nullable NSString *)function
                            line:(NSUInteger)line
-                            tag:(id __nullable)tag
+                            tag:(nullable id)tag
                         options:(AWSDDLogMessageOptions)options
-                      timestamp:(NSDate * __nullable)timestamp NS_DESIGNATED_INITIALIZER;
+                      timestamp:(nullable NSDate *)timestamp
+__attribute__((deprecated("Use initializer taking unformatted message and args instead", "initWithFormat:formatted:level:flag:context:file:function:line:tag:options:timestamp:")));
 
 /**
  * Read-only properties
  **/
 
 /**
- *  The log message
+ *  The log message.
  */
 @property (readonly, nonatomic) NSString *message;
+/**
+ * The message format. When the deprecated initializer is used, this might be the same as `message`.
+ */
+@property (readonly, nonatomic) NSString *messageFormat;
 @property (readonly, nonatomic) AWSDDLogLevel level;
 @property (readonly, nonatomic) AWSDDLogFlag flag;
 @property (readonly, nonatomic) NSInteger context;
 @property (readonly, nonatomic) NSString *file;
 @property (readonly, nonatomic) NSString *fileName;
-@property (readonly, nonatomic) NSString * __nullable function;
+@property (readonly, nonatomic, nullable) NSString * function;
 @property (readonly, nonatomic) NSUInteger line;
-@property (readonly, nonatomic) id __nullable tag;
+#if AWSDD_LEGACY_MESSAGE_TAG
+@property (readonly, nonatomic, nullable) id tag __attribute__((deprecated("Use representedObject instead", "representedObject")));
+#endif
+@property (readonly, nonatomic, nullable) id representedObject;
 @property (readonly, nonatomic) AWSDDLogMessageOptions options;
 @property (readonly, nonatomic) NSDate *timestamp;
 @property (readonly, nonatomic) NSString *threadID; // ID as it appears in NSLog calculated from the machThreadID
-@property (readonly, nonatomic) NSString *threadName;
+@property (readonly, nonatomic, nullable) NSString *threadName;
 @property (readonly, nonatomic) NSString *queueLabel;
+@property (readonly, nonatomic) NSUInteger qos API_AVAILABLE(macos(10.10), ios(8.0));
 
 @end
 
@@ -863,10 +958,10 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
  * The `AWSDDLogger` protocol specifies that an optional formatter can be added to a logger.
  * Most (but not all) loggers will want to support formatters.
  *
- * However, writting getters and setters in a thread safe manner,
+ * However, writing getters and setters in a thread safe manner,
  * while still maintaining maximum speed for the logging process, is a difficult task.
  *
- * To do it right, the implementation of the getter/setter has strict requiremenets:
+ * To do it right, the implementation of the getter/setter has strict requirements:
  * - Must NOT require the `logMessage:` method to acquire a lock.
  * - Must NOT require the `logMessage:` method to access an atomic property (also a lock of sorts).
  *
@@ -879,7 +974,7 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
 {
     // Direct accessors to be used only for performance
     @public
-    id <AWSDDLogFormatter> _logFormatter;
+    _Nullable id <AWSDDLogFormatter> _logFormatter;
     dispatch_queue_t _loggerQueue;
 }
 
@@ -891,7 +986,7 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
 /**
  *  Return YES if the current logger uses a global queue for logging
  */
-@property (nonatomic, readonly, getter=isOnGlobalLoggingQueue)  BOOL onGlobalLoggingQueue;
+@property (nonatomic, readonly, getter=isOnGlobalLoggingQueue) BOOL onGlobalLoggingQueue;
 
 /**
  *  Return YES if the current logger uses the internal designated queue for logging
@@ -900,17 +995,34 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
 
 @end
 
+#define _AWSDDAbstractLoggerSelectorMessage(msg) [NSStringFromSelector(_cmd) stringByAppendingString:@" " msg]
+// Note: we do not wrap these in any do {...} while 0 construct, because NSAssert does that for us.
+#define AWSDDAbstractLoggerAssertOnGlobalLoggingQueue() \
+NSAssert([self isOnGlobalLoggingQueue], _AWSDDAbstractLoggerSelectorMessage("must only be called on the global logging queue!"))
+#define AWSDDAbstractLoggerAssertOnInternalLoggerQueue() \
+NSAssert([self isOnInternalLoggerQueue], _AWSDDAbstractLoggerSelectorMessage("must only be called on the internal logger queue!"))
+#define AWSDDAbstractLoggerAssertNotOnGlobalLoggingQueue() \
+    NSAssert(![self isOnGlobalLoggingQueue], _AWSDDAbstractLoggerSelectorMessage("must not be called on the global logging queue!"))
+#define AWSDDAbstractLoggerAssertNotOnInternalLoggerQueue() \
+    NSAssert(![self isOnGlobalLoggingQueue], _AWSDDAbstractLoggerSelectorMessage("must not be called on the internal logger queue!"))
+
+#define AWSDDAbstractLoggerAssertLockedPropertyAccess() \
+    AWSDDAbstractLoggerAssertNotOnGlobalLoggingQueue(); \
+    NSAssert(![self isOnInternalLoggerQueue], @"MUST access ivar directly, NOT via self.* syntax.")
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+AWSDD_SENDABLE
 @interface AWSDDLoggerInformation : NSObject
 
 @property (nonatomic, readonly) id <AWSDDLogger> logger;
 @property (nonatomic, readonly) AWSDDLogLevel level;
 
-+ (AWSDDLoggerInformation *)informationWithLogger:(id <AWSDDLogger>)logger
-                           andLevel:(AWSDDLogLevel)level;
++ (instancetype)informationWithLogger:(id <AWSDDLogger>)logger
+                             andLevel:(AWSDDLogLevel)level;
 
 @end
 

--- a/AWSCore/Logging/AWSDDLogMacros.h
+++ b/AWSCore/Logging/AWSDDLogMacros.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -19,6 +19,13 @@
 #endif
 
 #import "AWSDDLog.h"
+
+/**
+ * The constant/variable/method responsible for controlling the current log level.
+ **/
+#ifndef LOG_LEVEL_DEF
+    #define LOG_LEVEL_DEF [AWSDDLog sharedInstance].logLevel
+#endif
 
 /**
  * Whether async should be used by log messages, excluding error messages that are always sent sync.
@@ -73,22 +80,22 @@
  * We also define shorthand versions for asynchronous and synchronous logging.
  **/
 #define AWSDD_LOG_MAYBE(async, lvl, flg, ctx, tag, fnct, frmt, ...) \
-        do { AWSDD_LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if(((NSUInteger)lvl & (NSUInteger)flg) != 0) AWSDD_LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_MAYBE_TO_AWSDDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ...) \
-        do { LOG_MACRO_TO_AWSDDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if(((NSUInteger)lvl & (NSUInteger)flg) != 0) LOG_MACRO_TO_AWSDDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 /**
  * Ready to use log macros with no context or tag.
  **/
-#define AWSDDLogError(frmt, ...)   AWSDD_LOG_MAYBE(NO,                [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogWarn(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogInfo(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogDebug(frmt, ...)   AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogVerbose(frmt, ...) AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogError(frmt, ...)   AWSDD_LOG_MAYBE(NO,                      LOG_LEVEL_DEF, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogWarn(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogInfo(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogDebug(frmt, ...)   AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogVerbose(frmt, ...) AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
-#define AWSDDLogErrorToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, NO,                [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogWarnToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogInfoToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogDebugToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogVerboseToAWSDDLog(ddlog, frmt, ...) LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogErrorToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, NO,                      LOG_LEVEL_DEF, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogWarnToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogInfoToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogDebugToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogVerboseToAWSDDLog(ddlog, frmt, ...) LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)

--- a/AWSCore/Logging/AWSDDLoggerNames.h
+++ b/AWSCore/Logging/AWSDDLoggerNames.h
@@ -13,34 +13,18 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
-
-@protocol AWSDDLogger;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
+typedef NSString *AWSDDLoggerName NS_EXTENSIBLE_STRING_ENUM;
 
-/**
- *  Start capturing logs
- */
-+ (void)start;
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameOS NS_SWIFT_NAME(AWSDDLoggerName.os);     // AWSDDOSLogger
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameFile NS_SWIFT_NAME(AWSDDLoggerName.file); // AWSDDFileLogger
 
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameTTY NS_SWIFT_NAME(AWSDDLoggerName.tty);   // AWSDDTTYLogger
 
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
-
-@end
+API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4, 10.12), ios(2.0, 10.0), watchos(2.0, 3.0), tvos(9.0, 10.0))
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameASL NS_SWIFT_NAME(AWSDDLoggerName.asl);   // AWSDDASLLogger
 
 NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDLoggerNames.m
+++ b/AWSCore/Logging/AWSDDLoggerNames.m
@@ -13,34 +13,9 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
+#import "AWSDDLoggerNames.h"
 
-@protocol AWSDDLogger;
-
-NS_ASSUME_NONNULL_BEGIN
-
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
-
-/**
- *  Start capturing logs
- */
-+ (void)start;
-
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
-
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
-
-@end
-
-NS_ASSUME_NONNULL_END
+AWSDDLoggerName const AWSDDLoggerNameASL    = @"cocoa.lumberjack.aslLogger";
+AWSDDLoggerName const AWSDDLoggerNameTTY    = @"cocoa.lumberjack.ttyLogger";
+AWSDDLoggerName const AWSDDLoggerNameOS     = @"cocoa.lumberjack.osLogger";
+AWSDDLoggerName const AWSDDLoggerNameFile   = @"cocoa.lumberjack.fileLogger";

--- a/AWSCore/Logging/AWSDDMultiFormatter.m
+++ b/AWSCore/Logging/AWSDDMultiFormatter.m
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -13,33 +13,11 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDMultiFormatter.h"
-
-
-#if TARGET_OS_IOS
-// Compiling for iOS
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000 // iOS 6.0 or later
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else                                         // iOS 5.X or earlier
-#define NEEDS_DISPATCH_RETAIN_RELEASE 1
-#endif
-#elif TARGET_OS_WATCH || TARGET_OS_TV
-// Compiling for watchOS, tvOS
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else
-// Compiling for Mac OS X
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080     // Mac OS X 10.8 or later
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else                                         // Mac OS X 10.7 or earlier
-#define NEEDS_DISPATCH_RETAIN_RELEASE 1
-#endif
-#endif
-
-
 #if !__has_feature(objc_arc)
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
+#import "AWSDDMultiFormatter.h"
 
 @interface AWSDDMultiFormatter () {
     dispatch_queue_t _queue;
@@ -57,32 +35,21 @@
     self = [super init];
 
     if (self) {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
         _queue = dispatch_queue_create("cocoa.lumberjack.multiformatter", DISPATCH_QUEUE_CONCURRENT);
-#else
-        _queue = dispatch_queue_create("cocoa.lumberjack.multiformatter", NULL);
-#endif
         _formatters = [NSMutableArray new];
     }
 
     return self;
 }
 
-#if NEEDS_DISPATCH_RETAIN_RELEASE
-- (void)dealloc {
-    dispatch_release(_queue);
-}
-
-#endif
-
 #pragma mark Processing
 
 - (NSString *)formatLogMessage:(AWSDDLogMessage *)logMessage {
-    __block NSString *line = logMessage->_message;
+    __block __auto_type line = logMessage->_message;
 
     dispatch_sync(_queue, ^{
         for (id<AWSDDLogFormatter> formatter in self->_formatters) {
-            AWSDDLogMessage *message = [self logMessageForLine:line originalMessage:logMessage];
+            __auto_type message = [self logMessageForLine:line originalMessage:logMessage];
             line = [formatter formatLogMessage:message];
 
             if (!line) {
@@ -96,7 +63,6 @@
 
 - (AWSDDLogMessage *)logMessageForLine:(NSString *)line originalMessage:(AWSDDLogMessage *)message {
     AWSDDLogMessage *newMessage = [message copy];
-
     newMessage->_message = line;
     return newMessage;
 }

--- a/AWSCore/Logging/AWSDDOSLogger.h
+++ b/AWSCore/Logging/AWSDDOSLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -16,23 +16,41 @@
 #import <Foundation/Foundation.h>
 
 // Disable legacy macros
-#ifndef DD_LEGACY_MACROS
-    #define DD_LEGACY_MACROS 0
+#ifndef AWSDD_LEGACY_MACROS
+    #define AWSDD_LEGACY_MACROS 0
 #endif
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This class provides a logger for the Apple os_log facility.
  **/
-API_AVAILABLE(ios(10.0), macos(10.12), tvos(10.0), watchos(3.0))
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
+AWSDD_SENDABLE
 @interface AWSDDOSLogger : AWSDDAbstractLogger <AWSDDLogger>
 
 /**
  *  Singleton method
  *
- *  @return the shared instance
+ *  @return the shared instance with OS_LOG_DEFAULT.
  */
-@property (class, readonly, strong) AWSDDOSLogger *sharedInstance;
+@property (nonatomic, class, readonly, strong) AWSDDOSLogger *sharedInstance;
+
+/**
+ Designated initializer
+ 
+ @param subsystem Desired subsystem in log. E.g. "org.example"
+ @param category Desired category in log. E.g. "Point of interests."
+ @return New instance of AWSDDOSLogger.
+ 
+ @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
+ If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
+ If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`
+ */
+- (instancetype)initWithSubsystem:(nullable NSString *)subsystem category:(nullable NSString *)category NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDTTYLogger.h
+++ b/AWSCore/Logging/AWSDDTTYLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -28,20 +28,21 @@
     // iOS or tvOS or watchOS
     #import <UIKit/UIColor.h>
     typedef UIColor AWSDDColor;
-    static inline AWSDDColor* AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline AWSDDColor* _Nonnull AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithRed:(r/(CGFloat)255.0) green:(g/(CGFloat)255.0) blue:(b/(CGFloat)255.0) alpha:1.0];}
 #elif defined(AWSDD_CLI) || !__has_include(<AppKit/NSColor.h>)
     // OS X CLI
-    #import "CLIColor.h"
+    #import "AWSCLIColor.h"
     typedef CLIColor AWSDDColor;
-    static inline AWSDDColor* AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline AWSDDColor* _Nonnull AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #else
     // OS X with AppKit
     #import <AppKit/NSColor.h>
     typedef NSColor AWSDDColor;
-    static inline AWSDDColor* AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline AWSDDColor  * _Nonnull AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #endif
 #pragma clang diagnostic pop
 
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * This class provides a logger for Terminal output or Xcode console output,
@@ -60,9 +61,9 @@
 @interface AWSDDTTYLogger : AWSDDAbstractLogger <AWSDDLogger>
 
 /**
- *  Singleton method
+ *  Singleton instance. Returns `nil` if the initialization of the AWSDDTTYLogger fails.
  */
-@property (class, readonly, strong) AWSDDTTYLogger *sharedInstance;
+@property (nonatomic, class, readonly, strong, nullable) AWSDDTTYLogger *sharedInstance;
 
 /* Inherited from the AWSDDLogger protocol:
  *
@@ -104,6 +105,11 @@
 @property (nonatomic, readwrite, assign) BOOL automaticallyAppendNewlineForCustomFormatters;
 
 /**
+ Using this initializer is not supported. Please use `AWSDDTTYLogger.sharedInstance`.
+ **/
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
  * The default color set (foregroundColor, backgroundColor) is:
  *
  * - AWSDDLogFlagError   = (red, nil)
@@ -125,7 +131,7 @@
  *
  * This method invokes setForegroundColor:backgroundColor:forFlag:context: and applies it to `LOG_CONTEXT_ALL`.
  **/
-- (void)setForegroundColor:(AWSDDColor *)txtColor backgroundColor:(AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask;
+- (void)setForegroundColor:(nullable AWSDDColor *)txtColor backgroundColor:(nullable AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask;
 
 /**
  * Just like setForegroundColor:backgroundColor:flag, but allows you to specify a particular logging context.
@@ -133,12 +139,12 @@
  * A logging context is often used to identify log messages coming from a 3rd party framework,
  * although logging context's can be used for many different functions.
  *
- * Use LOG_CONTEXT_ALL to set the deafult color for all contexts that have no specific color set defined.
+ * Use LOG_CONTEXT_ALL to set the default color for all contexts that have no specific color set defined.
  *
  * Logging context's are explained in further detail here:
  * Documentation/CustomContext.md
  **/
-- (void)setForegroundColor:(AWSDDColor *)txtColor backgroundColor:(AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask context:(NSInteger)ctxt;
+- (void)setForegroundColor:(nullable AWSDDColor *)txtColor backgroundColor:(nullable AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask context:(NSInteger)ctxt;
 
 /**
  * Similar to the methods above, but allows you to map AWSDDLogMessage->tag to a particular color profile.
@@ -147,14 +153,14 @@
  * static NSString *const PurpleTag = @"PurpleTag";
  *
  * #define AWSDDLogPurple(frmt, ...) LOG_OBJC_TAG_MACRO(NO, 0, 0, 0, PurpleTag, frmt, ##__VA_ARGS__)
- * 
+ *
  * And then where you configure CocoaLumberjack:
  *
  * purple = AWSDDMakeColor((64/255.0), (0/255.0), (128/255.0));
  *
  * or any UIColor/NSColor constructor.
  *
- * Note: For CLI OS X projects that don't link with AppKit use CLIColor objects instead
+ * Note: For CLI OS X projects that don't link with AppKit use AWSCLIColor objects instead
  *
  * [[AWSDDTTYLogger sharedInstance] setForegroundColor:purple backgroundColor:nil forTag:PurpleTag];
  * [AWSDDLog addLogger:[AWSDDTTYLogger sharedInstance]];
@@ -163,7 +169,7 @@
  *
  * AWSDDLogPurple(@"I'm a purple log message!");
  **/
-- (void)setForegroundColor:(AWSDDColor *)txtColor backgroundColor:(AWSDDColor *)bgColor forTag:(id <NSCopying>)tag;
+- (void)setForegroundColor:(nullable AWSDDColor *)txtColor backgroundColor:(nullable AWSDDColor *)bgColor forTag:(id <NSCopying>)tag;
 
 /**
  * Clearing color profiles.
@@ -176,3 +182,5 @@
 - (void)clearAllColors;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.h
+++ b/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.h
@@ -1,0 +1,119 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import "AWSDDContextFilterLogFormatter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class provides a log formatter that filters log statements from a logging context not on the whitelist.
+ * @deprecated Use AWSDDContextAllowlistFilterLogFormatter instead.
+ *
+ * A log formatter can be added to any logger to format and/or filter its output.
+ * You can learn more about log formatters here:
+ * Documentation/CustomFormatters.md
+ *
+ * You can learn more about logging context's here:
+ * Documentation/CustomContext.md
+ *
+ * But here's a quick overview / refresher:
+ *
+ * Every log statement has a logging context.
+ * These come from the underlying logging macros defined in AWSDDLog.h.
+ * The default logging context is zero.
+ * You can define multiple logging context's for use in your application.
+ * For example, logically separate parts of your app each have a different logging context.
+ * Also 3rd party frameworks that make use of Lumberjack generally use their own dedicated logging context.
+ **/
+__attribute__((deprecated("Use AWSDDContextAllowlistFilterLogFormatter instead")))
+typedef AWSDDContextAllowlistFilterLogFormatter AWSDDContextWhitelistFilterLogFormatter;
+
+@interface AWSDDContextAllowlistFilterLogFormatter (Deprecated)
+
+/**
+ *  Add a context to the whitelist
+ *  @deprecated Use -addToAllowlist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)addToWhitelist:(NSInteger)loggingContext __attribute__((deprecated("Use -addToAllowlist: instead")));
+
+/**
+ *  Remove context from whitelist
+ *  @deprecated Use -removeFromAllowlist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)removeFromWhitelist:(NSInteger)loggingContext __attribute__((deprecated("Use -removeFromAllowlist: instead")));
+
+/**
+ *  Return the whitelist
+ *  @deprecated Use allowlist instead.
+ */
+@property (nonatomic, readonly, copy) NSArray<NSNumber *> *whitelist __attribute__((deprecated("Use allowlist instead")));
+
+/**
+ *  Check if a context is on the whitelist
+ *  @deprecated Use -isOnAllowlist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (BOOL)isOnWhitelist:(NSInteger)loggingContext __attribute__((deprecated("Use -isOnAllowlist: instead")));
+
+@end
+
+
+/**
+ * This class provides a log formatter that filters log statements from a logging context on the blacklist.
+ * @deprecated Use AWSDDContextDenylistFilterLogFormatter instead.
+ **/
+__attribute__((deprecated("Use AWSDDContextDenylistFilterLogFormatter instead")))
+typedef AWSDDContextDenylistFilterLogFormatter AWSDDContextBlacklistFilterLogFormatter;
+
+@interface AWSDDContextDenylistFilterLogFormatter (Deprecated)
+
+/**
+ *  Add a context to the blacklist
+ *  @deprecated Use -addToDenylist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)addToBlacklist:(NSInteger)loggingContext __attribute__((deprecated("Use -addToDenylist: instead")));
+
+/**
+ *  Remove context from blacklist
+ *  @deprecated Use -removeFromDenylist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)removeFromBlacklist:(NSInteger)loggingContext __attribute__((deprecated("Use -removeFromDenylist: instead")));
+
+/**
+ *  Return the blacklist
+ *  @deprecated Use denylist instead.
+ */
+@property (readonly, copy) NSArray<NSNumber *> *blacklist __attribute__((deprecated("Use denylist instead")));
+
+/**
+ *  Check if a context is on the blacklist
+ *  @deprecated Use -isOnDenylist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (BOOL)isOnBlacklist:(NSInteger)loggingContext __attribute__((deprecated("Use -isOnDenylist: instead")));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.m
+++ b/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.m
@@ -1,0 +1,57 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import "AWSDDContextFilterLogFormatter+Deprecated.h"
+
+@implementation AWSDDContextAllowlistFilterLogFormatter (Deprecated)
+
+- (void)addToWhitelist:(NSInteger)loggingContext {
+    [self addToAllowlist:loggingContext];
+}
+
+- (void)removeFromWhitelist:(NSInteger)loggingContext {
+    [self removeFromAllowlist:loggingContext];
+}
+
+- (NSArray *)whitelist {
+    return [self allowlist];
+}
+
+- (BOOL)isOnWhitelist:(NSInteger)loggingContext {
+    return [self isOnAllowlist:loggingContext];
+}
+
+@end
+
+
+@implementation AWSDDContextDenylistFilterLogFormatter (Deprecated)
+
+- (void)addToBlacklist:(NSInteger)loggingContext {
+    [self addToDenylist:loggingContext];
+}
+
+- (void)removeFromBlacklist:(NSInteger)loggingContext {
+    [self removeFromDenylist:loggingContext];
+}
+
+- (NSArray *)blacklist {
+    return [self denylist];
+}
+
+- (BOOL)isOnBlacklist:(NSInteger)loggingContext {
+    return [self isOnDenylist:loggingContext];
+}
+
+@end

--- a/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h
+++ b/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -22,8 +22,10 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
- * This class provides a log formatter that filters log statements from a logging context not on the whitelist.
+ * This class provides a log formatter that filters log statements from a logging context not on the allowlist.
  *
  * A log formatter can be added to any logger to format and/or filter its output.
  * You can learn more about log formatters here:
@@ -41,7 +43,7 @@
  * For example, logically separate parts of your app each have a different logging context.
  * Also 3rd party frameworks that make use of Lumberjack generally use their own dedicated logging context.
  **/
-@interface AWSDDContextWhitelistFilterLogFormatter : NSObject <AWSDDLogFormatter>
+@interface AWSDDContextAllowlistFilterLogFormatter : NSObject <AWSDDLogFormatter>
 
 /**
  *  Designated default initializer
@@ -49,69 +51,67 @@
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Add a context to the whitelist
+ *  Add a context to the allowlist
  *
  *  @param loggingContext the context
  */
-- (void)addToWhitelist:(NSUInteger)loggingContext;
+- (void)addToAllowlist:(NSInteger)loggingContext;
 
 /**
- *  Remove context from whitelist
+ *  Remove context from allowlist
  *
  *  @param loggingContext the context
  */
-- (void)removeFromWhitelist:(NSUInteger)loggingContext;
+- (void)removeFromAllowlist:(NSInteger)loggingContext;
 
 /**
- *  Return the whitelist
+ *  Return the allowlist
  */
-@property (readonly, copy) NSArray<NSNumber *> *whitelist;
+@property (nonatomic, readonly, copy) NSArray<NSNumber *> *allowlist;
 
 /**
- *  Check if a context is on the whitelist
+ *  Check if a context is on the allowlist
  *
  *  @param loggingContext the context
  */
-- (BOOL)isOnWhitelist:(NSUInteger)loggingContext;
+- (BOOL)isOnAllowlist:(NSInteger)loggingContext;
 
 @end
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#pragma mark -
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * This class provides a log formatter that filters log statements from a logging context on the blacklist.
+ * This class provides a log formatter that filters log statements from a logging context on the denylist.
  **/
-@interface AWSDDContextBlacklistFilterLogFormatter : NSObject <AWSDDLogFormatter>
+@interface AWSDDContextDenylistFilterLogFormatter : NSObject <AWSDDLogFormatter>
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Add a context to the blacklist
+ *  Add a context to the denylist
  *
  *  @param loggingContext the context
  */
-- (void)addToBlacklist:(NSUInteger)loggingContext;
+- (void)addToDenylist:(NSInteger)loggingContext;
 
 /**
- *  Remove context from blacklist
+ *  Remove context from denylist
  *
  *  @param loggingContext the context
  */
-- (void)removeFromBlacklist:(NSUInteger)loggingContext;
+- (void)removeFromDenylist:(NSInteger)loggingContext;
 
 /**
- *  Return the blacklist
+ *  Return the denylist
  */
-@property (readonly, copy) NSArray<NSNumber *> *blacklist;
-
+@property (readonly, copy) NSArray<NSNumber *> *denylist;
 
 /**
- *  Check if a context is on the blacklist
+ *  Check if a context is on the denylist
  *
  *  @param loggingContext the context
  */
-- (BOOL)isOnBlacklist:(NSUInteger)loggingContext;
+- (BOOL)isOnDenylist:(NSInteger)loggingContext;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h
+++ b/AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -14,7 +14,6 @@
 //   prior written permission of Deusty, LLC.
 
 #import <Foundation/Foundation.h>
-#import <libkern/OSAtomic.h>
 
 // Disable legacy macros
 #ifndef AWSDD_LEGACY_MACROS
@@ -23,9 +22,12 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  Log formatter mode
  */
+__attribute__((deprecated("AWSDDDispatchQueueLogFormatter is always shareable")))
 typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
     /**
      *  This is the default option, means the formatter can be reused between multiple loggers and therefore is thread-safe.
@@ -39,6 +41,36 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
     AWSDDDispatchQueueLogFormatterModeNonShareble,
 };
 
+/**
+ * Quality of Service names.
+ *
+ * Since macOS 10.10 and iOS 8.0, pthreads, dispatch queues and NSOperations express their
+ * scheduling priority by using an abstract classification called Quality of Service (QOS).
+ *
+ * This formatter will add a representation of this QOS in the log message by using those
+ * string constants.
+ * For example:
+ *
+ * `2011-10-17 20:21:45.435 AppName[19928:5207 (QOS:DF)] Your log message here`
+ *
+ * Where QOS is one of:
+ * `- UI = User Interactive`
+ * `- IN = User Initiated`
+ * `- DF = Default`
+ * `- UT = Utility`
+ * `- BG = Background`
+ * `- UN = Unspecified`
+ *
+ * Note: QOS will be absent in the log messages if running on OS versions that don't support it.
+ **/
+typedef NSString * AWSDDQualityOfServiceName NS_STRING_ENUM;
+
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUserInteractive NS_SWIFT_NAME(AWSDDQualityOfServiceName.userInteractive) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUserInitiated NS_SWIFT_NAME(AWSDDQualityOfServiceName.userInitiated) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceDefault NS_SWIFT_NAME(AWSDDQualityOfServiceName.default) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUtility NS_SWIFT_NAME(AWSDDQualityOfServiceName.utility) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceBackground NS_SWIFT_NAME(AWSDDQualityOfServiceName.background) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUnspecified NS_SWIFT_NAME(AWSDDQualityOfServiceName.unspecified) API_AVAILABLE(macos(10.10), ios(8.0));
 
 /**
  * This class provides a log formatter that prints the dispatch_queue label instead of the mach_thread_id.
@@ -90,7 +122,7 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
  *
  *  @param mode choose between AWSDDDispatchQueueLogFormatterModeShareble and AWSDDDispatchQueueLogFormatterModeNonShareble, depending if the formatter is shared between several loggers or not
  */
-- (instancetype)initWithMode:(AWSDDDispatchQueueLogFormatterMode)mode;
+- (instancetype)initWithMode:(AWSDDDispatchQueueLogFormatterMode)mode __attribute__((deprecated("AWSDDDispatchQueueLogFormatter is always shareable")));
 
 /**
  * The minQueueLength restricts the minimum size of the [detail box].
@@ -141,12 +173,12 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
  *
  * To remove/undo a previous replacement, invoke this method with nil for the 'shortLabel' parameter.
  **/
-- (NSString *)replacementStringForQueueLabel:(NSString *)longLabel;
+- (nullable NSString *)replacementStringForQueueLabel:(NSString *)longLabel;
 
 /**
  *  See the `replacementStringForQueueLabel:` description
  */
-- (void)setReplacementString:(NSString *)shortLabel forQueueLabel:(NSString *)longLabel;
+- (void)setReplacementString:(nullable NSString *)shortLabel forQueueLabel:(NSString *)longLabel;
 
 @end
 
@@ -170,9 +202,22 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
  */
 - (NSString *)queueThreadLabelForLogMessage:(AWSDDLogMessage *)logMessage;
 
-/**
- *  The actual method that formats a message (transforms a `AWSDDLogMessage` model into a printable string)
- */
-- (NSString *)formatLogMessage:(AWSDDLogMessage *)logMessage;
+@end
+
+#pragma mark - AWSDDAtomicCountable
+
+__attribute__((deprecated("AWSDDAtomicCountable is useless since AWSDDDispatchQueueLogFormatter is always shareable now")))
+@protocol AWSDDAtomicCountable <NSObject>
+
+- (instancetype)initWithDefaultValue:(int32_t)defaultValue;
+- (int32_t)increment;
+- (int32_t)decrement;
+- (int32_t)value;
 
 @end
+
+__attribute__((deprecated("AWSDDAtomicCountable is deprecated")))
+@interface AWSDDAtomicCounter: NSObject<AWSDDAtomicCountable>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.h
+++ b/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.h
@@ -13,33 +13,14 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
-
-@protocol AWSDDLogger;
+#import "AWSDDFileLogger.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
+@interface AWSDDFileLogger (Buffering)
 
-/**
- *  Start capturing logs
- */
-+ (void)start;
-
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
-
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
+- (instancetype)wrapWithBuffer;
+- (instancetype)unwrapFromBuffer;
 
 @end
 

--- a/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.m
+++ b/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.m
@@ -1,0 +1,202 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <sys/mount.h>
+
+#import "AWSDDFileLogger+Buffering.h"
+#import "AWSDDFileLogger+Internal.h"
+
+static const NSUInteger kAWSDDDefaultBufferSize = 4096; // 4 kB, block f_bsize on iphone7
+static const NSUInteger kAWSDDMaxBufferSize = 1048576; // ~1 mB, f_iosize on iphone7
+
+// Reads attributes from base file system to determine buffer size.
+// see statfs in sys/mount.h for descriptions of f_iosize and f_bsize.
+// f_bsize == "default", and f_iosize == "max"
+static inline NSUInteger p_AWSDDGetDefaultBufferSizeBytesMax(const BOOL max) {
+    struct statfs *mountedFileSystems = NULL;
+    __auto_type count = getmntinfo(&mountedFileSystems, 0);
+
+    for (int i = 0; i < count; i++) {
+        __auto_type mounted = mountedFileSystems[i];
+        __auto_type name = mounted.f_mntonname;
+
+        // We can use 2 as max here, since any length > 1 will fail the if-statement.
+        if (strnlen(name, 2) == 1 && *name == '/') {
+            return max ? (NSUInteger)mounted.f_iosize : (NSUInteger)mounted.f_bsize;
+        }
+    }
+
+    return max ? kAWSDDMaxBufferSize : kAWSDDDefaultBufferSize;
+}
+
+static NSUInteger AWSDDGetMaxBufferSizeBytes(void) {
+    static NSUInteger maxBufferSize = 0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        maxBufferSize = p_AWSDDGetDefaultBufferSizeBytesMax(YES);
+    });
+    return maxBufferSize;
+}
+
+static NSUInteger AWSDDGetDefaultBufferSizeBytes(void) {
+    static NSUInteger defaultBufferSize = 0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        defaultBufferSize = p_AWSDDGetDefaultBufferSizeBytesMax(NO);
+    });
+    return defaultBufferSize;
+}
+
+@interface AWSDDBufferedProxy : NSProxy
+
+@property (nonatomic) AWSDDFileLogger *fileLogger;
+@property (nonatomic) NSOutputStream *buffer;
+
+@property (nonatomic) NSUInteger maxBufferSizeBytes;
+@property (nonatomic) NSUInteger currentBufferSizeBytes;
+
+@end
+
+@implementation AWSDDBufferedProxy
+
+- (instancetype)initWithFileLogger:(AWSDDFileLogger *)fileLogger {
+    _fileLogger = fileLogger;
+    _maxBufferSizeBytes = AWSDDGetDefaultBufferSizeBytes();
+    [self flushBuffer];
+
+    return self;
+}
+
+- (void)dealloc {
+    __auto_type block = ^{
+        [self lt_sendBufferedDataToFileLogger];
+        self.fileLogger = nil;
+    };
+
+    if ([self->_fileLogger isOnInternalLoggerQueue]) {
+        block();
+    } else {
+        dispatch_sync(self->_fileLogger.loggerQueue, block);
+    }
+}
+
+#pragma mark - Buffering
+
+- (void)flushBuffer {
+    [_buffer close];
+    _buffer = [NSOutputStream outputStreamToMemory];
+    [_buffer open];
+    _currentBufferSizeBytes = 0;
+}
+
+- (void)lt_sendBufferedDataToFileLogger {
+    NSData *data = [_buffer propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+    [_fileLogger lt_logData:data];
+    [self flushBuffer];
+}
+
+#pragma mark - Logging
+
+- (void)logMessage:(AWSDDLogMessage *)logMessage {
+    // Don't need to check for isOnInternalLoggerQueue, -lt_dataForMessage: will do it for us.
+    __auto_type data = [_fileLogger lt_dataForMessage:logMessage];
+
+    if (data.length == 0) {
+        return;
+    }
+
+    [data enumerateByteRangesUsingBlock:^(const void * __nonnull bytes, NSRange byteRange, BOOL * __nonnull __unused stop) {
+        __auto_type bytesLength = byteRange.length;
+#ifdef NS_BLOCK_ASSERTIONS
+        __unused
+#endif
+        __auto_type written = [_buffer write:bytes maxLength:bytesLength];
+        NSAssert(written > 0 && (NSUInteger)written == bytesLength, @"Failed to write to memory buffer.");
+
+        _currentBufferSizeBytes += bytesLength;
+
+        if (_currentBufferSizeBytes >= _maxBufferSizeBytes) {
+            [self lt_sendBufferedDataToFileLogger];
+        }
+    }];
+}
+
+- (void)flush {
+    // This method is public.
+    // We need to execute the rolling on our logging thread/queue.
+
+    __auto_type block = ^{
+        @autoreleasepool {
+            [self lt_sendBufferedDataToFileLogger];
+            [self.fileLogger flush];
+        }
+    };
+
+    // The design of this method is taken from the AWSDDAbstractLogger implementation.
+    // For extensive documentation please refer to the AWSDDAbstractLogger implementation.
+
+    if ([self.fileLogger isOnInternalLoggerQueue]) {
+        block();
+    } else {
+        NSAssert(![self.fileLogger isOnGlobalLoggingQueue], @"Core architecture requirement failure");
+        dispatch_sync(AWSDDLog.loggingQueue, ^{
+            dispatch_sync(self.fileLogger.loggerQueue, block);
+        });
+    }
+}
+
+#pragma mark - Properties
+
+- (void)setMaxBufferSizeBytes:(NSUInteger)newBufferSizeBytes {
+    _maxBufferSizeBytes = MIN(newBufferSizeBytes, AWSDDGetMaxBufferSizeBytes());
+}
+
+#pragma mark - Wrapping
+
+- (AWSDDFileLogger *)wrapWithBuffer {
+    return (AWSDDFileLogger *)self;
+}
+
+- (AWSDDFileLogger *)unwrapFromBuffer {
+    return (AWSDDFileLogger *)self.fileLogger;
+}
+
+#pragma mark - NSProxy
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
+    return [self.fileLogger methodSignatureForSelector:sel];
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+    return [self.fileLogger respondsToSelector:aSelector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    [invocation invokeWithTarget:self.fileLogger];
+}
+
+@end
+
+@implementation AWSDDFileLogger (Buffering)
+
+- (instancetype)wrapWithBuffer {
+    return (AWSDDFileLogger *)[[AWSDDBufferedProxy alloc] initWithFileLogger:self];
+}
+
+- (instancetype)unwrapFromBuffer {
+    return self;
+}
+
+@end

--- a/AWSCore/Logging/Extensions/AWSDDFileLogger+Internal.h
+++ b/AWSCore/Logging/Extensions/AWSDDFileLogger+Internal.h
@@ -13,33 +13,18 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
-
-@protocol AWSDDLogger;
+#import "AWSDDFileLogger.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
+@interface AWSDDFileLogger (Internal)
 
-/**
- *  Start capturing logs
- */
-+ (void)start;
+- (void)logData:(NSData *)data;
 
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
+// Will assert if used outside logger's queue.
+- (void)lt_logData:(NSData *)data;
 
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
+- (nullable NSData *)lt_dataForMessage:(AWSDDLogMessage *)message;
 
 @end
 

--- a/AWSCore/Logging/Extensions/AWSDDLog+Optional.swift
+++ b/AWSCore/Logging/Extensions/AWSDDLog+Optional.swift
@@ -1,0 +1,129 @@
+//
+// Copyright 2010-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+import Foundation
+
+public extension AWSDDLog {
+
+    /**
+     * Adds the logger to the system.
+     *
+     * This is equivalent to invoking `[AWSDDLog addLogger:logger withLogLevel:AWSDDLogLevelAll]`.
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:) with a non-optional logger instead.")
+    static func add(_ logger: AWSDDLogger?) {
+        if let logger = logger {
+            add(logger)
+        }
+    }
+
+    /**
+     * Adds the logger to the system.
+     *
+     * The level that you provide here is a preemptive filter (for performance).
+     * That is, the level specified here will be used to filter out logMessages so that
+     * the logger is never even invoked for the messages.
+     *
+     * More information:
+     * When you issue a log statement, the logging framework iterates over each logger,
+     * and checks to see if it should forward the logMessage to the logger.
+     * This check is done using the level parameter passed to this method.
+     *
+     * For example:
+     *
+     * `[AWSDDLog addLogger:consoleLogger withLogLevel:AWSDDLogLevelVerbose];`
+     * `[AWSDDLog addLogger:fileLogger    withLogLevel:AWSDDLogLevelWarning];`
+     *
+     * `AWSDDLogError(@"oh no");` => gets forwarded to consoleLogger & fileLogger
+     * `AWSDDLogInfo(@"hi");`     => gets forwarded to consoleLogger only
+     *
+     * It is important to remember that Lumberjack uses a BITMASK.
+     * Many developers & third party frameworks may define extra log levels & flags.
+     * For example:
+     *
+     * `#define SOME_FRAMEWORK_LOG_FLAG_TRACE (1 << 6) // 0...1000000`
+     *
+     * So if you specify `AWSDDLogLevelVerbose` to this method, you won't see the framework's trace messages.
+     *
+     * `(SOME_FRAMEWORK_LOG_FLAG_TRACE & AWSDDLogLevelVerbose) => (01000000 & 00011111) => NO`
+     *
+     * Consider passing `AWSDDLogLevelAll` to this method, which has all bits set.
+     * You can also use the exclusive-or bitwise operator to get a bitmask that has all flags set,
+     * except the ones you explicitly don't want. For example, if you wanted everything except verbose & debug:
+     *
+     * `((AWSDDLogLevelAll ^ AWSDDLogLevelVerbose) | AWSDDLogLevelInfo)`
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:with:) with a non-optional logger instead.")
+    class func add(_ logger: AWSDDLogger?, with level: AWSDDLogLevel) {
+        if let logger = logger {
+            add(logger, with: level)
+        }
+    }
+
+    /**
+     * Adds the logger to the system.
+     *
+     * This is equivalent to invoking `[AWSDDLog addLogger:logger withLogLevel:AWSDDLogLevelAll]`.
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:) with a non-optional logger instead.")
+    func add(_ logger: AWSDDLogger?) {
+        if let logger = logger {
+            add(logger)
+        }
+    }
+
+    /**
+     * Adds the logger to the system.
+     *
+     * The level that you provide here is a preemptive filter (for performance).
+     * That is, the level specified here will be used to filter out logMessages so that
+     * the logger is never even invoked for the messages.
+     *
+     * More information:
+     * When you issue a log statement, the logging framework iterates over each logger,
+     * and checks to see if it should forward the logMessage to the logger.
+     * This check is done using the level parameter passed to this method.
+     *
+     * For example:
+     *
+     * `[AWSDDLog addLogger:consoleLogger withLogLevel:AWSDDLogLevelVerbose];`
+     * `[AWSDDLog addLogger:fileLogger    withLogLevel:AWSDDLogLevelWarning];`
+     *
+     * `AWSDDLogError(@"oh no");` => gets forwarded to consoleLogger & fileLogger
+     * `AWSDDLogInfo(@"hi");`     => gets forwarded to consoleLogger only
+     *
+     * It is important to remember that Lumberjack uses a BITMASK.
+     * Many developers & third party frameworks may define extra log levels & flags.
+     * For example:
+     *
+     * `#define SOME_FRAMEWORK_LOG_FLAG_TRACE (1 << 6) // 0...1000000`
+     *
+     * So if you specify `AWSDDLogLevelVerbose` to this method, you won't see the framework's trace messages.
+     *
+     * `(SOME_FRAMEWORK_LOG_FLAG_TRACE & AWSDDLogLevelVerbose) => (01000000 & 00011111) => NO`
+     *
+     * Consider passing `AWSDDLogLevelAll` to this method, which has all bits set.
+     * You can also use the exclusive-or bitwise operator to get a bitmask that has all flags set,
+     * except the ones you explicitly don't want. For example, if you wanted everything except verbose & debug:
+     *
+     * `((AWSDDLogLevelAll ^ AWSDDLogLevelVerbose) | AWSDDLogLevelInfo)`
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:with:) with a non-optional logger instead.")
+    func add(_ logger: AWSDDLogger?, with level: AWSDDLogLevel) {
+        if let logger = logger {
+            add(logger, with: level)
+        }
+    }
+}

--- a/AWSCore/Logging/Extensions/AWSDDMultiFormatter.h
+++ b/AWSCore/Logging/Extensions/AWSDDMultiFormatter.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -22,6 +22,8 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This formatter can be used to chain different formatters together.
  * The log message will processed in the order of the formatters added.
@@ -31,7 +33,7 @@
 /**
  *  Array of chained formatters
  */
-@property (readonly) NSArray<id<AWSDDLogFormatter>> *formatters;
+@property (nonatomic, readonly) NSArray<id<AWSDDLogFormatter>> *formatters;
 
 /**
  *  Add a new formatter
@@ -54,3 +56,5 @@
 - (BOOL)isFormattingWithFormatter:(id<AWSDDLogFormatter>)formatter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSS3UnitTests/AWSS3TransferUtilityCreatePartialFileTests.swift
+++ b/AWSS3UnitTests/AWSS3TransferUtilityCreatePartialFileTests.swift
@@ -33,7 +33,7 @@ class AWSS3TransferUtilityCreatePartialFileTests: XCTestCase {
         self.transferUtility = transferUtility
 
         AWSDDLog.sharedInstance.logLevel = .verbose
-        AWSDDLog.sharedInstance.add(AWSDDTTYLogger())
+        AWSDDLog.sharedInstance.add(AWSDDTTYLogger.sharedInstance)
     }
 
     func testCreatingPartialFile() throws {

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -283,30 +283,6 @@
 		183BD93E1D8A4076004B2659 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		183BD9471D8B0030004B2659 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		183BD9481D8B0040004B2659 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8EF551C6A6A2E0098B15B /* libOCMock.a */; };
-		184F430F1E930A2D004F3FE2 /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F42FE1E930A2D004F3FE2 /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43101E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F42FF1E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h */; };
-		184F43111E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43001E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m */; };
-		184F43121E930A2D004F3FE2 /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43011E930A2D004F3FE2 /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43131E930A2D004F3FE2 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43021E930A2D004F3FE2 /* AWSDDASLLogCapture.m */; };
-		184F43141E930A2D004F3FE2 /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43031E930A2D004F3FE2 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43151E930A2D004F3FE2 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43041E930A2D004F3FE2 /* AWSDDASLLogger.m */; };
-		184F43161E930A2D004F3FE2 /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43051E930A2D004F3FE2 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43171E930A2D004F3FE2 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43061E930A2D004F3FE2 /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43181E930A2D004F3FE2 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43071E930A2D004F3FE2 /* AWSDDFileLogger.m */; };
-		184F431A1E930A2D004F3FE2 /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43091E930A2D004F3FE2 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F431B1E930A2D004F3FE2 /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F430A1E930A2D004F3FE2 /* AWSDDLog.m */; };
-		184F431C1E930A2D004F3FE2 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F430B1E930A2D004F3FE2 /* AWSDDLog+LOGV.h */; };
-		184F431D1E930A2D004F3FE2 /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F430C1E930A2D004F3FE2 /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F431E1E930A2D004F3FE2 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F430D1E930A2D004F3FE2 /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F431F1E930A2D004F3FE2 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F430E1E930A2D004F3FE2 /* AWSDDTTYLogger.m */; };
-		184F43261E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43201E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h */; };
-		184F43271E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43211E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m */; };
-		184F43281E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43221E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h */; };
-		184F43291E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43231E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m */; };
-		184F432A1E930A34004F3FE2 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43241E930A34004F3FE2 /* AWSDDMultiFormatter.h */; };
-		184F432E1E930E05004F3FE2 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F432C1E930E05004F3FE2 /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F432F1E930E05004F3FE2 /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F432D1E930E05004F3FE2 /* AWSDDOSLogger.m */; };
-		184F43311E9336BD004F3FE2 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43301E9336BD004F3FE2 /* AWSDDLegacyMacros.h */; };
 		185251351DED4F9800AF47F6 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		1868C0261E207E33001CDA82 /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 1868C0251E207E33001CDA82 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		186ABB031D9CADBC00AB8980 /* libBlueAudioSourceiOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 186ABB021D9CADBC00AB8980 /* libBlueAudioSourceiOS.a */; };
@@ -583,6 +559,40 @@
 		5C71F33F295672B8001183A4 /* guten_tag.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5C71F33E295672B8001183A4 /* guten_tag.wav */; };
 		6883619E2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */; };
 		688361A12B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */; };
+		68A45B792B8D5F7D00A0851E /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45B7B2B8D5F7D00A0851E /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */; };
+		68A45B7C2B8D5F7D00A0851E /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */; };
+		68A45B7D2B8D5F7D00A0851E /* AWSDDFileLogger+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45B7E2B8D5F7D00A0851E /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */; };
+		68A45B7F2B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */; };
+		68A45B802B8D5F7D00A0851E /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */; };
+		68A45B812B8D5F7D00A0851E /* AWSDDFileLogger+Buffering.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */; };
+		68A45B822B8D5F7D00A0851E /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5F2B8D5F7C00A0851E /* AWSDDMultiFormatter.m */; };
+		68A45B832B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B602B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m */; };
+		68A45B842B8D5F7D00A0851E /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B612B8D5F7C00A0851E /* AWSDDOSLogger.m */; };
+		68A45B852B8D5F7D00A0851E /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B622B8D5F7C00A0851E /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45B862B8D5F7D00A0851E /* AWSDDLoggerNames.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B632B8D5F7C00A0851E /* AWSDDLoggerNames.m */; };
+		68A45B982B8D5F7D00A0851E /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B762B8D5F7D00A0851E /* AWSDDLog.m */; };
+		68A45B992B8D5F7D00A0851E /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B772B8D5F7D00A0851E /* AWSDDASLLogCapture.m */; };
+		68A45B9A2B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B782B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m */; };
+		68A45BAC2B8D6ADE00A0851E /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9B2B8D6ADD00A0851E /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BAD2B8D6ADE00A0851E /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9C2B8D6ADD00A0851E /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BAE2B8D6ADE00A0851E /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9D2B8D6ADD00A0851E /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BAF2B8D6ADE00A0851E /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9E2B8D6ADD00A0851E /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB02B8D6ADE00A0851E /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9F2B8D6ADD00A0851E /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB12B8D6ADE00A0851E /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA02B8D6ADD00A0851E /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB22B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA12B8D6ADD00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB32B8D6ADE00A0851E /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA22B8D6ADD00A0851E /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB42B8D6ADE00A0851E /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA32B8D6ADD00A0851E /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB62B8D6ADE00A0851E /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA52B8D6ADE00A0851E /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB72B8D6ADE00A0851E /* AWSDDLoggerNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA62B8D6ADE00A0851E /* AWSDDLoggerNames.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB82B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA72B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB92B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBA2B8D6ADE00A0851E /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA92B8D6ADE00A0851E /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBB2B8D6ADE00A0851E /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BAA2B8D6ADE00A0851E /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBC2B8D6ADE00A0851E /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBF2B8E74F900A0851E /* AWSCLIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BBD2B8E74F800A0851E /* AWSCLIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BC02B8E74F900A0851E /* AWSCLIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45BBE2B8E74F900A0851E /* AWSCLIColor.m */; };
 		68EE1A6C2B713D8100B7CF41 /* AWSIoTStreamThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 68EE1A6B2B713D8100B7CF41 /* AWSIoTStreamThread.h */; };
 		68EE1A6E2B713D8900B7CF41 /* AWSIoTStreamThread.m in Sources */ = {isa = PBXBuildFile; fileRef = 68EE1A6D2B713D8900B7CF41 /* AWSIoTStreamThread.m */; };
 		6BE9D6AA25A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6A925A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift */; };
@@ -2884,30 +2894,6 @@
 		181270E31E8EB78900174785 /* AWSLogsService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSLogsService.h; sourceTree = "<group>"; };
 		181270E41E8EB78900174785 /* AWSLogsService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSLogsService.m; sourceTree = "<group>"; };
 		181270EB1E8EB7D300174785 /* AWSGeneralLogsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralLogsTests.m; sourceTree = "<group>"; };
-		184F42FE1E930A2D004F3FE2 /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCocoaLumberjack.h; sourceTree = "<group>"; };
-		184F42FF1E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
-		184F43001E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		184F43011E930A2D004F3FE2 /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogCapture.h; sourceTree = "<group>"; };
-		184F43021E930A2D004F3FE2 /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogCapture.m; sourceTree = "<group>"; };
-		184F43031E930A2D004F3FE2 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogger.h; sourceTree = "<group>"; };
-		184F43041E930A2D004F3FE2 /* AWSDDASLLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogger.m; sourceTree = "<group>"; };
-		184F43051E930A2D004F3FE2 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAssertMacros.h; sourceTree = "<group>"; };
-		184F43061E930A2D004F3FE2 /* AWSDDFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDFileLogger.h; sourceTree = "<group>"; };
-		184F43071E930A2D004F3FE2 /* AWSDDFileLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDFileLogger.m; sourceTree = "<group>"; };
-		184F43091E930A2D004F3FE2 /* AWSDDLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLog.h; sourceTree = "<group>"; };
-		184F430A1E930A2D004F3FE2 /* AWSDDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDLog.m; sourceTree = "<group>"; };
-		184F430B1E930A2D004F3FE2 /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
-		184F430C1E930A2D004F3FE2 /* AWSDDLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLogMacros.h; sourceTree = "<group>"; };
-		184F430D1E930A2D004F3FE2 /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDTTYLogger.h; sourceTree = "<group>"; };
-		184F430E1E930A2D004F3FE2 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDTTYLogger.m; sourceTree = "<group>"; };
-		184F43201E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		184F43211E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		184F43221E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		184F43231E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		184F43241E930A34004F3FE2 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDMultiFormatter.h; sourceTree = "<group>"; };
-		184F432C1E930E05004F3FE2 /* AWSDDOSLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDOSLogger.h; sourceTree = "<group>"; };
-		184F432D1E930E05004F3FE2 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDOSLogger.m; sourceTree = "<group>"; };
-		184F43301E9336BD004F3FE2 /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLegacyMacros.h; sourceTree = "<group>"; };
 		185111CB1D78F03B0009F5C3 /* AWSLex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSLex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		185111CF1D78F03B0009F5C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		185111D41D78F03B0009F5C3 /* AWSLexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSLexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3147,6 +3133,40 @@
 		5C71F33E295672B8001183A4 /* guten_tag.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = guten_tag.wav; sourceTree = "<group>"; };
 		6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PreSignedURLBuilderUnitTests.swift; sourceTree = "<group>"; };
 		688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThreadTests.m; sourceTree = "<group>"; };
+		68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCocoaLumberjack.h; sourceTree = "<group>"; };
+		68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogger.m; sourceTree = "<group>"; };
+		68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDFileLogger.m; sourceTree = "<group>"; };
+		68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDFileLogger+Internal.h"; sourceTree = "<group>"; };
+		68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDTTYLogger.m; sourceTree = "<group>"; };
+		68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSDDFileLogger+Buffering.m"; sourceTree = "<group>"; };
+		68A45B5F2B8D5F7C00A0851E /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDMultiFormatter.m; sourceTree = "<group>"; };
+		68A45B602B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSDDContextFilterLogFormatter+Deprecated.m"; sourceTree = "<group>"; };
+		68A45B612B8D5F7C00A0851E /* AWSDDOSLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDOSLogger.m; sourceTree = "<group>"; };
+		68A45B622B8D5F7C00A0851E /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLegacyMacros.h; sourceTree = "<group>"; };
+		68A45B632B8D5F7C00A0851E /* AWSDDLoggerNames.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDLoggerNames.m; sourceTree = "<group>"; };
+		68A45B762B8D5F7D00A0851E /* AWSDDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDLog.m; sourceTree = "<group>"; };
+		68A45B772B8D5F7D00A0851E /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogCapture.m; sourceTree = "<group>"; };
+		68A45B782B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		68A45B9B2B8D6ADD00A0851E /* AWSDDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogger.h; sourceTree = "<group>"; };
+		68A45B9C2B8D6ADD00A0851E /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDTTYLogger.h; sourceTree = "<group>"; };
+		68A45B9D2B8D6ADD00A0851E /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		68A45B9E2B8D6ADD00A0851E /* AWSDDFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDFileLogger.h; sourceTree = "<group>"; };
+		68A45B9F2B8D6ADD00A0851E /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
+		68A45BA02B8D6ADD00A0851E /* AWSDDLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLogMacros.h; sourceTree = "<group>"; };
+		68A45BA12B8D6ADD00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDContextFilterLogFormatter+Deprecated.h"; sourceTree = "<group>"; };
+		68A45BA22B8D6ADD00A0851E /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogCapture.h; sourceTree = "<group>"; };
+		68A45BA32B8D6ADD00A0851E /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		68A45BA52B8D6ADE00A0851E /* AWSDDLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLog.h; sourceTree = "<group>"; };
+		68A45BA62B8D6ADE00A0851E /* AWSDDLoggerNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLoggerNames.h; sourceTree = "<group>"; };
+		68A45BA72B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDFileLogger+Buffering.h"; sourceTree = "<group>"; };
+		68A45BA92B8D6ADE00A0851E /* AWSDDOSLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDOSLogger.h; sourceTree = "<group>"; };
+		68A45BAA2B8D6ADE00A0851E /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAssertMacros.h; sourceTree = "<group>"; };
+		68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDMultiFormatter.h; sourceTree = "<group>"; };
+		68A45BBD2B8E74F800A0851E /* AWSCLIColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCLIColor.h; sourceTree = "<group>"; };
+		68A45BBE2B8E74F900A0851E /* AWSCLIColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSCLIColor.m; sourceTree = "<group>"; };
 		68EE1A6B2B713D8100B7CF41 /* AWSIoTStreamThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSIoTStreamThread.h; sourceTree = "<group>"; };
 		68EE1A6D2B713D8900B7CF41 /* AWSIoTStreamThread.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThread.m; sourceTree = "<group>"; };
 		6BE9D6A925A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSIotDataManagerRetainTests.swift; sourceTree = "<group>"; };
@@ -5406,40 +5426,33 @@
 		184F42CE1E930839004F3FE2 /* Logging */ = {
 			isa = PBXGroup;
 			children = (
-				184F42FE1E930A2D004F3FE2 /* AWSCocoaLumberjack.h */,
-				184F43301E9336BD004F3FE2 /* AWSDDLegacyMacros.h */,
-				184F432C1E930E05004F3FE2 /* AWSDDOSLogger.h */,
-				184F432D1E930E05004F3FE2 /* AWSDDOSLogger.m */,
-				184F42FF1E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h */,
-				184F43001E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m */,
-				184F43011E930A2D004F3FE2 /* AWSDDASLLogCapture.h */,
-				184F43021E930A2D004F3FE2 /* AWSDDASLLogCapture.m */,
-				184F43031E930A2D004F3FE2 /* AWSDDASLLogger.h */,
-				184F43041E930A2D004F3FE2 /* AWSDDASLLogger.m */,
-				184F43051E930A2D004F3FE2 /* AWSDDAssertMacros.h */,
-				184F43061E930A2D004F3FE2 /* AWSDDFileLogger.h */,
-				184F43071E930A2D004F3FE2 /* AWSDDFileLogger.m */,
-				184F43091E930A2D004F3FE2 /* AWSDDLog.h */,
-				184F430A1E930A2D004F3FE2 /* AWSDDLog.m */,
-				184F430B1E930A2D004F3FE2 /* AWSDDLog+LOGV.h */,
-				184F430C1E930A2D004F3FE2 /* AWSDDLogMacros.h */,
-				184F430D1E930A2D004F3FE2 /* AWSDDTTYLogger.h */,
-				184F430E1E930A2D004F3FE2 /* AWSDDTTYLogger.m */,
-				184F42F11E930925004F3FE2 /* Extensions */,
+				68A45BBD2B8E74F800A0851E /* AWSCLIColor.h */,
+				68A45BBE2B8E74F900A0851E /* AWSCLIColor.m */,
+				68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */,
+				68A45B9D2B8D6ADD00A0851E /* AWSDDAbstractDatabaseLogger.h */,
+				68A45B782B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m */,
+				68A45BA22B8D6ADD00A0851E /* AWSDDASLLogCapture.h */,
+				68A45B772B8D5F7D00A0851E /* AWSDDASLLogCapture.m */,
+				68A45B9B2B8D6ADD00A0851E /* AWSDDASLLogger.h */,
+				68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */,
+				68A45BAA2B8D6ADE00A0851E /* AWSDDAssertMacros.h */,
+				68A45B9E2B8D6ADD00A0851E /* AWSDDFileLogger.h */,
+				68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */,
+				68A45B622B8D5F7C00A0851E /* AWSDDLegacyMacros.h */,
+				68A45BA52B8D6ADE00A0851E /* AWSDDLog.h */,
+				68A45B762B8D5F7D00A0851E /* AWSDDLog.m */,
+				68A45B9F2B8D6ADD00A0851E /* AWSDDLog+LOGV.h */,
+				68A45BA62B8D6ADE00A0851E /* AWSDDLoggerNames.h */,
+				68A45B632B8D5F7C00A0851E /* AWSDDLoggerNames.m */,
+				68A45BA02B8D6ADD00A0851E /* AWSDDLogMacros.h */,
+				68A45B5F2B8D5F7C00A0851E /* AWSDDMultiFormatter.m */,
+				68A45BA92B8D6ADE00A0851E /* AWSDDOSLogger.h */,
+				68A45B612B8D5F7C00A0851E /* AWSDDOSLogger.m */,
+				68A45B9C2B8D6ADD00A0851E /* AWSDDTTYLogger.h */,
+				68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */,
+				68A45B5B2B8D5F7C00A0851E /* Extensions */,
 			);
 			path = Logging;
-			sourceTree = "<group>";
-		};
-		184F42F11E930925004F3FE2 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				184F43201E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h */,
-				184F43211E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m */,
-				184F43221E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h */,
-				184F43231E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m */,
-				184F43241E930A34004F3FE2 /* AWSDDMultiFormatter.h */,
-			);
-			path = Extensions;
 			sourceTree = "<group>";
 		};
 		185111CC1D78F03B0009F5C3 /* AWSLex */ = {
@@ -5923,6 +5936,23 @@
 				48885FB62A0C1F170012EEB7 /* AWSKinesisVideoWebRTCStorageResources.h */,
 			);
 			path = AWSKinesisVideoWebRTCStorage;
+			sourceTree = "<group>";
+		};
+		68A45B5B2B8D5F7C00A0851E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				68A45BA72B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h */,
+				68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */,
+				68A45BA12B8D6ADD00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h */,
+				68A45B602B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m */,
+				68A45BA32B8D6ADD00A0851E /* AWSDDDispatchQueueLogFormatter.h */,
+				68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */,
+				68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */,
+				68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */,
+				68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */,
+				68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		9A7ACC2120B0E85000DDBEC1 /* AWSTranslate */ = {
@@ -8156,14 +8186,17 @@
 				CE0D42A51C6A673E006B91B5 /* AWSModel.h in Headers */,
 				CE0D42251C6A673E006B91B5 /* AWSIdentityProvider.h in Headers */,
 				CE0D422C1C6A673E006B91B5 /* AWSCancellationToken.h in Headers */,
+				68A45BBB2B8D6ADE00A0851E /* AWSDDAssertMacros.h in Headers */,
 				CE0D42A71C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.h in Headers */,
 				CE0D42441C6A673E006B91B5 /* AWSFMDatabase.h in Headers */,
 				CE0D42511C6A673E006B91B5 /* AWSGZIP.h in Headers */,
+				68A45BB12B8D6ADE00A0851E /* AWSDDLogMacros.h in Headers */,
 				CE0D42921C6A673E006B91B5 /* AWSSTSService.h in Headers */,
 				CE0D42801C6A673E006B91B5 /* AWSURLRequestRetryHandler.h in Headers */,
 				CE0D424D1C6A673E006B91B5 /* AWSFMResultSet.h in Headers */,
 				CE0D423B1C6A673E006B91B5 /* AWSCognitoIdentityResources.h in Headers */,
 				CE0D426B1C6A673E006B91B5 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */,
+				68A45BB22B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h in Headers */,
 				CE0D42381C6A673E006B91B5 /* AWSCognitoIdentity.h in Headers */,
 				CE0D426F1C6A673E006B91B5 /* NSObject+AWSMTLComparisonAdditions.h in Headers */,
 				CE0D428D1C6A673E006B91B5 /* AWSSTS.h in Headers */,
@@ -8172,16 +8205,21 @@
 				CE0D42301C6A673E006B91B5 /* AWSCancellationTokenSource.h in Headers */,
 				CE0D428E1C6A673E006B91B5 /* AWSSTSModel.h in Headers */,
 				CE0D424C1C6A673E006B91B5 /* AWSFMDB.h in Headers */,
+				68A45BB42B8D6ADE00A0851E /* AWSDDDispatchQueueLogFormatter.h in Headers */,
 				CE0D42271C6A673E006B91B5 /* AWSSignature.h in Headers */,
 				CE0D428A1C6A673E006B91B5 /* AWSService.h in Headers */,
 				CE0D42A31C6A673E006B91B5 /* AWSLogging.h in Headers */,
+				68A45B852B8D5F7D00A0851E /* AWSDDLegacyMacros.h in Headers */,
 				CE0D422E1C6A673E006B91B5 /* AWSCancellationTokenRegistration.h in Headers */,
+				68A45BAD2B8D6ADE00A0851E /* AWSDDTTYLogger.h in Headers */,
+				68A45BB32B8D6ADE00A0851E /* AWSDDASLLogCapture.h in Headers */,
 				18DF08DB1D34866E004C7D19 /* AWSCognitoIdentity+Fabric.h in Headers */,
 				CE0D423D1C6A673E006B91B5 /* AWSCognitoIdentityService.h in Headers */,
 				CE0D425C1C6A673E006B91B5 /* AWSMTLModel.h in Headers */,
 				CE0D42861C6A673E006B91B5 /* AWSValidation.h in Headers */,
+				68A45BB82B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h in Headers */,
+				68A45BB02B8D6ADE00A0851E /* AWSDDLog+LOGV.h in Headers */,
 				FA7A44C62305D09C00F55D7A /* AWSNetworkingHelpers.h in Headers */,
-				184F43261E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h in Headers */,
 				CEA33FB61C8A37230083D6BC /* Fabric+FABKits.h in Headers */,
 				CE0D42481C6A673E006B91B5 /* AWSFMDatabasePool.h in Headers */,
 				CE0D428C1C6A673E006B91B5 /* AWSServiceEnum.h in Headers */,
@@ -8189,46 +8227,43 @@
 				CE0D42551C6A673E006B91B5 /* AWSMantle.h in Headers */,
 				CE0D42231C6A673E006B91B5 /* AWSCredentialsProvider.h in Headers */,
 				CE0D425A1C6A673E006B91B5 /* AWSMTLModel+NSCoding.h in Headers */,
+				68A45BBF2B8E74F900A0851E /* AWSCLIColor.h in Headers */,
 				CE0D42821C6A673E006B91B5 /* AWSURLRequestSerialization.h in Headers */,
+				68A45BB92B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h in Headers */,
+				68A45BAF2B8D6ADE00A0851E /* AWSDDFileLogger.h in Headers */,
 				CE0D42881C6A673E006B91B5 /* AWSClientContext.h in Headers */,
 				CE0D429D1C6A673E006B91B5 /* AWSUICKeyChainStore.h in Headers */,
 				CE0D42781C6A673E006B91B5 /* AWSURLSessionManager.h in Headers */,
+				68A45BAC2B8D6ADE00A0851E /* AWSDDASLLogger.h in Headers */,
 				CE0D42761C6A673E006B91B5 /* AWSNetworking.h in Headers */,
 				CE0D42391C6A673E006B91B5 /* AWSCognitoIdentityModel.h in Headers */,
 				CE0D42581C6A673E006B91B5 /* AWSMTLManagedObjectAdapter.h in Headers */,
 				CE0D42601C6A673E006B91B5 /* AWSMTLValueTransformer.h in Headers */,
+				68A45BB62B8D6ADE00A0851E /* AWSDDLog.h in Headers */,
 				CEA33FB41C8A37230083D6BC /* FABAttributes.h in Headers */,
 				CE0D42A11C6A673E006B91B5 /* AWSCategory.h in Headers */,
-				184F431D1E930A2D004F3FE2 /* AWSDDLogMacros.h in Headers */,
-				184F43141E930A2D004F3FE2 /* AWSDDASLLogger.h in Headers */,
+				68A45BBC2B8D6ADE00A0851E /* AWSDDMultiFormatter.h in Headers */,
 				FA5D34FC250C0D77007AA030 /* AWSNSCodingUtilities.h in Headers */,
 				CE0D42291C6A673E006B91B5 /* AWSBolts.h in Headers */,
 				CE0D42561C6A673E006B91B5 /* AWSMTLJSONAdapter.h in Headers */,
-				184F43121E930A2D004F3FE2 /* AWSDDASLLogCapture.h in Headers */,
 				1868C0261E207E33001CDA82 /* AWSGeneric.h in Headers */,
 				EFE40B7C1CC5BDCA0045D710 /* AWSInfo.h in Headers */,
-				184F432E1E930E05004F3FE2 /* AWSDDOSLogger.h in Headers */,
-				184F431E1E930A2D004F3FE2 /* AWSDDTTYLogger.h in Headers */,
-				184F430F1E930A2D004F3FE2 /* AWSCocoaLumberjack.h in Headers */,
 				2171EBE0254C725C00FAB22F /* AWSTimestampSerialization.h in Headers */,
-				184F431A1E930A2D004F3FE2 /* AWSDDLog.h in Headers */,
-				184F43161E930A2D004F3FE2 /* AWSDDAssertMacros.h in Headers */,
 				CE0D42341C6A673E006B91B5 /* AWSTask.h in Headers */,
-				184F43171E930A2D004F3FE2 /* AWSDDFileLogger.h in Headers */,
-				184F43311E9336BD004F3FE2 /* AWSDDLegacyMacros.h in Headers */,
-				184F432A1E930A34004F3FE2 /* AWSDDMultiFormatter.h in Headers */,
-				184F431C1E930A2D004F3FE2 /* AWSDDLog+LOGV.h in Headers */,
-				184F43281E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h in Headers */,
-				184F43101E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h in Headers */,
+				68A45BBA2B8D6ADE00A0851E /* AWSDDOSLogger.h in Headers */,
 				CE0D42731C6A673E006B91B5 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */,
 				CE0D42461C6A673E006B91B5 /* AWSFMDatabaseAdditions.h in Headers */,
 				CE0D41701C6A66E5006B91B5 /* AWSCore.h in Headers */,
 				CE0D42901C6A673E006B91B5 /* AWSSTSResources.h in Headers */,
 				CE0D426D1C6A673E006B91B5 /* NSError+AWSMTLModelException.h in Headers */,
+				68A45B7D2B8D5F7D00A0851E /* AWSDDFileLogger+Internal.h in Headers */,
 				CE0D425E1C6A673E006B91B5 /* AWSMTLReflection.h in Headers */,
 				CEA33FB51C8A37230083D6BC /* FABKitProtocol.h in Headers */,
 				CE0D42AD1C6A673E006B91B5 /* AWSXMLWriter.h in Headers */,
+				68A45B792B8D5F7D00A0851E /* AWSCocoaLumberjack.h in Headers */,
 				CE0D42A91C6A673E006B91B5 /* AWSXMLDictionary.h in Headers */,
+				68A45BAE2B8D6ADE00A0851E /* AWSDDAbstractDatabaseLogger.h in Headers */,
+				68A45BB72B8D6ADE00A0851E /* AWSDDLoggerNames.h in Headers */,
 				CE0D42671C6A673E006B91B5 /* AWSmetamacros.h in Headers */,
 				CE3627CE1CEBA92B003E85B9 /* AWSKSReachability.h in Headers */,
 				CE0D42621C6A673E006B91B5 /* AWSEXTKeyPathCoding.h in Headers */,
@@ -12815,65 +12850,70 @@
 				CE0D42351C6A673E006B91B5 /* AWSTask.m in Sources */,
 				CE0D42741C6A673E006B91B5 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */,
 				CE0D42911C6A673E006B91B5 /* AWSSTSResources.m in Sources */,
-				184F43181E930A2D004F3FE2 /* AWSDDFileLogger.m in Sources */,
 				CE0D42371C6A673E006B91B5 /* AWSTaskCompletionSource.m in Sources */,
+				68A45B7B2B8D5F7D00A0851E /* AWSDDASLLogger.m in Sources */,
+				68A45B7E2B8D5F7D00A0851E /* AWSDDTTYLogger.m in Sources */,
 				CE0D422D1C6A673E006B91B5 /* AWSCancellationToken.m in Sources */,
 				CE0D42451C6A673E006B91B5 /* AWSFMDatabase.m in Sources */,
 				CE0D42311C6A673E006B91B5 /* AWSCancellationTokenSource.m in Sources */,
+				68A45B9A2B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m in Sources */,
 				CE0D42331C6A673E006B91B5 /* AWSExecutor.m in Sources */,
+				68A45BC02B8E74F900A0851E /* AWSCLIColor.m in Sources */,
 				CE0D42661C6A673E006B91B5 /* AWSEXTScope.m in Sources */,
 				CE0D42831C6A673E006B91B5 /* AWSURLRequestSerialization.m in Sources */,
 				CE0D42811C6A673E006B91B5 /* AWSURLRequestRetryHandler.m in Sources */,
-				184F43111E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m in Sources */,
 				CE0D422A1C6A673E006B91B5 /* AWSBolts.m in Sources */,
 				CE0D42791C6A673E006B91B5 /* AWSURLSessionManager.m in Sources */,
+				68A45B842B8D5F7D00A0851E /* AWSDDOSLogger.m in Sources */,
 				CE0D42A61C6A673E006B91B5 /* AWSModel.m in Sources */,
 				CE0D425F1C6A673E006B91B5 /* AWSMTLReflection.m in Sources */,
-				184F43291E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m in Sources */,
 				CE0D42A41C6A673E006B91B5 /* AWSLogging.m in Sources */,
+				68A45B822B8D5F7D00A0851E /* AWSDDMultiFormatter.m in Sources */,
 				CE0D42AE1C6A673E006B91B5 /* AWSXMLWriter.m in Sources */,
 				CE0D42261C6A673E006B91B5 /* AWSIdentityProvider.m in Sources */,
+				68A45B802B8D5F7D00A0851E /* AWSDDDispatchQueueLogFormatter.m in Sources */,
 				FAC3E7022208B0D60037813E /* AWSFMDB+AWSHelpers.m in Sources */,
 				CE0D42471C6A673E006B91B5 /* AWSFMDatabaseAdditions.m in Sources */,
 				CE0D423E1C6A673E006B91B5 /* AWSCognitoIdentityService.m in Sources */,
-				184F43131E930A2D004F3FE2 /* AWSDDASLLogCapture.m in Sources */,
 				CE0D425D1C6A673E006B91B5 /* AWSMTLModel.m in Sources */,
 				CE0D42A21C6A673E006B91B5 /* AWSCategory.m in Sources */,
 				CE0D42591C6A673E006B91B5 /* AWSMTLManagedObjectAdapter.m in Sources */,
-				184F432F1E930E05004F3FE2 /* AWSDDOSLogger.m in Sources */,
+				68A45B7F2B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter.m in Sources */,
 				CE0D422F1C6A673E006B91B5 /* AWSCancellationTokenRegistration.m in Sources */,
 				CE0D426A1C6A673E006B91B5 /* NSArray+AWSMTLManipulationAdditions.m in Sources */,
 				18DF08D51D347633004C7D19 /* AWSCognitoIdentity+Fabric.m in Sources */,
-				184F43271E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m in Sources */,
 				2171EB6A254C721E00FAB22F /* AWSTimestampSerialization.m in Sources */,
 				CE0D42491C6A673E006B91B5 /* AWSFMDatabasePool.m in Sources */,
+				68A45B812B8D5F7D00A0851E /* AWSDDFileLogger+Buffering.m in Sources */,
 				CE0D424E1C6A673E006B91B5 /* AWSFMResultSet.m in Sources */,
 				CE0D426E1C6A673E006B91B5 /* NSError+AWSMTLModelException.m in Sources */,
 				CE0D42851C6A673E006B91B5 /* AWSURLResponseSerialization.m in Sources */,
 				CE0D429E1C6A673E006B91B5 /* AWSUICKeyChainStore.m in Sources */,
-				184F43151E930A2D004F3FE2 /* AWSDDASLLogger.m in Sources */,
 				FA7A44C72305D09C00F55D7A /* AWSNetworkingHelpers.m in Sources */,
 				CE0D42571C6A673E006B91B5 /* AWSMTLJSONAdapter.m in Sources */,
+				68A45B832B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m in Sources */,
 				CE0D42281C6A673E006B91B5 /* AWSSignature.m in Sources */,
 				FA5D34FD250C0D77007AA030 /* AWSNSCodingUtilities.m in Sources */,
 				CE0D42701C6A673E006B91B5 /* NSObject+AWSMTLComparisonAdditions.m in Sources */,
 				CE0D42241C6A673E006B91B5 /* AWSCredentialsProvider.m in Sources */,
-				184F431B1E930A2D004F3FE2 /* AWSDDLog.m in Sources */,
+				68A45B862B8D5F7D00A0851E /* AWSDDLoggerNames.m in Sources */,
 				CE0D42721C6A673E006B91B5 /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */,
 				CE0D424B1C6A673E006B91B5 /* AWSFMDatabaseQueue.m in Sources */,
 				CE0D42611C6A673E006B91B5 /* AWSMTLValueTransformer.m in Sources */,
 				CE3627CF1CEBA92B003E85B9 /* AWSKSReachability.m in Sources */,
+				68A45B7C2B8D5F7D00A0851E /* AWSDDFileLogger.m in Sources */,
 				CE0D428B1C6A673E006B91B5 /* AWSService.m in Sources */,
 				CE0D42521C6A673E006B91B5 /* AWSGZIP.m in Sources */,
 				CE0D428F1C6A673E006B91B5 /* AWSSTSModel.m in Sources */,
 				CE0D423A1C6A673E006B91B5 /* AWSCognitoIdentityModel.m in Sources */,
 				CE0D42771C6A673E006B91B5 /* AWSNetworking.m in Sources */,
 				CE0D42871C6A673E006B91B5 /* AWSValidation.m in Sources */,
+				68A45B992B8D5F7D00A0851E /* AWSDDASLLogCapture.m in Sources */,
+				68A45B982B8D5F7D00A0851E /* AWSDDLog.m in Sources */,
 				CE0D42891C6A673E006B91B5 /* AWSClientContext.m in Sources */,
 				CE0D42931C6A673E006B91B5 /* AWSSTSService.m in Sources */,
 				CE0D42641C6A673E006B91B5 /* AWSEXTRuntimeExtensions.m in Sources */,
 				CE0D423C1C6A673E006B91B5 /* AWSCognitoIdentityResources.m in Sources */,
-				184F431F1E930A2D004F3FE2 /* AWSDDTTYLogger.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -557,12 +557,13 @@
 		5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		5C1978DD2702364800F9C11E /* AWSLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1978DC2702364800F9C11E /* AWSLocationTests.swift */; };
 		5C71F33F295672B8001183A4 /* guten_tag.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5C71F33E295672B8001183A4 /* guten_tag.wav */; };
+		687952932B8FE2C5001E8990 /* AWSDDLog+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */; };
 		6883619E2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */; };
 		688361A12B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */; };
 		68A45B792B8D5F7D00A0851E /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		68A45B7B2B8D5F7D00A0851E /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */; };
 		68A45B7C2B8D5F7D00A0851E /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */; };
-		68A45B7D2B8D5F7D00A0851E /* AWSDDFileLogger+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45B7D2B8D5F7D00A0851E /* AWSDDFileLogger+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */; };
 		68A45B7E2B8D5F7D00A0851E /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */; };
 		68A45B7F2B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */; };
 		68A45B802B8D5F7D00A0851E /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */; };
@@ -3131,6 +3132,7 @@
 		5C1978DB2702364800F9C11E /* AWSLocationTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSLocationTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5C1978DC2702364800F9C11E /* AWSLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLocationTests.swift; sourceTree = "<group>"; };
 		5C71F33E295672B8001183A4 /* guten_tag.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = guten_tag.wav; sourceTree = "<group>"; };
+		687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDDLog+Optional.swift"; sourceTree = "<group>"; };
 		6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PreSignedURLBuilderUnitTests.swift; sourceTree = "<group>"; };
 		688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThreadTests.m; sourceTree = "<group>"; };
 		68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCocoaLumberjack.h; sourceTree = "<group>"; };
@@ -5950,6 +5952,7 @@
 				68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */,
 				68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */,
 				68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */,
+				687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */,
 				68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */,
 			);
 			path = Extensions;
@@ -12867,6 +12870,7 @@
 				68A45B842B8D5F7D00A0851E /* AWSDDOSLogger.m in Sources */,
 				CE0D42A61C6A673E006B91B5 /* AWSModel.m in Sources */,
 				CE0D425F1C6A673E006B91B5 /* AWSMTLReflection.m in Sources */,
+				687952932B8FE2C5001E8990 /* AWSDDLog+Optional.swift in Sources */,
 				CE0D42A41C6A673E006B91B5 /* AWSLogging.m in Sources */,
 				68A45B822B8D5F7D00A0851E /* AWSDDMultiFormatter.m in Sources */,
 				CE0D42AE1C6A673E006B91B5 /* AWSXMLWriter.m in Sources */,
@@ -17520,6 +17524,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -17538,6 +17543,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
   - AWSTranslate
   - AWSUserPoolsSignIn
 
+- **AWSCore**
+  - Updating CocoaLumberjack to version 3.4.8
+
 ## 2.34.0
 
 ### Misc. Updates

--- a/README.md
+++ b/README.md
@@ -413,13 +413,13 @@ To initialize logging to your Xcode console, use the following code:
 **Swift**
 
 ```swift
-AWSDDLog.add(AWSDDTTYLogger.sharedInstance) // TTY = Xcode console
+AWSDDLog.add(AWSDDOSLogger.sharedInstance) // Apple's unified logging
 ```
 
 **Objective-C**
 
 ```objective-c
-[AWSDDLog addLogger:[AWSDDTTYLogger sharedInstance]]; // TTY = Xcode console
+[AWSDDLog addLogger:[AWSDDOSLogger sharedInstance]]; // Apple's unified logging
 ```
 
 ## Open Source Contributions


### PR DESCRIPTION
### Description of changes

This PR upgrades the **CocoaLumberjack** fork within `AWSCore` (called `AWSCocoaLumberjack`) to version [3.8.4](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.8.4).

I've also updated the README to use `AWSDDOSLogger` instead of `AWSDDTTYLogger` in our logging example.

**Additional Changes**

The following has been made for backwards compatibility:
- Addition of the `logLevel` property in `AWSDDLog`, so that customers can easily set the global log level.
- `AWSDDTTYLogger.sharedInstance` is explicitly marked as `nullable`, but the `id<AWSLogger>` arguments in `[AWSDDLog add:]` and `[AWSDDLog add:withLevel:]` have been explicitly marked as `non-null`. This is technically a breaking change for Swift customers, so I've added a Swift extension that offers methods that take optionals, but are deprecated and instruct to not use optionals
  - ⚠️ Note: The _**actual**_ behaviour has not changed. In the old version, `AWSDDTTYLogger.sharedInstance` could still return `nil` and then it would just be ignored by `[AWSDDLog add:]` and `[AWSDDLog add:withLevel:]`.

*Check points:*

- [ ] ~Added new tests to cover change, if needed~
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] ~Documentation update for the change if required~
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
