### PR TITLE
chore(IoT): Updating keepAliveTimeInterval attribute comment

### DIFF
--- a/AWSIoT/AWSIoTDataManager.h
+++ b/AWSIoT/AWSIoTDataManager.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign, readonly) NSTimeInterval maximumReconnectTimeInterval;
 
 /**
- The MQTT keep-alive time in seconds.  Default value: 60s seconds.
+ The MQTT keep-alive time in seconds.  Default value: 300 seconds.
  */
 @property(nonatomic, assign, readonly) NSTimeInterval keepAliveTimeInterval;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--Features for next release
+### Misc. Updates
+- **AWSIoT**
+  - Updating `AWSIoTMQTTConfiguration.keepAliveTimeInterval`'s default value in its attribute comment.
 
 ## 2.35.0
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5282

**Description of changes:**

The default value for `keepAliveTimeInterval` was updated to 300 seconds in version [2.6.6](https://github.com/aws-amplify/aws-sdk-ios/blob/main/CHANGELOG.md#266), but its corresponding attribute comment was not.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
