### PR TITLE
fix(AWSCore): Fixing a name collision with CocoaLumberjack

### DIFF
--- a/AWSCore/Logging/AWSDDFileLogger.m
+++ b/AWSCore/Logging/AWSDDFileLogger.m
@@ -43,7 +43,7 @@
 
 
 #if TARGET_OS_IPHONE
-BOOL doesAppRunInBackground(void);
+BOOL awsDoesAppRunInBackground(void);
 #endif
 
 unsigned long long const kAWSDDDefaultLogMaxFileSize      = 1024 * 1024;      // 1 MB
@@ -174,7 +174,7 @@ NSTimeInterval     const kAWSDDRollingLeeway              = 1.0;              //
 - (NSFileProtectionType)logFileProtection {
     if (_defaultFileProtectionLevel.length > 0) {
         return _defaultFileProtectionLevel;
-    } else if (doesAppRunInBackground()) {
+    } else if (awsDoesAppRunInBackground()) {
         return NSFileProtectionCompleteUntilFirstUserAuthentication;
     } else {
         return NSFileProtectionCompleteUnlessOpen;
@@ -1026,7 +1026,7 @@ NSTimeInterval     const kAWSDDRollingLeeway              = 1.0;              //
     // a new one.
     //
     // If user has overwritten to NSFileProtectionNone there is no need to create a new one.
-    if (doesAppRunInBackground()) {
+    if (awsDoesAppRunInBackground()) {
         NSFileProtectionType key = mostRecentLogFileInfo.fileAttributes[NSFileProtectionKey];
         __auto_type isUntilFirstAuth = [key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication];
         __auto_type isNone = [key isEqualToString:NSFileProtectionNone];
@@ -1846,7 +1846,7 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
  * want (even if device is locked). Thats why that attribute have to be changed to
  * NSFileProtectionCompleteUntilFirstUserAuthentication.
  */
-BOOL doesAppRunInBackground(void) {
+BOOL awsDoesAppRunInBackground(void) {
     if ([[[NSBundle mainBundle] executablePath] containsString:@".appex/"]) {
         return YES;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
--Features for next release
+- **AWSCore**
+  - Fixing a name collision with CocoaLumberjack (#5361)
 
 ## 2.36.2
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5355

*Description of changes:*
This PR fixes the name collision on the `doesAppRunInBackground` function between CocoaLumberjack and our internal fork. 

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
