### PR TITLE
test: Fixing S3's integration tests due to GetTorrentObject going EoS

### DIFF
--- a/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
+++ b/AWSS3Tests/AWSS3PreSignedURLBuilderTests.m
@@ -604,7 +604,6 @@ static long unsigned testObjectSize = 10000;
             switch (count) {
                 case 0:
                     preSignedURLBuilder = [AWSS3PreSignedURLBuilder defaultS3PreSignedURLBuilder];
-                    [getPreSignedURLRequest setValue:@"" forRequestParameter:AWSS3PresignedURLTorrent];
                     break;
                 case 2:
                     preSignedURLBuilder = [AWSS3PreSignedURLBuilder S3PreSignedURLBuilderForKey:testS3PresignedURLEUCentralKey];
@@ -648,7 +647,7 @@ static long unsigned testObjectSize = 10000;
                                                      if (count == 0) {
                                                          XCTAssertTrue([data length] > 0);
                                                          NSString *responseContentTypeStr = [((NSHTTPURLResponse *)response) allHeaderFields][@"Content-Type"];
-                                                         XCTAssertEqualObjects(@"application/x-bittorrent", responseContentTypeStr);
+                                                         XCTAssertEqualObjects(@"binary/octet-stream", responseContentTypeStr);
                                                      } else {
                                                          XCTAssertEqual(testObjectSize, [data length]);
                                                      }


### PR DESCRIPTION
*Description of changes:*
`GetObjectTorrent ` is reaching EoS and the integration tests are failing because of that.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
