### PR TITLE
chore: Fixing AWSLex.podspec

### DIFF
--- a/AWSLex.podspec
+++ b/AWSLex.podspec
@@ -21,6 +21,9 @@ Pod::Spec.new do |s|
   s.resource_bundle = { 'AWSLex' => ['AWSLex/Media.xcassets', 'AWSLex/PrivacyInfo.xcprivacy'] }
   
   # Exclude arm64 when building for simulator on Xcode 12+
-  s.pod_target_xcconfig = {'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64',
+    'OTHER_LDFLAGS': '-ObjC -ld64'
+  }
 
 end


### PR DESCRIPTION
**Description of changes:**
This PR adds the necessary `-ld64`  flag to the `AWSLex` podspec, so it successfully builds in Xcode 15+

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
