### PR TITLE
chore: Setting workflows runners to macos-12

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -62,7 +62,7 @@ jobs:
           - project: AWSAuthSDK/AWSAuthSDK.xcodeproj
             scheme: AWSMobileClient
 
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/kick-off-release.yml
+++ b/.github/workflows/kick-off-release.yml
@@ -34,7 +34,7 @@ jobs:
 
   create-release-pr:
     name: Create release PR for ${{ github.event.inputs.release-version }}
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - validate-version-format
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
   build-xcframeworks:
     name: Build xcframeworks
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - extract-release-version
       - unit-test
@@ -82,7 +82,7 @@ jobs:
 
   release-xcframeworks:
     name: Release xcframeworks
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: ReleaseArtifacts
     needs:
       - extract-release-version
@@ -135,7 +135,7 @@ jobs:
 
   release-spm:
     name: Release SPM
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: Release
     needs:
       - extract-release-version
@@ -179,7 +179,7 @@ jobs:
 
   release-combined-xcframeworks:
     name: Release combine xcframeworks
-    runs-on: macos-latest
+    runs-on: macos-12
     environment: ReleaseArtifacts
     needs:
       - extract-release-version
@@ -251,7 +251,7 @@ jobs:
 
   release-tag:
     name: Rlease tag
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - extract-release-version
       - release-combined-xcframeworks
@@ -324,7 +324,7 @@ jobs:
 
   release-doc:
     name: Release docs
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - extract-release-version
       - update-main-branch
@@ -372,7 +372,7 @@ jobs:
 
   add-doc-tag:
     name: Add doc tag
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - extract-release-version
       - release-doc
@@ -400,7 +400,7 @@ jobs:
 
   release-cocoapods:
     name: Release Cocoapods
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - add-doc-tag
     environment: Release
@@ -432,7 +432,7 @@ jobs:
 
   release-carthage:
     name: Release Carthage
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - extract-release-version
       - add-doc-tag
@@ -463,7 +463,7 @@ jobs:
 
   bump-ios-sampleapp-version:
     name: 'Bump iOS sample App version'
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - release-xcframeworks
       - release-cocoapods

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -70,7 +70,7 @@ jobs:
           - project: AWSAuthSDK/AWSAuthSDK.xcodeproj
             scheme: AWSMobileClient
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3


### PR DESCRIPTION
*Description of changes:*

This PR sets the runners in our workflows to use `macos-13`, as many of them depend on x86-only mocks

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
