### PR TITLE
fix(IoT): Fixing a potential race condition in the timer ring queue

### DIFF
--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTTimerRing.h
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTTimerRing.h
@@ -1,0 +1,30 @@
+//
+// Copyright 2010-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A circular collection containing the messages that need to be retried at a given clock tick.
+/// The maximum number of ticks is 60
+@interface AWSMQTTTimerRing: NSObject
+
+- (void)addMsgId:(NSNumber *)msgId atTick:(NSUInteger)tick;
+- (void)removeMsgId:(NSNumber *)msgId atTick:(NSUInteger)tick;
+- (NSArray<NSNumber *> *)allMsgIdsAtTick:(NSUInteger)tick;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTTimerRing.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTTimerRing.m
@@ -1,0 +1,60 @@
+//
+// Copyright 2010-2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+#import "AWSMQTTTimerRing.h"
+
+@interface AWSMQTTTimerRing()
+
+@property (nonatomic, strong) NSLock *lock;
+// Array of 60, with each index being a tick, and its value a set containing the messages that need to be retried.
+@property (strong,atomic) NSMutableArray<NSMutableSet *>* timerRing;
+
+@end
+
+@implementation AWSMQTTTimerRing
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _lock = [[NSLock alloc] init];
+        _timerRing = [[NSMutableArray alloc] initWithCapacity:60];
+        int i;
+        for (i = 0; i < 60; i++) {
+            [_timerRing addObject:[NSMutableSet new]];
+        }
+    }
+    return self;
+}
+- (void)addMsgId:(NSNumber *)msgId atTick:(NSUInteger)tick {
+    [self.lock lock];
+    [[self.timerRing objectAtIndex:(tick % 60)] addObject:msgId];
+    [self.lock unlock];
+}
+
+- (void)removeMsgId:(NSNumber *)msgId atTick:(NSUInteger)tick {
+    [self.lock lock];
+    [[self.timerRing objectAtIndex:(tick % 60)] removeObject:msgId];
+    [self.lock unlock];
+}
+
+- (NSArray<NSNumber *> *)allMsgIdsAtTick:(NSUInteger)tick {
+    [self.lock lock];
+    NSArray<NSNumber *> *result = [[self.timerRing objectAtIndex:(tick % 60)] allObjects];
+    [self.lock unlock];
+    return result;
+}
+
+@end

--- a/AWSiOSSDKv2.xcodeproj/project.pbxproj
+++ b/AWSiOSSDKv2.xcodeproj/project.pbxproj
@@ -598,6 +598,8 @@
 		5C1590172755727C00F88085 /* AWSCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0D416D1C6A66E5006B91B5 /* AWSCore.framework */; };
 		5C1978DD2702364800F9C11E /* AWSLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1978DC2702364800F9C11E /* AWSLocationTests.swift */; };
 		5C71F33F295672B8001183A4 /* guten_tag.wav in Resources */ = {isa = PBXBuildFile; fileRef = 5C71F33E295672B8001183A4 /* guten_tag.wav */; };
+		685AA2112CDA7843008EFC7B /* AWSMQTTTimerRing.h in Headers */ = {isa = PBXBuildFile; fileRef = 685AA20F2CDA7843008EFC7B /* AWSMQTTTimerRing.h */; };
+		685AA2122CDA7843008EFC7B /* AWSMQTTTimerRing.m in Sources */ = {isa = PBXBuildFile; fileRef = 685AA2102CDA7843008EFC7B /* AWSMQTTTimerRing.m */; };
 		687952932B8FE2C5001E8990 /* AWSDDLog+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */; };
 		6883619E2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */; };
 		688361A12B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */; };
@@ -3215,6 +3217,8 @@
 		5C1978DB2702364800F9C11E /* AWSLocationTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AWSLocationTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5C1978DC2702364800F9C11E /* AWSLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLocationTests.swift; sourceTree = "<group>"; };
 		5C71F33E295672B8001183A4 /* guten_tag.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = guten_tag.wav; sourceTree = "<group>"; };
+		685AA20F2CDA7843008EFC7B /* AWSMQTTTimerRing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AWSMQTTTimerRing.h; sourceTree = "<group>"; };
+		685AA2102CDA7843008EFC7B /* AWSMQTTTimerRing.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSMQTTTimerRing.m; sourceTree = "<group>"; };
 		687952922B8FE2C5001E8990 /* AWSDDLog+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSDDLog+Optional.swift"; sourceTree = "<group>"; };
 		6883619D2B72D1C200D74FF4 /* AWSS3PreSignedURLBuilderUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSS3PreSignedURLBuilderUnitTests.swift; sourceTree = "<group>"; };
 		688361A02B73D25B00D74FF4 /* AWSIoTStreamThreadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AWSIoTStreamThreadTests.m; sourceTree = "<group>"; };
@@ -7244,6 +7248,8 @@
 				CE9DE6461C6A78D70060793F /* AWSMQTTSession.m */,
 				CE9DE6471C6A78D70060793F /* AWSMQttTxFlow.h */,
 				CE9DE6481C6A78D70060793F /* AWSMQttTxFlow.m */,
+				685AA20F2CDA7843008EFC7B /* AWSMQTTTimerRing.h */,
+				685AA2102CDA7843008EFC7B /* AWSMQTTTimerRing.m */,
 			);
 			path = MQTTSDK;
 			sourceTree = "<group>";
@@ -8455,6 +8461,7 @@
 			files = (
 				CE9DE6521C6A78D70060793F /* AWSIoTDataResources.h in Headers */,
 				CE9DE65A1C6A78D70060793F /* AWSIoTResources.h in Headers */,
+				685AA2112CDA7843008EFC7B /* AWSMQTTTimerRing.h in Headers */,
 				68EE1A6C2B713D8100B7CF41 /* AWSIoTStreamThread.h in Headers */,
 				CE9DE6231C6A78AF0060793F /* AWSIoT.h in Headers */,
 				CE9DE6561C6A78D70060793F /* AWSIoTManager.h in Headers */,
@@ -13398,6 +13405,7 @@
 				CE9DE66D1C6A78D70060793F /* AWSMQTTSession.m in Sources */,
 				CE9DE6551C6A78D70060793F /* AWSIoTDataService.m in Sources */,
 				0342776A269D185200379263 /* AWSIoTMessage+AWSMQTTMessage.m in Sources */,
+				685AA2122CDA7843008EFC7B /* AWSMQTTTimerRing.m in Sources */,
 				CE9DE66B1C6A78D70060793F /* AWSMQTTMessage.m in Sources */,
 				CE9DE65D1C6A78D70060793F /* AWSIoTService.m in Sources */,
 				68DD11872C5AF52B004E1C37 /* AWSIoTAtomicDictionary.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+
+- **AWSIoT** 
+  - Fixing a potential race condition in the timer ring queue (#5461)
 
 ## 2.38.0
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5436

**Description of changes:**
`AWSMQTTSession.timerRing` is a `NSArray` with each element being a `NSSet`. This can potentially cause a race condition that leads to a crash, if two different threads attempt to access/modify these collections at the same time.

I'm creating a new `AWSMQTTTimerRing` class that encapsulates these collections and protects their access with a `NSLock`, similar to what I previously did for `AWSIoTAtomicDictionary`


**Check points:**

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
