### PR TITLE
feat: Upgrade iOS deployment target to iOS 12

### DIFF
--- a/AWSAPIGateway.podspec
+++ b/AWSAPIGateway.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSAuth.podspec
+++ b/AWSAuth.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'http://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSAuthCore.podspec
+++ b/AWSAuthCore.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'http://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -4629,7 +4629,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSUserPoolsSignIn/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSUserPoolsSignIn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4646,7 +4646,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSUserPoolsSignIn/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSUserPoolsSignIn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4704,7 +4704,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -4758,7 +4758,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -4779,7 +4779,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSFacebookSignIn/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSFacebookSignIn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4797,7 +4797,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSFacebookSignIn/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSFacebookSignIn;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4816,7 +4816,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSAuthSDKTestAppUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -4842,7 +4842,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSAuthSDKTestAppUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -4870,7 +4870,7 @@
 				);
 				INFOPLIST_FILE = Sources/AWSGoogleSignIn/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4898,7 +4898,7 @@
 				);
 				INFOPLIST_FILE = Sources/AWSGoogleSignIn/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4999,7 +4999,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSAuthSDKTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACH_O_TYPE = mh_execute;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -5034,7 +5034,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSAuthSDKTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACH_O_TYPE = mh_execute;
 				MTL_FAST_MATH = YES;
@@ -5091,7 +5091,7 @@
 				);
 				INFOPLIST_FILE = Sources/AWSMobileClientXCF/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "-Xfrontend -module-interface-preserve-types-as-written";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClient;
@@ -5131,7 +5131,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "USE_XCF=1";
 				INFOPLIST_FILE = Sources/AWSMobileClientXCF/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_SWIFT_FLAGS = "-Xfrontend -module-interface-preserve-types-as-written";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClient;
@@ -5411,7 +5411,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSAuthCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSAuthCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5430,7 +5430,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSAuthCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSAuthCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5448,7 +5448,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSAuthUI/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSAuthUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5466,7 +5466,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/AWSAuthUI/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSAuthUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5497,7 +5497,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Sources/AWSMobileClient/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClient;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -5531,7 +5531,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Sources/AWSMobileClient/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSMobileClient;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/AWSAuthUI.podspec
+++ b/AWSAuthUI.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'http://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSAutoScaling.podspec
+++ b/AWSAutoScaling.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSChimeSDKIdentity.podspec
+++ b/AWSChimeSDKIdentity.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSChimeSDKMessaging.podspec
+++ b/AWSChimeSDKMessaging.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSCloudWatch.podspec
+++ b/AWSCloudWatch.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSCloudWatch/AWSCloudWatchService.m
+++ b/AWSCloudWatch/AWSCloudWatchService.m
@@ -49,7 +49,6 @@ static NSDictionary *errorCodeDictionary = nil;
                             @"InvalidParameterValue" : @(AWSCloudWatchErrorInvalidParameterValue),
                             @"LimitExceeded" : @(AWSCloudWatchErrorLimitExceeded),
                             @"MissingParameter" : @(AWSCloudWatchErrorMissingRequiredParameter),
-                            @"ResourceNotFound" : @(AWSCloudWatchErrorResourceNotFound),
                             };
 }
 

--- a/AWSCloudWatch/AWSCloudWatchService.m
+++ b/AWSCloudWatch/AWSCloudWatchService.m
@@ -41,7 +41,6 @@ static NSDictionary *errorCodeDictionary = nil;
 + (void)initialize {
     errorCodeDictionary = @{
                             @"InvalidParameterInput" : @(AWSCloudWatchErrorDashboardInvalidInput),
-                            @"ResourceNotFound" : @(AWSCloudWatchErrorDashboardNotFound),
                             @"InternalServiceError" : @(AWSCloudWatchErrorInternalService),
                             @"InvalidFormat" : @(AWSCloudWatchErrorInvalidFormat),
                             @"InvalidNextToken" : @(AWSCloudWatchErrorInvalidNextToken),
@@ -49,6 +48,7 @@ static NSDictionary *errorCodeDictionary = nil;
                             @"InvalidParameterValue" : @(AWSCloudWatchErrorInvalidParameterValue),
                             @"LimitExceeded" : @(AWSCloudWatchErrorLimitExceeded),
                             @"MissingParameter" : @(AWSCloudWatchErrorMissingRequiredParameter),
+                            @"ResourceNotFound" : @(AWSCloudWatchErrorResourceNotFound),
                             };
 }
 

--- a/AWSCognitoAuth.podspec
+++ b/AWSCognitoAuth.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -51,7 +51,7 @@ NSString *const AWSCognitoAuthErrorDomain = @"com.amazon.cognito.AWSCognitoAuthE
 API_AVAILABLE(ios(11.0))
 @interface AWSCognitoAuth()
 
-@property (nonatomic, strong) SFAuthenticationSession *sfAuthSession;
+@property (nonatomic, strong) ASWebAuthenticationSession *sfAuthSession;
 
 @end
 
@@ -358,10 +358,10 @@ withPresentingViewController:(UIViewController *)presentingViewController {
     self.sfAuthenticationSessionAvailable = YES;
     NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signInRedirectUri] copy];
     __weak AWSCognitoAuth *weakSelf = self;
-    self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:hostedUIURL
-                                                    callbackURLScheme:callbackURLScheme
-                                                    completionHandler:^(NSURL * _Nullable url,
-                                                                        NSError * _Nullable error) {
+    self.sfAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:hostedUIURL
+                                                       callbackURLScheme:callbackURLScheme
+                                                       completionHandler:^(NSURL * _Nullable url,
+                                                                           NSError * _Nullable error) {
         __strong AWSCognitoAuth *strongSelf = weakSelf;
         [strongSelf handleSignInCallbackWithURL:url error:error];
     }];
@@ -403,7 +403,9 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 
 -(void)showSFSafariViewControllerForURL:(NSURL *)url
            withPresentingViewController:(UIViewController *)presentingViewController{
-    self.svc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:NO];
+    SFSafariViewControllerConfiguration *configuration = [[SFSafariViewControllerConfiguration alloc] init];
+    configuration.entersReaderIfAvailable = NO;
+    self.svc = [[SFSafariViewController alloc] initWithURL:url configuration:configuration];
     self.svc.delegate = self;
     self.svc.modalPresentationStyle = UIModalPresentationPopover;
     self.isProcessingSignIn = YES;
