### PR TITLE
fix incorrect recover

### DIFF
--- a/AWSS3/AWSS3TransferUtilityTasks.h
+++ b/AWSS3/AWSS3TransferUtilityTasks.h
@@ -145,6 +145,9 @@ typedef void (^AWSS3TransferUtilityMultiPartProgressBlock) (AWSS3TransferUtility
  */
 - (void)cancel;
 
+// Modify by Dart: it will cancel NSURLSessionTask, but not remove task record from DB, in order to be recover later
+- (void)stop;
+
 /**
  Resumes the task, if it is suspended.
  */

--- a/AWSS3/AWSS3TransferUtility_private.h
+++ b/AWSS3/AWSS3TransferUtility_private.h
@@ -42,6 +42,9 @@
 @property (strong, nonatomic) AWSS3TransferUtilityUploadExpression *expression;
 @property NSString *responseData;
 @property (atomic) BOOL cancelled;
+
+// Modify by Dark: remember stop status
+@property BOOL stopped;
 @property BOOL temporaryFileCreated;
 
 @end
@@ -52,6 +55,9 @@
 @property (strong, nonatomic) AWSS3TransferUtilityMultiPartUploadExpression *expression;
 @property (copy) NSString * uploadID;
 @property BOOL cancelled;
+
+// Modify by Dark: add stopped status, it will cancel uploading
+@property BOOL stopped;
 @property BOOL temporaryFileCreated;
 @property NSMutableDictionary <NSNumber *, AWSS3TransferUtilityUploadSubTask *> *waitingPartsDictionary;
 @property (strong, nonatomic) NSMutableSet <AWSS3TransferUtilityUploadSubTask *> *completedPartsSet;


### PR DESCRIPTION
Description of changes:
1. add an stop method to UploadTask and MultiPartUploadTask, this function will cancel current upload but not remove record from DB, and could be recover later.
2. fix incorrect recover logic:
- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
