### PR TITLE
fix(IoT): Fixing a intermittent crash when deallocating `AWSIoTStreamThread`

### DIFF
--- a/AWSIoT/Internal/AWSIoTStreamThread.m
+++ b/AWSIoT/Internal/AWSIoTStreamThread.m
@@ -55,10 +55,6 @@
     return self;
 }
 
--(void)dealloc {
-    [self cleanUp];
-}
-
 - (void)main {
     AWSDDLogVerbose(@"Started execution of Thread: [%@]", self);
     //This is invoked in a new thread by the webSocketDidOpen method or by the Connect method. Get the runLoop from the thread.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSIoT**
+  - Fixing an intermittent crash when deallocating AWSIoTStreamThread (See [PR #5269](https://github.com/aws-amplify/aws-sdk-ios/issues/5269))
 
 ## 2.34.2
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5258

**Description of changes:**
We're currently calling `[self cleanUp]` on `dealloc`, which basically invalidates the timer and checks if it should close the streams and invoke a callback.

Generally, it's not recommended to rely on the `dealloc` method to perform expensive operations. `cleanUp` is already **always** being called when the thread is cancelled, so calling it again when the thread is deallocated is not only redundant, but _might_ be the cause of the linked crash due to attempting to access other near-deallocated objects and/or properties. 

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [x] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