@@ -655,15 +657,15 @@ withPresentingViewController:(UIViewController *)presentingViewController {
     self.sfAuthenticationSessionAvailable = YES;
     NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
     __weak AWSCognitoAuth *weakSelf = self;
-    self.sfAuthSession = [[SFAuthenticationSession alloc] initWithURL:url
-                                                    callbackURLScheme:callbackURLScheme
-                                                    completionHandler:^(NSURL * _Nullable url,
-                                                                        NSError * _Nullable error) {
+    self.sfAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:url
+                                                       callbackURLScheme:callbackURLScheme
+                                                       completionHandler:^(NSURL * _Nullable url,
+                                                                           NSError * _Nullable error) {
         __strong AWSCognitoAuth *strongSelf = weakSelf;
         if (url) {
             [strongSelf processURL:url forRedirection:NO];
         } else {
-            if (error.code != SFAuthenticationErrorCanceledLogin) {
+            if (error.code != ASWebAuthenticationSessionErrorCodeCanceledLogin) {
                 [strongSelf signOutLocallyAndClearLastKnownUser];
             }
             [strongSelf dismissSafariViewControllerAndCompleteSignOut:error];
@@ -674,7 +676,9 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 
 - (void)signOutSFSafariVC: (UIViewController *) vc
                       url:(NSURL *)url {
-    self.svc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:NO];
+    SFSafariViewControllerConfiguration *configuration = [[SFSafariViewControllerConfiguration alloc] init];
+    configuration.entersReaderIfAvailable = NO;
+    self.svc = [[SFSafariViewController alloc] initWithURL:url configuration:configuration];
     self.svc.delegate = self;
     self.svc.modalPresentationStyle = UIModalPresentationPopover;
     self.isProcessingSignOut = YES;

--- a/AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h
+++ b/AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.h
@@ -87,12 +87,12 @@ typedef NS_ENUM(NSInteger, AWSCognitoAuthUICKeyChainStoreAuthenticationType) {
 typedef NS_ENUM(NSInteger, AWSCognitoAuthUICKeyChainStoreAccessibility) {
     AWSCognitoAuthUICKeyChainStoreAccessibilityWhenUnlocked = 1,
     AWSCognitoAuthUICKeyChainStoreAccessibilityAfterFirstUnlock,
-    AWSCognitoAuthUICKeyChainStoreAccessibilityAlways,
+    AWSCognitoAuthUICKeyChainStoreAccessibilityAlways __deprecated_enum_msg("Use an accessibility level that provides some user protection, such as AWSCognitoAuthUICKeyChainStoreAccessibilityAfterFirstUnlock"),
     AWSCognitoAuthUICKeyChainStoreAccessibilityWhenPasscodeSetThisDeviceOnly
     __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0),
     AWSCognitoAuthUICKeyChainStoreAccessibilityWhenUnlockedThisDeviceOnly,
     AWSCognitoAuthUICKeyChainStoreAccessibilityAfterFirstUnlockThisDeviceOnly,
-    AWSCognitoAuthUICKeyChainStoreAccessibilityAlwaysThisDeviceOnly,
+    AWSCognitoAuthUICKeyChainStoreAccessibilityAlwaysThisDeviceOnly __deprecated_enum_msg("Use an accessibility level that provides some user protection, such as AWSCognitoAuthUICKeyChainStoreAccessibilityAfterFirstUnlockThisDeviceOnly"),
 }
 __OSX_AVAILABLE_STARTING(__MAC_10_9, __IPHONE_4_0);
 

--- a/AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m
+++ b/AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m
@@ -527,14 +527,7 @@ static NSString *_defaultService;
     NSMutableDictionary *query = [self query];
     query[(__bridge __strong id)kSecAttrAccount] = key;
 #if TARGET_OS_IOS
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if (floor(NSFoundationVersionNumber) > floor(1144.17)) { // iOS 9+
-        query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
-    } else if (floor(NSFoundationVersionNumber) > floor(1047.25)) { // iOS 8+
-        query[(__bridge __strong id)kSecUseNoAuthenticationUI] = (__bridge id)kCFBooleanTrue;
-    }
-#pragma clang diagnostic pop
+    query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
 #elif TARGET_OS_WATCH || TARGET_OS_TV
     query[(__bridge __strong id)kSecUseAuthenticationUI] = (__bridge id)kSecUseAuthenticationUIFail;
 #endif
@@ -1094,6 +1087,8 @@ static NSString *_defaultService;
 
 #pragma mark -
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)synchronize
 {
     // Deprecated, calling this method is no longer required
@@ -1104,6 +1099,7 @@ static NSString *_defaultService;
     // Deprecated, calling this method is no longer required
     return true;
 }
+#pragma clang diagnostic pop
 
 #pragma mark -
 
@@ -1348,6 +1344,8 @@ static NSString *_defaultService;
     }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (CFTypeRef)accessibilityObject
 {
     switch (_accessibility) {
@@ -1369,6 +1367,7 @@ static NSString *_defaultService;
             return nil;
     }
 }
+#pragma clang diagnostic pop
 
 + (NSError *)argumentError:(NSString *)message
 {

--- a/AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m
+++ b/AWSCognitoAuth/Internal/UICKeyChainStore/AWSCognitoAuthUICKeyChainStore.m
@@ -1087,6 +1087,7 @@ static NSString *_defaultService;
 
 #pragma mark -
 
+// These methods are deprecated, but still need to be implemented
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)synchronize
@@ -1344,6 +1345,9 @@ static NSString *_defaultService;
     }
 }
 
+// The following keys are deprecated, but they still need to be supported:
+// - AWSCognitoAuthUICKeyChainStoreAccessibilityAlways, kSecAttrAccessibleAlways,
+// - AWSCognitoAuthUICKeyChainStoreAccessibilityAlwaysThisDeviceOnly, kSecAttrAccessibleAlwaysThisDeviceOnly
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (CFTypeRef)accessibilityObject

--- a/AWSCognitoIdentityProvider.podspec
+++ b/AWSCognitoIdentityProvider.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1172,6 +1172,8 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
 /**
  * Invoke developer's ui to prompt user for mfa code and call enhanceAuth
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 -(AWSTask<AWSCognitoIdentityUserSession *>*) mfaAuthInternal: (NSString *) deliveryMedium
                                                  destination: (NSString *) destination
                                                    authState: (NSString *) authState
@@ -1208,6 +1210,7 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
                 }];
     }
 }
+#pragma clang diagnostic pop
 
 -(AWSTask<AWSCognitoIdentityUserSession *>*) mfaAuthInternal: (NSString *) deliveryMedium
                                                  destination: (NSString *) destination

--- a/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
+++ b/AWSCognitoIdentityProvider/AWSCognitoIdentityUser.m
@@ -1169,11 +1169,12 @@ static const NSString * AWSCognitoIdentityUserUserAttributePrefix = @"userAttrib
     [self addDeviceKey:authParameters];
 }
 
+// getMultiFactorAuthenticationCode is deprecated
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 /**
  * Invoke developer's ui to prompt user for mfa code and call enhanceAuth
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 -(AWSTask<AWSCognitoIdentityUserSession *>*) mfaAuthInternal: (NSString *) deliveryMedium
                                                  destination: (NSString *) destination
                                                    authState: (NSString *) authState

--- a/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m
+++ b/AWSCognitoIdentityProvider/Internal/NSData+AWSCognitoIdentityProvider.m
@@ -8,7 +8,7 @@
 #import "NSData+AWSCognitoIdentityProvider.h"
 #import "AWSJKBigInteger.h"
 
-void awsbigint_loadBigInt(){
+void awsbigint_loadBigInt(void){
 }
 
 AWSJKBigInteger *unsignedBigIntegerFromNSData(NSData* data) {

--- a/AWSCognitoIdentityProviderASF.podspec
+++ b/AWSCognitoIdentityProviderASF.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSComprehend.podspec
+++ b/AWSComprehend.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSConnect.podspec
+++ b/AWSConnect.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSConnectParticipant.podspec
+++ b/AWSConnectParticipant.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
 
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}

--- a/AWSCore.podspec
+++ b/AWSCore.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.libraries    = 'z', 'sqlite3'
   s.requires_arc = true
 
-  s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}'
+  s.source_files = 'AWSCore/*.{h,m}', 'AWSCore/**/*.{h,m}', 'AWSCore/Logging/Extensions/*.swift'
   s.private_header_files = 'AWSCore/XMLWriter/**/*.h', 'AWSCore/FMDB/AWSFMDatabase+Private.h', 'AWSCore/Fabric/*.h', 'AWSCore/Mantle/extobjc/*.h', 'AWSCore/CognitoIdentity/AWSCognitoIdentity+Fabric.h'
   s.resource_bundle = { 'AWSCore' => ['AWSCore/PrivacyInfo.xcprivacy']}
 end

--- a/AWSCore/Bolts/AWSTask.m
+++ b/AWSCore/Bolts/AWSTask.m
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-__attribute__ ((noinline)) void awsbf_warnBlockingOperationOnMainThread() {
+__attribute__ ((noinline)) void awsbf_warnBlockingOperationOnMainThread(void) {
     NSLog(@"Warning: A long-running operation is being executed on the main thread. \n"
           " Break on awsbf_warnBlockingOperationOnMainThread() to debug.");
 }

--- a/AWSCore/Bolts/AWSTask.m
+++ b/AWSCore/Bolts/AWSTask.m
@@ -10,7 +10,7 @@
 
 #import "AWSTask.h"
 
-#import <libkern/OSAtomic.h>
+#import <stdatomic.h>
 
 #import "AWSBolts.h"
 
@@ -98,12 +98,12 @@ NSString *const AWSTaskMultipleErrorsUserInfoKey = @"errors";
 }
 
 + (instancetype)taskForCompletionOfAllTasks:(nullable NSArray<AWSTask *> *)tasks {
-    __block int32_t total = (int32_t)tasks.count;
+    __block _Atomic(int32_t) total = (int32_t)tasks.count;
     if (total == 0) {
         return [self taskWithResult:nil];
     }
 
-    __block int32_t cancelled = 0;
+    __block _Atomic(int32_t) cancelled = 0;
     NSObject *lock = [[NSObject alloc] init];
     NSMutableArray *errors = [NSMutableArray array];
 
@@ -115,10 +115,11 @@ NSString *const AWSTaskMultipleErrorsUserInfoKey = @"errors";
                     [errors addObject:t.error];
                 }
             } else if (t.cancelled) {
-                OSAtomicIncrement32Barrier(&cancelled);
+                atomic_fetch_add(&cancelled, 1);
             }
 
-            if (OSAtomicDecrement32Barrier(&total) == 0) {
+            atomic_fetch_sub(&total, 1);
+            if (total == 0) {
                 if (errors.count > 0) {
                     if (errors.count == 1) {
                         tcs.error = [errors firstObject];
@@ -148,14 +149,14 @@ NSString *const AWSTaskMultipleErrorsUserInfoKey = @"errors";
 
 + (instancetype)taskForCompletionOfAnyTask:(nullable NSArray<AWSTask *> *)tasks
 {
-    __block int32_t total = (int32_t)tasks.count;
+    __block _Atomic(int32_t) total = (int32_t)tasks.count;
     if (total == 0) {
         return [self taskWithResult:nil];
     }
     
-    __block int completed = 0;
-    __block int32_t cancelled = 0;
-    
+    __block _Atomic(BOOL) completed = NO;
+    __block _Atomic(int32_t) cancelled = 0;
+
     NSObject *lock = [NSObject new];
     NSMutableArray<NSError *> *errors = [NSMutableArray new];
     
@@ -167,15 +168,17 @@ NSString *const AWSTaskMultipleErrorsUserInfoKey = @"errors";
                     [errors addObject:t.error];
                 }
             } else if (t.cancelled) {
-                OSAtomicIncrement32Barrier(&cancelled);
+                atomic_fetch_add(&cancelled, 1);
             } else {
-                if(OSAtomicCompareAndSwap32Barrier(0, 1, &completed)) {
+                BOOL expected = NO;
+                if(atomic_compare_exchange_strong(&completed, &expected, YES)) {
                     [source setResult:t.result];
                 }
             }
-            
-            if (OSAtomicDecrement32Barrier(&total) == 0 &&
-                OSAtomicCompareAndSwap32Barrier(0, 1, &completed)) {
+
+            atomic_fetch_sub(&total, 1);
+            BOOL expected = NO;
+            if (total == 0 && atomic_compare_exchange_strong(&completed, &expected, YES)) {
                 if (cancelled > 0) {
                     [source cancel];
                 } else if (errors.count > 0) {

--- a/AWSCore/GZIP/AWSGZIP.m
+++ b/AWSCore/GZIP/AWSGZIP.m
@@ -34,7 +34,7 @@
 #import "AWSGZIP.h"
 #import <zlib.h>
 
-void awsgzip_loadGZIP(){
+void awsgzip_loadGZIP(void){
 }
 
 static const NSUInteger ChunkSize = 16384;

--- a/AWSCore/Logging/AWSCLIColor.h
+++ b/AWSCore/Logging/AWSCLIColor.h
@@ -1,0 +1,54 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class represents an NSColor replacement for CLI projects that don't link with AppKit
+ **/
+@interface AWSCLIColor : NSObject
+
+/**
+ *  Convenience method for creating a `AWSCLIColor` instance from RGBA params
+ *
+ *  @param red   red channel, between 0 and 1
+ *  @param green green channel, between 0 and 1
+ *  @param blue  blue channel, between 0 and 1
+ *  @param alpha alpha channel, between 0 and 1
+ */
++ (instancetype)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha;
+
+/**
+ *  Get the RGBA components from a `AWSCLIColor`
+ *
+ *  @param red   red channel, between 0 and 1
+ *  @param green green channel, between 0 and 1
+ *  @param blue  blue channel, between 0 and 1
+ *  @param alpha alpha channel, between 0 and 1
+ */
+- (void)getRed:(nullable CGFloat *)red green:(nullable CGFloat *)green blue:(nullable CGFloat *)blue alpha:(nullable CGFloat *)alpha NS_SWIFT_NAME(get(red:green:blue:alpha:));
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/AWSCore/Logging/AWSCLIColor.m
+++ b/AWSCore/Logging/AWSCLIColor.m
@@ -1,0 +1,57 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <TargetConditionals.h>
+
+#if TARGET_OS_OSX
+
+#import "AWSCLIColor.h"
+
+@interface AWSCLIColor () {
+    CGFloat _red, _green, _blue, _alpha;
+}
+
+@end
+
+
+@implementation AWSCLIColor
+
++ (instancetype)colorWithCalibratedRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha {
+    __auto_type color = [CLIColor new];
+    color->_red     = red;
+    color->_green   = green;
+    color->_blue    = blue;
+    color->_alpha   = alpha;
+    return color;
+}
+
+- (void)getRed:(CGFloat *)red green:(CGFloat *)green blue:(CGFloat *)blue alpha:(CGFloat *)alpha {
+    if (red) {
+        *red    = _red;
+    }
+    if (green) {
+        *green  = _green;
+    }
+    if (blue) {
+        *blue   = _blue;
+    }
+    if (alpha) {
+        *alpha  = _alpha;
+    }
+}
+
+@end
+
+#endif

--- a/AWSCore/Logging/AWSCocoaLumberjack.h
+++ b/AWSCore/Logging/AWSCocoaLumberjack.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -76,12 +76,24 @@
 #import "AWSDDASLLogCapture.h"
 
 // Loggers
+#import "AWSDDLoggerNames.h"
+
 #import "AWSDDTTYLogger.h"
 #import "AWSDDASLLogger.h"
 #import "AWSDDFileLogger.h"
 #import "AWSDDOSLogger.h"
 
+// Extensions
+#import "AWSDDContextFilterLogFormatter.h"
+#import "AWSDDContextFilterLogFormatter+Deprecated.h"
+#import "AWSDDDispatchQueueLogFormatter.h"
+#import "AWSDDMultiFormatter.h"
+#import "AWSDDFileLogger+Buffering.h"
+
 // CLI
-#if __has_include("CLIColor.h") && TARGET_OS_OSX
-#import "CLIColor.h"
-#endif
+#import "AWSCLIColor.h"
+
+// etc
+#import "AWSDDAbstractDatabaseLogger.h"
+#import "AWSDDLog+LOGV.h"
+#import "AWSDDLegacyMacros.h"

--- a/AWSCore/Logging/AWSDDASLLogger.h
+++ b/AWSCore/Logging/AWSDDASLLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -22,6 +22,8 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Custom key set on messages sent to ASL
 extern const char* const kAWSDDASLKeyAWSDDLog;
 
@@ -41,6 +43,7 @@ extern const char* const kAWSDDASLAWSDDLogValue;
  * However, if you instead choose to use file logging (for faster performance),
  * you may choose to use a file logger and a tty logger.
  **/
+API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
 @interface AWSDDASLLogger : AWSDDAbstractLogger <AWSDDLogger>
 
 /**
@@ -48,7 +51,7 @@ extern const char* const kAWSDDASLAWSDDLogValue;
  *
  *  @return the shared instance
  */
-@property (class, readonly, strong) AWSDDASLLogger *sharedInstance;
+@property (nonatomic, class, readonly, strong) AWSDDASLLogger *sharedInstance;
 
 // Inherited from AWSDDAbstractLogger
 
@@ -56,3 +59,5 @@ extern const char* const kAWSDDASLAWSDDLogValue;
 // - (void)setLogFormatter:(id <AWSDDLogFormatter>)formatter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDAbstractDatabaseLogger.h
+++ b/AWSCore/Logging/AWSDDAbstractDatabaseLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -20,6 +20,8 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This class provides an abstract implementation of a database logger.
  *
@@ -28,7 +30,7 @@
  * and override the methods in the implementation file that are prefixed with "db_".
  **/
 @interface AWSDDAbstractDatabaseLogger : AWSDDAbstractLogger {
-    
+
 @protected
     NSUInteger _saveThreshold;
     NSTimeInterval _saveInterval;
@@ -36,7 +38,7 @@
     NSTimeInterval _deleteInterval;
     BOOL _deleteOnEverySave;
     
-    BOOL _saveTimerSuspended;
+    NSInteger _saveTimerSuspended;
     NSUInteger _unsavedCount;
     dispatch_time_t _unsavedTime;
     dispatch_source_t _saveTimer;
@@ -121,3 +123,5 @@
 - (void)deleteOldLogEntries;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDAssertMacros.h
+++ b/AWSCore/Logging/AWSDDAssertMacros.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -14,13 +14,17 @@
 //   prior written permission of Deusty, LLC.
 
 /**
- * NSAsset replacement that will output a log message even when assertions are disabled.
+ * NSAssert replacement that will output a log message even when assertions are disabled.
  **/
 #define AWSDDAssert(condition, frmt, ...)                                                \
         if (!(condition)) {                                                           \
             NSString *description = [NSString stringWithFormat:frmt, ## __VA_ARGS__]; \
             AWSDDLogError(@"%@", description);                                           \
-            NSAssert(NO, description);                                                \
+            NSAssert(NO, @"%@", description);                                         \
         }
-#define AWSDDAssertCondition(condition) AWSDDAssert(condition, @"Condition not satisfied: %s", #condition)
+#define AWSDDAssertCondition(condition) AWSDDAssert(condition, @"Condition not satisfied: %@", @(#condition))
 
+/**
+ * Analog to `AWSDDAssertionFailure` from AWSDDAssert.swift for use in Objective C
+ */
+#define AWSDDAssertionFailure(frmt, ...) AWSDDAssert(NO, frmt, ##__VA_ARGS__)

--- a/AWSCore/Logging/AWSDDLegacyMacros.h
+++ b/AWSCore/Logging/AWSDDLegacyMacros.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -20,8 +20,12 @@
  **/
 #if AWSDD_LEGACY_MACROS
 
-#warning CocoaLumberjack 1.9.x legacy macros enabled. \
+#warning AWSCocoaLumberjack 1.9.x legacy macros enabled. \
 Disable legacy macros by importing AWSCocoaLumberjack.h or AWSDDLogMacros.h instead of AWSDDLog.h or add `#define AWSDD_LEGACY_MACROS 0` before importing AWSDDLog.h.
+
+#ifndef LOG_LEVEL_DEF
+    #define LOG_LEVEL_DEF [AWSDDLog sharedInstance].logLevel
+#endif
 
 #define LOG_FLAG_ERROR    AWSDDLogFlagError
 #define LOG_FLAG_WARN     AWSDDLogFlagWarning
@@ -57,7 +61,7 @@ Disable legacy macros by importing AWSCocoaLumberjack.h or AWSDDLogMacros.h inst
                format : (frmt), ## __VA_ARGS__]
 
 #define AWSDD_LOG_MAYBE(async, lvl, flg, ctx, fnct, frmt, ...)                       \
-        do { if(lvl & flg) AWSDD_LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if((lvl & flg) != 0) AWSDD_LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_OBJC_MAYBE(async, lvl, flg, ctx, frmt, ...) \
         AWSDD_LOG_MAYBE(async, lvl, flg, ctx, __PRETTY_FUNCTION__, frmt, ## __VA_ARGS__)

--- a/AWSCore/Logging/AWSDDLog+LOGV.h
+++ b/AWSCore/Logging/AWSDDLog+LOGV.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -21,6 +21,13 @@
 #import "AWSDDLog.h"
 
 /**
+ * The constant/variable/method responsible for controlling the current log level.
+ **/
+#ifndef LOG_LEVEL_DEF
+    #define LOG_LEVEL_DEF [AWSDDLog sharedInstance].logLevel
+#endif
+
+/**
  * Whether async should be used by log messages, excluding error messages that are always sent sync.
  **/
 #ifndef LOG_ASYNC_ENABLED
@@ -31,17 +38,17 @@
  * This is the single macro that all other macros below compile into.
  * This big multiline macro makes all the other macros easier to read.
  **/
-#define LOGV_MACRO(isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, avalist) \
-        [AWSDDLog log : isAsynchronous                                     \
-             level : lvl                                                \
-              flag : flg                                                \
-           context : ctx                                                \
-              file : __FILE__                                           \
-          function : fnct                                               \
-              line : __LINE__                                           \
-               tag : atag                                               \
-            format : frmt                                               \
-              args : avalist]
+#define LOGV_MACRO(isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, avalist)    \
+        [AWSDDLog log : isAsynchronous                                          \
+                level : lvl                                                     \
+                 flag : flg                                                     \
+              context : ctx                                                     \
+                 file : __FILE__                                                \
+             function : fnct                                                    \
+                 line : __LINE__                                                \
+                  tag : atag                                                    \
+               format : frmt                                                    \
+                 args : avalist]
 
 /**
  * Define version of the macro that only execute if the log level is above the threshold.
@@ -73,4 +80,3 @@
 #define AWSDDLogVInfo(frmt, avalist)    LOGV_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, avalist)
 #define AWSDDLogVDebug(frmt, avalist)   LOGV_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, avalist)
 #define AWSDDLogVVerbose(frmt, avalist) LOGV_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, avalist)
-

--- a/AWSCore/Logging/AWSDDLog.h
+++ b/AWSCore/Logging/AWSDDLog.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -15,6 +15,23 @@
 
 #import <Foundation/Foundation.h>
 
+// The Swift Package integration has no support for the legacy macros.
+#if __has_include(<AWSDDLegacyMacros.h>)
+    // Enable 1.9.x legacy macros if imported directly and it's not a swift package build.
+    #ifndef AWSDD_LEGACY_MACROS
+        #define AWSDD_LEGACY_MACROS 1
+    #endif
+    // AWSDD_LEGACY_MACROS is checked in the file itself
+    #import <AWSDDLegacyMacros.h>
+#endif
+
+#ifndef AWSDD_LEGACY_MESSAGE_TAG
+    #define AWSDD_LEGACY_MESSAGE_TAG 1
+#endif
+
+// Names of loggers.
+#import "AWSDDLoggerNames.h"
+
 #if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong
 #else
@@ -25,6 +42,8 @@
 @class AWSDDLoggerInformation;
 @protocol AWSDDLogger;
 @protocol AWSDDLogFormatter;
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Define the standard options.
@@ -98,22 +117,22 @@ typedef NS_OPTIONS(NSUInteger, AWSDDLogFlag){
      *  0...00001 AWSDDLogFlagError
      */
     AWSDDLogFlagError      = (1 << 0),
-    
+
     /**
      *  0...00010 AWSDDLogFlagWarning
      */
     AWSDDLogFlagWarning    = (1 << 1),
-    
+
     /**
      *  0...00100 AWSDDLogFlagInfo
      */
     AWSDDLogFlagInfo       = (1 << 2),
-    
+
     /**
      *  0...01000 AWSDDLogFlagDebug
      */
     AWSDDLogFlagDebug      = (1 << 3),
-    
+
     /**
      *  0...10000 AWSDDLogFlagVerbose
      */
@@ -128,39 +147,37 @@ typedef NS_ENUM(NSUInteger, AWSDDLogLevel){
      *  No logs
      */
     AWSDDLogLevelOff       = 0,
-    
+
     /**
      *  Error logs only
      */
     AWSDDLogLevelError     = (AWSDDLogFlagError),
-    
+
     /**
      *  Error and warning logs
      */
     AWSDDLogLevelWarning   = (AWSDDLogLevelError   | AWSDDLogFlagWarning),
-    
+
     /**
      *  Error, warning and info logs
      */
     AWSDDLogLevelInfo      = (AWSDDLogLevelWarning | AWSDDLogFlagInfo),
-    
+
     /**
      *  Error, warning, info and debug logs
      */
     AWSDDLogLevelDebug     = (AWSDDLogLevelInfo    | AWSDDLogFlagDebug),
-    
+
     /**
      *  Error, warning, info, debug and verbose logs
      */
     AWSDDLogLevelVerbose   = (AWSDDLogLevelDebug   | AWSDDLogFlagVerbose),
-    
+
     /**
      *  All logs (1...11111)
      */
     AWSDDLogLevelAll       = NSUIntegerMax
 };
-
-NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Extracts just the file name, no path or extension
@@ -170,21 +187,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return the file name
  */
-NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
-
-/**
- * The THIS_FILE macro gives you an NSString of the file name.
- * For simplicity and clarity, the file name does not include the full path or file extension.
- *
- * For example: AWSDDLogWarn(@"%@: Unable to find thingy", THIS_FILE) -> @"MyViewController: Unable to find thingy"
- **/
-#ifndef THIS_FILE
-    #define THIS_FILE         (AWSDDExtractFileNameWithoutExtension(__FILE__, NO))
-#endif
+FOUNDATION_EXTERN NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 
 /**
  * The AWS_THIS_FILE macro gives you an NSString of the file name.
- * Provided for convenience in case of name conflicts of the THIS_FILE macro with CocoaLumberjack.
+ * For simplicity and clarity, the file name does not include the full path or file extension.
  *
  * For example: AWSDDLogWarn(@"%@: Unable to find thingy", AWS_THIS_FILE) -> @"MyViewController: Unable to find thingy"
  **/
@@ -200,6 +207,20 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  **/
 #define THIS_METHOD       NSStringFromSelector(_cmd)
 
+/**
+ * Makes a declaration "Sendable" in Swift (if supported by the compiler).
+ */
+#ifndef AWSDD_SENDABLE
+#ifdef __has_attribute
+#if __has_attribute(swift_attr)
+#define AWSDD_SENDABLE __attribute__((swift_attr("@Sendable")))
+#endif
+#endif
+#endif
+#ifndef AWSDD_SENDABLE
+#define AWSDD_SENDABLE
+#endif
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
@@ -209,6 +230,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  *  The main class, exposes all logging mechanisms, loggers, ...
  *  For most of the users, this class is hidden behind the logging functions like `AWSDDLogInfo`
  */
+AWSDD_SENDABLE
 @interface AWSDDLog : NSObject
 
 /**
@@ -218,7 +240,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 @property (class, nonatomic, strong, readonly) AWSDDLog *sharedInstance;
 
 /**
- * Log level setting.
+ * Log level setting.
  */
 @property (nonatomic, assign) AWSDDLogLevel logLevel;
 
@@ -249,9 +271,9 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format, ... NS_FORMAT_FUNCTION(9,10);
 
 /**
@@ -275,9 +297,9 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format, ... NS_FORMAT_FUNCTION(9,10);
 
 /**
@@ -302,9 +324,9 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format
        args:(va_list)argList NS_SWIFT_NAME(log(asynchronous:level:flag:context:file:function:line:tag:format:arguments:));
 
@@ -330,16 +352,16 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
        flag:(AWSDDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
-   function:(const char *)function
+   function:(nullable const char *)function
        line:(NSUInteger)line
-        tag:(id __nullable)tag
+        tag:(nullable id)tag
      format:(NSString *)format
        args:(va_list)argList NS_SWIFT_NAME(log(asynchronous:level:flag:context:file:function:line:tag:format:arguments:));
 
 /**
  * Logging Primitive.
  *
- * This method can be used if you manualy prepared AWSDDLogMessage.
+ * This method can be used if you manually prepared AWSDDLogMessage.
  *
  *  @param asynchronous YES if the logging is done async, NO if you want to force sync
  *  @param logMessage   the log message stored in a `AWSDDLogMessage` model object
@@ -350,7 +372,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 /**
  * Logging Primitive.
  *
- * This method can be used if you manualy prepared AWSDDLogMessage.
+ * This method can be used if you manually prepared AWSDDLogMessage.
  *
  *  @param asynchronous YES if the logging is done async, NO if you want to force sync
  *  @param logMessage   the log message stored in a `AWSDDLogMessage` model object
@@ -583,7 +605,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  * If no formatter is set, the logger simply logs the message as it is given in logMessage,
  * or it may use its own built in formatting style.
  **/
-@property (nonatomic, strong) id <AWSDDLogFormatter> logFormatter;
+@property (nonatomic, strong, nullable) id <AWSDDLogFormatter> logFormatter;
 
 @optional
 
@@ -614,16 +636,16 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 - (void)didAddLoggerInQueue:(dispatch_queue_t)queue;
 
 /**
- *  See the above description for `didAddLoger`
+ *  See the above description for `didAddLogger`
  */
 - (void)willRemoveLogger;
 
 /**
  * Some loggers may buffer IO for optimization purposes.
- * For example, a database logger may only save occasionaly as the disk IO is slow.
+ * For example, a database logger may only save occasionally as the disk IO is slow.
  * In such loggers, this method should be implemented to flush any pending IO.
  *
- * This allows invocations of AWSDDLog's flushLog method to be propogated to loggers that need it.
+ * This allows invocations of AWSDDLog's flushLog method to be propagated to loggers that need it.
  *
  * Note that AWSDDLog's flushLog method is invoked automatically when the application quits,
  * and it may be also invoked manually by the developer prior to application crashes, or other such reasons.
@@ -643,7 +665,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  * The created queue will receive its name from this method.
  * This may be helpful for debugging or profiling reasons.
  **/
-@property (nonatomic, readonly) NSString *loggerName;
+@property (copy, nonatomic, readonly) AWSDDLoggerName loggerName;
 
 @end
 
@@ -668,7 +690,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  * The formatter may also optionally filter the log message by returning nil,
  * in which case the logger will not log the message.
  **/
-- (NSString * __nullable)formatLogMessage:(AWSDDLogMessage *)logMessage NS_SWIFT_NAME(format(message:));
+- (nullable NSString *)formatLogMessage:(AWSDDLogMessage *)logMessage NS_SWIFT_NAME(format(message:));
 
 @optional
 
@@ -678,7 +700,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  *
  * This is primarily for thread-safety.
  * If a formatter is explicitly not thread-safe, it may wish to throw an exception if added to multiple loggers.
- * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter),
+ * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter with 10.0 behavior),
  * it could possibly use these hooks to switch to thread-safe versions of the code.
  **/
 - (void)didAddToLogger:(id <AWSDDLogger>)logger;
@@ -689,7 +711,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
  *
  * This is primarily for thread-safety.
  * If a formatter is explicitly not thread-safe, it may wish to throw an exception if added to multiple loggers.
- * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter),
+ * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter with 10.0 behavior),
  * it could possibly use these hooks to switch to thread-safe versions of the code or use dispatch_set_specific()
 .* to add its own specific values.
  **/
@@ -709,7 +731,7 @@ NSString * __nullable AWSDDExtractFileNameWithoutExtension(const char *filePath,
 /**
  *  This protocol describes a dynamic logging component
  */
-@protocol AWSDDRegisteredDynamicLogging
+@protocol AWSDRegisteredDynamicLogging
 
 /**
  * Implement these methods to allow a file's log level to be managed from a central location.
@@ -768,11 +790,13 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
  * The `AWSDDLogMessage` class encapsulates information about the log message.
  * If you write custom loggers or formatters, you will be dealing with objects of this class.
  **/
+AWSDD_SENDABLE
 @interface AWSDDLogMessage : NSObject <NSCopying>
 {
     // Direct accessors to be used only for performance
     @public
     NSString *_message;
+    NSString *_messageFormat;
     AWSDDLogLevel _level;
     AWSDDLogFlag _flag;
     NSInteger _context;
@@ -780,12 +804,16 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
     NSString *_fileName;
     NSString *_function;
     NSUInteger _line;
-    id _tag;
+#if AWSDD_LEGACY_MESSAGE_TAG
+    id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));
+#endif
+    id _representedObject;
     AWSDDLogMessageOptions _options;
-    NSDate *_timestamp;
+    NSDate * _timestamp;
     NSString *_threadID;
     NSString *_threadName;
     NSString *_queueLabel;
+    NSUInteger _qos;
 }
 
 /**
@@ -807,6 +835,64 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
  * so it makes sense to optimize and skip the unnecessary allocations.
  * However, if you need them to be copied you may use the options parameter to specify this.
  *
+ *  @param messageFormat   the message format
+ *  @param message  the formatted message
+ *  @param level     the log level
+ *  @param flag      the log flag
+ *  @param context   the context (if any is defined)
+ *  @param file      the current file
+ *  @param function  the current function
+ *  @param line      the current code line
+ *  @param tag       potential tag
+ *  @param options   a bitmask which supports AWSDDLogMessageCopyFile and AWSDDLogMessageCopyFunction.
+ *  @param timestamp the log timestamp
+ *
+ *  @return a new instance of a log message model object
+ */
+- (instancetype)initWithFormat:(NSString *)messageFormat
+                     formatted:(NSString *)message
+                         level:(AWSDDLogLevel)level
+                          flag:(AWSDDLogFlag)flag
+                       context:(NSInteger)context
+                          file:(NSString *)file
+                      function:(nullable NSString *)function
+                          line:(NSUInteger)line
+                           tag:(nullable id)tag
+                       options:(AWSDDLogMessageOptions)options
+                     timestamp:(nullable NSDate *)timestamp NS_DESIGNATED_INITIALIZER;
+
+/**
+ *     Convenience initializer taking a `va_list` as arguments to create the formatted message.
+ *
+ *  @param messageFormat   the message format
+ *  @param messageArgs   the message arguments.
+ *  @param level     the log level
+ *  @param flag      the log flag
+ *  @param context   the context (if any is defined)
+ *  @param file      the current file
+ *  @param function  the current function
+ *  @param line      the current code line
+ *  @param tag       potential tag
+ *  @param options   a bitmask which supports AWSDDLogMessageCopyFile and AWSDDLogMessageCopyFunction.
+ *  @param timestamp the log timestamp
+ *
+ *  @return a new instance of a log message model object
+ */
+- (instancetype)initWithFormat:(NSString *)messageFormat
+                          args:(va_list)messageArgs
+                         level:(AWSDDLogLevel)level
+                          flag:(AWSDDLogFlag)flag
+                       context:(NSInteger)context
+                          file:(NSString *)file
+                      function:(nullable NSString *)function
+                          line:(NSUInteger)line
+                           tag:(nullable id)tag
+                       options:(AWSDDLogMessageOptions)options
+                     timestamp:(nullable NSDate *)timestamp;
+
+/**
+ *  Deprecated initialier. See initWithFormat:args:formatted:level:flag:context:file:function:line:tag:options:timestamp:.
+ *
  *  @param message   the message
  *  @param level     the log level
  *  @param flag      the log flag
@@ -825,33 +911,42 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
                            flag:(AWSDDLogFlag)flag
                         context:(NSInteger)context
                            file:(NSString *)file
-                       function:(NSString * __nullable)function
+                       function:(nullable NSString *)function
                            line:(NSUInteger)line
-                            tag:(id __nullable)tag
+                            tag:(nullable id)tag
                         options:(AWSDDLogMessageOptions)options
-                      timestamp:(NSDate * __nullable)timestamp NS_DESIGNATED_INITIALIZER;
+                      timestamp:(nullable NSDate *)timestamp
+__attribute__((deprecated("Use initializer taking unformatted message and args instead", "initWithFormat:formatted:level:flag:context:file:function:line:tag:options:timestamp:")));
 
 /**
  * Read-only properties
  **/
 
 /**
- *  The log message
+ *  The log message.
  */
 @property (readonly, nonatomic) NSString *message;
+/**
+ * The message format. When the deprecated initializer is used, this might be the same as `message`.
+ */
+@property (readonly, nonatomic) NSString *messageFormat;
 @property (readonly, nonatomic) AWSDDLogLevel level;
 @property (readonly, nonatomic) AWSDDLogFlag flag;
 @property (readonly, nonatomic) NSInteger context;
 @property (readonly, nonatomic) NSString *file;
 @property (readonly, nonatomic) NSString *fileName;
-@property (readonly, nonatomic) NSString * __nullable function;
+@property (readonly, nonatomic, nullable) NSString * function;
 @property (readonly, nonatomic) NSUInteger line;
-@property (readonly, nonatomic) id __nullable tag;
+#if AWSDD_LEGACY_MESSAGE_TAG
+@property (readonly, nonatomic, nullable) id tag __attribute__((deprecated("Use representedObject instead", "representedObject")));
+#endif
+@property (readonly, nonatomic, nullable) id representedObject;
 @property (readonly, nonatomic) AWSDDLogMessageOptions options;
 @property (readonly, nonatomic) NSDate *timestamp;
 @property (readonly, nonatomic) NSString *threadID; // ID as it appears in NSLog calculated from the machThreadID
-@property (readonly, nonatomic) NSString *threadName;
+@property (readonly, nonatomic, nullable) NSString *threadName;
 @property (readonly, nonatomic) NSString *queueLabel;
+@property (readonly, nonatomic) NSUInteger qos API_AVAILABLE(macos(10.10), ios(8.0));
 
 @end
 
@@ -863,10 +958,10 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
  * The `AWSDDLogger` protocol specifies that an optional formatter can be added to a logger.
  * Most (but not all) loggers will want to support formatters.
  *
- * However, writting getters and setters in a thread safe manner,
+ * However, writing getters and setters in a thread safe manner,
  * while still maintaining maximum speed for the logging process, is a difficult task.
  *
- * To do it right, the implementation of the getter/setter has strict requiremenets:
+ * To do it right, the implementation of the getter/setter has strict requirements:
  * - Must NOT require the `logMessage:` method to acquire a lock.
  * - Must NOT require the `logMessage:` method to access an atomic property (also a lock of sorts).
  *
@@ -879,7 +974,7 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
 {
     // Direct accessors to be used only for performance
     @public
-    id <AWSDDLogFormatter> _logFormatter;
+    _Nullable id <AWSDDLogFormatter> _logFormatter;
     dispatch_queue_t _loggerQueue;
 }
 
@@ -891,7 +986,7 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
 /**
  *  Return YES if the current logger uses a global queue for logging
  */
-@property (nonatomic, readonly, getter=isOnGlobalLoggingQueue)  BOOL onGlobalLoggingQueue;
+@property (nonatomic, readonly, getter=isOnGlobalLoggingQueue) BOOL onGlobalLoggingQueue;
 
 /**
  *  Return YES if the current logger uses the internal designated queue for logging
@@ -900,17 +995,34 @@ typedef NS_OPTIONS(NSInteger, AWSDDLogMessageOptions){
 
 @end
 
+#define _AWSDDAbstractLoggerSelectorMessage(msg) [NSStringFromSelector(_cmd) stringByAppendingString:@" " msg]
+// Note: we do not wrap these in any do {...} while 0 construct, because NSAssert does that for us.
+#define AWSDDAbstractLoggerAssertOnGlobalLoggingQueue() \
+NSAssert([self isOnGlobalLoggingQueue], _AWSDDAbstractLoggerSelectorMessage("must only be called on the global logging queue!"))
+#define AWSDDAbstractLoggerAssertOnInternalLoggerQueue() \
+NSAssert([self isOnInternalLoggerQueue], _AWSDDAbstractLoggerSelectorMessage("must only be called on the internal logger queue!"))
+#define AWSDDAbstractLoggerAssertNotOnGlobalLoggingQueue() \
+    NSAssert(![self isOnGlobalLoggingQueue], _AWSDDAbstractLoggerSelectorMessage("must not be called on the global logging queue!"))
+#define AWSDDAbstractLoggerAssertNotOnInternalLoggerQueue() \
+    NSAssert(![self isOnGlobalLoggingQueue], _AWSDDAbstractLoggerSelectorMessage("must not be called on the internal logger queue!"))
+
+#define AWSDDAbstractLoggerAssertLockedPropertyAccess() \
+    AWSDDAbstractLoggerAssertNotOnGlobalLoggingQueue(); \
+    NSAssert(![self isOnInternalLoggerQueue], @"MUST access ivar directly, NOT via self.* syntax.")
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+AWSDD_SENDABLE
 @interface AWSDDLoggerInformation : NSObject
 
 @property (nonatomic, readonly) id <AWSDDLogger> logger;
 @property (nonatomic, readonly) AWSDDLogLevel level;
 
-+ (AWSDDLoggerInformation *)informationWithLogger:(id <AWSDDLogger>)logger
-                           andLevel:(AWSDDLogLevel)level;
++ (instancetype)informationWithLogger:(id <AWSDDLogger>)logger
+                             andLevel:(AWSDDLogLevel)level;
 
 @end
 

--- a/AWSCore/Logging/AWSDDLogMacros.h
+++ b/AWSCore/Logging/AWSDDLogMacros.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -19,6 +19,13 @@
 #endif
 
 #import "AWSDDLog.h"
+
+/**
+ * The constant/variable/method responsible for controlling the current log level.
+ **/
+#ifndef LOG_LEVEL_DEF
+    #define LOG_LEVEL_DEF [AWSDDLog sharedInstance].logLevel
+#endif
 
 /**
  * Whether async should be used by log messages, excluding error messages that are always sent sync.
@@ -73,22 +80,22 @@
  * We also define shorthand versions for asynchronous and synchronous logging.
  **/
 #define AWSDD_LOG_MAYBE(async, lvl, flg, ctx, tag, fnct, frmt, ...) \
-        do { AWSDD_LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if(((NSUInteger)lvl & (NSUInteger)flg) != 0) AWSDD_LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_MAYBE_TO_AWSDDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ...) \
-        do { LOG_MACRO_TO_AWSDDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if(((NSUInteger)lvl & (NSUInteger)flg) != 0) LOG_MACRO_TO_AWSDDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 /**
  * Ready to use log macros with no context or tag.
  **/
-#define AWSDDLogError(frmt, ...)   AWSDD_LOG_MAYBE(NO,                [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogWarn(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogInfo(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogDebug(frmt, ...)   AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogVerbose(frmt, ...) AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogError(frmt, ...)   AWSDD_LOG_MAYBE(NO,                      LOG_LEVEL_DEF, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogWarn(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogInfo(frmt, ...)    AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogDebug(frmt, ...)   AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogVerbose(frmt, ...) AWSDD_LOG_MAYBE(AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
-#define AWSDDLogErrorToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, NO,                [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogWarnToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogInfoToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogDebugToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define AWSDDLogVerboseToAWSDDLog(ddlog, frmt, ...) LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, [AWSDDLog sharedInstance].logLevel, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogErrorToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, NO,                      LOG_LEVEL_DEF, AWSDDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogWarnToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogInfoToAWSDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogDebugToAWSDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define AWSDDLogVerboseToAWSDDLog(ddlog, frmt, ...) LOG_MAYBE_TO_AWSDDLOG(ddlog, AWSDD_LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, AWSDDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)

--- a/AWSCore/Logging/AWSDDLoggerNames.h
+++ b/AWSCore/Logging/AWSDDLoggerNames.h
@@ -13,34 +13,18 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
-
-@protocol AWSDDLogger;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
+typedef NSString *AWSDDLoggerName NS_EXTENSIBLE_STRING_ENUM;
 
-/**
- *  Start capturing logs
- */
-+ (void)start;
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameOS NS_SWIFT_NAME(AWSDDLoggerName.os);     // AWSDDOSLogger
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameFile NS_SWIFT_NAME(AWSDDLoggerName.file); // AWSDDFileLogger
 
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameTTY NS_SWIFT_NAME(AWSDDLoggerName.tty);   // AWSDDTTYLogger
 
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
-
-@end
+API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4, 10.12), ios(2.0, 10.0), watchos(2.0, 3.0), tvos(9.0, 10.0))
+FOUNDATION_EXPORT AWSDDLoggerName const AWSDDLoggerNameASL NS_SWIFT_NAME(AWSDDLoggerName.asl);   // AWSDDASLLogger
 
 NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDLoggerNames.m
