### PR TITLE
feat(AWSCore): Adding support for the ap-southeast-5 region.

### DIFF
--- a/AWSCore/Service/AWSService.m
+++ b/AWSCore/Service/AWSService.m
@@ -260,6 +260,7 @@ static NSString *const AWSRegionNameAPNortheast2 = @"ap-northeast-2";
 static NSString *const AWSRegionNameAPSoutheast2 = @"ap-southeast-2";
 static NSString *const AWSRegionNameAPSoutheast3 = @"ap-southeast-3";
 static NSString *const AWSRegionNameAPSoutheast4 = @"ap-southeast-4";
+static NSString *const AWSRegionNameAPSoutheast5 = @"ap-southeast-5";
 static NSString *const AWSRegionNameAPSouth1 = @"ap-south-1";
 static NSString *const AWSRegionNameAPSouth2 = @"ap-south-2";
 static NSString *const AWSRegionNameSAEast1 = @"sa-east-1";
@@ -478,6 +479,8 @@ static NSString *const AWSServiceNameChimeSDKIdentity = @"chime";
             return AWSRegionNameAPSoutheast3;
         case AWSRegionAPSoutheast4:
             return AWSRegionNameAPSoutheast4;
+        case AWSRegionAPSoutheast5:
+            return AWSRegionNameAPSoutheast5;
         case AWSRegionAPNortheast1:
             return AWSRegionNameAPNortheast1;
         case AWSRegionAPNortheast2:

--- a/AWSCore/Service/AWSServiceEnum.h
+++ b/AWSCore/Service/AWSServiceEnum.h
@@ -84,6 +84,10 @@ typedef NS_ENUM(NSInteger, AWSRegionType) {
      */
     AWSRegionAPSoutheast4 NS_SWIFT_NAME(APSoutheast4),
     /**
+     * Asia Pacific (Malaysia)
+     */
+    AWSRegionAPSoutheast5 NS_SWIFT_NAME(APSoutheast5),
+    /**
      *  Asia Pacific (Mumbai)
      */
     AWSRegionAPSouth1 NS_SWIFT_NAME(APSouth1),

--- a/AWSCore/Utility/AWSCategory.m
+++ b/AWSCore/Utility/AWSCategory.m
@@ -530,6 +530,11 @@ static NSTimeInterval _clockskew = 0.0;
         || [self isEqualToString:@"ap-southeast-4"]) {
         return AWSRegionAPSoutheast4;
     }
+    if ([self isEqualToString:@"AWSRegionAPSoutheast5"]
+        || [self isEqualToString:@"APSoutheast5"]
+        || [self isEqualToString:@"ap-southeast-5"]) {
+        return AWSRegionAPSoutheast5;
+    }
     if ([self isEqualToString:@"AWSRegionAPSouth1"]
         || [self isEqualToString:@"APSouth1"]
         || [self isEqualToString:@"ap-south-1"]) {

--- a/AWSS3/AWSS3Model.h
+++ b/AWSS3/AWSS3Model.h
@@ -70,6 +70,7 @@ typedef NS_ENUM(NSInteger, AWSS3BucketLocationConstraint) {
     AWSS3BucketLocationConstraintAPSoutheast2,
     AWSS3BucketLocationConstraintAPSoutheast3,
     AWSS3BucketLocationConstraintAPSoutheast4,
+    AWSS3BucketLocationConstraintAPSoutheast5,
     AWSS3BucketLocationConstraintCACentral1,
     AWSS3BucketLocationConstraintCAWest1,
     AWSS3BucketLocationConstraintCNNorth1,

--- a/AWSS3/AWSS3Model.m
+++ b/AWSS3/AWSS3Model.m
@@ -1226,6 +1226,9 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
         if ([value caseInsensitiveCompare:@"ap-southeast-4"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintAPSoutheast4);
         }
+        if ([value caseInsensitiveCompare:@"ap-southeast-5"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintAPSoutheast5);
+        }
         if ([value caseInsensitiveCompare:@"ca-central-1"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintCACentral1);
         }
@@ -1319,6 +1322,8 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
                 return @"ap-southeast-3";
             case AWSS3BucketLocationConstraintAPSoutheast4:
                 return @"ap-southeast-4";
+            case AWSS3BucketLocationConstraintAPSoutheast5:
+                return @"ap-southeast-5";
             case AWSS3BucketLocationConstraintCACentral1:
                 return @"ca-central-1";
             case AWSS3BucketLocationConstraintCAWest1:
@@ -2844,6 +2849,9 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
         if ([value caseInsensitiveCompare:@"ap-southeast-4"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintAPSoutheast4);
         }
+        if ([value caseInsensitiveCompare:@"ap-southeast-5"] == NSOrderedSame) {
+            return @(AWSS3BucketLocationConstraintAPSoutheast5);
+        }
         if ([value caseInsensitiveCompare:@"ca-central-1"] == NSOrderedSame) {
             return @(AWSS3BucketLocationConstraintCACentral1);
         }
@@ -2937,6 +2945,8 @@ return [date aws_stringValue:AWSDateISO8601DateFormat1];
                 return @"ap-southeast-3";
             case AWSS3BucketLocationConstraintAPSoutheast4:
                 return @"ap-southeast-4";
+            case AWSS3BucketLocationConstraintAPSoutheast5:
+                return @"ap-southeast-5";
             case AWSS3BucketLocationConstraintCACentral1:
                 return @"ca-central-1";
             case AWSS3BucketLocationConstraintCAWest1:

--- a/AWSS3/AWSS3Resources.m
+++ b/AWSS3/AWSS3Resources.m
@@ -1375,6 +1375,7 @@
         \"ap-southeast-2\",\
         \"ap-southeast-3\",\
         \"ap-southeast-4\",\
+        \"ap-southeast-5\",\
         \"ca-central-1\",\
         \"ca-west-1\",\
         \"cn-north-1\",\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--Features for next release
+### New features
+- **AWSCore**
+  - Support for `ap-southeast-5` - Asia Pacific (Malaysia) (see [AWS Regional Services List](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/) for a list of services supported in the region)
 
 ## 2.36.7
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding support for the new `ap-southeast-5` Asia Pacific (Malaysia) region

https://regions.aws.dev/dimensions/regions/details/KUL

Reference previous region launch https://github.com/aws-amplify/aws-sdk-ios/pull/4392

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
