### PR TITLE
fix: privacy manifest pod specs

### DIFF
--- a/AWSAppleSignIn.podspec
+++ b/AWSAppleSignIn.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.dependency 'AWSAuthCore', '2.34.1'
   s.source_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.{h,m}'
   s.public_header_files = 'AWSAuthSDK/Sources/AWSAppleSignIn/*.h'
-  s.resource_bundle = { 'AWSAppleSignIn' => ['AWSAppleSignIn/PrivacyInfo.xcprivacy']}
+  s.resource_bundle = { 'AWSAppleSignIn' => ['AWSAuthSDK/Sources/AWSAppleSignIn/PrivacyInfo.xcprivacy']}
 end

--- a/AWSAuthCore.podspec
+++ b/AWSAuthCore.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
    s.dependency 'AWSCore', '2.34.1'
    s.source_files = 'AWSAuthSDK/Sources/AWSAuthCore/*.{h,m}'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSAuthCore/*.h'
-   s.resource_bundle = { 'AWSAuthCore' => ['AWSAuthCore/PrivacyInfo.xcprivacy']}
+   s.resource_bundle = { 'AWSAuthCore' => ['AWSAuthSDK/Sources/AWSAuthCore/PrivacyInfo.xcprivacy']}
  end
  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some pods did not pass validation
```
> pod lib lint AWSAppleSignIn.podspec            

 -> AWSAppleSignIn (2.34.0)
    - NOTE  | url: The URL (http://aws.amazon.com/mobile/sdk) is not reachable.
    - ERROR | [iOS] file patterns: The `resource_bundles` pattern for `AWSAppleSignIn` did not match any file.
…

[!] AWSAppleSignIn did not pass validation, due to 1 error.
You can use the `--no-clean` option to inspect any issue.
```

The incorrect references to the PrivacyInfo.xcprivacy is fixed in this PR, and validated with

```
for file in *.podspec; do pod lib lint "$file" --allow-warnings; done
```

Every pod spec no longer has an error due to the pattern for mismatch file. (except for AWSLex, whose error looks unrelated)

Some pods were not released since the error stopped the process for releasing the rest of the pods. We’ll need this fix merged in for subsequent releases, so we should merge this in and release 2.34.2 and deprecate 2.34.1 release.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
