### PR TITLE
fix(IoT): Using SecKeyCreateSignature instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSIoT** 
+  - Replacing deprecated `SecKeyRawSign` with `SecKeyCreateSignature` (#5442)
 
 ## 2.37.1
 


### PR DESCRIPTION
**Description of changes:**

This PR replaces the deprecated `SecKeyRawSign` API with `SecKeyCreateSignature`

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
