### PR TITLE
chore(MobileClient): Removing deprecated methods

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.h
@@ -94,60 +94,6 @@ NS_ASSUME_NONNULL_BEGIN
            sourceApplication:(nullable NSString *)sourceApplication
                   annotation:(id)annotation;
 
-/**
- Configures the different AWSMobile SDK Clientsfrom application delegate with options.
-
- @param application instance from application delegate.
- @param launchOptions from application delegate.
- @param completionHandler completion handler for resuming auth session.
- 
- *Swift*
- 
- AWSMobileClient
-    .sharedInstance()
-    .interceptApplication(application,
-        didFinishLaunchingWithOptions:launchOptions,
-        resumeSessionWithCompletionHandler:completionHandler)
- 
- *Objective-C*
- 
- AWSMobileClient *mobileClient = [AWSMobileClient sharedInstance];
- [mobileClient interceptApplication:application
-      didFinishLaunchingWithOptions:launchOptions
- resumeSessionWithCompletionHandler:completionHandler];
- */
-- (BOOL)interceptApplication:(UIApplication *)application
-didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
-resumeSessionWithCompletionHandler:(void (^)(id result, NSError *error))completionHandler;
-
-/**
- Configures the different AWSMobile SDK Clientsfrom application delegate with options.
- 
- @param application instance from application delegate.
- @param launchOptions from application delegate.
- 
- *Swift*
- 
- AWSMobileClient
-    .sharedInstance()
-    .interceptApplication(application, didFinishLaunchingWithOptions:launchOptions)
- 
- *Objective-C*
- 
- AWSMobileClient *mobileClient = [AWSMobileClient sharedInstance];
- [mobileClient interceptApplication:application
-      didFinishLaunchingWithOptions:launchOptions];
- */
-- (BOOL)interceptApplication:(UIApplication *)application
-didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
-
-/**
- Set the signInProviderConfig
- 
- @param signInProviderConfig the signInProviderConfiguration with permissions.
- **/
-- (void)setSignInProviders:(nullable NSArray<AWSSignInProviderConfig *> *)signInProviderConfig;
-
 
 -(void)showSignInScreen:(UINavigationController *)navController
   signInUIConfiguration:(SignInUIOptions *)signInUIConfiguration
@@ -158,12 +104,6 @@ didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions;
  * @param credentialsProvider The CredentialsProvider supplied by the user
  */
 - (void)setCredentialsProvider:(AWSCognitoCredentialsProvider *)credentialsProvider;
-
-/**
- * Retrieve the Credentials Provider.
- * @return AWSCognitoCredentialsProvider
- */
-- (AWSCognitoCredentialsProvider *)getCredentialsProvider;
 
 /**
  * Indicates whether the user is signed-in or not.

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/_AWSMobileClient.m
@@ -111,31 +111,6 @@ Class AWSCognitoUserPoolsSignInProviderClass;
                                                         annotation:annotation];
 }
 
-- (BOOL)interceptApplication:(UIApplication *)application
-didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
-resumeSessionWithCompletionHandler:(void (^)(id result, NSError *error))completionHandler {
-    
-    AWSDDLogInfo(@"didFinishLaunching:withOptions:resumeSessionWithCompletionHandler:");
-    
-    if (self.signInProviderConfig == nil) {
-        [self registerConfigSignInProviders];
-    } else {
-        [self registerUserSignInProviders:self.signInProviderConfig];
-    }
-    
-    BOOL didFinishLaunching = [[AWSSignInManager sharedInstance]
-                               interceptApplication:application
-                               didFinishLaunchingWithOptions:launchOptions];;
-    
-    if (!_isInitialized) {
-        AWSDDLogInfo(@"Resuming any previously signed-in session");
-        [[AWSSignInManager sharedInstance] resumeSessionWithCompletionHandler:completionHandler];
-        _isInitialized = YES;
-    }
-    
-    return didFinishLaunching;
-}
-
 -(void)showSignInScreen:(UINavigationController *)navController
 signInUIConfiguration:(SignInUIOptions *)signInUIConfiguration
       completionHandler:(void (^)(NSString * _Nullable signInProviderKey, NSString * _Nullable signInProviderToken, NSError * _Nullable error))completionHandler {
@@ -291,25 +266,6 @@ signInUIConfiguration:(SignInUIOptions *)signInUIConfiguration
 
 - (BOOL)isLoggedIn {
     return [[AWSSignInManager sharedInstance] isLoggedIn];
-}
-
-- (AWSCognitoCredentialsProvider *)getCredentialsProvider {
-    return [[AWSIdentityManager defaultIdentityManager] credentialsProvider];
-}
-
-- (void)setSignInProviders:(nullable NSArray<AWSSignInProviderConfig *> *)signInProviderConfig {
-    self.signInProviderConfig = signInProviderConfig;
-}
-
-- (BOOL)interceptApplication:(UIApplication *)application
-didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions {
-    
-    return [self interceptApplication:application
-        didFinishLaunchingWithOptions:launchOptions
-   resumeSessionWithCompletionHandler:^(id result, NSError *error) {
-       AWSDDLogInfo(@"Welcome to AWS! You are connected successfully.");
-       AWSDDLogInfo(@"result = %@,error = %@", result, error);
-   }];
 }
 
 @end

--- a/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
+++ b/AWSAuthSDK/Tests/AWSMobileClientCustomEndpointTest/AWSMobileClientCustomEndpointTest.swift
@@ -16,7 +16,6 @@ class AWSMobileClientCustomEndpointTest: AWSMobileClientTestBase {
     }
 
     override func setUp() {
-        _ = AWSMobileClient.default().getCredentialsProvider()
         continueAfterFailure = false
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
--Features for next release
+### Misc. Updates
+- **AWSMobileClient**
+  - **Breaking API change** Removing the following deprecated methods:
+    - `interceptApplication(_:didFinishLaunchingWithOptions:)`
+    - `interceptApplication(_:didFinishLaunchingWithOptions:resumeSessionWithCompletionHandler:)`
+    - `setSignInProviders(_:)`
+    - `getCredentialsProvider()`
 
 ## 2.37.2
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5458

**Description of changes:**
Removing the following methods from `AWSMobileClient`:
  - `interceptApplication(_:didFinishLaunchingWithOptions:)`
  - `interceptApplication(_:didFinishLaunchingWithOptions:resumeSessionWithCompletionHandler:)`
  - `setSignInProviders(_:)`
  - `getCredentialsProvider()`

These were meant to be removed way back in [`2.11.0`](https://github.com/aws-amplify/aws-sdk-ios/releases/tag/2.11.0), but since they still exists in the Objective-C interface they were still accessible.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
