### PR TITLE
fix(IoT): Fixing a potential race condition on topic listeners

### DIFF
--- a/AWSComprehendTests/AWSComprehendTests.swift
+++ b/AWSComprehendTests/AWSComprehendTests.swift
@@ -139,7 +139,7 @@ class AWSComprehendTests: XCTestCase {
         let comprehendClient = AWSComprehend.default()
         let detectSentimentRequest = AWSComprehendDetectSentimentRequest()
         detectSentimentRequest!.languageCode = AWSComprehendLanguageCode.en
-        detectSentimentRequest!.text = "I have no strong feelings one way or the other"
+        detectSentimentRequest!.text = "This sentence is a statement of fact"
         
         comprehendClient.detectSentiment(detectSentimentRequest!).continueWith{ (task)-> Any? in
             if let error = task.error {

--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -38,7 +38,7 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
 
 @property(atomic, assign, readwrite) AWSIoTMQTTStatus mqttStatus;
 @property(nonatomic, strong) AWSMQTTSession* session;
-@property(nonatomic, strong) NSMutableDictionary * topicListeners;
+@property(nonatomic, strong) AWSSynchronizedMutableDictionary * topicListeners;
 
 @property(atomic, assign) BOOL userDidIssueDisconnect; //Flag to indicate if requestor has issued a disconnect
 @property(atomic, assign) BOOL userDidIssueConnect; //Flag to indicate if requestor has issued a connect
@@ -91,7 +91,7 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
 
 - (instancetype)init {
     if (self = [super init]) {
-        _topicListeners = [NSMutableDictionary dictionary];
+        _topicListeners = [AWSSynchronizedMutableDictionary new];
         _clientCerts = nil;
         _session.delegate = nil;
         _session = nil;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
 - **AWSIoT** 
   - Fixing a potential race condition on topic listeners (#5402)
 
-## 2.36.4
+## 2.36.5
+
+### New features 
+
+- **AWSIoT** 
+  - Adding completion callbacks for registerWithShadow and unregisterFromShadow methods (#5192)
 
 ### Misc. Updates
 
@@ -25,15 +30,11 @@
   - AWSFirehose
   - AWSTranscribe
 
-### Bug Fixes
+## 2.36.4
 
-- **AWSS3** 
-  - Cleanup file cache after mpu task is cancelled (#5128)
+### Deprecated release
 
-### New features 
-
-- **AWSIoT** 
-  - Adding completion callbacks for registerWithShadow and unregisterFromShadow methods (#5192)
+This release is deprecated due to errors. Please use 2.36.5 or greater.
 
 ## 2.36.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AWS Mobile SDK for iOS CHANGELOG
 
+## Unreleased
+
+### Bug Fixes
+
+- **AWSIoT** 
+  - Fixing a potential race condition on topic listeners (#5402)
+
+## 2.36.4
+
 ### Misc. Updates
 
 - Model updates for the following services
@@ -16,11 +25,15 @@
   - AWSFirehose
   - AWSTranscribe
 
+### Bug Fixes
+
 - **AWSS3** 
-  - fix(s3): cleanup file cache after mpu task is cancelled (#5128)
- 
-- **AWSIOT** 
-  - feat(IoT): Adding completion callbacks for registerWithShadow and unregisterFromShadow methods (#5192)
+  - Cleanup file cache after mpu task is cancelled (#5128)
+
+### New features 
+
+- **AWSIoT** 
+  - Adding completion callbacks for registerWithShadow and unregisterFromShadow methods (#5192)
 
 ## 2.36.3
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5389

**Description of changes:**
This PR attempts to fix a crash that might be happening due to a race condition when trying to access the `topicListeners` dictionary.

We already have a custom [`AWSSynchronizedMutableDictionary`](https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSCore/Utility/AWSSynchronizedMutableDictionary.h) class that provides a thread-safe dictionary, so I'm replacing the old instance with that one.

Also fixing the CHANGELOG and a failing Comprehend integration test

----

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
