### PR TITLE
chore: Temporary using xcodeproj's commit that bumps rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'xcpretty', '0.3.0'
 gem 'cocoapods', '1.11.3'
 gem 'cocoapods-downloader', '1.6.3'
 gem 'jazzy', '0.14.2'
+gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,23 @@
+GIT
+  remote: https://github.com/CocoaPods/Xcodeproj.git
+  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
+  ref: fe55cf5
+  branch: master
+  specs:
+    xcodeproj (1.24.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -15,6 +31,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.2.0)
     claide (1.1.0)
     cocoapods (1.11.3)
       addressable (~> 2.8)
@@ -77,22 +94,25 @@ GEM
       xcinvoke (~> 0.3.0)
     json (2.6.1)
     liferaft (0.0.6)
+    mini_portile2 (2.8.7)
     minitest (5.19.0)
     molinillo (0.8.0)
     mustache (1.1.1)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nkf (0.2.0)
     open4 (1.3.4)
     public_suffix (4.0.6)
     redcarpet (3.5.1)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sqlite3 (1.4.2)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     strscan (3.1.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
@@ -100,13 +120,6 @@ GEM
       concurrent-ruby (~> 1.0)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
-    xcodeproj (1.21.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     zeitwerk (2.6.11)
@@ -118,6 +131,7 @@ DEPENDENCIES
   cocoapods (= 1.11.3)
   cocoapods-downloader (= 1.6.3)
   jazzy (= 0.14.2)
+  xcodeproj!
   xcpretty (= 0.3.0)
 
 BUNDLED WITH


### PR DESCRIPTION
**Description of changes:**

This PR uses Xcodeproj's latest [main commit](https://github.com/CocoaPods/Xcodeproj/commit/fe55cf57badef2ca27fb9d4f801d9b834de1f871) so that its dependency to `rexml` can be upgraded.

We're doing this temporary until they release a proper new version, at which point we will point to that one.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