+++ b/AWSCore/Logging/AWSDDLoggerNames.m
@@ -13,34 +13,9 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
+#import "AWSDDLoggerNames.h"
 
-@protocol AWSDDLogger;
-
-NS_ASSUME_NONNULL_BEGIN
-
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
-
-/**
- *  Start capturing logs
- */
-+ (void)start;
-
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
-
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
-
-@end
-
-NS_ASSUME_NONNULL_END
+AWSDDLoggerName const AWSDDLoggerNameASL    = @"cocoa.lumberjack.aslLogger";
+AWSDDLoggerName const AWSDDLoggerNameTTY    = @"cocoa.lumberjack.ttyLogger";
+AWSDDLoggerName const AWSDDLoggerNameOS     = @"cocoa.lumberjack.osLogger";
+AWSDDLoggerName const AWSDDLoggerNameFile   = @"cocoa.lumberjack.fileLogger";

--- a/AWSCore/Logging/AWSDDMultiFormatter.m
+++ b/AWSCore/Logging/AWSDDMultiFormatter.m
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -13,33 +13,11 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDMultiFormatter.h"
-
-
-#if TARGET_OS_IOS
-// Compiling for iOS
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000 // iOS 6.0 or later
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else                                         // iOS 5.X or earlier
-#define NEEDS_DISPATCH_RETAIN_RELEASE 1
-#endif
-#elif TARGET_OS_WATCH || TARGET_OS_TV
-// Compiling for watchOS, tvOS
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else
-// Compiling for Mac OS X
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1080     // Mac OS X 10.8 or later
-#define NEEDS_DISPATCH_RETAIN_RELEASE 0
-#else                                         // Mac OS X 10.7 or earlier
-#define NEEDS_DISPATCH_RETAIN_RELEASE 1
-#endif
-#endif
-
-
 #if !__has_feature(objc_arc)
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
+#import "AWSDDMultiFormatter.h"
 
 @interface AWSDDMultiFormatter () {
     dispatch_queue_t _queue;
@@ -57,32 +35,21 @@
     self = [super init];
 
     if (self) {
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
         _queue = dispatch_queue_create("cocoa.lumberjack.multiformatter", DISPATCH_QUEUE_CONCURRENT);
-#else
-        _queue = dispatch_queue_create("cocoa.lumberjack.multiformatter", NULL);
-#endif
         _formatters = [NSMutableArray new];
     }
 
     return self;
 }
 
