### PR TITLE
fix: privacy manifest targets for AWSAuthSDK targets

### DIFF
--- a/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
+++ b/AWSAuthSDK/AWSAuthSDK.xcodeproj/project.pbxproj
@@ -126,12 +126,13 @@
 		17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1786CA4D1F2BEDB8003421FF /* Images.xcassets */; };
 		17F4F75121F6B0750068B553 /* AWSCognitoAuth+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F4F74F21F6B0750068B553 /* AWSCognitoAuth+Extensions.m */; };
 		214609902B88FA8B002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609142B88FA8B002FCE7B /* PrivacyInfo.xcprivacy */; };
-		214609922B88FABA002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609912B88FABA002FCE7B /* PrivacyInfo.xcprivacy */; };
-		214609942B88FAD9002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609932B88FAD9002FCE7B /* PrivacyInfo.xcprivacy */; };
-		214609962B88FAFF002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609952B88FAFF002FCE7B /* PrivacyInfo.xcprivacy */; };
-		214609982B88FB0F002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609972B88FB0F002FCE7B /* PrivacyInfo.xcprivacy */; };
-		2146099A2B88FB2D002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609992B88FB2D002FCE7B /* PrivacyInfo.xcprivacy */; };
-		2146099C2B88FB46002FCE7B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146099B2B88FB46002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E0A2BAA07A400997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609912B88FABA002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E822BAA07A800997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609932B88FAD9002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E832BAA07AE00997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609952B88FAFF002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E842BAA07B200997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609972B88FB0F002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E852BAA07BA00997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609992B88FB2D002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E862BAA07C100997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214609992B88FB2D002FCE7B /* PrivacyInfo.xcprivacy */; };
+		21AF5E872BAA07C800997C99 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2146099B2B88FB46002FCE7B /* PrivacyInfo.xcprivacy */; };
 		5C3324972773F43400F2C47B /* AWSMobileClientDeleteUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3324962773F43400F2C47B /* AWSMobileClientDeleteUserTests.swift */; };
 		68B1317829A95E6400E3B3BC /* WeakHashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B1317729A95E6400E3B3BC /* WeakHashTable.swift */; };
 		68B1317929A95E6400E3B3BC /* WeakHashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B1317729A95E6400E3B3BC /* WeakHashTable.swift */; };
@@ -4048,6 +4049,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E872BAA07C800997C99 /* PrivacyInfo.xcprivacy in Resources */,
 				1711A4EA1F43A49E006105D3 /* AWSUserPools.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4056,6 +4058,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E832BAA07AE00997C99 /* PrivacyInfo.xcprivacy in Resources */,
 				176375681F328D510086588B /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4071,6 +4074,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E842BAA07B200997C99 /* PrivacyInfo.xcprivacy in Resources */,
 				17DED2A61F32A4E400397F88 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4096,6 +4100,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E862BAA07C100997C99 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4119,12 +4124,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2146099A2B88FB2D002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
-				2146099C2B88FB46002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
-				214609942B88FAD9002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
-				214609922B88FABA002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
-				214609962B88FAFF002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
-				214609982B88FB0F002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 				214609902B88FA8B002FCE7B /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4148,6 +4147,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E0A2BAA07A400997C99 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4155,6 +4155,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E822BAA07A800997C99 /* PrivacyInfo.xcprivacy in Resources */,
 				B5150B1C1F3CE0E500AC8D08 /* Images.xcassets in Resources */,
 				B58F54C21F382449009ED450 /* SignIn.storyboard in Resources */,
 			);
@@ -4164,6 +4165,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21AF5E852BAA07BA00997C99 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -446,6 +446,7 @@
 		2109EDD025475AD30057043C /* AWSNSSecureCodingTestBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA1C57E42539E80C00DBC24C /* AWSNSSecureCodingTestBase.framework */; };
 		2109EDD325475B3D0057043C /* AWSGeneralLocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2109EDD125475B3C0057043C /* AWSGeneralLocationTests.m */; };
 		2109EDD425475B3D0057043C /* AWSLocationNSSecureCodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2109EDD225475B3D0057043C /* AWSLocationNSSecureCodingTests.m */; };
