### PR TITLE
fix(Core): Fixing concurrency issues in `AWSSynchronizedMutableDictionary`

### DIFF
--- a/AWSCore/Utility/AWSSynchronizedMutableDictionary.m
+++ b/AWSCore/Utility/AWSSynchronizedMutableDictionary.m
@@ -74,13 +74,13 @@
 }
 
 - (void)setObject:(id)anObject forKey:(id)aKey {
-    dispatch_barrier_sync(self.dispatchQueue, ^{
+    dispatch_barrier_async(self.dispatchQueue, ^{
         [self.dictionary setObject:anObject forKey:aKey];
     });
 }
 
 - (void)removeObject:(id)object {
-    dispatch_barrier_sync(self.dispatchQueue, ^{
+    dispatch_barrier_async(self.dispatchQueue, ^{
         for (NSString *key in self.dictionary) {
             if (object == self.dictionary[key]) {
                 [self.dictionary removeObjectForKey:key];
@@ -91,19 +91,19 @@
 }
 
 - (void)removeObjectForKey:(id)aKey {
-    dispatch_barrier_sync(self.dispatchQueue, ^{
+    dispatch_barrier_async(self.dispatchQueue, ^{
         [self.dictionary removeObjectForKey:aKey];
     });
 }
 
 - (void)removeAllObjects {
-    dispatch_barrier_sync(self.dispatchQueue, ^{
+    dispatch_barrier_async(self.dispatchQueue, ^{
         [self.dictionary removeAllObjects];
     });
 }
 
 - (void)mutateWithBlock:(void (^)(NSMutableDictionary *))block {
-    dispatch_barrier_sync(self.dispatchQueue, ^{
+    dispatch_barrier_async(self.dispatchQueue, ^{
         block(self.dictionary);
     });
 }
@@ -112,7 +112,7 @@
     AWSSynchronizedMutableDictionary *first = [dictionaries firstObject];
     if (!first) { return; }
 
-    dispatch_barrier_sync(first.dispatchQueue, ^{
+    dispatch_barrier_async(first.dispatchQueue, ^{
         [dictionaries enumerateObjectsUsingBlock:^(AWSSynchronizedMutableDictionary * _Nonnull atomicDictionary, NSUInteger index, BOOL * _Nonnull stop) {
             NSCAssert([first.syncKey isEqual:atomicDictionary.syncKey], @"Sync keys much match");
             block(atomicDictionary.instanceKey, atomicDictionary.dictionary);

--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -681,8 +681,8 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
     }
 
     if (self.reconnectThread) {
-        if ( ![[NSThread currentThread] isEqual:self.reconnectThread]) {
-            // Move to reconnect thread to cleanup
+        if (!self.reconnectThread.isFinished && ![[NSThread currentThread] isEqual:self.reconnectThread]) {
+            // Move to reconnect thread to cleanup only if it's still running
             [self performSelector:@selector(cleanupReconnectTimer)
                          onThread:self.reconnectThread
                        withObject:nil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
--Features for next release
+- **AWSCore** 
+  - Fixing concurrency issues in `AWSSynchronizedMutableDictionary` (#5413)
+
+- **AWSIoT** 
+  - Fixing random crash when a connection is attempted just after disconnecting
 
 ## 2.36.6
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5412

**Description of changes:**

When using barriers and concurrent queues, doing `dispatch_barrier_sync` can cause deadlocks (and crashes), so `dispatch_barrier_async` is recommended.
Our `AWSSynchronizedMutableDictionary` was using sync for write operations, which are really unnecessary and can be async. Read operations do remain `sync`, but with no barrier involved.

---

Also included in this PR is a potential fix for the random crash when disconnecting and quickly connecting again. If a disconnection happens due to an error, the `reconnectThread` is trigger, which sets the `reconnectTimer` so that a reconnection is attempted in x seconds.
But if a new connection is explicitly triggered, a new `streamsThread` will be created and the old one discarded. We do attempt to invalidate the `reconnectTimer` in these situations, but we try to do it in the `reconnectThread` as that is where the timer was set.

However, if the `reconnectThread` has finished (i.e. not running), then the timer will not be invalidated and will fire eventually, which will attempt to use the now deallocated old `streamsThread`.
So I'm just adding a simple check to allow us to invalidate the timer anyway if the `reconnectThread` has finished. 

----

*Check points:*

- [ ] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