-#if NEEDS_DISPATCH_RETAIN_RELEASE
-- (void)dealloc {
-    dispatch_release(_queue);
-}
-
-#endif
-
 #pragma mark Processing
 
 - (NSString *)formatLogMessage:(AWSDDLogMessage *)logMessage {
-    __block NSString *line = logMessage->_message;
+    __block __auto_type line = logMessage->_message;
 
     dispatch_sync(_queue, ^{
         for (id<AWSDDLogFormatter> formatter in self->_formatters) {
-            AWSDDLogMessage *message = [self logMessageForLine:line originalMessage:logMessage];
+            __auto_type message = [self logMessageForLine:line originalMessage:logMessage];
             line = [formatter formatLogMessage:message];
 
             if (!line) {
@@ -96,7 +63,6 @@
 
 - (AWSDDLogMessage *)logMessageForLine:(NSString *)line originalMessage:(AWSDDLogMessage *)message {
     AWSDDLogMessage *newMessage = [message copy];
-
     newMessage->_message = line;
     return newMessage;
 }

--- a/AWSCore/Logging/AWSDDOSLogger.h
+++ b/AWSCore/Logging/AWSDDOSLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -16,23 +16,41 @@
 #import <Foundation/Foundation.h>
 
 // Disable legacy macros
-#ifndef DD_LEGACY_MACROS
-    #define DD_LEGACY_MACROS 0
+#ifndef AWSDD_LEGACY_MACROS
+    #define AWSDD_LEGACY_MACROS 0
 #endif
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This class provides a logger for the Apple os_log facility.
  **/
-API_AVAILABLE(ios(10.0), macos(10.12), tvos(10.0), watchos(3.0))
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
+AWSDD_SENDABLE
 @interface AWSDDOSLogger : AWSDDAbstractLogger <AWSDDLogger>
 
 /**
  *  Singleton method
  *
- *  @return the shared instance
+ *  @return the shared instance with OS_LOG_DEFAULT.
  */
-@property (class, readonly, strong) AWSDDOSLogger *sharedInstance;
+@property (nonatomic, class, readonly, strong) AWSDDOSLogger *sharedInstance;
+
+/**
+ Designated initializer
+ 
+ @param subsystem Desired subsystem in log. E.g. "org.example"
+ @param category Desired category in log. E.g. "Point of interests."
+ @return New instance of AWSDDOSLogger.
+ 
+ @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
+ If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
+ If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`
+ */
+- (instancetype)initWithSubsystem:(nullable NSString *)subsystem category:(nullable NSString *)category NS_DESIGNATED_INITIALIZER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/AWSDDTTYLogger.h
+++ b/AWSCore/Logging/AWSDDTTYLogger.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -28,20 +28,21 @@
     // iOS or tvOS or watchOS
     #import <UIKit/UIColor.h>
     typedef UIColor AWSDDColor;
-    static inline AWSDDColor* AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline AWSDDColor* _Nonnull AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithRed:(r/(CGFloat)255.0) green:(g/(CGFloat)255.0) blue:(b/(CGFloat)255.0) alpha:1.0];}
 #elif defined(AWSDD_CLI) || !__has_include(<AppKit/NSColor.h>)
     // OS X CLI
-    #import "CLIColor.h"
+    #import "AWSCLIColor.h"
     typedef CLIColor AWSDDColor;
-    static inline AWSDDColor* AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline AWSDDColor* _Nonnull AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #else
     // OS X with AppKit
     #import <AppKit/NSColor.h>
     typedef NSColor AWSDDColor;
-    static inline AWSDDColor* AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline AWSDDColor  * _Nonnull AWSDDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [AWSDDColor colorWithCalibratedRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #endif
 #pragma clang diagnostic pop
 
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  * This class provides a logger for Terminal output or Xcode console output,
@@ -60,9 +61,9 @@
 @interface AWSDDTTYLogger : AWSDDAbstractLogger <AWSDDLogger>
 
 /**
- *  Singleton method
+ *  Singleton instance. Returns `nil` if the initialization of the AWSDDTTYLogger fails.
  */
-@property (class, readonly, strong) AWSDDTTYLogger *sharedInstance;
+@property (nonatomic, class, readonly, strong, nullable) AWSDDTTYLogger *sharedInstance;
 
 /* Inherited from the AWSDDLogger protocol:
  *
@@ -104,6 +105,11 @@
 @property (nonatomic, readwrite, assign) BOOL automaticallyAppendNewlineForCustomFormatters;
 
 /**
+ Using this initializer is not supported. Please use `AWSDDTTYLogger.sharedInstance`.
+ **/
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
  * The default color set (foregroundColor, backgroundColor) is:
  *
  * - AWSDDLogFlagError   = (red, nil)
@@ -125,7 +131,7 @@
  *
  * This method invokes setForegroundColor:backgroundColor:forFlag:context: and applies it to `LOG_CONTEXT_ALL`.
  **/
-- (void)setForegroundColor:(AWSDDColor *)txtColor backgroundColor:(AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask;
+- (void)setForegroundColor:(nullable AWSDDColor *)txtColor backgroundColor:(nullable AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask;
 
 /**
  * Just like setForegroundColor:backgroundColor:flag, but allows you to specify a particular logging context.
@@ -133,12 +139,12 @@
  * A logging context is often used to identify log messages coming from a 3rd party framework,
  * although logging context's can be used for many different functions.
  *
- * Use LOG_CONTEXT_ALL to set the deafult color for all contexts that have no specific color set defined.
+ * Use LOG_CONTEXT_ALL to set the default color for all contexts that have no specific color set defined.
  *
  * Logging context's are explained in further detail here:
  * Documentation/CustomContext.md
  **/
-- (void)setForegroundColor:(AWSDDColor *)txtColor backgroundColor:(AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask context:(NSInteger)ctxt;
+- (void)setForegroundColor:(nullable AWSDDColor *)txtColor backgroundColor:(nullable AWSDDColor *)bgColor forFlag:(AWSDDLogFlag)mask context:(NSInteger)ctxt;
 
 /**
  * Similar to the methods above, but allows you to map AWSDDLogMessage->tag to a particular color profile.
@@ -147,14 +153,14 @@
  * static NSString *const PurpleTag = @"PurpleTag";
  *
  * #define AWSDDLogPurple(frmt, ...) LOG_OBJC_TAG_MACRO(NO, 0, 0, 0, PurpleTag, frmt, ##__VA_ARGS__)
- * 
+ *
  * And then where you configure CocoaLumberjack:
  *
  * purple = AWSDDMakeColor((64/255.0), (0/255.0), (128/255.0));
  *
  * or any UIColor/NSColor constructor.
  *
- * Note: For CLI OS X projects that don't link with AppKit use CLIColor objects instead
+ * Note: For CLI OS X projects that don't link with AppKit use AWSCLIColor objects instead
  *
  * [[AWSDDTTYLogger sharedInstance] setForegroundColor:purple backgroundColor:nil forTag:PurpleTag];
  * [AWSDDLog addLogger:[AWSDDTTYLogger sharedInstance]];
@@ -163,7 +169,7 @@
  *
  * AWSDDLogPurple(@"I'm a purple log message!");
  **/
-- (void)setForegroundColor:(AWSDDColor *)txtColor backgroundColor:(AWSDDColor *)bgColor forTag:(id <NSCopying>)tag;
+- (void)setForegroundColor:(nullable AWSDDColor *)txtColor backgroundColor:(nullable AWSDDColor *)bgColor forTag:(id <NSCopying>)tag;
 
 /**
  * Clearing color profiles.
@@ -176,3 +182,5 @@
 - (void)clearAllColors;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.h
+++ b/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.h
@@ -1,0 +1,119 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import "AWSDDContextFilterLogFormatter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * This class provides a log formatter that filters log statements from a logging context not on the whitelist.
+ * @deprecated Use AWSDDContextAllowlistFilterLogFormatter instead.
+ *
+ * A log formatter can be added to any logger to format and/or filter its output.
+ * You can learn more about log formatters here:
+ * Documentation/CustomFormatters.md
+ *
+ * You can learn more about logging context's here:
+ * Documentation/CustomContext.md
+ *
+ * But here's a quick overview / refresher:
+ *
+ * Every log statement has a logging context.
+ * These come from the underlying logging macros defined in AWSDDLog.h.
+ * The default logging context is zero.
+ * You can define multiple logging context's for use in your application.
+ * For example, logically separate parts of your app each have a different logging context.
+ * Also 3rd party frameworks that make use of Lumberjack generally use their own dedicated logging context.
+ **/
+__attribute__((deprecated("Use AWSDDContextAllowlistFilterLogFormatter instead")))
+typedef AWSDDContextAllowlistFilterLogFormatter AWSDDContextWhitelistFilterLogFormatter;
+
+@interface AWSDDContextAllowlistFilterLogFormatter (Deprecated)
+
+/**
+ *  Add a context to the whitelist
+ *  @deprecated Use -addToAllowlist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)addToWhitelist:(NSInteger)loggingContext __attribute__((deprecated("Use -addToAllowlist: instead")));
+
+/**
+ *  Remove context from whitelist
+ *  @deprecated Use -removeFromAllowlist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)removeFromWhitelist:(NSInteger)loggingContext __attribute__((deprecated("Use -removeFromAllowlist: instead")));
+
+/**
+ *  Return the whitelist
+ *  @deprecated Use allowlist instead.
+ */
+@property (nonatomic, readonly, copy) NSArray<NSNumber *> *whitelist __attribute__((deprecated("Use allowlist instead")));
+
+/**
+ *  Check if a context is on the whitelist
+ *  @deprecated Use -isOnAllowlist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (BOOL)isOnWhitelist:(NSInteger)loggingContext __attribute__((deprecated("Use -isOnAllowlist: instead")));
+
+@end
+
+
+/**
+ * This class provides a log formatter that filters log statements from a logging context on the blacklist.
+ * @deprecated Use AWSDDContextDenylistFilterLogFormatter instead.
+ **/
+__attribute__((deprecated("Use AWSDDContextDenylistFilterLogFormatter instead")))
+typedef AWSDDContextDenylistFilterLogFormatter AWSDDContextBlacklistFilterLogFormatter;
+
+@interface AWSDDContextDenylistFilterLogFormatter (Deprecated)
+
+/**
+ *  Add a context to the blacklist
+ *  @deprecated Use -addToDenylist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)addToBlacklist:(NSInteger)loggingContext __attribute__((deprecated("Use -addToDenylist: instead")));
+
+/**
+ *  Remove context from blacklist
+ *  @deprecated Use -removeFromDenylist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (void)removeFromBlacklist:(NSInteger)loggingContext __attribute__((deprecated("Use -removeFromDenylist: instead")));
+
+/**
+ *  Return the blacklist
+ *  @deprecated Use denylist instead.
+ */
+@property (readonly, copy) NSArray<NSNumber *> *blacklist __attribute__((deprecated("Use denylist instead")));
+
+/**
+ *  Check if a context is on the blacklist
+ *  @deprecated Use -isOnDenylist: instead.
+ *
+ *  @param loggingContext the context
+ */
+- (BOOL)isOnBlacklist:(NSInteger)loggingContext __attribute__((deprecated("Use -isOnDenylist: instead")));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.m
+++ b/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter+Deprecated.m
@@ -1,0 +1,57 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import "AWSDDContextFilterLogFormatter+Deprecated.h"
+
+@implementation AWSDDContextAllowlistFilterLogFormatter (Deprecated)
+
+- (void)addToWhitelist:(NSInteger)loggingContext {
+    [self addToAllowlist:loggingContext];
+}
+
+- (void)removeFromWhitelist:(NSInteger)loggingContext {
+    [self removeFromAllowlist:loggingContext];
+}
+
+- (NSArray *)whitelist {
+    return [self allowlist];
+}
+
+- (BOOL)isOnWhitelist:(NSInteger)loggingContext {
+    return [self isOnAllowlist:loggingContext];
+}
+
+@end
+
+
+@implementation AWSDDContextDenylistFilterLogFormatter (Deprecated)
+
+- (void)addToBlacklist:(NSInteger)loggingContext {
+    [self addToDenylist:loggingContext];
+}
+
+- (void)removeFromBlacklist:(NSInteger)loggingContext {
+    [self removeFromDenylist:loggingContext];
+}
+
+- (NSArray *)blacklist {
+    return [self denylist];
+}
+
+- (BOOL)isOnBlacklist:(NSInteger)loggingContext {
+    return [self isOnDenylist:loggingContext];
+}
+
+@end

--- a/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h
+++ b/AWSCore/Logging/Extensions/AWSDDContextFilterLogFormatter.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -22,8 +22,10 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
- * This class provides a log formatter that filters log statements from a logging context not on the whitelist.
+ * This class provides a log formatter that filters log statements from a logging context not on the allowlist.
  *
  * A log formatter can be added to any logger to format and/or filter its output.
  * You can learn more about log formatters here:
@@ -41,7 +43,7 @@
  * For example, logically separate parts of your app each have a different logging context.
  * Also 3rd party frameworks that make use of Lumberjack generally use their own dedicated logging context.
  **/
-@interface AWSDDContextWhitelistFilterLogFormatter : NSObject <AWSDDLogFormatter>
+@interface AWSDDContextAllowlistFilterLogFormatter : NSObject <AWSDDLogFormatter>
 
 /**
  *  Designated default initializer
@@ -49,69 +51,67 @@
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Add a context to the whitelist
+ *  Add a context to the allowlist
  *
  *  @param loggingContext the context
  */
-- (void)addToWhitelist:(NSUInteger)loggingContext;
+- (void)addToAllowlist:(NSInteger)loggingContext;
 
 /**
- *  Remove context from whitelist
+ *  Remove context from allowlist
  *
  *  @param loggingContext the context
  */
-- (void)removeFromWhitelist:(NSUInteger)loggingContext;
+- (void)removeFromAllowlist:(NSInteger)loggingContext;
 
 /**
- *  Return the whitelist
+ *  Return the allowlist
  */
-@property (readonly, copy) NSArray<NSNumber *> *whitelist;
+@property (nonatomic, readonly, copy) NSArray<NSNumber *> *allowlist;
 
 /**
- *  Check if a context is on the whitelist
+ *  Check if a context is on the allowlist
  *
  *  @param loggingContext the context
  */
-- (BOOL)isOnWhitelist:(NSUInteger)loggingContext;
+- (BOOL)isOnAllowlist:(NSInteger)loggingContext;
 
 @end
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#pragma mark -
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * This class provides a log formatter that filters log statements from a logging context on the blacklist.
+ * This class provides a log formatter that filters log statements from a logging context on the denylist.
  **/
-@interface AWSDDContextBlacklistFilterLogFormatter : NSObject <AWSDDLogFormatter>
+@interface AWSDDContextDenylistFilterLogFormatter : NSObject <AWSDDLogFormatter>
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Add a context to the blacklist
+ *  Add a context to the denylist
  *
  *  @param loggingContext the context
  */
-- (void)addToBlacklist:(NSUInteger)loggingContext;
+- (void)addToDenylist:(NSInteger)loggingContext;
 
 /**
- *  Remove context from blacklist
+ *  Remove context from denylist
  *
  *  @param loggingContext the context
  */
-- (void)removeFromBlacklist:(NSUInteger)loggingContext;
+- (void)removeFromDenylist:(NSInteger)loggingContext;
 
 /**
- *  Return the blacklist
+ *  Return the denylist
  */
-@property (readonly, copy) NSArray<NSNumber *> *blacklist;
-
+@property (readonly, copy) NSArray<NSNumber *> *denylist;
 
 /**
- *  Check if a context is on the blacklist
+ *  Check if a context is on the denylist
  *
  *  @param loggingContext the context
  */
-- (BOOL)isOnBlacklist:(NSUInteger)loggingContext;
+- (BOOL)isOnDenylist:(NSInteger)loggingContext;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h
+++ b/AWSCore/Logging/Extensions/AWSDDDispatchQueueLogFormatter.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -14,7 +14,6 @@
 //   prior written permission of Deusty, LLC.
 
 #import <Foundation/Foundation.h>
-#import <libkern/OSAtomic.h>
 
 // Disable legacy macros
 #ifndef AWSDD_LEGACY_MACROS
@@ -23,9 +22,12 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  Log formatter mode
  */
+__attribute__((deprecated("AWSDDDispatchQueueLogFormatter is always shareable")))
 typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
     /**
      *  This is the default option, means the formatter can be reused between multiple loggers and therefore is thread-safe.
@@ -39,6 +41,36 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
     AWSDDDispatchQueueLogFormatterModeNonShareble,
 };
 
+/**
+ * Quality of Service names.
+ *
+ * Since macOS 10.10 and iOS 8.0, pthreads, dispatch queues and NSOperations express their
+ * scheduling priority by using an abstract classification called Quality of Service (QOS).
+ *
+ * This formatter will add a representation of this QOS in the log message by using those
+ * string constants.
+ * For example:
+ *
+ * `2011-10-17 20:21:45.435 AppName[19928:5207 (QOS:DF)] Your log message here`
+ *
+ * Where QOS is one of:
+ * `- UI = User Interactive`
+ * `- IN = User Initiated`
+ * `- DF = Default`
+ * `- UT = Utility`
+ * `- BG = Background`
+ * `- UN = Unspecified`
+ *
+ * Note: QOS will be absent in the log messages if running on OS versions that don't support it.
+ **/
+typedef NSString * AWSDDQualityOfServiceName NS_STRING_ENUM;
+
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUserInteractive NS_SWIFT_NAME(AWSDDQualityOfServiceName.userInteractive) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUserInitiated NS_SWIFT_NAME(AWSDDQualityOfServiceName.userInitiated) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceDefault NS_SWIFT_NAME(AWSDDQualityOfServiceName.default) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUtility NS_SWIFT_NAME(AWSDDQualityOfServiceName.utility) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceBackground NS_SWIFT_NAME(AWSDDQualityOfServiceName.background) API_AVAILABLE(macos(10.10), ios(8.0));
+FOUNDATION_EXPORT AWSDDQualityOfServiceName const AWSDDQualityOfServiceUnspecified NS_SWIFT_NAME(AWSDDQualityOfServiceName.unspecified) API_AVAILABLE(macos(10.10), ios(8.0));
 
 /**
  * This class provides a log formatter that prints the dispatch_queue label instead of the mach_thread_id.
@@ -90,7 +122,7 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
  *
  *  @param mode choose between AWSDDDispatchQueueLogFormatterModeShareble and AWSDDDispatchQueueLogFormatterModeNonShareble, depending if the formatter is shared between several loggers or not
  */
-- (instancetype)initWithMode:(AWSDDDispatchQueueLogFormatterMode)mode;
+- (instancetype)initWithMode:(AWSDDDispatchQueueLogFormatterMode)mode __attribute__((deprecated("AWSDDDispatchQueueLogFormatter is always shareable")));
 
 /**
  * The minQueueLength restricts the minimum size of the [detail box].
@@ -141,12 +173,12 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
  *
  * To remove/undo a previous replacement, invoke this method with nil for the 'shortLabel' parameter.
  **/
-- (NSString *)replacementStringForQueueLabel:(NSString *)longLabel;
+- (nullable NSString *)replacementStringForQueueLabel:(NSString *)longLabel;
 
 /**
  *  See the `replacementStringForQueueLabel:` description
  */
-- (void)setReplacementString:(NSString *)shortLabel forQueueLabel:(NSString *)longLabel;
+- (void)setReplacementString:(nullable NSString *)shortLabel forQueueLabel:(NSString *)longLabel;
 
 @end
 
@@ -170,9 +202,22 @@ typedef NS_ENUM(NSUInteger, AWSDDDispatchQueueLogFormatterMode){
  */
 - (NSString *)queueThreadLabelForLogMessage:(AWSDDLogMessage *)logMessage;
 
-/**
- *  The actual method that formats a message (transforms a `AWSDDLogMessage` model into a printable string)
- */
-- (NSString *)formatLogMessage:(AWSDDLogMessage *)logMessage;
+@end
+
+#pragma mark - AWSDDAtomicCountable
+
+__attribute__((deprecated("AWSDDAtomicCountable is useless since AWSDDDispatchQueueLogFormatter is always shareable now")))
+@protocol AWSDDAtomicCountable <NSObject>
+
+- (instancetype)initWithDefaultValue:(int32_t)defaultValue;
+- (int32_t)increment;
+- (int32_t)decrement;
+- (int32_t)value;
 
 @end
+
+__attribute__((deprecated("AWSDDAtomicCountable is deprecated")))
+@interface AWSDDAtomicCounter: NSObject<AWSDDAtomicCountable>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.h
+++ b/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.h
@@ -13,33 +13,14 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
-
-@protocol AWSDDLogger;
+#import "AWSDDFileLogger.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
+@interface AWSDDFileLogger (Buffering)
 
-/**
- *  Start capturing logs
- */
-+ (void)start;
-
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
-
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
+- (instancetype)wrapWithBuffer;
+- (instancetype)unwrapFromBuffer;
 
 @end
 

--- a/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.m
+++ b/AWSCore/Logging/Extensions/AWSDDFileLogger+Buffering.m
@@ -1,0 +1,202 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2024, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <sys/mount.h>
+
+#import "AWSDDFileLogger+Buffering.h"
+#import "AWSDDFileLogger+Internal.h"
+
+static const NSUInteger kAWSDDDefaultBufferSize = 4096; // 4 kB, block f_bsize on iphone7
+static const NSUInteger kAWSDDMaxBufferSize = 1048576; // ~1 mB, f_iosize on iphone7
+
+// Reads attributes from base file system to determine buffer size.
+// see statfs in sys/mount.h for descriptions of f_iosize and f_bsize.
+// f_bsize == "default", and f_iosize == "max"
+static inline NSUInteger p_AWSDDGetDefaultBufferSizeBytesMax(const BOOL max) {
+    struct statfs *mountedFileSystems = NULL;
+    __auto_type count = getmntinfo(&mountedFileSystems, 0);
+
+    for (int i = 0; i < count; i++) {
+        __auto_type mounted = mountedFileSystems[i];
+        __auto_type name = mounted.f_mntonname;
+
+        // We can use 2 as max here, since any length > 1 will fail the if-statement.
+        if (strnlen(name, 2) == 1 && *name == '/') {
+            return max ? (NSUInteger)mounted.f_iosize : (NSUInteger)mounted.f_bsize;
+        }
+    }
+
+    return max ? kAWSDDMaxBufferSize : kAWSDDDefaultBufferSize;
+}
+
+static NSUInteger AWSDDGetMaxBufferSizeBytes(void) {
+    static NSUInteger maxBufferSize = 0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        maxBufferSize = p_AWSDDGetDefaultBufferSizeBytesMax(YES);
+    });
+    return maxBufferSize;
+}
+
+static NSUInteger AWSDDGetDefaultBufferSizeBytes(void) {
+    static NSUInteger defaultBufferSize = 0;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        defaultBufferSize = p_AWSDDGetDefaultBufferSizeBytesMax(NO);
+    });
+    return defaultBufferSize;
+}
+
+@interface AWSDDBufferedProxy : NSProxy
+
+@property (nonatomic) AWSDDFileLogger *fileLogger;
+@property (nonatomic) NSOutputStream *buffer;
+
+@property (nonatomic) NSUInteger maxBufferSizeBytes;
+@property (nonatomic) NSUInteger currentBufferSizeBytes;
+
+@end
+
+@implementation AWSDDBufferedProxy
+
+- (instancetype)initWithFileLogger:(AWSDDFileLogger *)fileLogger {
+    _fileLogger = fileLogger;
+    _maxBufferSizeBytes = AWSDDGetDefaultBufferSizeBytes();
+    [self flushBuffer];
+
+    return self;
+}
+
+- (void)dealloc {
+    __auto_type block = ^{
+        [self lt_sendBufferedDataToFileLogger];
+        self.fileLogger = nil;
+    };
+
+    if ([self->_fileLogger isOnInternalLoggerQueue]) {
+        block();
+    } else {
+        dispatch_sync(self->_fileLogger.loggerQueue, block);
+    }
+}
+
+#pragma mark - Buffering
+
+- (void)flushBuffer {
+    [_buffer close];
+    _buffer = [NSOutputStream outputStreamToMemory];
+    [_buffer open];
+    _currentBufferSizeBytes = 0;
+}
+
+- (void)lt_sendBufferedDataToFileLogger {
+    NSData *data = [_buffer propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
+    [_fileLogger lt_logData:data];
+    [self flushBuffer];
+}
+
+#pragma mark - Logging
+
+- (void)logMessage:(AWSDDLogMessage *)logMessage {
+    // Don't need to check for isOnInternalLoggerQueue, -lt_dataForMessage: will do it for us.
+    __auto_type data = [_fileLogger lt_dataForMessage:logMessage];
+
+    if (data.length == 0) {
+        return;
+    }
+
+    [data enumerateByteRangesUsingBlock:^(const void * __nonnull bytes, NSRange byteRange, BOOL * __nonnull __unused stop) {
+        __auto_type bytesLength = byteRange.length;
+#ifdef NS_BLOCK_ASSERTIONS
+        __unused
+#endif
+        __auto_type written = [_buffer write:bytes maxLength:bytesLength];
+        NSAssert(written > 0 && (NSUInteger)written == bytesLength, @"Failed to write to memory buffer.");
+
+        _currentBufferSizeBytes += bytesLength;
+
+        if (_currentBufferSizeBytes >= _maxBufferSizeBytes) {
+            [self lt_sendBufferedDataToFileLogger];
+        }
+    }];
+}
+
+- (void)flush {
+    // This method is public.
+    // We need to execute the rolling on our logging thread/queue.
+
+    __auto_type block = ^{
+        @autoreleasepool {
+            [self lt_sendBufferedDataToFileLogger];
+            [self.fileLogger flush];
+        }
+    };
+
+    // The design of this method is taken from the AWSDDAbstractLogger implementation.
+    // For extensive documentation please refer to the AWSDDAbstractLogger implementation.
+
+    if ([self.fileLogger isOnInternalLoggerQueue]) {
+        block();
+    } else {
+        NSAssert(![self.fileLogger isOnGlobalLoggingQueue], @"Core architecture requirement failure");
+        dispatch_sync(AWSDDLog.loggingQueue, ^{
+            dispatch_sync(self.fileLogger.loggerQueue, block);
+        });
+    }
+}
+
+#pragma mark - Properties
+
+- (void)setMaxBufferSizeBytes:(NSUInteger)newBufferSizeBytes {
+    _maxBufferSizeBytes = MIN(newBufferSizeBytes, AWSDDGetMaxBufferSizeBytes());
+}
+
+#pragma mark - Wrapping
+
+- (AWSDDFileLogger *)wrapWithBuffer {
+    return (AWSDDFileLogger *)self;
+}
+
+- (AWSDDFileLogger *)unwrapFromBuffer {
+    return (AWSDDFileLogger *)self.fileLogger;
+}
+
+#pragma mark - NSProxy
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel {
+    return [self.fileLogger methodSignatureForSelector:sel];
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+    return [self.fileLogger respondsToSelector:aSelector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    [invocation invokeWithTarget:self.fileLogger];
+}
+
+@end
+
+@implementation AWSDDFileLogger (Buffering)
+
+- (instancetype)wrapWithBuffer {
+    return (AWSDDFileLogger *)[[AWSDDBufferedProxy alloc] initWithFileLogger:self];
+}
+
+- (instancetype)unwrapFromBuffer {
+    return self;
+}
+
+@end

--- a/AWSCore/Logging/Extensions/AWSDDFileLogger+Internal.h
+++ b/AWSCore/Logging/Extensions/AWSDDFileLogger+Internal.h
@@ -13,33 +13,18 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "AWSDDASLLogger.h"
-
-@protocol AWSDDLogger;
+#import "AWSDDFileLogger.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- *  This class provides the ability to capture the ASL (Apple System Logs)
- */
-API_DEPRECATED("Use AWSDDOSLogger instead", macosx(10.4,10.12), ios(2.0,10.0), watchos(2.0,3.0), tvos(9.0,10.0))
-@interface AWSDDASLLogCapture : NSObject
+@interface AWSDDFileLogger (Internal)
 
-/**
- *  Start capturing logs
- */
-+ (void)start;
+- (void)logData:(NSData *)data;
 
-/**
- *  Stop capturing logs
- */
-+ (void)stop;
+// Will assert if used outside logger's queue.
+- (void)lt_logData:(NSData *)data;
 
-/**
- *  The current capture level.
- *  @note Default log level: AWSDDLogLevelVerbose (i.e. capture all ASL messages).
- */
-@property (class) AWSDDLogLevel captureLevel;
+- (nullable NSData *)lt_dataForMessage:(AWSDDLogMessage *)message;
 
 @end
 

--- a/AWSCore/Logging/Extensions/AWSDDLog+Optional.swift
+++ b/AWSCore/Logging/Extensions/AWSDDLog+Optional.swift
@@ -1,0 +1,129 @@
+//
+// Copyright 2010-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+import Foundation
+
+public extension AWSDDLog {
+
+    /**
+     * Adds the logger to the system.
+     *
+     * This is equivalent to invoking `[AWSDDLog addLogger:logger withLogLevel:AWSDDLogLevelAll]`.
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:) with a non-optional logger instead.")
+    static func add(_ logger: AWSDDLogger?) {
+        if let logger = logger {
+            add(logger)
+        }
+    }
+
+    /**
+     * Adds the logger to the system.
+     *
+     * The level that you provide here is a preemptive filter (for performance).
+     * That is, the level specified here will be used to filter out logMessages so that
+     * the logger is never even invoked for the messages.
+     *
+     * More information:
+     * When you issue a log statement, the logging framework iterates over each logger,
+     * and checks to see if it should forward the logMessage to the logger.
+     * This check is done using the level parameter passed to this method.
+     *
+     * For example:
+     *
+     * `[AWSDDLog addLogger:consoleLogger withLogLevel:AWSDDLogLevelVerbose];`
+     * `[AWSDDLog addLogger:fileLogger    withLogLevel:AWSDDLogLevelWarning];`
+     *
+     * `AWSDDLogError(@"oh no");` => gets forwarded to consoleLogger & fileLogger
+     * `AWSDDLogInfo(@"hi");`     => gets forwarded to consoleLogger only
+     *
+     * It is important to remember that Lumberjack uses a BITMASK.
+     * Many developers & third party frameworks may define extra log levels & flags.
+     * For example:
+     *
+     * `#define SOME_FRAMEWORK_LOG_FLAG_TRACE (1 << 6) // 0...1000000`
+     *
+     * So if you specify `AWSDDLogLevelVerbose` to this method, you won't see the framework's trace messages.
+     *
+     * `(SOME_FRAMEWORK_LOG_FLAG_TRACE & AWSDDLogLevelVerbose) => (01000000 & 00011111) => NO`
+     *
+     * Consider passing `AWSDDLogLevelAll` to this method, which has all bits set.
+     * You can also use the exclusive-or bitwise operator to get a bitmask that has all flags set,
+     * except the ones you explicitly don't want. For example, if you wanted everything except verbose & debug:
+     *
+     * `((AWSDDLogLevelAll ^ AWSDDLogLevelVerbose) | AWSDDLogLevelInfo)`
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:with:) with a non-optional logger instead.")
+    class func add(_ logger: AWSDDLogger?, with level: AWSDDLogLevel) {
+        if let logger = logger {
+            add(logger, with: level)
+        }
+    }
+
+    /**
+     * Adds the logger to the system.
+     *
+     * This is equivalent to invoking `[AWSDDLog addLogger:logger withLogLevel:AWSDDLogLevelAll]`.
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:) with a non-optional logger instead.")
+    func add(_ logger: AWSDDLogger?) {
+        if let logger = logger {
+            add(logger)
+        }
+    }
+
+    /**
+     * Adds the logger to the system.
+     *
+     * The level that you provide here is a preemptive filter (for performance).
+     * That is, the level specified here will be used to filter out logMessages so that
+     * the logger is never even invoked for the messages.
+     *
+     * More information:
+     * When you issue a log statement, the logging framework iterates over each logger,
+     * and checks to see if it should forward the logMessage to the logger.
+     * This check is done using the level parameter passed to this method.
+     *
+     * For example:
+     *
+     * `[AWSDDLog addLogger:consoleLogger withLogLevel:AWSDDLogLevelVerbose];`
+     * `[AWSDDLog addLogger:fileLogger    withLogLevel:AWSDDLogLevelWarning];`
+     *
+     * `AWSDDLogError(@"oh no");` => gets forwarded to consoleLogger & fileLogger
+     * `AWSDDLogInfo(@"hi");`     => gets forwarded to consoleLogger only
+     *
+     * It is important to remember that Lumberjack uses a BITMASK.
+     * Many developers & third party frameworks may define extra log levels & flags.
+     * For example:
+     *
+     * `#define SOME_FRAMEWORK_LOG_FLAG_TRACE (1 << 6) // 0...1000000`
+     *
+     * So if you specify `AWSDDLogLevelVerbose` to this method, you won't see the framework's trace messages.
+     *
+     * `(SOME_FRAMEWORK_LOG_FLAG_TRACE & AWSDDLogLevelVerbose) => (01000000 & 00011111) => NO`
+     *
+     * Consider passing `AWSDDLogLevelAll` to this method, which has all bits set.
+     * You can also use the exclusive-or bitwise operator to get a bitmask that has all flags set,
+     * except the ones you explicitly don't want. For example, if you wanted everything except verbose & debug:
+     *
+     * `((AWSDDLogLevelAll ^ AWSDDLogLevelVerbose) | AWSDDLogLevelInfo)`
+     */
+    @available(*, deprecated, message: "Providing a nil logger will fail silently. Use add(_:with:) with a non-optional logger instead.")
+    func add(_ logger: AWSDDLogger?, with level: AWSDDLogLevel) {
+        if let logger = logger {
+            add(logger, with: level)
+        }
+    }
+}

--- a/AWSCore/Logging/Extensions/AWSDDMultiFormatter.h
+++ b/AWSCore/Logging/Extensions/AWSDDMultiFormatter.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2024, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -22,6 +22,8 @@
 
 #import "AWSDDLog.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * This formatter can be used to chain different formatters together.
  * The log message will processed in the order of the formatters added.
@@ -31,7 +33,7 @@
 /**
  *  Array of chained formatters
  */
-@property (readonly) NSArray<id<AWSDDLogFormatter>> *formatters;
+@property (nonatomic, readonly) NSArray<id<AWSDDLogFormatter>> *formatters;
 
 /**
  *  Add a new formatter
@@ -54,3 +56,5 @@
 - (BOOL)isFormattingWithFormatter:(id<AWSDDLogFormatter>)formatter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSCore/Mantle/AWSMTLModel+NSCoding.m
+++ b/AWSCore/Mantle/AWSMTLModel+NSCoding.m
@@ -12,7 +12,7 @@
 #import "AWSMTLReflection.h"
 #import <objc/runtime.h>
 
-void awsmtl_loadMTLNSCoding(){
+void awsmtl_loadMTLNSCoding(void){
 }
 
 // Used in archives to store the modelVersion of the archived instance.

--- a/AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m
+++ b/AWSCore/Mantle/NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m
@@ -11,7 +11,7 @@
 #import "AWSMTLModel.h"
 #import "AWSMTLValueTransformer.h"
 
-void awsmtl_loadMTLPredefinedTransformerAdditions(){
+void awsmtl_loadMTLPredefinedTransformerAdditions(void){
 }
 
 NSString * const AWSMTLURLValueTransformerName = @"AWSMTLURLValueTransformerName";

--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.h
@@ -87,12 +87,12 @@ typedef NS_ENUM(NSInteger, AWSUICKeyChainStoreAuthenticationType) {
 typedef NS_ENUM(NSInteger, AWSUICKeyChainStoreAccessibility) {
     AWSUICKeyChainStoreAccessibilityWhenUnlocked = 1,
     AWSUICKeyChainStoreAccessibilityAfterFirstUnlock,
-    AWSUICKeyChainStoreAccessibilityAlways,
+    AWSUICKeyChainStoreAccessibilityAlways __deprecated_enum_msg("Use an accessibility level that provides some user protection, such as AWSUICKeyChainStoreAccessibilityAfterFirstUnlock"),
     AWSUICKeyChainStoreAccessibilityWhenPasscodeSetThisDeviceOnly
     __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0),
     AWSUICKeyChainStoreAccessibilityWhenUnlockedThisDeviceOnly,
     AWSUICKeyChainStoreAccessibilityAfterFirstUnlockThisDeviceOnly,
-    AWSUICKeyChainStoreAccessibilityAlwaysThisDeviceOnly,
+    AWSUICKeyChainStoreAccessibilityAlwaysThisDeviceOnly __deprecated_enum_msg("Use an accessibility level that provides some user protection, such as AWSUICKeyChainStoreAccessibilityAfterFirstUnlockThisDeviceOnly"),
 }
 __OSX_AVAILABLE_STARTING(__MAC_10_9, __IPHONE_4_0);
 

--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -1337,6 +1337,8 @@ static NSString *_defaultService;
     }
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (CFTypeRef)accessibilityObject
 {
     switch (_accessibility) {
@@ -1358,6 +1360,7 @@ static NSString *_defaultService;
             return nil;
     }
 }
+#pragma clang diagnostic pop
 
 + (NSError *)argumentError:(NSString *)message
 {

--- a/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
+++ b/AWSCore/UICKeyChainStore/AWSUICKeyChainStore.m
@@ -1337,6 +1337,9 @@ static NSString *_defaultService;
     }
 }
 
+// The following keys are deprecated, but they still need to be supported:
+// - AWSUICKeyChainStoreAccessibilityAlways, kSecAttrAccessibleAlways,
+// - AWSUICKeyChainStoreAccessibilityAlwaysThisDeviceOnly, kSecAttrAccessibleAlwaysThisDeviceOnly
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (CFTypeRef)accessibilityObject

--- a/AWSCore/Utility/AWSNSCodingUtilities.m
+++ b/AWSCore/Utility/AWSNSCodingUtilities.m
@@ -23,17 +23,12 @@
 + (nullable NSData *)versionSafeArchivedDataWithRootObject:(id)obj
                                      requiringSecureCoding:(BOOL)requireSecureCoding
                                                      error:(NSError *__autoreleasing *)error {
-    NSData *archivedData;
-    if (@available(iOS 11, *)) {
-        archivedData = [NSKeyedArchiver archivedDataWithRootObject:obj
-                                             requiringSecureCoding:requireSecureCoding
-                                                             error:error];
-        if (error && *error) {
-            AWSDDLogError(@"Error archiving object: %@", *error);
-            return nil;
-        }
-    } else {
-        archivedData = [NSKeyedArchiver archivedDataWithRootObject:obj];
+    NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:obj
+                                                 requiringSecureCoding:requireSecureCoding
+                                                                 error:error];
+    if (error && *error) {
+        AWSDDLogError(@"Error archiving object: %@", *error);
+        return nil;
     }
 
     return archivedData;
@@ -44,18 +39,12 @@
 + (nullable id)versionSafeUnarchivedObjectOfClass:(Class)cls
                                          fromData:(NSData *)data
                                             error:(NSError *__autoreleasing *)error {
-    id returnValue;
-
-    if (@available(iOS 11, *)) {
-        returnValue = [NSKeyedUnarchiver unarchivedObjectOfClass:cls
-                                                        fromData:data
-                                                           error:error];
-        if (error && *error) {
-            AWSDDLogError(@"Error unarchiving class `%@`: %@", cls, *error);
-            return nil;
-        }
-    } else {
-        returnValue = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    id returnValue = [NSKeyedUnarchiver unarchivedObjectOfClass:cls
+                                                       fromData:data
+                                                          error:error];
+    if (error && *error) {
+        AWSDDLogError(@"Error unarchiving class `%@`: %@", cls, *error);
+        return nil;
     }
 
     return returnValue;
@@ -64,18 +53,12 @@
 + (nullable id)versionSafeUnarchivedObjectOfClasses:(NSSet<Class> *)classes
                                            fromData:(NSData *)data
                                               error:(NSError *__autoreleasing *)error {
-    id returnValue;
-
-    if (@available(iOS 11, *)) {
-        returnValue = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
-                                                          fromData:data
-                                                             error:error];
-        if (error && *error) {
-            AWSDDLogError(@"Error unarchiving data into allowed classes `%@`: %@", classes, *error);
-            return nil;
-        }
-    } else {
-        returnValue = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    id returnValue = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
+                                                         fromData:data
+                                                            error:error];
+    if (error && *error) {
+        AWSDDLogError(@"Error unarchiving data into allowed classes `%@`: %@", classes, *error);
+        return nil;
     }
 
     return returnValue;
@@ -83,27 +66,20 @@
 
 + (NSMutableDictionary *)versionSafeMutableDictionaryFromData:(NSData *)data
                                                         error:(NSError *__autoreleasing *)error {
-    NSMutableDictionary *returnValue;
-
-    if (@available(iOS 11, *)) {
-        NSSet *allowableClasses = [[NSSet alloc] initWithObjects:[NSMutableString class],
-                                   [NSNumber class],
-                                   [NSString class],
-                                   [NSDictionary class],
-                                   nil];
-        NSDictionary *immutableDict = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClasses:allowableClasses
-                                                                                        fromData:data
-                                                                                           error:error];
-        if (error && *error) {
-            AWSDDLogError(@"Error unarchiving data into allowed classes `%@`: %@", allowableClasses, *error);
-            return nil;
-        }
-
-        returnValue = [immutableDict mutableCopy];
-    } else {
-        returnValue = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    NSSet *allowableClasses = [[NSSet alloc] initWithObjects:[NSMutableString class],
+                               [NSNumber class],
+                               [NSString class],
+                               [NSDictionary class],
+                               nil];
+    NSDictionary *immutableDict = [AWSNSCodingUtilities versionSafeUnarchivedObjectOfClasses:allowableClasses
+                                                                                    fromData:data
+                                                                                       error:error];
+    if (error && *error) {
+        AWSDDLogError(@"Error unarchiving data into allowed classes `%@`: %@", allowableClasses, *error);
+        return nil;
     }
 
+    NSMutableDictionary *returnValue = [immutableDict mutableCopy];
     return returnValue;
 }
 

--- a/AWSDynamoDB.podspec
+++ b/AWSDynamoDB.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSEC2.podspec
+++ b/AWSEC2.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSElasticLoadBalancing.podspec
+++ b/AWSElasticLoadBalancing.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSFacebookSignIn.podspec
+++ b/AWSFacebookSignIn.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'http://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSGoogleSignIn.podspec
+++ b/AWSGoogleSignIn.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'http://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSIoT.podspec
+++ b/AWSIoT.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSIoT/AWSIoTKeyChainTypes.h
+++ b/AWSIoT/AWSIoTKeyChainTypes.h
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, AWSIoTKeyChainAccessibility) {
     AWSIoTKeyChainAccessibilityWhenUnlocked = 1,
     AWSIoTKeyChainAccessibilityAfterFirstUnlock,
-    AWSIoTKeyChainAccessibilityAlways,
+    AWSIoTKeyChainAccessibilityAlways __deprecated_enum_msg("Use an accessibility level that provides some user protection, such as AWSIoTKeyChainAccessibilityAfterFirstUnlock"),
     AWSIoTKeyChainAccessibilityWhenPasscodeSetThisDeviceOnly,
     AWSIoTKeyChainAccessibilityWhenUnlockedThisDeviceOnly,
     AWSIoTKeyChainAccessibilityAfterFirstUnlockThisDeviceOnly,
-    AWSIoTKeyChainAccessibilityAlwaysThisDeviceOnly,
+    AWSIoTKeyChainAccessibilityAlwaysThisDeviceOnly __deprecated_enum_msg("Use an accessibility level that provides some user protection, such as AWSIoTKeyChainAccessibilityAfterFirstUnlockThisDeviceOnly"),
 };
 
 NS_ASSUME_NONNULL_END

--- a/AWSIoT/Internal/AWSIoTKeychain.m
+++ b/AWSIoT/Internal/AWSIoTKeychain.m
@@ -522,6 +522,8 @@ static AWSIoTKeyChainAccessibility _accessibility = AWSIoTKeyChainAccessibilityA
     _accessibility = accessibility;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (CFTypeRef)accessibilityType {
     switch (_accessibility) {
         case AWSIoTKeyChainAccessibilityWhenUnlocked:
@@ -542,5 +544,6 @@ static AWSIoTKeyChainAccessibility _accessibility = AWSIoTKeyChainAccessibilityA
             return nil;
     }
 }
+#pragma clang diagnostic pop
 
 @end

--- a/AWSIoT/Internal/AWSIoTKeychain.m
+++ b/AWSIoT/Internal/AWSIoTKeychain.m
@@ -522,6 +522,9 @@ static AWSIoTKeyChainAccessibility _accessibility = AWSIoTKeyChainAccessibilityA
     _accessibility = accessibility;
 }
 
+// The following keys are deprecated, but they still need to be supported:
+// - AWSIoTKeyChainAccessibilityAlways, kSecAttrAccessibleAlways,
+// - AWSIoTKeyChainAccessibilityAlwaysThisDeviceOnly, kSecAttrAccessibleAlwaysThisDeviceOnly
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (CFTypeRef)accessibilityType {

--- a/AWSKMS.podspec
+++ b/AWSKMS.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSKinesis.podspec
+++ b/AWSKinesis.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSKinesisVideo.podspec
+++ b/AWSKinesisVideo.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSKinesisVideoArchivedMedia.podspec
+++ b/AWSKinesisVideoArchivedMedia.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSKinesisVideoSignaling.podspec
+++ b/AWSKinesisVideoSignaling.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSKinesisVideoWebRTCStorage.podspec
+++ b/AWSKinesisVideoWebRTCStorage.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSLambda.podspec
+++ b/AWSLambda.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSLex.podspec
+++ b/AWSLex.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache 2.0 AND AWS Customer Agreement'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSLex/AWSLexSignature.m
+++ b/AWSLex/AWSLexSignature.m
@@ -89,7 +89,7 @@ static NSString *const AWSLexSignatureScope = @"lex";
         contentSha256 = @"UNSIGNED-PAYLOAD";
         [request setValue:contentSha256 forHTTPHeaderField:@"x-amz-content-sha256"];
     }else{
-        contentSha256 = [AWSSignatureSignerUtility hexEncode:[[NSString alloc] initWithData:[AWSSignatureSignerUtility hash:request.HTTPBody] encoding:NSASCIIStringEncoding]];
+        contentSha256 = [AWSSignatureSignerUtility hexEncode:[[NSString alloc] initWithData:[AWSSignatureSignerUtility hashData:request.HTTPBody] encoding:NSASCIIStringEncoding]];
     }
     
     NSString *canonicalRequest = [AWSSignatureV4Signer getCanonicalizedRequest:request.HTTPMethod

--- a/AWSLocation.podspec
+++ b/AWSLocation.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSLogs.podspec
+++ b/AWSLogs.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSMachineLearning.podspec
+++ b/AWSMachineLearning.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSMobileClient.podspec
+++ b/AWSMobileClient.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'https://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSPinpoint.podspec
+++ b/AWSPinpoint.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSPinpoint/AWSPinpointEvent.m
+++ b/AWSPinpoint/AWSPinpointEvent.m
@@ -188,7 +188,7 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
     NSString* trimmedKey = [AWSPinpointStringUtils clipString:theKey
                                                    toMaxChars:AWSPinpointEventMaxAttributeAndMetricKeyLength andAppendEllipses:NO];
     if(trimmedKey.length < theKey.length) {
-        AWSDDLogWarn(@"The %@ key has been trimmed to a length of %0d characters", theType, AWSPinpointEventMaxAttributeAndMetricKeyLength);
+        AWSDDLogWarn(@"The %@ key has been trimmed to a length of %0ld characters", theType, (long)AWSPinpointEventMaxAttributeAndMetricKeyLength);
     }
     
     return trimmedKey;
@@ -198,7 +198,7 @@ NSString *const AWSPinpointEventErrorDomain = @"com.amazonaws.AWSPinpointEventEr
     NSString* trimmedValue = [AWSPinpointStringUtils clipString:theValue
                                                      toMaxChars:AWSPinpointEventMaxAttributeValueLength andAppendEllipses:NO];
     if(trimmedValue.length < theValue.length) {
-        AWSDDLogWarn( @"The attribute value has been trimmed to a length of %0d characters", AWSPinpointEventMaxAttributeValueLength);
+        AWSDDLogWarn( @"The attribute value has been trimmed to a length of %0ld characters", (long)AWSPinpointEventMaxAttributeValueLength);
     }
     
     return trimmedValue;

--- a/AWSPinpoint/AWSPinpointNotificationManager.m
+++ b/AWSPinpoint/AWSPinpointNotificationManager.m
@@ -174,7 +174,10 @@ NSString *const AWSPinpointJourneyKey = @"journey";
         NSURL *deepLinkURL = [NSURL URLWithString:amaDict[AWSCampaignDeepLinkKey]];
         if ([[UIApplication sharedApplication] canOpenURL:deepLinkURL]) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [[UIApplication sharedApplication] openURL:deepLinkURL];
+                [[UIApplication sharedApplication] openURL:deepLinkURL
+                                                   options:@{}
+                                         completionHandler:nil
+                ];
             });
         }
     }

--- a/AWSPinpointTests/AWSPinpointTargetingClientTests.m
+++ b/AWSPinpointTests/AWSPinpointTargetingClientTests.m
@@ -33,7 +33,7 @@ static NSString *userId;
 @interface AWSPinpointTargetingClientTests : XCTestCase
 @property (nonatomic, strong) AWSPinpoint *pinpoint;
 @property (nonatomic, strong) AWSPinpointConfiguration *configuration;
-@property (nonatomic, strong) UIApplication *application;
+@property (nonatomic, strong) id mockApplication;
 @property (nonatomic, strong) NSUserDefaults *userDefaults;
 @property (nonatomic, strong) AWSUICKeyChainStore *keychain;
 
@@ -72,6 +72,7 @@ static NSString *userId;
 }
 
 - (void)tearDown {
+    [self.mockApplication stopMocking];
     [super tearDown];
 }
 
@@ -122,6 +123,7 @@ static NSString *userId;
     UIUserNotificationSettings *notificationSettings = [UIUserNotificationSettings settingsForTypes:notificationType categories:nil];
     OCMStub([mockApplication currentUserNotificationSettings]).andReturn(notificationSettings);
     OCMStub([mockApplication isRegisteredForRemoteNotifications]).andReturn(withRemoteNotifications);
+    self.mockApplication = mockApplication;
 }
 
 - (void)testConstructors {

--- a/AWSPolly.podspec
+++ b/AWSPolly.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSRekognition.podspec
+++ b/AWSRekognition.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSS3.podspec
+++ b/AWSS3.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSS3UnitTests/AWSS3TransferUtilityCreatePartialFileTests.swift
+++ b/AWSS3UnitTests/AWSS3TransferUtilityCreatePartialFileTests.swift
@@ -33,7 +33,7 @@ class AWSS3TransferUtilityCreatePartialFileTests: XCTestCase {
         self.transferUtility = transferUtility
 
         AWSDDLog.sharedInstance.logLevel = .verbose
-        AWSDDLog.sharedInstance.add(AWSDDTTYLogger())
+        AWSDDLog.sharedInstance.add(AWSDDTTYLogger.sharedInstance)
     }
 
     func testCreatingPartialFile() throws {

--- a/AWSSES.podspec
+++ b/AWSSES.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSSNS.podspec
+++ b/AWSSNS.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSSQS.podspec
+++ b/AWSSQS.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSSageMakerRuntime.podspec
+++ b/AWSSageMakerRuntime.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSSimpleDB.podspec
+++ b/AWSSimpleDB.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSTextract.podspec
+++ b/AWSTextract.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSTranscribe.podspec
+++ b/AWSTranscribe.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSTranscribeStreaming.podspec
+++ b/AWSTranscribeStreaming.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSTranslate.podspec
+++ b/AWSTranslate.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSUserPoolsSignIn.podspec
+++ b/AWSUserPoolsSignIn.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
    s.homepage     = 'http://aws.amazon.com/mobile/sdk'
    s.license      = 'Apache License, Version 2.0'
    s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-   s.platform     = :ios, '9.0'
+   s.platform     = :ios, '12.0'
    s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                       :tag => s.version}
    s.requires_arc = true

--- a/AWSiOSSDKv2.podspec
+++ b/AWSiOSSDKv2.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'http://aws.amazon.com/mobile/sdk'
   s.license      = 'Apache License, Version 2.0'
   s.author       = { 'Amazon Web Services' => 'amazonwebservices' }
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '12.0'
   s.source       = { :git => 'https://github.com/aws-amplify/aws-sdk-ios.git',
                      :tag => s.version}
   s.requires_arc = true

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -14680,7 +14680,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideo/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideo;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -14704,7 +14704,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideo/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideo;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -14729,7 +14729,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoArchivedMedia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoArchivedMedia;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -14755,7 +14755,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoArchivedMedia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoArchivedMedia;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -14776,7 +14776,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoArchivedMediaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoArchivedMediaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests-Bridging-Header.h";
@@ -14799,7 +14799,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoArchivedMediaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoArchivedMediaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSKinesisVideoArchivedMediaTests/AWSKinesisVideoArchivedMediaTests-Bridging-Header.h";
@@ -14820,7 +14820,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -14843,7 +14843,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -14866,7 +14866,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoArchivedMediaUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -14889,7 +14889,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoArchivedMediaUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -14912,7 +14912,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -14934,7 +14934,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AWSKinesisVideoTests/AWSKinesisVideoTests-Bridging-Header.h";
@@ -14960,7 +14960,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeStreaming/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeStreaming;
@@ -14987,7 +14987,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeStreaming/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeStreaming;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -15010,7 +15010,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeStreamingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeStreamingTests;
@@ -15036,7 +15036,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeStreamingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeStreamingTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -15057,7 +15057,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15084,7 +15084,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15115,7 +15115,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribe/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribe;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -15140,7 +15140,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribe/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribe;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -15159,7 +15159,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15182,7 +15182,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15204,7 +15204,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = AWSAllTestsHost/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSAllTestsHost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -15222,7 +15222,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = AWSAllTestsHost/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSAllTestsHost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -15240,7 +15240,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSLogs/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSLogs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15258,7 +15258,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSLogs/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSLogs;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15270,7 +15270,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSLogsUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15286,7 +15286,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSLogsUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15310,7 +15310,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/AWSLex/Bluefront/include";
 				INFOPLIST_FILE = "$(SRCROOT)/AWSLex/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSLex/Bluefront",
@@ -15336,7 +15336,7 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/AWSLex/Bluefront/include";
 				INFOPLIST_FILE = "$(SRCROOT)/AWSLex/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSLex/Bluefront",
@@ -15354,7 +15354,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSLexTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15369,7 +15369,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSLexTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15390,7 +15390,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSPinpoint/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSPinpoint;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15408,7 +15408,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSPinpoint/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSPinpoint;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15420,7 +15420,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPinpointTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15437,7 +15437,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPinpointTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15454,7 +15454,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPinpointUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15470,7 +15470,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPinpointUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15492,7 +15492,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSRekognition/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSRekognition;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15510,7 +15510,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSRekognition/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSRekognition;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15522,7 +15522,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSRekognitionUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15538,7 +15538,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSRekognitionUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15562,7 +15562,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSPolly/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSPolly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15582,7 +15582,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSPolly/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSPolly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -15594,7 +15594,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPollyTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15610,7 +15610,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPollyTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15626,7 +15626,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPollyUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15642,7 +15642,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = AWSPollyUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15657,7 +15657,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSLexUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15672,7 +15672,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSLexUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15703,7 +15703,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -15736,7 +15736,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSLocation;
@@ -15761,7 +15761,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -15794,7 +15794,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -15824,7 +15824,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocationUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -15853,7 +15853,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocationUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -15886,7 +15886,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoSignaling/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 2.12.2;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -15914,7 +15914,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoSignaling/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 2.12.2;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSKinesisVideoSignaling;
@@ -15937,7 +15937,7 @@
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoSignalingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15968,7 +15968,7 @@
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoSignalingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -15996,7 +15996,7 @@
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoSignalingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16022,7 +16022,7 @@
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSKinesisVideoSignalingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16053,7 +16053,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKIdentity/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.24.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -16084,7 +16084,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKIdentity/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.24.4;
 				MTL_FAST_MATH = YES;
@@ -16108,7 +16108,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKIdentityTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16137,7 +16137,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKIdentityTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16171,7 +16171,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKMessaging/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.24.4;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -16203,7 +16203,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKMessaging/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.24.4;
 				MTL_FAST_MATH = YES;
@@ -16228,7 +16228,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKMessagingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16257,7 +16257,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKMessagingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16285,7 +16285,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKMessagingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16313,7 +16313,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKMessagingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16340,7 +16340,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKIdentityUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16368,7 +16368,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSChimeSDKIdentityUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
@@ -16402,7 +16402,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -16435,7 +16435,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSLocation/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSLocation;
@@ -16470,7 +16470,7 @@
 				INFOPLIST_FILE = AWSKinesisVideoWebRTCStorage/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Amazon Web Services. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -16510,7 +16510,7 @@
 				INFOPLIST_FILE = AWSKinesisVideoWebRTCStorage/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Amazon Web Services. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
@@ -16539,7 +16539,7 @@
 				DEVELOPMENT_TEAM = 94KV3E626L;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16573,7 +16573,7 @@
 				DEVELOPMENT_TEAM = 94KV3E626L;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16606,7 +16606,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranslate/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranslate;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -16630,7 +16630,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranslate/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranslate;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -16649,7 +16649,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranslateUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16672,7 +16672,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranslateUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16700,7 +16700,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSComprehend/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSComprehend;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -16724,7 +16724,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSComprehend/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSComprehend;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -16743,7 +16743,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSComprehendUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16766,7 +16766,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSComprehendUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16789,7 +16789,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSComprehendTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16816,7 +16816,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSComprehendTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16841,7 +16841,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranslateTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16868,7 +16868,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranslateTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -16893,7 +16893,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSRekognitionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/AWSCoreTests/OCMock";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSRekognitionTests;
@@ -16917,7 +16917,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSRekognitionTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/AWSCoreTests/OCMock";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.AWSRekognitionTests;
@@ -16945,7 +16945,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSSageMakerRuntime/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSSageMakerRuntime;
@@ -16972,7 +16972,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSSageMakerRuntime/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSSageMakerRuntime;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -16993,7 +16993,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSSageMakerRuntimeUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17019,7 +17019,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSSageMakerRuntimeUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17049,7 +17049,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectParticipant/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSConnectParticipant;
@@ -17076,7 +17076,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectParticipant/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSConnectParticipant;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -17097,7 +17097,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectParticipantUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17123,7 +17123,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectParticipantUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17148,7 +17148,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectParticipantTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17179,7 +17179,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectParticipantTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"${inherited}",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17207,7 +17207,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTextractUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17233,7 +17233,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTextractUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17263,7 +17263,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTextract/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTextract;
@@ -17290,7 +17290,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTextract/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTextract;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -17311,7 +17311,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTextractTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTextractTests;
@@ -17334,7 +17334,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTextractTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTextractTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -17361,7 +17361,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnect/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
@@ -17389,7 +17389,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnect/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSConnect;
@@ -17412,7 +17412,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -17439,7 +17439,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSConnectTests;
@@ -17463,7 +17463,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17489,7 +17489,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSConnectUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17638,7 +17638,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = AWSCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -17656,7 +17656,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -17667,7 +17667,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCoreTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -17684,7 +17684,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCoreTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -17702,7 +17702,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSCoreUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -17722,7 +17722,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSCoreUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -17740,7 +17740,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSAPIGatewayUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17755,7 +17755,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSAPIGatewayUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17770,7 +17770,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSAutoScalingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17785,7 +17785,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSAutoScalingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17800,7 +17800,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCloudWatchUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17815,7 +17815,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCloudWatchUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17830,7 +17830,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSDynamoDBUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17845,7 +17845,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSDynamoDBUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17860,7 +17860,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSEC2UnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17875,7 +17875,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSEC2UnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17890,7 +17890,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSElasticLoadBalancingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17905,7 +17905,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSElasticLoadBalancingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17920,7 +17920,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSIoTUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17935,7 +17935,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSIoTUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17950,7 +17950,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSKinesisUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17965,7 +17965,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSKinesisUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17980,7 +17980,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSLambdaUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -17995,7 +17995,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSLambdaUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18010,7 +18010,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSMachineLearningUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18025,7 +18025,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSMachineLearningUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18041,7 +18041,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSS3UnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -18061,7 +18061,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSS3UnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -18079,7 +18079,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSESUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18094,7 +18094,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSESUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18109,7 +18109,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSimpleDBUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18124,7 +18124,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSimpleDBUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18139,7 +18139,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSNSUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18154,7 +18154,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSNSUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18169,7 +18169,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSQSUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18184,7 +18184,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSQSUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18206,7 +18206,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSAutoScaling/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSAutoScaling;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18224,7 +18224,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSAutoScaling/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSAutoScaling;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18235,7 +18235,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSAutoScalingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18250,7 +18250,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSAutoScalingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18272,7 +18272,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSDynamoDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSDynamoDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18290,7 +18290,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSDynamoDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSDynamoDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18302,7 +18302,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSDynamoDBTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18321,7 +18321,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSDynamoDBTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18345,7 +18345,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSEC2/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSEC2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18363,7 +18363,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSEC2/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSEC2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18374,7 +18374,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSEC2Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18389,7 +18389,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSEC2Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18411,7 +18411,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSElasticLoadBalancing/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSElasticLoadBalancing;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18429,7 +18429,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSElasticLoadBalancing/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSElasticLoadBalancing;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18440,7 +18440,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSElasticLoadBalancingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18455,7 +18455,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSElasticLoadBalancingTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18477,7 +18477,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSIoT/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSIoT;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18495,7 +18495,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSIoT/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSIoT;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18507,7 +18507,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSIoTTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18527,7 +18527,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSIoTTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18552,7 +18552,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSKinesis/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSKinesis;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18570,7 +18570,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSKinesis/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSKinesis;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18581,7 +18581,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSKinesisTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18596,7 +18596,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSKinesisTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18618,7 +18618,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSLambda/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSLambda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18636,7 +18636,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSLambda/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSLambda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18647,7 +18647,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSLambdaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18662,7 +18662,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSLambdaTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18684,7 +18684,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSMachineLearning/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSMachineLearning;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18702,7 +18702,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSMachineLearning/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSMachineLearning;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18722,7 +18722,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSS3/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSS3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18741,7 +18741,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSS3/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSS3;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18754,7 +18754,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = AWSS3Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18775,7 +18775,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = AWSS3Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18800,7 +18800,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSES/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18818,7 +18818,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSES/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18829,7 +18829,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSESTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18844,7 +18844,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSESTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18866,7 +18866,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSimpleDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSimpleDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18884,7 +18884,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSimpleDB/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSimpleDB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18895,7 +18895,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSimpleDBTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18910,7 +18910,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSimpleDBTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18932,7 +18932,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSNS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSNS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18950,7 +18950,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSNS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSNS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -18961,7 +18961,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSNSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18976,7 +18976,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSNSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -18998,7 +18998,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSQS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSQS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19016,7 +19016,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSSQS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSSQS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19027,7 +19027,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSQSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19042,7 +19042,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSSQSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19064,7 +19064,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSAPIGateway/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSAPIGateway;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19082,7 +19082,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSAPIGateway/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSAPIGateway;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19094,7 +19094,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSAPIGatewayTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19114,7 +19114,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSAPIGatewayTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19139,7 +19139,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCloudWatch/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCloudWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19157,7 +19157,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCloudWatch/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCloudWatch;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19168,7 +19168,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCloudWatchTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19183,7 +19183,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCloudWatchTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19206,7 +19206,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/AWSCognitoIdentityProvider/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCognitoIdentityProvider/Internal",
@@ -19230,7 +19230,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/AWSCognitoIdentityProvider/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCognitoIdentityProvider/Internal",
@@ -19246,7 +19246,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCognitoIdentityProviderTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19261,7 +19261,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCognitoIdentityProviderTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19277,7 +19277,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSCognitoIdentityProviderUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19296,7 +19296,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = AWSCognitoIdentityProviderUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19313,7 +19313,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -19322,7 +19322,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -19340,7 +19340,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSKMS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSKMS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19360,7 +19360,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSKMS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSKMS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -19373,7 +19373,7 @@
 				CLANG_ANALYZER_NONNULL = YES_NONAGGRESSIVE;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
 				INFOPLIST_FILE = AWSKMSUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19390,7 +19390,7 @@
 				CLANG_ANALYZER_NONNULL = YES_NONAGGRESSIVE;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
 				INFOPLIST_FILE = AWSKMSUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19407,7 +19407,7 @@
 				CLANG_ANALYZER_NONNULL = YES_NONAGGRESSIVE;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
 				INFOPLIST_FILE = AWSKMSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19424,7 +19424,7 @@
 				CLANG_ANALYZER_NONNULL = YES_NONAGGRESSIVE;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
 				INFOPLIST_FILE = AWSKMSTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19447,7 +19447,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCognitoIdentityProviderASF/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCognitoIdentityProviderASF",
@@ -19471,7 +19471,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCognitoIdentityProviderASF/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCognitoIdentityProviderASF",
@@ -19495,7 +19495,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCognitoAuth/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCognitoAuth/Internal",
@@ -19519,7 +19519,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AWSCognitoAuth/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCognitoAuth/Internal",
@@ -19535,7 +19535,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCognitoAuthTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19549,7 +19549,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCognitoAuthTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19563,7 +19563,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCognitoAuthUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19578,7 +19578,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				INFOPLIST_FILE = AWSCognitoAuthUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/AWSCoreTests/OCMock",
@@ -19659,7 +19659,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeStreamingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeStreamingUnitTests;
@@ -19684,7 +19684,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTranscribeStreamingUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTranscribeStreamingUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -19697,6 +19697,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -19705,6 +19706,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -19728,7 +19730,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTestResources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTestResources;
@@ -19756,7 +19758,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSTestResources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSTestResources;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -19874,7 +19876,7 @@
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSCoreServiceConfigurationTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -19897,7 +19899,7 @@
 				DEVELOPMENT_TEAM = W3DRXD72QU;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = AWSCoreServiceConfigurationTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(FRAMEWORK_SEARCH_PATHS)";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.AWSCoreServiceConfigurationTest;

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -283,30 +283,6 @@
 		183BD93E1D8A4076004B2659 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		183BD9471D8B0030004B2659 /* AWSTestUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = CEB8EF2E1C6A69A00098B15B /* AWSTestUtility.m */; };
 		183BD9481D8B0040004B2659 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB8EF551C6A6A2E0098B15B /* libOCMock.a */; };
-		184F430F1E930A2D004F3FE2 /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F42FE1E930A2D004F3FE2 /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43101E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F42FF1E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h */; };
-		184F43111E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43001E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m */; };
-		184F43121E930A2D004F3FE2 /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43011E930A2D004F3FE2 /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43131E930A2D004F3FE2 /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43021E930A2D004F3FE2 /* AWSDDASLLogCapture.m */; };
-		184F43141E930A2D004F3FE2 /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43031E930A2D004F3FE2 /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43151E930A2D004F3FE2 /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43041E930A2D004F3FE2 /* AWSDDASLLogger.m */; };
-		184F43161E930A2D004F3FE2 /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43051E930A2D004F3FE2 /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43171E930A2D004F3FE2 /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43061E930A2D004F3FE2 /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F43181E930A2D004F3FE2 /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43071E930A2D004F3FE2 /* AWSDDFileLogger.m */; };
-		184F431A1E930A2D004F3FE2 /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43091E930A2D004F3FE2 /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F431B1E930A2D004F3FE2 /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F430A1E930A2D004F3FE2 /* AWSDDLog.m */; };
-		184F431C1E930A2D004F3FE2 /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F430B1E930A2D004F3FE2 /* AWSDDLog+LOGV.h */; };
-		184F431D1E930A2D004F3FE2 /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F430C1E930A2D004F3FE2 /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F431E1E930A2D004F3FE2 /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F430D1E930A2D004F3FE2 /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F431F1E930A2D004F3FE2 /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F430E1E930A2D004F3FE2 /* AWSDDTTYLogger.m */; };
-		184F43261E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43201E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h */; };
-		184F43271E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43211E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m */; };
-		184F43281E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43221E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h */; };
-		184F43291E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F43231E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m */; };
-		184F432A1E930A34004F3FE2 /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43241E930A34004F3FE2 /* AWSDDMultiFormatter.h */; };
-		184F432E1E930E05004F3FE2 /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F432C1E930E05004F3FE2 /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		184F432F1E930E05004F3FE2 /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 184F432D1E930E05004F3FE2 /* AWSDDOSLogger.m */; };
-		184F43311E9336BD004F3FE2 /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 184F43301E9336BD004F3FE2 /* AWSDDLegacyMacros.h */; };
 		185251351DED4F9800AF47F6 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		1868C0261E207E33001CDA82 /* AWSGeneric.h in Headers */ = {isa = PBXBuildFile; fileRef = 1868C0251E207E33001CDA82 /* AWSGeneric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		186ABB031D9CADBC00AB8980 /* libBlueAudioSourceiOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 186ABB021D9CADBC00AB8980 /* libBlueAudioSourceiOS.a */; };