+		210F43EC2BAB38F40011DB93 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 214608F32B88F3FF002FCE7B /* PrivacyInfo.xcprivacy */; };
 		211166FF2399C24900902FC1 /* AWSKinesisVideoSignaling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 211166F62399C24900902FC1 /* AWSKinesisVideoSignaling.framework */; };
 		211167132399C37300902FC1 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		2111671C2399C5BF00902FC1 /* AWSKinesisVideoSignalingResources.h in Headers */ = {isa = PBXBuildFile; fileRef = 211167142399C5BB00902FC1 /* AWSKinesisVideoSignalingResources.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -11662,6 +11663,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				210F43EC2BAB38F40011DB93 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ran into issues during the release process with the error when creating the xcframeworks
```
Could not create xcodebuild archive: AWSAppleSignIn output: 
Command line invocation:
    /Applications/Xcode_14.2.app/Contents/Developer/usr/bin/xcodebuild archive -project ./AWSAuthSDK/AWSAuthSDK.xcodeproj -scheme AWSAppleSignIn -destination generic/platform=iOS -archivePath /Users/runner/work/aws-sdk-ios/aws-sdk-ios/xcframeworks/output/iOS/AWSAppleSignIn SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES

User defaults from command line:
    IDEArchivePathOverride = /Users/runner/work/aws-sdk-ios/aws-sdk-ios/xcframeworks/output/iOS/AWSAppleSignIn
    IDEPackageSupportUseBuiltinSCM = YES

Build settings from command line:
    BUILD_LIBRARY_FOR_DISTRIBUTION = YES
    SKIP_INSTALL = NO

Prepare packages

Computing target dependency graph and provisioning inputs

Create build description
Build description signature: b2213a5341de3346cbea4d9e86bf0461
Build description path: /Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfzobkslttqdvxwumk/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/IntermediateBuildFilesPath/XCBuildData/b2213a5341de3346cbea4d9e86bf0461-desc.xcbuild

Note: Building targets in dependency order

Error: 
Multiple commands produce '/Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfzobkslttqdvxwumk/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy':
    - Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/runner/work/aws-sdk-ios/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy' to '/Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfzobkslttqdvxwumk/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy'
    - Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/runner/work/aws-sdk-ios/aws-sdk-ios/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy' to '/Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfzobkslttqdvxwumk/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy'
    - Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/runner/work/aws-sdk-ios/aws-sdk-ios/AWSAuthSDK/Sources/AWSAuthUI/PrivacyInfo.xcprivacy' to '/Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfzobkslttqdvxwumk/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy'
    - Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/runner/work/aws-sdk-ios/aws-sdk-ios/AWSAuthSDK/Sources/AWSFacebookSignIn/PrivacyInfo.xcprivacy' to '/Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfzobkslttqdvxwumk/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy'
    - Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/runner/work/aws-sdk-ios/aws-sdk-ios/AWSAuthSDK/Sources/AWSGoogleSignIn/PrivacyInfo.xcprivacy' to '/Users/runner/Library/Developer/Xcode/DerivedData/AWSAuthSDK-eprzhjvfcfnfz
```


The mistake was that the privacy manifest file was added to the AWSAppleSignIn target multiple times from the different places under "Add to target" of the files. Each file under their respective target folders were updated to the correct target. These were AWSAuthCore, AWSAuthUI, AWSFacebookSignIn, etc. in the AWSAuthSDK project.

`AWSLocationXCF` was also missed, the privacy file was not added to the AWSLocationXCF target. We exclude AWSLocation from being created and add AWSLocationXCF (see `framework_list.py`).


With a modified version of `framework_list.py`, running `create_xcframeworks.py` against this PR:
```
aws-sdk-ios % python3 CircleciScripts/create_xcframeworks.py
2024-03-20 11:41:11.223794: Waiting for process 76600
2024-03-20 11:41:12.671440: List of schema found
2024-03-20 11:41:12.671723: Creating XCFrameworks in /Users/mdlaw/aws-amplify/aws-sdk-ios
2024-03-20 11:41:12.695108: Creating archives for AWSCore
2024-03-20 11:41:12.697050: Waiting for process 76614
2024-03-20 11:41:12.757910: Waiting for process 76615
2024-03-20 11:41:12.777715: Waiting for process 76616
2024-03-20 11:41:12.792402: Waiting for process 76621
2024-03-20 11:41:12.793259: Waiting for process 76619
2024-03-20 11:41:12.793672: Waiting for process 76618
2024-03-20 11:41:12.794131: Waiting for process 76620
2024-03-20 11:41:12.795705: Waiting for process 76617
2024-03-20 11:41:12.796268: Waiting for process 76622
2024-03-20 11:41:12.803569: Waiting for process 76623
2024-03-20 11:41:12.810743: Waiting for process 76624
2024-03-20 11:41:15.690751: List of schema found
2024-03-20 11:41:15.714454: List of schema found
2024-03-20 11:41:15.718146: List of schema found
2024-03-20 11:41:15.723511: List of schema found
2024-03-20 11:41:15.733810: List of schema found
2024-03-20 11:41:15.738414: List of schema found
2024-03-20 11:41:15.764149: List of schema found
2024-03-20 11:41:15.766530: List of schema found
2024-03-20 11:41:15.773285: List of schema found
2024-03-20 11:41:15.782442: List of schema found
2024-03-20 11:41:19.074884: Created iOS archive AWSCore generic/platform=iOS
2024-03-20 11:41:19.076778: Waiting for process 76854
2024-03-20 11:41:24.832461: Created iOS archive AWSCore generic/platform=iOS Simulator
2024-03-20 11:41:24.832562: Creating archives for AWSCognitoIdentityProviderASF
2024-03-20 11:41:24.834445: Waiting for process 77302
2024-03-20 11:41:29.392537: Created iOS archive AWSCognitoIdentityProviderASF generic/platform=iOS
2024-03-20 11:41:29.394629: Waiting for process 77551
2024-03-20 11:41:35.217191: Created iOS archive AWSCognitoIdentityProviderASF generic/platform=iOS Simulator
2024-03-20 11:41:35.217282: Creating archives for AWSCognitoAuth
2024-03-20 11:41:35.218942: Waiting for process 78030
2024-03-20 11:41:40.024055: Created iOS archive AWSCognitoAuth generic/platform=iOS
2024-03-20 11:41:40.026008: Waiting for process 78297
2024-03-20 11:41:46.531756: Created iOS archive AWSCognitoAuth generic/platform=iOS Simulator
2024-03-20 11:41:46.531835: Creating archives for AWSCognitoIdentityProvider
2024-03-20 11:41:46.533661: Waiting for process 78808
2024-03-20 11:41:52.279544: Created iOS archive AWSCognitoIdentityProvider generic/platform=iOS
2024-03-20 11:41:52.281360: Waiting for process 79101
2024-03-20 11:42:00.701536: Created iOS archive AWSCognitoIdentityProvider generic/platform=iOS Simulator
2024-03-20 11:42:00.701621: Creating archives for AWSAuthCore
2024-03-20 11:42:00.703503: Waiting for process 79669
2024-03-20 11:42:05.368052: Created iOS archive AWSAuthCore generic/platform=iOS
2024-03-20 11:42:05.370452: Waiting for process 79917
2024-03-20 11:42:11.733164: Created iOS archive AWSAuthCore generic/platform=iOS Simulator
2024-03-20 11:42:11.733508: Creating archives for AWSAuthUI
2024-03-20 11:42:11.733537: Creating archives for AWSAppleSignIn
2024-03-20 11:42:11.733603: Creating archives for AWSFacebookSignIn
2024-03-20 11:42:11.733650: Creating archives for AWSGoogleSignIn
2024-03-20 11:42:11.733715: Creating archives for AWSUserPoolsSignIn
2024-03-20 11:42:11.733765: Creating archives for AWSMobileClientXCF
2024-03-20 11:42:11.733829: Creating archives for AWSLocationXCF
2024-03-20 11:42:11.735988: Waiting for process 80401
2024-03-20 11:42:11.736048: Waiting for process 80399
2024-03-20 11:42:11.736641: Waiting for process 80400
2024-03-20 11:42:11.736776: Waiting for process 80397
2024-03-20 11:42:11.736838: Waiting for process 80398
2024-03-20 11:42:11.736860: Waiting for process 80403
2024-03-20 11:42:11.736941: Waiting for process 80402
2024-03-20 11:42:26.006758: Created iOS archive AWSFacebookSignIn generic/platform=iOS
2024-03-20 11:42:26.009739: Waiting for process 81975
2024-03-20 11:42:29.135688: Created iOS archive AWSGoogleSignIn generic/platform=iOS
2024-03-20 11:42:29.143030: Waiting for process 82225
2024-03-20 11:42:30.086386: Created iOS archive AWSAppleSignIn generic/platform=iOS
2024-03-20 11:42:30.090231: Waiting for process 82299
2024-03-20 11:42:30.964170: Created iOS archive AWSLocationXCF generic/platform=iOS
2024-03-20 11:42:30.966328: Waiting for process 82331
2024-03-20 11:42:31.448121: Created iOS archive AWSAuthUI generic/platform=iOS
2024-03-20 11:42:31.457784: Waiting for process 82341
2024-03-20 11:42:32.514419: Created iOS archive AWSMobileClientXCF generic/platform=iOS
2024-03-20 11:42:32.558625: Waiting for process 82389
2024-03-20 11:42:35.152928: Created iOS archive AWSUserPoolsSignIn generic/platform=iOS
2024-03-20 11:42:35.158944: Waiting for process 82610
2024-03-20 11:42:42.711757: Created iOS archive AWSFacebookSignIn generic/platform=iOS Simulator
2024-03-20 11:42:48.071608: Created iOS archive AWSGoogleSignIn generic/platform=iOS Simulator
2024-03-20 11:42:48.567563: Created iOS archive AWSAppleSignIn generic/platform=iOS Simulator
2024-03-20 11:42:58.919867: Created iOS archive AWSAuthUI generic/platform=iOS Simulator
2024-03-20 11:43:03.935396: Created iOS archive AWSLocationXCF generic/platform=iOS Simulator
2024-03-20 11:43:05.170325: Created iOS archive AWSUserPoolsSignIn generic/platform=iOS Simulator
2024-03-20 11:43:09.305739: Created iOS archive AWSMobileClientXCF generic/platform=iOS Simulator
2024-03-20 11:43:09.336560: Creating XCF for AWSCore
2024-03-20 11:43:09.338511: Waiting for process 86237
2024-03-20 11:43:09.443242: Waiting for process 86239
2024-03-20 11:43:09.444507: Waiting for process 86240
2024-03-20 11:43:09.446981: Waiting for process 86241
2024-03-20 11:43:09.449622: Waiting for process 86244
2024-03-20 11:43:09.454253: Waiting for process 86243
2024-03-20 11:43:09.454751: Waiting for process 86242
2024-03-20 11:43:09.463704: Waiting for process 86245
2024-03-20 11:43:09.467388: Waiting for process 86247
2024-03-20 11:43:09.469116: Waiting for process 86246
2024-03-20 11:43:09.479715: Waiting for process 86248
2024-03-20 11:43:11.138686: Created XCFramework for AWSCore
2024-03-20 11:43:11.138778: Creating XCF for AWSCognitoIdentityProviderASF
2024-03-20 11:43:11.140360: Waiting for process 86258
2024-03-20 11:43:12.146225: Created XCFramework for AWSCognitoIdentityProviderASF
2024-03-20 11:43:12.146316: Creating XCF for AWSCognitoAuth
2024-03-20 11:43:12.148230: Waiting for process 86262
2024-03-20 11:43:12.250405: List of schema found
2024-03-20 11:43:12.372821: List of schema found
2024-03-20 11:43:12.378744: List of schema found
2024-03-20 11:43:12.380109: List of schema found
2024-03-20 11:43:12.405604: List of schema found
2024-03-20 11:43:12.414491: List of schema found
2024-03-20 11:43:12.417623: List of schema found
2024-03-20 11:43:12.430034: List of schema found
2024-03-20 11:43:12.460994: List of schema found
2024-03-20 11:43:12.476979: List of schema found
2024-03-20 11:43:12.908215: Created XCFramework for AWSCognitoAuth
2024-03-20 11:43:12.908316: Creating XCF for AWSCognitoIdentityProvider
2024-03-20 11:43:12.909948: Waiting for process 86268
2024-03-20 11:43:13.597159: Created XCFramework for AWSCognitoIdentityProvider
2024-03-20 11:43:13.597255: Creating XCF for AWSAuthCore
2024-03-20 11:43:13.598741: Waiting for process 86280
2024-03-20 11:43:14.294679: Created XCFramework for AWSAuthCore
2024-03-20 11:43:14.295136: Creating XCF for AWSAuthUI
2024-03-20 11:43:14.295633: Creating XCF for AWSAppleSignIn
2024-03-20 11:43:14.295862: Creating XCF for AWSFacebookSignIn
2024-03-20 11:43:14.296169: Creating XCF for AWSGoogleSignIn
2024-03-20 11:43:14.297386: Creating XCF for AWSUserPoolsSignIn
2024-03-20 11:43:14.297726: Creating XCF for AWSMobileClientXCF
2024-03-20 11:43:14.298597: Creating XCF for AWSLocationXCF
2024-03-20 11:43:14.299847: Waiting for process 86286
2024-03-20 11:43:14.300247: Waiting for process 86288
2024-03-20 11:43:14.300478: Waiting for process 86289
2024-03-20 11:43:14.300478: Waiting for process 86287
2024-03-20 11:43:14.300805: Waiting for process 86290
2024-03-20 11:43:14.302564: Waiting for process 86292
2024-03-20 11:43:14.302786: Waiting for process 86291
2024-03-20 11:43:15.381851: Created XCFramework for AWSAuthUI
2024-03-20 11:43:15.415844: Created XCFramework for AWSLocationXCF
2024-03-20 11:43:15.423941: Created XCFramework for AWSAppleSignIn
2024-03-20 11:43:15.424741: Created XCFramework for AWSGoogleSignIn
2024-03-20 11:43:15.428098: Created XCFramework for AWSFacebookSignIn
2024-03-20 11:43:15.437544: Created XCFramework for AWSUserPoolsSignIn
2024-03-20 11:43:15.438274: Created XCFramework for AWSMobileClientXCF
```

Running without the PR changes same verifies the issue:
```
Could not create xcodebuild archive: AWSAppleSignIn output: b"Command line invocation:\n    /Applications/Xcode-15.2.0.app/Contents/Developer/usr/bin/xcodebuild archive -project ./AWSAuthSDK/AWSAuthSDK.xcodeproj -scheme AWSAppleSignIn -destination generic/platform=iOS -archivePath /Users/mdlaw/aws-amplify/aws-sdk-ios/xcframeworks/output/iOS/AWSAppleSignIn SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES\n\nUser defaults from command line:\n    IDEArchivePathOverride = /Users/mdlaw/aws-amplify/aws-sdk-ios/xcframeworks/output/iOS/AWSAppleSignIn\n    IDEPackageSupportUseBuiltinSCM = YES\n\nBuild settings from command line:\n    BUILD_LIBRARY_FOR_DISTRIBUTION = YES\n    SKIP_INSTALL = NO\n\nPrepare packages\n\nComputeTargetDependencyGraph\nnote: Building targets in dependency order\nnote: Target dependency graph (3 targets)\n    Target 'AWSAppleSignIn' in project 'AWSAuthSDK'\n        \xe2\x9e\x9c Implicit dependency on target 'AWSAuthCore' in project 'AWSAuthSDK' via file 'AWSAuthCore.framework' in build phase 'Link Binary'\n        \xe2\x9e\x9c Implicit dependency on target 'AWSCore' in project 'AWSiOSSDKv2' via file 'AWSCore.framework' in build phase 'Link Binary'\n    Target 'AWSAuthCore' in project 'AWSAuthSDK'\n        \xe2\x9e\x9c Implicit dependency on target 'AWSCore' in project 'AWSiOSSDKv2' via file 'AWSCore.framework' in build phase 'Link Binary'\n    Target 'AWSCore' in project 'AWSiOSSDKv2' (no dependencies)\n\nGatherProvisioningInputs\n\nCreateBuildDescription\nBuild description signature: f841b37a72d19f5e765293552f9f8ee5\nBuild description path: /Users/mdlaw/Library/Developer/Xcode/DerivedData/AWSAuthSDK-dhymxvqhyblrhwapzmnyuykgpmwu/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/IntermediateBuildFilesPath/XCBuildData/f841b37a72d19f5e765293552f9f8ee5.xcbuilddata\n\nerror: Multiple commands produce '/Users/mdlaw/Library/Developer/Xcode/DerivedData/AWSAuthSDK-dhymxvqhyblrhwapzmnyuykgpmwu/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy'\n    note: Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/mdlaw/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy' to '/Users/mdlaw/Library/Developer/Xcode/DerivedData/AWSAuthSDK-dhymxvqhyblrhwapzmnyuykgpmwu/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks/AWSAppleSignIn.framework/PrivacyInfo.xcprivacy'\n    note: Target 'AWSAppleSignIn' (project 'AWSAuthSDK') has copy command from '/Users/mdlaw/aws-amplify/aws-sdk-ios/AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy' to '/Users/mdlaw/Library/Developer/Xcode/DerivedData/AWSAuthSDK-dhymxvqhyblrhwapzmnyuykgpmwu/Build/Intermediates.noindex/ArchiveIntermediates/AWSAppleSignIn/InstallationBuildProductsLocation/Library/Frameworks
```


*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
