### PR TITLE
fix(IoT): Fixing a race condition when invalidating/creating the reconnect timer

### DIFF
--- a/AWSIoT/Internal/AWSIoTMQTTClient.m
+++ b/AWSIoT/Internal/AWSIoTMQTTClient.m
@@ -690,10 +690,17 @@ typedef void (^StatusCallback)(AWSIoTMQTTStatus status);
                     waitUntilDone:NO];
             return;
         }
-        
-        [self.reconnectTimer invalidate];
-        self.reconnectTimer = nil;
+
+        [self invalidateReconnectTimer];
     }
+}
+
+- (void)invalidateReconnectTimer {
+    __weak AWSIoTMQTTClient *weakSelf = self;
+    dispatch_async(self.timerQueue, ^{
+        [weakSelf.reconnectTimer invalidate];
+        weakSelf.reconnectTimer = nil;
+    });
 }
 
 - (void)cleanUpWebsocketOutputStream {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSIoT** 
+  - Fixing a race condition when invalidating/creating the reconnect timer (#5454)
 
 ## 2.38.0
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5453

**Description of changes:**

The `reconnectTimer` property is created in the `timerQueue` queue, but it can be invalidated and set to `nil` in the main queue inside the `cleanupReconnectTimer` method.

See the issue for a more detailed analysis and explanation by @AndrKonovalov

**Check points:**

- [ ] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