@@ -622,8 +598,43 @@
 		5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		5C1978DD2702364800F9C11E /* AWSLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1978DC2702364800F9C11E /* AWSLocationTests.swift */; };
 		5C71F33F295672B8001183A4 /* guten_tag.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5C71F33E295672B8001183A4 /* guten_tag.wav */; };
+		687952932B8FE2C5001E8990 /* AWSDDLog+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */; };
 		6883619E2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */; };
 		688361A12B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */; };
+		68A45B792B8D5F7D00A0851E /* AWSCocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45B7B2B8D5F7D00A0851E /* AWSDDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */; };
+		68A45B7C2B8D5F7D00A0851E /* AWSDDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */; };
+		68A45B7D2B8D5F7D00A0851E /* AWSDDFileLogger+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */; };
+		68A45B7E2B8D5F7D00A0851E /* AWSDDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */; };
+		68A45B7F2B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */; };
+		68A45B802B8D5F7D00A0851E /* AWSDDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */; };
+		68A45B812B8D5F7D00A0851E /* AWSDDFileLogger+Buffering.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */; };
+		68A45B822B8D5F7D00A0851E /* AWSDDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B5F2B8D5F7C00A0851E /* AWSDDMultiFormatter.m */; };
+		68A45B832B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B602B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m */; };
+		68A45B842B8D5F7D00A0851E /* AWSDDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B612B8D5F7C00A0851E /* AWSDDOSLogger.m */; };
+		68A45B852B8D5F7D00A0851E /* AWSDDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B622B8D5F7C00A0851E /* AWSDDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45B862B8D5F7D00A0851E /* AWSDDLoggerNames.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B632B8D5F7C00A0851E /* AWSDDLoggerNames.m */; };
+		68A45B982B8D5F7D00A0851E /* AWSDDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B762B8D5F7D00A0851E /* AWSDDLog.m */; };
+		68A45B992B8D5F7D00A0851E /* AWSDDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B772B8D5F7D00A0851E /* AWSDDASLLogCapture.m */; };
+		68A45B9A2B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45B782B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m */; };
+		68A45BAC2B8D6ADE00A0851E /* AWSDDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9B2B8D6ADD00A0851E /* AWSDDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BAD2B8D6ADE00A0851E /* AWSDDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9C2B8D6ADD00A0851E /* AWSDDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BAE2B8D6ADE00A0851E /* AWSDDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9D2B8D6ADD00A0851E /* AWSDDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BAF2B8D6ADE00A0851E /* AWSDDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9E2B8D6ADD00A0851E /* AWSDDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB02B8D6ADE00A0851E /* AWSDDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45B9F2B8D6ADD00A0851E /* AWSDDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB12B8D6ADE00A0851E /* AWSDDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA02B8D6ADD00A0851E /* AWSDDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB22B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA12B8D6ADD00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB32B8D6ADE00A0851E /* AWSDDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA22B8D6ADD00A0851E /* AWSDDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB42B8D6ADE00A0851E /* AWSDDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA32B8D6ADD00A0851E /* AWSDDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB62B8D6ADE00A0851E /* AWSDDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA52B8D6ADE00A0851E /* AWSDDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB72B8D6ADE00A0851E /* AWSDDLoggerNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA62B8D6ADE00A0851E /* AWSDDLoggerNames.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB82B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA72B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BB92B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBA2B8D6ADE00A0851E /* AWSDDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BA92B8D6ADE00A0851E /* AWSDDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBB2B8D6ADE00A0851E /* AWSDDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BAA2B8D6ADE00A0851E /* AWSDDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBC2B8D6ADE00A0851E /* AWSDDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BBF2B8E74F900A0851E /* AWSCLIColor.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A45BBD2B8E74F800A0851E /* AWSCLIColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		68A45BC02B8E74F900A0851E /* AWSCLIColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A45BBE2B8E74F900A0851E /* AWSCLIColor.m */; };
 		68EE1A6C2B713D8100B7CF41 /* AWSIoTStreamThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 68EE1A6B2B713D8100B7CF41 /* AWSIoTStreamThread.h */; };
 		68EE1A6E2B713D8900B7CF41 /* AWSIoTStreamThread.m in Sources */ = {isa = PBXBuildFile; fileRef = 68EE1A6D2B713D8900B7CF41 /* AWSIoTStreamThread.m */; };
 		6BE9D6AA25A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BE9D6A925A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift */; };
