### PR TITLE
fix(Pinpoint): Fixing error decoding `AWSPinpointEndpointProfile` when attributes are set.

### DIFF
--- a/AWSPinpoint/AWSPinpointEndpointProfile.m
+++ b/AWSPinpoint/AWSPinpointEndpointProfile.m
@@ -578,7 +578,8 @@ NSString *const AWSPinpointDefaultEndpointDemographicUnknown = @"Unknown";
 - (id)initWithCoder:(NSCoder *)decoder {
     if (self = [super init]) {
         _userId = [decoder decodeObjectOfClass:[NSString class] forKey:@"userId"];
-        _userAttributes = [decoder decodeObjectOfClass:[NSDictionary class] forKey:@"userAttributes"];
+        NSSet * attributesClasses = [NSSet setWithObjects:[NSDictionary class], [NSArray class], [NSString class], nil];
+        _userAttributes = [decoder decodeObjectOfClasses:attributesClasses forKey:@"userAttributes"];
     }
     return self;
 }

--- a/AWSPinpointUnitTests/AWSPinpointNSSecureCodingTests.m
+++ b/AWSPinpointUnitTests/AWSPinpointNSSecureCodingTests.m
@@ -40,14 +40,6 @@
 
 @property (nonatomic, strong) NSURL *archiveURL;
 
-// Specifically declare these methods in the interface so we can set availability
-// to iOS 11. Tests that don't use newer APIs don't need to be declared here.
-- (void)testProfileArchivesAndUnarchivesUsingSecureCoding API_AVAILABLE(ios(11));
-- (void)testProfileArchivesAndUnarchivesWithLegacyAPI API_AVAILABLE(ios(11));
-
-- (void)testSessionArchivesAndUnarchivesSecurely API_AVAILABLE(ios(11));
-- (void)testSessionArchivesAndUnarchivesWithLegacyAPI API_AVAILABLE(ios(11));
-
 @end
 
 @implementation AWSPinpointNSSecureCodingTests
@@ -59,6 +51,16 @@
                                                                  isRegisteredForRemoteNotifications:YES
                                                                                               debug:YES
                                                                                        userDefaults:[NSUserDefaults standardUserDefaults] keychain:[AWSUICKeyChainStore keyChainStoreWithService: @"com.amazonaws.AWSPinpointContext"]];
+
+    [profile addAttribute:@[@"Attribute1", @"Attribute2"]
+                   forKey:@"profileAttributeKey"];
+    [profile addMetric:[NSNumber numberWithInt:10] forKey:@"profileMetricKey"];
+
+    AWSPinpointEndpointProfileUser *user = [AWSPinpointEndpointProfileUser new];
+    user.userId = @"UserId";
+    [user addUserAttribute:@[@"Attribute1", @"Attribute2"] 
+                    forKey:@"userAttributeKey"];
+    profile.user = user;
 
     NSError *error;
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profile
@@ -78,21 +80,6 @@
 
 - (void)testProfileSupportsSecureCoding {
     XCTAssert([AWSPinpointEndpointProfile supportsSecureCoding]);
-}
-
-- (void)testProfileArchivesAndUnarchivesWithLegacyAPI {
-    AWSPinpointEndpointProfile *profile = [[AWSPinpointEndpointProfile alloc] initWithApplicationId:@"app-id-123"
-                                                                                         endpointId:@"endpoint-id-123"
-                                                                             applicationLevelOptOut:YES
-                                                                 isRegisteredForRemoteNotifications:YES
-                                                                                              debug:YES
-                                                                                       userDefaults:[NSUserDefaults standardUserDefaults] keychain:[AWSUICKeyChainStore keyChainStoreWithService: @"com.amazonaws.AWSPinpointContext"]];
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profile];
-
-    AWSPinpointEndpointProfile *unarchivedProfile = (AWSPinpointEndpointProfile *)[NSKeyedUnarchiver unarchiveObjectWithData:data];
-
-    // The class doesn't support `isEqual` so we'll compare string descriptions
-    XCTAssertEqualObjects([unarchivedProfile description], [profile description]);
 }
 
 - (void)testSessionArchivesAndUnarchivesSecurely {
@@ -119,20 +106,6 @@
 
 - (void)testSessionSupportsSecureCoding {
     XCTAssert([AWSPinpointSession supportsSecureCoding]);
-}
-
-- (void)testSessionArchivesAndUnarchivesWithLegacyAPI {
-    AWSPinpointSession *session = [[AWSPinpointSession alloc] initWithSessionId:@"session-123"
-                                                                  withStartTime:[NSDate new]
-                                                                   withStopTime:nil];
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:session];
-
-    AWSPinpointSession *unarchivedSession = (AWSPinpointSession *)[NSKeyedUnarchiver unarchiveObjectWithData:data];
-
-    // The class doesn't support `isEqual` or `description` so we'll compare property-by-property
-    XCTAssertEqualObjects(unarchivedSession.sessionId, session.sessionId);
-    XCTAssertEqualObjects(unarchivedSession.startTime, session.startTime);
-    XCTAssertEqualObjects(unarchivedSession.stopTime, session.stopTime);
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSPinpoint**
+  - Fixing error decoding `AWSPinpointEndpointProfile` when user attributes are set. (#5431)
 
 ## 2.37.0
 


### PR DESCRIPTION
**Description of changes:**

When the user sets user attributes to Pinpoint's `AWSPinpointEndpointProfile`, it's successfully encoded and stored in the Keychain. However, attempting to decode it back failed with an error.

```
Error unarchiving class `AWSPinpointEndpointProfile`: Error Domain=NSCocoaErrorDomain Code=4864 "value for key 'NS.objects' was of unexpected class 'NSMutableArray' (0x1ec41f220) [/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.5.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework].
Allowed classes are:
 {(
    "'NSDictionary' (0x1ec41edc0)
 )}
```

This was caused due to not setting the right classes on the `AWSPinpointEndpointProfileUser` decoding process.

*Check points:*

- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
