### PR TITLE
fix(MobileClient): Fixing a crash when attempting to use HostedUI

### DIFF
--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -356,7 +356,9 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 
 - (void)launchSFWebAuthenticationSession:(NSURL *)hostedUIURL API_AVAILABLE(ios(11.0)) {
     self.sfAuthenticationSessionAvailable = YES;
-    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signInRedirectUri] copy];
+    NSString *callbackURLString = [[self urlEncode:self.authConfiguration.signInRedirectUri] copy];
+    NSURL *callbackURL = [[NSURL alloc] initWithString:callbackURLString];
+    NSString *callbackURLScheme = callbackURL.scheme;
     __weak AWSCognitoAuth *weakSelf = self;
     self.sfAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:hostedUIURL
                                                        callbackURLScheme:callbackURLScheme
@@ -655,7 +657,9 @@ withPresentingViewController:(UIViewController *)presentingViewController {
 
 - (void)launchSFAuthenticationSessionForSignOut:(NSURL *) url API_AVAILABLE(ios(11.0)) {
     self.sfAuthenticationSessionAvailable = YES;
-    NSString *callbackURLScheme = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
+    NSString *callbackURLString = [[self urlEncode:self.authConfiguration.signOutRedirectUri] copy];
+    NSURL *callbackURL = [[NSURL alloc] initWithString:callbackURLString];
+    NSString *callbackURLScheme = callbackURL.scheme;
     __weak AWSCognitoAuth *weakSelf = self;
     self.sfAuthSession = [[ASWebAuthenticationSession alloc] initWithURL:url
                                                        callbackURLScheme:callbackURLScheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSMobileClient**
+  - Fixing a crash when attempting to use HostedUI (#5316)
 
 ## 2.36.0
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5315

**Description of changes:**

This PR fixes a crash when attempting to use HostedUI. 

It was caused by the upgrade from `SFAuthenticationSession ` to `ASWebAuthenticationSession` in our bump to iOS 12, as `ASWebAuthenticationSession` does not allow the `scheme` to contain special characters.

Fixing it by validating the scheme first as we do in other methods dealing with `ASWebAuthenticationSession`

*Check points:*

- [ ] Added new tests to cover change, if needed
- [x] All unit tests pass
- [ ] All integration tests pass
- [x] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