@@ -2925,30 +2936,6 @@
 		181270E31E8EB78900174785 /* AWSLogsService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSLogsService.h; sourceTree = "<group>"; };
 		181270E41E8EB78900174785 /* AWSLogsService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSLogsService.m; sourceTree = "<group>"; };
 		181270EB1E8EB7D300174785 /* AWSGeneralLogsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSGeneralLogsTests.m; sourceTree = "<group>"; };
-		184F42FE1E930A2D004F3FE2 /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCocoaLumberjack.h; sourceTree = "<group>"; };
-		184F42FF1E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
-		184F43001E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		184F43011E930A2D004F3FE2 /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogCapture.h; sourceTree = "<group>"; };
-		184F43021E930A2D004F3FE2 /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogCapture.m; sourceTree = "<group>"; };
-		184F43031E930A2D004F3FE2 /* AWSDDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogger.h; sourceTree = "<group>"; };
-		184F43041E930A2D004F3FE2 /* AWSDDASLLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogger.m; sourceTree = "<group>"; };
-		184F43051E930A2D004F3FE2 /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAssertMacros.h; sourceTree = "<group>"; };
-		184F43061E930A2D004F3FE2 /* AWSDDFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDFileLogger.h; sourceTree = "<group>"; };
-		184F43071E930A2D004F3FE2 /* AWSDDFileLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDFileLogger.m; sourceTree = "<group>"; };
-		184F43091E930A2D004F3FE2 /* AWSDDLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLog.h; sourceTree = "<group>"; };
-		184F430A1E930A2D004F3FE2 /* AWSDDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDLog.m; sourceTree = "<group>"; };
-		184F430B1E930A2D004F3FE2 /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
-		184F430C1E930A2D004F3FE2 /* AWSDDLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLogMacros.h; sourceTree = "<group>"; };
-		184F430D1E930A2D004F3FE2 /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDTTYLogger.h; sourceTree = "<group>"; };
-		184F430E1E930A2D004F3FE2 /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDTTYLogger.m; sourceTree = "<group>"; };
-		184F43201E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		184F43211E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		184F43221E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		184F43231E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		184F43241E930A34004F3FE2 /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDMultiFormatter.h; sourceTree = "<group>"; };
-		184F432C1E930E05004F3FE2 /* AWSDDOSLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDOSLogger.h; sourceTree = "<group>"; };
-		184F432D1E930E05004F3FE2 /* AWSDDOSLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDOSLogger.m; sourceTree = "<group>"; };
-		184F43301E9336BD004F3FE2 /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLegacyMacros.h; sourceTree = "<group>"; };
 		185111CB1D78F03B0009F5C3 /* AWSLex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AWSLex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		185111CF1D78F03B0009F5C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		185111D41D78F03B0009F5C3 /* AWSLexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AWSLexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3226,8 +3213,43 @@
 		5C1978DB2702364800F9C11E /* AWSLocationTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSLocationTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5C1978DC2702364800F9C11E /* AWSLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLocationTests.swift; sourceTree = "<group>"; };
 		5C71F33E295672B8001183A4 /* guten_tag.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = guten_tag.wav; sourceTree = "<group>"; };
+		687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDDLog+Optional.swift"; sourceTree = "<group>"; };
 		6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PreSignedURLBuilderUnitTests.swift; sourceTree = "<group>"; };
 		688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThreadTests.m; sourceTree = "<group>"; };
+		68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCocoaLumberjack.h; sourceTree = "<group>"; };
+		68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogger.m; sourceTree = "<group>"; };
+		68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDFileLogger.m; sourceTree = "<group>"; };
+		68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDFileLogger+Internal.h"; sourceTree = "<group>"; };
+		68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDTTYLogger.m; sourceTree = "<group>"; };
+		68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSDDFileLogger+Buffering.m"; sourceTree = "<group>"; };
+		68A45B5F2B8D5F7C00A0851E /* AWSDDMultiFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDMultiFormatter.m; sourceTree = "<group>"; };
+		68A45B602B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AWSDDContextFilterLogFormatter+Deprecated.m"; sourceTree = "<group>"; };
+		68A45B612B8D5F7C00A0851E /* AWSDDOSLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDOSLogger.m; sourceTree = "<group>"; };
+		68A45B622B8D5F7C00A0851E /* AWSDDLegacyMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLegacyMacros.h; sourceTree = "<group>"; };
+		68A45B632B8D5F7C00A0851E /* AWSDDLoggerNames.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDLoggerNames.m; sourceTree = "<group>"; };
+		68A45B762B8D5F7D00A0851E /* AWSDDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDLog.m; sourceTree = "<group>"; };
+		68A45B772B8D5F7D00A0851E /* AWSDDASLLogCapture.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDASLLogCapture.m; sourceTree = "<group>"; };
+		68A45B782B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSDDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		68A45B9B2B8D6ADD00A0851E /* AWSDDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogger.h; sourceTree = "<group>"; };
+		68A45B9C2B8D6ADD00A0851E /* AWSDDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDTTYLogger.h; sourceTree = "<group>"; };
+		68A45B9D2B8D6ADD00A0851E /* AWSDDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		68A45B9E2B8D6ADD00A0851E /* AWSDDFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDFileLogger.h; sourceTree = "<group>"; };
+		68A45B9F2B8D6ADD00A0851E /* AWSDDLog+LOGV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDLog+LOGV.h"; sourceTree = "<group>"; };
+		68A45BA02B8D6ADD00A0851E /* AWSDDLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLogMacros.h; sourceTree = "<group>"; };
+		68A45BA12B8D6ADD00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDContextFilterLogFormatter+Deprecated.h"; sourceTree = "<group>"; };
+		68A45BA22B8D6ADD00A0851E /* AWSDDASLLogCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDASLLogCapture.h; sourceTree = "<group>"; };
+		68A45BA32B8D6ADD00A0851E /* AWSDDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		68A45BA52B8D6ADE00A0851E /* AWSDDLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLog.h; sourceTree = "<group>"; };
+		68A45BA62B8D6ADE00A0851E /* AWSDDLoggerNames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDLoggerNames.h; sourceTree = "<group>"; };
+		68A45BA72B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AWSDDFileLogger+Buffering.h"; sourceTree = "<group>"; };
+		68A45BA92B8D6ADE00A0851E /* AWSDDOSLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDOSLogger.h; sourceTree = "<group>"; };
+		68A45BAA2B8D6ADE00A0851E /* AWSDDAssertMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDAssertMacros.h; sourceTree = "<group>"; };
+		68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSDDMultiFormatter.h; sourceTree = "<group>"; };
+		68A45BBD2B8E74F800A0851E /* AWSCLIColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSCLIColor.h; sourceTree = "<group>"; };
+		68A45BBE2B8E74F900A0851E /* AWSCLIColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSCLIColor.m; sourceTree = "<group>"; };
 		68EE1A6B2B713D8100B7CF41 /* AWSIoTStreamThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AWSIoTStreamThread.h; sourceTree = "<group>"; };
 		68EE1A6D2B713D8900B7CF41 /* AWSIoTStreamThread.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThread.m; sourceTree = "<group>"; };
 		6BE9D6A925A54EBA00AB5C9A /* AWSIotDataManagerRetainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSIotDataManagerRetainTests.swift; sourceTree = "<group>"; };
@@ -5492,40 +5514,33 @@
 		184F42CE1E930839004F3FE2 /* Logging */ = {
 			isa = PBXGroup;
 			children = (
-				184F42FE1E930A2D004F3FE2 /* AWSCocoaLumberjack.h */,
-				184F43301E9336BD004F3FE2 /* AWSDDLegacyMacros.h */,
-				184F432C1E930E05004F3FE2 /* AWSDDOSLogger.h */,
-				184F432D1E930E05004F3FE2 /* AWSDDOSLogger.m */,
-				184F42FF1E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h */,
-				184F43001E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m */,
-				184F43011E930A2D004F3FE2 /* AWSDDASLLogCapture.h */,
-				184F43021E930A2D004F3FE2 /* AWSDDASLLogCapture.m */,
-				184F43031E930A2D004F3FE2 /* AWSDDASLLogger.h */,
-				184F43041E930A2D004F3FE2 /* AWSDDASLLogger.m */,
-				184F43051E930A2D004F3FE2 /* AWSDDAssertMacros.h */,
-				184F43061E930A2D004F3FE2 /* AWSDDFileLogger.h */,
-				184F43071E930A2D004F3FE2 /* AWSDDFileLogger.m */,
-				184F43091E930A2D004F3FE2 /* AWSDDLog.h */,
-				184F430A1E930A2D004F3FE2 /* AWSDDLog.m */,
-				184F430B1E930A2D004F3FE2 /* AWSDDLog+LOGV.h */,
-				184F430C1E930A2D004F3FE2 /* AWSDDLogMacros.h */,
-				184F430D1E930A2D004F3FE2 /* AWSDDTTYLogger.h */,
-				184F430E1E930A2D004F3FE2 /* AWSDDTTYLogger.m */,
-				184F42F11E930925004F3FE2 /* Extensions */,
+				68A45BBD2B8E74F800A0851E /* AWSCLIColor.h */,
+				68A45BBE2B8E74F900A0851E /* AWSCLIColor.m */,
+				68A45B542B8D5F7C00A0851E /* AWSCocoaLumberjack.h */,
+				68A45B9D2B8D6ADD00A0851E /* AWSDDAbstractDatabaseLogger.h */,
+				68A45B782B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m */,
+				68A45BA22B8D6ADD00A0851E /* AWSDDASLLogCapture.h */,
+				68A45B772B8D5F7D00A0851E /* AWSDDASLLogCapture.m */,
+				68A45B9B2B8D6ADD00A0851E /* AWSDDASLLogger.h */,
+				68A45B572B8D5F7C00A0851E /* AWSDDASLLogger.m */,
+				68A45BAA2B8D6ADE00A0851E /* AWSDDAssertMacros.h */,
+				68A45B9E2B8D6ADD00A0851E /* AWSDDFileLogger.h */,
+				68A45B582B8D5F7C00A0851E /* AWSDDFileLogger.m */,
+				68A45B622B8D5F7C00A0851E /* AWSDDLegacyMacros.h */,
+				68A45BA52B8D6ADE00A0851E /* AWSDDLog.h */,
+				68A45B762B8D5F7D00A0851E /* AWSDDLog.m */,
+				68A45B9F2B8D6ADD00A0851E /* AWSDDLog+LOGV.h */,
+				68A45BA62B8D6ADE00A0851E /* AWSDDLoggerNames.h */,
+				68A45B632B8D5F7C00A0851E /* AWSDDLoggerNames.m */,
+				68A45BA02B8D6ADD00A0851E /* AWSDDLogMacros.h */,
+				68A45B5F2B8D5F7C00A0851E /* AWSDDMultiFormatter.m */,
+				68A45BA92B8D6ADE00A0851E /* AWSDDOSLogger.h */,
+				68A45B612B8D5F7C00A0851E /* AWSDDOSLogger.m */,
+				68A45B9C2B8D6ADD00A0851E /* AWSDDTTYLogger.h */,
+				68A45B5A2B8D5F7C00A0851E /* AWSDDTTYLogger.m */,
+				68A45B5B2B8D5F7C00A0851E /* Extensions */,
 			);
 			path = Logging;
-			sourceTree = "<group>";
-		};
-		184F42F11E930925004F3FE2 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				184F43201E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h */,
-				184F43211E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m */,
-				184F43221E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h */,
-				184F43231E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m */,
-				184F43241E930A34004F3FE2 /* AWSDDMultiFormatter.h */,
-			);
-			path = Extensions;
 			sourceTree = "<group>";
 		};
 		185111CC1D78F03B0009F5C3 /* AWSLex */ = {
@@ -6018,6 +6033,24 @@
 				48885FB62A0C1F170012EEB7 /* AWSKinesisVideoWebRTCStorageResources.h */,
 			);
 			path = AWSKinesisVideoWebRTCStorage;
