### PR TITLE
Fix reading content_length from DB in getTransferTaskDataFromDB

### DIFF
--- a/AWSS3/AWSS3TransferUtilityDatabaseHelper.m
+++ b/AWSS3/AWSS3TransferUtilityDatabaseHelper.m
@@ -326,7 +326,7 @@ NSString *const AWSS3TransferUtilityDatabaseName = @"transfer_utility_database";
             [transfer setObject:[rs stringForColumn:@"etag"] forKey:@"etag"];
             [transfer setObject:[AWSS3TransferUtilityDatabaseHelper absolutePathFromRelativePath:[rs stringForColumn:@"file"]] forKey:@"file"];
             [transfer setObject:@([rs intForColumn:@"temporary_file_created"]) forKey:@"temporary_file_created"];
-            [transfer setObject:@([rs intForColumn:@"content_length"]) forKey:@"content_length"];
+            [transfer setObject:@([rs longForColumn:@"content_length"]) forKey:@"content_length"];
             [transfer setObject:@([rs intForColumn:@"retry_count"]) forKey:@"retry_count"];
             [transfer setObject:[rs stringForColumn:@"request_headers"] forKey:@"request_headers"];
             [transfer setObject:[rs stringForColumn:@"request_parameters"] forKey:@"request_parameters"];


### PR DESCRIPTION
*Issue #, if available:*

At least partly addresses #5468 

*Description of changes:*

Fixes reading the `content_length` integer from DB. The content size can be greater than an `int`, so we should read it in a format that supports larger amounts.

See https://github.com/aws-amplify/aws-sdk-ios/issues/5468#issuecomment-2515024144 for screenshots/testing.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