+			sourceTree = "<group>";
+		};
+		68A45B5B2B8D5F7C00A0851E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				68A45BA72B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h */,
+				68A45B5C2B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter.m */,
+				68A45BA12B8D6ADD00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h */,
+				68A45B602B8D5F7C00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m */,
+				68A45BA32B8D6ADD00A0851E /* AWSDDDispatchQueueLogFormatter.h */,
+				68A45B5D2B8D5F7C00A0851E /* AWSDDDispatchQueueLogFormatter.m */,
+				68A45BA82B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h */,
+				68A45B5E2B8D5F7C00A0851E /* AWSDDFileLogger+Buffering.m */,
+				68A45B592B8D5F7C00A0851E /* AWSDDFileLogger+Internal.h */,
+				687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */,
+				68A45BAB2B8D6ADE00A0851E /* AWSDDMultiFormatter.h */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		9A7ACC2120B0E85000DDBEC1 /* AWSTranslate */ = {
@@ -8277,14 +8310,17 @@
 				CE0D42A51C6A673E006B91B5 /* AWSModel.h in Headers */,
 				CE0D42251C6A673E006B91B5 /* AWSIdentityProvider.h in Headers */,
 				CE0D422C1C6A673E006B91B5 /* AWSCancellationToken.h in Headers */,
+				68A45BBB2B8D6ADE00A0851E /* AWSDDAssertMacros.h in Headers */,
 				CE0D42A71C6A673E006B91B5 /* AWSSynchronizedMutableDictionary.h in Headers */,
 				CE0D42441C6A673E006B91B5 /* AWSFMDatabase.h in Headers */,
 				CE0D42511C6A673E006B91B5 /* AWSGZIP.h in Headers */,
+				68A45BB12B8D6ADE00A0851E /* AWSDDLogMacros.h in Headers */,
 				CE0D42921C6A673E006B91B5 /* AWSSTSService.h in Headers */,
 				CE0D42801C6A673E006B91B5 /* AWSURLRequestRetryHandler.h in Headers */,
 				CE0D424D1C6A673E006B91B5 /* AWSFMResultSet.h in Headers */,
 				CE0D423B1C6A673E006B91B5 /* AWSCognitoIdentityResources.h in Headers */,
 				CE0D426B1C6A673E006B91B5 /* NSDictionary+AWSMTLManipulationAdditions.h in Headers */,
+				68A45BB22B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.h in Headers */,
 				CE0D42381C6A673E006B91B5 /* AWSCognitoIdentity.h in Headers */,
 				CE0D426F1C6A673E006B91B5 /* NSObject+AWSMTLComparisonAdditions.h in Headers */,
 				CE0D428D1C6A673E006B91B5 /* AWSSTS.h in Headers */,
@@ -8293,16 +8329,21 @@
 				CE0D42301C6A673E006B91B5 /* AWSCancellationTokenSource.h in Headers */,
 				CE0D428E1C6A673E006B91B5 /* AWSSTSModel.h in Headers */,
 				CE0D424C1C6A673E006B91B5 /* AWSFMDB.h in Headers */,
+				68A45BB42B8D6ADE00A0851E /* AWSDDDispatchQueueLogFormatter.h in Headers */,
 				CE0D42271C6A673E006B91B5 /* AWSSignature.h in Headers */,
 				CE0D428A1C6A673E006B91B5 /* AWSService.h in Headers */,
 				CE0D42A31C6A673E006B91B5 /* AWSLogging.h in Headers */,
+				68A45B852B8D5F7D00A0851E /* AWSDDLegacyMacros.h in Headers */,
 				CE0D422E1C6A673E006B91B5 /* AWSCancellationTokenRegistration.h in Headers */,
+				68A45BAD2B8D6ADE00A0851E /* AWSDDTTYLogger.h in Headers */,
+				68A45BB32B8D6ADE00A0851E /* AWSDDASLLogCapture.h in Headers */,
 				18DF08DB1D34866E004C7D19 /* AWSCognitoIdentity+Fabric.h in Headers */,
 				CE0D423D1C6A673E006B91B5 /* AWSCognitoIdentityService.h in Headers */,
 				CE0D425C1C6A673E006B91B5 /* AWSMTLModel.h in Headers */,
 				CE0D42861C6A673E006B91B5 /* AWSValidation.h in Headers */,
+				68A45BB82B8D6ADE00A0851E /* AWSDDContextFilterLogFormatter.h in Headers */,
+				68A45BB02B8D6ADE00A0851E /* AWSDDLog+LOGV.h in Headers */,
 				FA7A44C62305D09C00F55D7A /* AWSNetworkingHelpers.h in Headers */,
-				184F43261E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.h in Headers */,
 				CEA33FB61C8A37230083D6BC /* Fabric+FABKits.h in Headers */,
 				CE0D42481C6A673E006B91B5 /* AWSFMDatabasePool.h in Headers */,
 				CE0D428C1C6A673E006B91B5 /* AWSServiceEnum.h in Headers */,
@@ -8310,46 +8351,43 @@
 				CE0D42551C6A673E006B91B5 /* AWSMantle.h in Headers */,
 				CE0D42231C6A673E006B91B5 /* AWSCredentialsProvider.h in Headers */,
 				CE0D425A1C6A673E006B91B5 /* AWSMTLModel+NSCoding.h in Headers */,
+				68A45BBF2B8E74F900A0851E /* AWSCLIColor.h in Headers */,
 				CE0D42821C6A673E006B91B5 /* AWSURLRequestSerialization.h in Headers */,
+				68A45BB92B8D6ADE00A0851E /* AWSDDFileLogger+Buffering.h in Headers */,
+				68A45BAF2B8D6ADE00A0851E /* AWSDDFileLogger.h in Headers */,
 				CE0D42881C6A673E006B91B5 /* AWSClientContext.h in Headers */,
 				CE0D429D1C6A673E006B91B5 /* AWSUICKeyChainStore.h in Headers */,
 				CE0D42781C6A673E006B91B5 /* AWSURLSessionManager.h in Headers */,
+				68A45BAC2B8D6ADE00A0851E /* AWSDDASLLogger.h in Headers */,
 				CE0D42761C6A673E006B91B5 /* AWSNetworking.h in Headers */,
 				CE0D42391C6A673E006B91B5 /* AWSCognitoIdentityModel.h in Headers */,
 				CE0D42581C6A673E006B91B5 /* AWSMTLManagedObjectAdapter.h in Headers */,
 				CE0D42601C6A673E006B91B5 /* AWSMTLValueTransformer.h in Headers */,
+				68A45BB62B8D6ADE00A0851E /* AWSDDLog.h in Headers */,
 				CEA33FB41C8A37230083D6BC /* FABAttributes.h in Headers */,
 				CE0D42A11C6A673E006B91B5 /* AWSCategory.h in Headers */,
-				184F431D1E930A2D004F3FE2 /* AWSDDLogMacros.h in Headers */,
-				184F43141E930A2D004F3FE2 /* AWSDDASLLogger.h in Headers */,
+				68A45BBC2B8D6ADE00A0851E /* AWSDDMultiFormatter.h in Headers */,
 				FA5D34FC250C0D77007AA030 /* AWSNSCodingUtilities.h in Headers */,
 				CE0D42291C6A673E006B91B5 /* AWSBolts.h in Headers */,
 				CE0D42561C6A673E006B91B5 /* AWSMTLJSONAdapter.h in Headers */,
-				184F43121E930A2D004F3FE2 /* AWSDDASLLogCapture.h in Headers */,
 				1868C0261E207E33001CDA82 /* AWSGeneric.h in Headers */,
 				EFE40B7C1CC5BDCA0045D710 /* AWSInfo.h in Headers */,
-				184F432E1E930E05004F3FE2 /* AWSDDOSLogger.h in Headers */,
-				184F431E1E930A2D004F3FE2 /* AWSDDTTYLogger.h in Headers */,
-				184F430F1E930A2D004F3FE2 /* AWSCocoaLumberjack.h in Headers */,
 				2171EBE0254C725C00FAB22F /* AWSTimestampSerialization.h in Headers */,
-				184F431A1E930A2D004F3FE2 /* AWSDDLog.h in Headers */,
-				184F43161E930A2D004F3FE2 /* AWSDDAssertMacros.h in Headers */,
 				CE0D42341C6A673E006B91B5 /* AWSTask.h in Headers */,
-				184F43171E930A2D004F3FE2 /* AWSDDFileLogger.h in Headers */,
-				184F43311E9336BD004F3FE2 /* AWSDDLegacyMacros.h in Headers */,
-				184F432A1E930A34004F3FE2 /* AWSDDMultiFormatter.h in Headers */,
-				184F431C1E930A2D004F3FE2 /* AWSDDLog+LOGV.h in Headers */,
-				184F43281E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.h in Headers */,
-				184F43101E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.h in Headers */,
+				68A45BBA2B8D6ADE00A0851E /* AWSDDOSLogger.h in Headers */,
 				CE0D42731C6A673E006B91B5 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.h in Headers */,
 				CE0D42461C6A673E006B91B5 /* AWSFMDatabaseAdditions.h in Headers */,
 				CE0D41701C6A66E5006B91B5 /* AWSCore.h in Headers */,
 				CE0D42901C6A673E006B91B5 /* AWSSTSResources.h in Headers */,
 				CE0D426D1C6A673E006B91B5 /* NSError+AWSMTLModelException.h in Headers */,
+				68A45B7D2B8D5F7D00A0851E /* AWSDDFileLogger+Internal.h in Headers */,
 				CE0D425E1C6A673E006B91B5 /* AWSMTLReflection.h in Headers */,
 				CEA33FB51C8A37230083D6BC /* FABKitProtocol.h in Headers */,
 				CE0D42AD1C6A673E006B91B5 /* AWSXMLWriter.h in Headers */,
+				68A45B792B8D5F7D00A0851E /* AWSCocoaLumberjack.h in Headers */,
 				CE0D42A91C6A673E006B91B5 /* AWSXMLDictionary.h in Headers */,
+				68A45BAE2B8D6ADE00A0851E /* AWSDDAbstractDatabaseLogger.h in Headers */,
+				68A45BB72B8D6ADE00A0851E /* AWSDDLoggerNames.h in Headers */,
 				CE0D42671C6A673E006B91B5 /* AWSmetamacros.h in Headers */,
 				CE3627CE1CEBA92B003E85B9 /* AWSKSReachability.h in Headers */,
 				CE0D42621C6A673E006B91B5 /* AWSEXTKeyPathCoding.h in Headers */,
@@ -12977,65 +13015,71 @@
 				CE0D42351C6A673E006B91B5 /* AWSTask.m in Sources */,
 				CE0D42741C6A673E006B91B5 /* NSValueTransformer+AWSMTLPredefinedTransformerAdditions.m in Sources */,
 				CE0D42911C6A673E006B91B5 /* AWSSTSResources.m in Sources */,
-				184F43181E930A2D004F3FE2 /* AWSDDFileLogger.m in Sources */,
 				CE0D42371C6A673E006B91B5 /* AWSTaskCompletionSource.m in Sources */,
+				68A45B7B2B8D5F7D00A0851E /* AWSDDASLLogger.m in Sources */,
+				68A45B7E2B8D5F7D00A0851E /* AWSDDTTYLogger.m in Sources */,
 				CE0D422D1C6A673E006B91B5 /* AWSCancellationToken.m in Sources */,
 				CE0D42451C6A673E006B91B5 /* AWSFMDatabase.m in Sources */,
 				CE0D42311C6A673E006B91B5 /* AWSCancellationTokenSource.m in Sources */,
+				68A45B9A2B8D5F7D00A0851E /* AWSDDAbstractDatabaseLogger.m in Sources */,
 				CE0D42331C6A673E006B91B5 /* AWSExecutor.m in Sources */,
+				68A45BC02B8E74F900A0851E /* AWSCLIColor.m in Sources */,
 				CE0D42661C6A673E006B91B5 /* AWSEXTScope.m in Sources */,
 				CE0D42831C6A673E006B91B5 /* AWSURLRequestSerialization.m in Sources */,
 				CE0D42811C6A673E006B91B5 /* AWSURLRequestRetryHandler.m in Sources */,
-				184F43111E930A2D004F3FE2 /* AWSDDAbstractDatabaseLogger.m in Sources */,
 				CE0D422A1C6A673E006B91B5 /* AWSBolts.m in Sources */,
 				CE0D42791C6A673E006B91B5 /* AWSURLSessionManager.m in Sources */,
+				68A45B842B8D5F7D00A0851E /* AWSDDOSLogger.m in Sources */,
 				CE0D42A61C6A673E006B91B5 /* AWSModel.m in Sources */,
 				CE0D425F1C6A673E006B91B5 /* AWSMTLReflection.m in Sources */,
-				184F43291E930A34004F3FE2 /* AWSDDDispatchQueueLogFormatter.m in Sources */,
+				687952932B8FE2C5001E8990 /* AWSDDLog+Optional.swift in Sources */,
 				CE0D42A41C6A673E006B91B5 /* AWSLogging.m in Sources */,
+				68A45B822B8D5F7D00A0851E /* AWSDDMultiFormatter.m in Sources */,
 				CE0D42AE1C6A673E006B91B5 /* AWSXMLWriter.m in Sources */,
 				CE0D42261C6A673E006B91B5 /* AWSIdentityProvider.m in Sources */,
+				68A45B802B8D5F7D00A0851E /* AWSDDDispatchQueueLogFormatter.m in Sources */,
 				FAC3E7022208B0D60037813E /* AWSFMDB+AWSHelpers.m in Sources */,
 				CE0D42471C6A673E006B91B5 /* AWSFMDatabaseAdditions.m in Sources */,
 				CE0D423E1C6A673E006B91B5 /* AWSCognitoIdentityService.m in Sources */,
-				184F43131E930A2D004F3FE2 /* AWSDDASLLogCapture.m in Sources */,
 				CE0D425D1C6A673E006B91B5 /* AWSMTLModel.m in Sources */,
 				CE0D42A21C6A673E006B91B5 /* AWSCategory.m in Sources */,
 				CE0D42591C6A673E006B91B5 /* AWSMTLManagedObjectAdapter.m in Sources */,
-				184F432F1E930E05004F3FE2 /* AWSDDOSLogger.m in Sources */,
+				68A45B7F2B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter.m in Sources */,
 				CE0D422F1C6A673E006B91B5 /* AWSCancellationTokenRegistration.m in Sources */,
 				CE0D426A1C6A673E006B91B5 /* NSArray+AWSMTLManipulationAdditions.m in Sources */,
 				18DF08D51D347633004C7D19 /* AWSCognitoIdentity+Fabric.m in Sources */,
-				184F43271E930A34004F3FE2 /* AWSDDContextFilterLogFormatter.m in Sources */,
 				2171EB6A254C721E00FAB22F /* AWSTimestampSerialization.m in Sources */,
 				CE0D42491C6A673E006B91B5 /* AWSFMDatabasePool.m in Sources */,
+				68A45B812B8D5F7D00A0851E /* AWSDDFileLogger+Buffering.m in Sources */,
 				CE0D424E1C6A673E006B91B5 /* AWSFMResultSet.m in Sources */,
 				CE0D426E1C6A673E006B91B5 /* NSError+AWSMTLModelException.m in Sources */,
 				CE0D42851C6A673E006B91B5 /* AWSURLResponseSerialization.m in Sources */,
 				CE0D429E1C6A673E006B91B5 /* AWSUICKeyChainStore.m in Sources */,
-				184F43151E930A2D004F3FE2 /* AWSDDASLLogger.m in Sources */,
 				FA7A44C72305D09C00F55D7A /* AWSNetworkingHelpers.m in Sources */,
 				CE0D42571C6A673E006B91B5 /* AWSMTLJSONAdapter.m in Sources */,
+				68A45B832B8D5F7D00A0851E /* AWSDDContextFilterLogFormatter+Deprecated.m in Sources */,
 				CE0D42281C6A673E006B91B5 /* AWSSignature.m in Sources */,
 				FA5D34FD250C0D77007AA030 /* AWSNSCodingUtilities.m in Sources */,
 				CE0D42701C6A673E006B91B5 /* NSObject+AWSMTLComparisonAdditions.m in Sources */,
 				CE0D42241C6A673E006B91B5 /* AWSCredentialsProvider.m in Sources */,
-				184F431B1E930A2D004F3FE2 /* AWSDDLog.m in Sources */,
+				68A45B862B8D5F7D00A0851E /* AWSDDLoggerNames.m in Sources */,
 				CE0D42721C6A673E006B91B5 /* NSValueTransformer+AWSMTLInversionAdditions.m in Sources */,
 				CE0D424B1C6A673E006B91B5 /* AWSFMDatabaseQueue.m in Sources */,
 				CE0D42611C6A673E006B91B5 /* AWSMTLValueTransformer.m in Sources */,
 				CE3627CF1CEBA92B003E85B9 /* AWSKSReachability.m in Sources */,
+				68A45B7C2B8D5F7D00A0851E /* AWSDDFileLogger.m in Sources */,
 				CE0D428B1C6A673E006B91B5 /* AWSService.m in Sources */,
 				CE0D42521C6A673E006B91B5 /* AWSGZIP.m in Sources */,
 				CE0D428F1C6A673E006B91B5 /* AWSSTSModel.m in Sources */,
 				CE0D423A1C6A673E006B91B5 /* AWSCognitoIdentityModel.m in Sources */,
 				CE0D42771C6A673E006B91B5 /* AWSNetworking.m in Sources */,
 				CE0D42871C6A673E006B91B5 /* AWSValidation.m in Sources */,
+				68A45B992B8D5F7D00A0851E /* AWSDDASLLogCapture.m in Sources */,
+				68A45B982B8D5F7D00A0851E /* AWSDDLog.m in Sources */,
 				CE0D42891C6A673E006B91B5 /* AWSClientContext.m in Sources */,
 				CE0D42931C6A673E006B91B5 /* AWSSTSService.m in Sources */,
 				CE0D42641C6A673E006B91B5 /* AWSEXTRuntimeExtensions.m in Sources */,
 				CE0D423C1C6A673E006B91B5 /* AWSCognitoIdentityResources.m in Sources */,
-				184F431F1E930A2D004F3FE2 /* AWSDDTTYLogger.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -17642,6 +17686,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -17660,6 +17705,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.sdk.ios.AWSCore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 ## Unreleased
 
+### New features
+
+- Updating the iOS deployment target to 12.0 for the following services:
+  - AWSAPIGateway
+  - AWSAuth
+  - AWSAuthCore
+  - AWSAuthUI
+  - AWSAutoScaling
+  - AWSChimeSDKIdentity
+  - AWSChimeSDKMessaging
+  - AWSCloudWatch
+  - AWSCognitoAuth
+  - AWSCognitoIdentityProvider
+  - AWSCognitoIdentityProviderASF
+  - AWSComprehend
+  - AWSConnect
+  - AWSConnectParticipant
+  - AWSCore
+  - AWSDynamoDB
+  - AWSEC2
+  - AWSElasticLoadBalancing
+  - AWSFacebookSignIn
+  - AWSGoogleSignIn
+  - AWSiOSSDKv2
+  - AWSIoT
+  - AWSKinesis
+  - AWSKinesisVideo
+  - AWSKinesisVideoArchivedMedia
+  - AWSKinesisVideoSignaling
+  - AWSKinesisVideoWebRTCStorage
+  - AWSKMS
+  - AWSLambda
+  - AWSLex
+  - AWSLocation
+  - AWSLogs
+  - AWSMachineLearning
+  - AWSMobileClient
+  - AWSPinpoint
+  - AWSPolly
+  - AWSRekognition
+  - AWSS3
+  - AWSSageMakerRuntime
+  - AWSSES
+  - AWSSimpleDB
+  - AWSSNS
+  - AWSSQS
+  - AWSTextract
+  - AWSTranscribe
+  - AWSTranscribeStreaming
+  - AWSTranslate
+  - AWSUserPoolsSignIn
+
 ### Misc. Updates
 - **AWSIoT**
   - Updating `AWSIoTMQTTConfiguration.keepAliveTimeInterval`'s default value in its attribute comment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
   - AWSTranslate
   - AWSUserPoolsSignIn
 
+- **AWSCore**
+  - Updating CocoaLumberjack to version 3.4.8
+
 ### Misc. Updates
 - **AWSIoT**
   - Updating `AWSIoTMQTTConfiguration.keepAliveTimeInterval`'s default value in its attribute comment.

--- a/README.md
+++ b/README.md
@@ -413,13 +413,13 @@ To initialize logging to your Xcode console, use the following code:
 **Swift**
 
 ```swift
-AWSDDLog.add(AWSDDTTYLogger.sharedInstance) // TTY = Xcode console
+AWSDDLog.add(AWSDDOSLogger.sharedInstance) // Apple's unified logging
 ```
 
 **Objective-C**
 
 ```objective-c
-[AWSDDLog addLogger:[AWSDDTTYLogger sharedInstance]]; // TTY = Xcode console
+[AWSDDLog addLogger:[AWSDDOSLogger sharedInstance]]; // Apple's unified logging
 ```
 
 ## Open Source Contributions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To get started with the AWS SDK for iOS, check out the [Developer Guide for iOS]
 To use the AWS SDK for iOS, you will need the following installed on your development machine:
 
 * Xcode 11.0 or later
-* iOS 9 or later
+* iOS 12 or later
 
 ## Include the SDK for iOS in an Existing Application
 


### PR DESCRIPTION
**Description of changes:**
This PR updates the iOS deployment target version to iOS 12 to all the pods that had it at iOS 9.

Xcode 15's minimum deployment target is iOS 9, so attempting to use any of the products resulted in a warning
> The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 12.0 to 17.2.99.
 
Bumping the version also reveals a couple of deprecation warnings, so I've fixed the ones that were simple fixes (e.g. SFAuthenticationSession -> ASWebAuthenticationSession). 

- Related PR: https://github.com/aws-amplify/aws-sdk-ios/pull/5222

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
