### PR TITLE
fix(IoT): Fixing race conditions during cleanup in `AWSIoTStreamThread`

### DIFF
--- a/AWSIoT/Internal/AWSIoTStreamThread.h
+++ b/AWSIoT/Internal/AWSIoTStreamThread.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AWSIoTStreamThread : NSThread
 
-@property(strong, nullable) void (^onStop)(void);
+@property(nonatomic, copy, nullable) void (^onStop)(void);
 
 -(instancetype)initWithSession:(nonnull AWSMQTTSession *)session
             decoderInputStream:(nonnull NSInputStream *)decoderInputStream

--- a/AWSIoT/Internal/AWSIoTStreamThread.m
+++ b/AWSIoT/Internal/AWSIoTStreamThread.m
@@ -27,11 +27,16 @@
 @property(nonatomic, assign) NSTimeInterval defaultRunLoopTimeInterval;
 @property(nonatomic, assign) BOOL isRunning;
 @property(nonatomic, assign) BOOL shouldDisconnect;
+
+// Add synchronization primitives
+@property(nonatomic, strong) dispatch_queue_t cleanupQueue;
+@property(nonatomic, strong) dispatch_semaphore_t cleanupSemaphore;
+@property(nonatomic, assign) BOOL isCleaningUp;
 @end
 
 @implementation AWSIoTStreamThread
 
-- (nonnull instancetype)initWithSession:(nonnull AWSMQTTSession *)session
+- (nonnull instancetype)initWithSession:(nonnull AWSMQTTSession *)session 
                      decoderInputStream:(nonnull NSInputStream *)decoderInputStream
                     encoderOutputStream:(nonnull NSOutputStream *)encoderOutputStream {
     return [self initWithSession:session
@@ -40,10 +45,10 @@
                     outputStream:nil];
 }
 
--(instancetype)initWithSession:(nonnull AWSMQTTSession *)session
-            decoderInputStream:(nonnull NSInputStream *)decoderInputStream
-           encoderOutputStream:(nonnull NSOutputStream *)encoderOutputStream
-                  outputStream:(nullable NSOutputStream *)outputStream; {
+- (instancetype)initWithSession:(nonnull AWSMQTTSession *)session
+             decoderInputStream:(nonnull NSInputStream *)decoderInputStream
+            encoderOutputStream:(nonnull NSOutputStream *)encoderOutputStream
+                   outputStream:(nullable NSOutputStream *)outputStream {
     if (self = [super init]) {
         _session = session;
         _decoderInputStream = decoderInputStream;
@@ -51,103 +56,184 @@
         _outputStream = outputStream;
         _defaultRunLoopTimeInterval = 10;
         _shouldDisconnect = NO;
+        _isCleaningUp = NO;
+        
+        // Initialize synchronization primitives
+        _cleanupQueue = dispatch_queue_create("com.amazonaws.iot.streamthread.cleanup", DISPATCH_QUEUE_SERIAL);
+        _cleanupSemaphore = dispatch_semaphore_create(1);
     }
     return self;
 }
 
 - (void)main {
-    AWSDDLogVerbose(@"Started execution of Thread: [%@]", self);
-    //This is invoked in a new thread by the webSocketDidOpen method or by the Connect method. Get the runLoop from the thread.
-    self.runLoopForStreamsThread = [NSRunLoop currentRunLoop];
+    @autoreleasepool {
+        AWSDDLogVerbose(@"Started execution of Thread: [%@]", self);
+        
+        if (![self setupRunLoop]) {
+            AWSDDLogError(@"Failed to setup run loop for thread: [%@]", self);
+            return;
+        }
+        
+        [self startIOOperations];
+        
+        while ([self shouldContinueRunning]) {
+            @autoreleasepool {
+                [self.runLoopForStreamsThread runMode:NSDefaultRunLoopMode
+                                           beforeDate:[NSDate dateWithTimeIntervalSinceNow:self.defaultRunLoopTimeInterval]];
+            }
+        }
+        
+        [self performCleanup];
+        
+        AWSDDLogVerbose(@"Finished execution of Thread: [%@]", self);
+    }
+}
 
-    //Setup a default timer to ensure that the RunLoop always has atleast one timer on it. This is to prevent the while loop
-    //below to spin in tight loop when all input sources and session timers are shutdown during a reconnect sequence.
+- (BOOL)setupRunLoop {
+    if (self.isRunning) {
+        AWSDDLogError(@"Thread already running");
+        return NO;
+    }
+    
+    self.runLoopForStreamsThread = [NSRunLoop currentRunLoop];
+    
+    // Setup timer with weak reference to prevent retain cycles
+    __weak typeof(self) weakSelf = self;
     self.defaultRunLoopTimer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:60.0]
-                                                            interval:60.0
-                                                              target:self
-                                                            selector:@selector(timerHandler:)
-                                                            userInfo:nil
-                                                             repeats:YES];
+                                                        interval:60.0
+                                                          target:weakSelf
+                                                        selector:@selector(timerHandler:)
+                                                        userInfo:nil
+                                                         repeats:YES];
+    
+    if (!self.defaultRunLoopTimer) {
+        AWSDDLogError(@"Failed to create run loop timer");
+        return NO;
+    }
     [self.runLoopForStreamsThread addTimer:self.defaultRunLoopTimer
                                    forMode:NSDefaultRunLoopMode];
-
     self.isRunning = YES;
+    return YES;
+}
+
+- (void)startIOOperations {
     if (self.outputStream) {
         [self.outputStream scheduleInRunLoop:self.runLoopForStreamsThread
-                                        forMode:NSDefaultRunLoopMode];
+                                     forMode:NSDefaultRunLoopMode];
         [self.outputStream open];
     }
-
-    //Update the runLoop and runLoopMode in session.
     [self.session connectToInputStream:self.decoderInputStream
                           outputStream:self.encoderOutputStream];
+}
 
-    while (self.isRunning && !self.isCancelled) {
-        //This will continue run until the thread is cancelled
-        //Run one cycle of the runloop. This will return after a input source event or timer event is processed
-        [self.runLoopForStreamsThread runMode:NSDefaultRunLoopMode
-                                   beforeDate:[NSDate dateWithTimeIntervalSinceNow:self.defaultRunLoopTimeInterval]];
-    }
+- (BOOL)shouldContinueRunning {
+    __block BOOL shouldRun;
+    dispatch_sync(self.cleanupQueue, ^{
+        shouldRun = self.isRunning && !self.isCancelled && self.defaultRunLoopTimer != nil;
+    });
+    return shouldRun;
+}
 
-    [self cleanUp];
-
-    AWSDDLogVerbose(@"Finished execution of Thread: [%@]", self);
+- (void)invalidateTimer {
+    dispatch_sync(self.cleanupQueue, ^{
+        if (self.defaultRunLoopTimer) {
+            [self.defaultRunLoopTimer invalidate];
+            self.defaultRunLoopTimer = nil;
+        }
+    });
 }
 
 - (void)cancel {
     AWSDDLogVerbose(@"Issued Cancel on thread [%@]", (NSThread *)self);
-    self.isRunning = NO;
-    [super cancel];
+    [self cancelWithDisconnect:NO];
 }
 
 - (void)cancelAndDisconnect:(BOOL)shouldDisconnect {
-    AWSDDLogVerbose(@"Issued Cancel and Disconnect = [%@] on thread [%@]", shouldDisconnect ? @"YES" : @"NO", (NSThread *)self);
-    self.shouldDisconnect = shouldDisconnect;
-    self.isRunning = NO;
-    [super cancel];
+    AWSDDLogVerbose(@"Issued Cancel and Disconnect = [%@] on thread [%@]",
+                    shouldDisconnect ? @"YES" : @"NO", (NSThread *)self);
+    [self cancelWithDisconnect:shouldDisconnect];
 }
 
-- (void)cleanUp {
-    if (self.defaultRunLoopTimer) {
-        [self.defaultRunLoopTimer invalidate];
-        self.defaultRunLoopTimer = nil;
+- (void)cancelWithDisconnect:(BOOL)shouldDisconnect {
+    // Ensure thread-safe property updates
+    dispatch_sync(self.cleanupQueue, ^{
+        if (!self.isCleaningUp) {
+            self.shouldDisconnect = shouldDisconnect;
+            self.isRunning = NO;
+            [super cancel];
+            
+            // Invalidate timer to trigger run loop exit
+            [self invalidateTimer];
+        }
+    });
+}
+
+- (void)performCleanup {
+    dispatch_semaphore_wait(self.cleanupSemaphore, DISPATCH_TIME_FOREVER);
+    
+    if (self.isCleaningUp) {
+        dispatch_semaphore_signal(self.cleanupSemaphore);
+        return;
     }
+    
+    self.isCleaningUp = YES;
+    dispatch_semaphore_signal(self.cleanupSemaphore);
+    
+    dispatch_sync(self.cleanupQueue, ^{
+        [self cleanupResources];
+    });
+}
 
+- (void)cleanupResources {
     if (self.shouldDisconnect) {
-        if (self.session) {
-            [self.session close];
-            self.session = nil;
-        }
-
-        if (self.outputStream) {
-            self.outputStream.delegate = nil;
-            [self.outputStream close];
-            [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread
-                                         forMode:NSDefaultRunLoopMode];
-            self.outputStream = nil;
-        }
-
-        if (self.decoderInputStream) {
-            [self.decoderInputStream close];
-            self.decoderInputStream = nil;
-        }
-
-        if (self.encoderOutputStream) {
-            [self.encoderOutputStream close];
-            self.encoderOutputStream = nil;
-        }
+        [self closeSession];
+        [self closeStreams];
     } else {
         AWSDDLogVerbose(@"Skipping disconnect for thread: [%@]", (NSThread *)self);
     }
-
-    if (self.onStop) {
-        self.onStop();
+    
+    // Handle onStop callback
+    dispatch_block_t stopBlock = self.onStop;
+    if (stopBlock) {
         self.onStop = nil;
+        stopBlock();
+    }
+}
+
+- (void)closeSession {
+    if (self.session) {
+        [self.session close];
+        self.session = nil;
+    }
+}
+
+- (void)closeStreams {
+    if (self.outputStream) {
+        self.outputStream.delegate = nil;
+        [self.outputStream close];
+        [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread
+                                     forMode:NSDefaultRunLoopMode];
+        self.outputStream = nil;
+    }
+    
+    if (self.decoderInputStream) {
+        [self.decoderInputStream close];
+        self.decoderInputStream = nil;
+    }
+    
+    if (self.encoderOutputStream) {
+        [self.encoderOutputStream close];
+        self.encoderOutputStream = nil;
     }
 }
 
 - (void)timerHandler:(NSTimer*)theTimer {
-    AWSDDLogVerbose(@"Default run loop timer executed on Thread: [%@]. isRunning = %@. isCancelled = %@", self, self.isRunning ? @"YES" : @"NO", self.isCancelled ? @"YES" : @"NO");
+    AWSDDLogVerbose(@"Default run loop timer executed on Thread: [%@]. isRunning = %@. isCancelled = %@",
+                    self, self.isRunning ? @"YES" : @"NO", self.isCancelled ? @"YES" : @"NO");
+}
+
+- (void)dealloc {
+    AWSDDLogVerbose(@"Deallocating AWSIoTStreamThread: [%@]", self);
 }
 
 @end

--- a/AWSIoT/Internal/AWSIoTStreamThread.m
+++ b/AWSIoT/Internal/AWSIoTStreamThread.m
@@ -27,16 +27,13 @@
 @property(nonatomic, assign) NSTimeInterval defaultRunLoopTimeInterval;
 @property(nonatomic, assign) BOOL isRunning;
 @property(nonatomic, assign) BOOL shouldDisconnect;
-
-// Add synchronization primitives
-@property(nonatomic, strong) dispatch_queue_t cleanupQueue;
-@property(nonatomic, strong) dispatch_semaphore_t cleanupSemaphore;
-@property(nonatomic, assign) BOOL isCleaningUp;
+@property(nonatomic, strong) dispatch_queue_t serialQueue;
+@property(nonatomic, assign) BOOL didCleanUp;
 @end
 
 @implementation AWSIoTStreamThread
 
-- (nonnull instancetype)initWithSession:(nonnull AWSMQTTSession *)session 
+- (nonnull instancetype)initWithSession:(nonnull AWSMQTTSession *)session
                      decoderInputStream:(nonnull NSInputStream *)decoderInputStream
                     encoderOutputStream:(nonnull NSOutputStream *)encoderOutputStream {
     return [self initWithSession:session
@@ -56,184 +53,127 @@
         _outputStream = outputStream;
         _defaultRunLoopTimeInterval = 10;
         _shouldDisconnect = NO;
-        _isCleaningUp = NO;
-        
-        // Initialize synchronization primitives
-        _cleanupQueue = dispatch_queue_create("com.amazonaws.iot.streamthread.cleanup", DISPATCH_QUEUE_SERIAL);
-        _cleanupSemaphore = dispatch_semaphore_create(1);
+        _serialQueue = dispatch_queue_create("com.amazonaws.iot.streamthread.syncQueue", DISPATCH_QUEUE_SERIAL);
+        _didCleanUp = NO;
     }
     return self;
 }
 
 - (void)main {
-    @autoreleasepool {
-        AWSDDLogVerbose(@"Started execution of Thread: [%@]", self);
-        
-        if (![self setupRunLoop]) {
-            AWSDDLogError(@"Failed to setup run loop for thread: [%@]", self);
-            return;
-        }
-        
-        [self startIOOperations];
-        
-        while ([self shouldContinueRunning]) {
-            @autoreleasepool {
-                [self.runLoopForStreamsThread runMode:NSDefaultRunLoopMode
-                                           beforeDate:[NSDate dateWithTimeIntervalSinceNow:self.defaultRunLoopTimeInterval]];
-            }
-        }
-        
-        [self performCleanup];
-        
-        AWSDDLogVerbose(@"Finished execution of Thread: [%@]", self);
-    }
-}
-
-- (BOOL)setupRunLoop {
     if (self.isRunning) {
-        AWSDDLogError(@"Thread already running");
-        return NO;
+        AWSDDLogWarn(@"Attempted to start a thread that is already running: [%@]", self);
+        return;
     }
-    
+
+    AWSDDLogVerbose(@"Started execution of Thread: [%@]", self);
+    //This is invoked in a new thread by the webSocketDidOpen method or by the Connect method. Get the runLoop from the thread.
     self.runLoopForStreamsThread = [NSRunLoop currentRunLoop];
-    
-    // Setup timer with weak reference to prevent retain cycles
+
+    //Setup a default timer to ensure that the RunLoop always has atleast one timer on it. This is to prevent the while loop
+    //below to spin in tight loop when all input sources and session timers are shutdown during a reconnect sequence.
     __weak typeof(self) weakSelf = self;
     self.defaultRunLoopTimer = [[NSTimer alloc] initWithFireDate:[NSDate dateWithTimeIntervalSinceNow:60.0]
                                                         interval:60.0
-                                                          target:weakSelf
-                                                        selector:@selector(timerHandler:)
-                                                        userInfo:nil
-                                                         repeats:YES];
-    
-    if (!self.defaultRunLoopTimer) {
-        AWSDDLogError(@"Failed to create run loop timer");
-        return NO;
-    }
+                                                         repeats:YES
+                                                           block:^(NSTimer * _Nonnull timer) {
+        AWSDDLogVerbose(@"Default run loop timer executed on Thread: [%@]. isRunning = %@. isCancelled = %@", weakSelf, weakSelf.isRunning ? @"YES" : @"NO", weakSelf.isCancelled ? @"YES" : @"NO");
+    }];
     [self.runLoopForStreamsThread addTimer:self.defaultRunLoopTimer
                                    forMode:NSDefaultRunLoopMode];
-    self.isRunning = YES;
-    return YES;
-}
 
-- (void)startIOOperations {
+    self.isRunning = YES;
     if (self.outputStream) {
         [self.outputStream scheduleInRunLoop:self.runLoopForStreamsThread
-                                     forMode:NSDefaultRunLoopMode];
+                                        forMode:NSDefaultRunLoopMode];
         [self.outputStream open];
     }
+
+    //Update the runLoop and runLoopMode in session.
     [self.session connectToInputStream:self.decoderInputStream
                           outputStream:self.encoderOutputStream];
+
+    while ([self shouldContinueRunning]) {
+        //This will continue run until the thread is cancelled
+        //Run one cycle of the runloop. This will return after a input source event or timer event is processed
+        [self.runLoopForStreamsThread runMode:NSDefaultRunLoopMode
+                                   beforeDate:[NSDate dateWithTimeIntervalSinceNow:self.defaultRunLoopTimeInterval]];
+    }
+
+    [self cleanUp];
+
+    AWSDDLogVerbose(@"Finished execution of Thread: [%@]", self);
 }
 
 - (BOOL)shouldContinueRunning {
     __block BOOL shouldRun;
-    dispatch_sync(self.cleanupQueue, ^{
+    dispatch_sync(self.serialQueue, ^{
         shouldRun = self.isRunning && !self.isCancelled && self.defaultRunLoopTimer != nil;
     });
     return shouldRun;
 }
 
-- (void)invalidateTimer {
-    dispatch_sync(self.cleanupQueue, ^{
+- (void)cancel {
+    AWSDDLogVerbose(@"Issued Cancel on thread [%@]", (NSThread *)self);
+    dispatch_sync(self.serialQueue, ^{
+        self.isRunning = NO;
+        [super cancel];
+    });
+}
+
+- (void)cancelAndDisconnect:(BOOL)shouldDisconnect {
+    AWSDDLogVerbose(@"Issued Cancel and Disconnect = [%@] on thread [%@]", shouldDisconnect ? @"YES" : @"NO", (NSThread *)self);
+    dispatch_sync(self.serialQueue, ^{
+        self.shouldDisconnect = shouldDisconnect;
+        self.isRunning = NO;
+        [super cancel];
+    });
+}
+
+- (void)cleanUp {
+    dispatch_sync(self.serialQueue, ^{
+        if (self.didCleanUp) {
+            AWSDDLogVerbose(@"Clean up already called for thread: [%@]", (NSThread *)self);
+            return;
+        }
+
+        self.didCleanUp = YES;
         if (self.defaultRunLoopTimer) {
             [self.defaultRunLoopTimer invalidate];
             self.defaultRunLoopTimer = nil;
         }
-    });
-}
 
-- (void)cancel {
-    AWSDDLogVerbose(@"Issued Cancel on thread [%@]", (NSThread *)self);
-    [self cancelWithDisconnect:NO];
-}
+        if (self.shouldDisconnect) {
+            if (self.session) {
+                [self.session close];
+                self.session = nil;
+            }
 
-- (void)cancelAndDisconnect:(BOOL)shouldDisconnect {
-    AWSDDLogVerbose(@"Issued Cancel and Disconnect = [%@] on thread [%@]",
-                    shouldDisconnect ? @"YES" : @"NO", (NSThread *)self);
-    [self cancelWithDisconnect:shouldDisconnect];
-}
+            if (self.outputStream) {
+                self.outputStream.delegate = nil;
+                [self.outputStream close];
+                [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread
+                                             forMode:NSDefaultRunLoopMode];
+                self.outputStream = nil;
+            }
 
-- (void)cancelWithDisconnect:(BOOL)shouldDisconnect {
-    // Ensure thread-safe property updates
-    dispatch_sync(self.cleanupQueue, ^{
-        if (!self.isCleaningUp) {
-            self.shouldDisconnect = shouldDisconnect;
-            self.isRunning = NO;
-            [super cancel];
-            
-            // Invalidate timer to trigger run loop exit
-            [self invalidateTimer];
+            if (self.decoderInputStream) {
+                [self.decoderInputStream close];
+                self.decoderInputStream = nil;
+            }
+
+            if (self.encoderOutputStream) {
+                [self.encoderOutputStream close];
+                self.encoderOutputStream = nil;
+            }
+        } else {
+            AWSDDLogVerbose(@"Skipping disconnect for thread: [%@]", (NSThread *)self);
+        }
+
+        if (self.onStop) {
+            self.onStop();
+            self.onStop = nil;
         }
     });
-}
-
-- (void)performCleanup {
-    dispatch_semaphore_wait(self.cleanupSemaphore, DISPATCH_TIME_FOREVER);
-    
-    if (self.isCleaningUp) {
-        dispatch_semaphore_signal(self.cleanupSemaphore);
-        return;
-    }
-    
-    self.isCleaningUp = YES;
-    dispatch_semaphore_signal(self.cleanupSemaphore);
-    
-    dispatch_sync(self.cleanupQueue, ^{
-        [self cleanupResources];
-    });
-}
-
-- (void)cleanupResources {
-    if (self.shouldDisconnect) {
-        [self closeSession];
-        [self closeStreams];
-    } else {
-        AWSDDLogVerbose(@"Skipping disconnect for thread: [%@]", (NSThread *)self);
-    }
-    
-    // Handle onStop callback
-    dispatch_block_t stopBlock = self.onStop;
-    if (stopBlock) {
-        self.onStop = nil;
-        stopBlock();
-    }
-}
-
-- (void)closeSession {
-    if (self.session) {
-        [self.session close];
-        self.session = nil;
-    }
-}
-
-- (void)closeStreams {
-    if (self.outputStream) {
-        self.outputStream.delegate = nil;
-        [self.outputStream close];
-        [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread
-                                     forMode:NSDefaultRunLoopMode];
-        self.outputStream = nil;
-    }
-    
-    if (self.decoderInputStream) {
-        [self.decoderInputStream close];
-        self.decoderInputStream = nil;
-    }
-    
-    if (self.encoderOutputStream) {
-        [self.encoderOutputStream close];
-        self.encoderOutputStream = nil;
-    }
-}
-
-- (void)timerHandler:(NSTimer*)theTimer {
-    AWSDDLogVerbose(@"Default run loop timer executed on Thread: [%@]. isRunning = %@. isCancelled = %@",
-                    self, self.isRunning ? @"YES" : @"NO", self.isCancelled ? @"YES" : @"NO");
-}
-
-- (void)dealloc {
-    AWSDDLogVerbose(@"Deallocating AWSIoTStreamThread: [%@]", self);
 }
 
 @end

--- a/AWSIoTUnitTests/AWSIoTStreamThreadTests.m
+++ b/AWSIoTUnitTests/AWSIoTStreamThreadTests.m
@@ -134,7 +134,7 @@
     XCTAssertFalse(didInvokeOutputStreamClose, @"The `close` method on `outputStream` should not be invoked");
 }
 
-- (void)testCancelAndDisconnect_shouldSeDidCleanUp_andInvalidateTimer {
+- (void)testCancelAndDisconnect_shouldSetDidCleanUp_andInvalidateTimer {
     XCTestExpectation *stopExpectation = [self expectationWithDescription:@"AWSIoTStreamThread.onStop expectation"];
     self.thread.onStop = ^{
         [stopExpectation fulfill];

--- a/AWSIoTUnitTests/AWSIoTStreamThreadTests.m
+++ b/AWSIoTUnitTests/AWSIoTStreamThreadTests.m
@@ -18,7 +18,17 @@
 #import "AWSIoTStreamThread.h"
 
 @interface AWSIoTStreamThread()
+
 @property(nonatomic, assign) NSTimeInterval defaultRunLoopTimeInterval;
+@property (nonatomic, assign) BOOL isRunning;
+@property (nonatomic, strong) dispatch_queue_t cleanupQueue;
+@property (nonatomic, assign) BOOL isCleaningUp;
+@property (nonatomic, strong, nullable) NSTimer *defaultRunLoopTimer;
+@property (nonatomic, strong, nullable) NSRunLoop *runLoopForStreamsThread;
+
+- (void)invalidateTimer;
+
+
 @end
 
 
@@ -51,11 +61,13 @@
                                           encoderOutputStream:self.encoderOutputStream
                                                  outputStream:self.outputStream];
     self.thread.defaultRunLoopTimeInterval = 0.1;
+
     [self.thread start];
     [self waitForExpectations:@[startExpectation] timeout:1];
 }
 
 - (void)tearDown {
+    [self.thread cancelAndDisconnect:YES];
     self.thread = nil;
     self.session = nil;
     self.decoderInputStream = nil;
@@ -67,6 +79,7 @@
 /// When: The thread is started
 /// Then: The output stream is opened and the session is connected to the decoder and encoder streams
 - (void)testStart_shouldOpenStream_andInvokeConnectOnSession {
+    OCMVerify([self.outputStream scheduleInRunLoop:[OCMArg any] forMode:NSDefaultRunLoopMode]);
     OCMVerify([self.outputStream open]);
     OCMVerify([self.session connectToInputStream:[OCMArg any] outputStream:[OCMArg any]]);
 }
@@ -87,44 +100,112 @@
     OCMVerify([self.encoderOutputStream close]);
     OCMVerify([self.outputStream close]);
     OCMVerify([self.session close]);
+    XCTAssertFalse(self.thread.isRunning);
 }
 
 /// Given: A running AWSIoTStreamThread
 /// When: The thread is cancelled with disconnect set to NO
 /// Then: Neither the session nor the streams are closed
 - (void)testCancel_shouldNotCloseStreams_andInvokeOnStop {
+   XCTestExpectation *stopExpectation = [self expectationWithDescription:@"AWSIoTStreamThread.onStop expectation"];
+   self.thread.onStop = ^{
+       [stopExpectation fulfill];
+   };
+
+   __block BOOL didInvokeSessionClose = NO;
+   OCMStub([self.session close]).andDo(^(NSInvocation *invocation) {
+       didInvokeSessionClose = YES;
+   });
+
+   __block BOOL didInvokeDecoderInputStreamClose = NO;
+   OCMStub([self.decoderInputStream close]).andDo(^(NSInvocation *invocation) {
+       didInvokeDecoderInputStreamClose = YES;
+   });
+
+   __block BOOL didInvokeEncoderOutputStreamClose = NO;
+   OCMStub([self.encoderOutputStream close]).andDo(^(NSInvocation *invocation) {
+       didInvokeEncoderOutputStreamClose = YES;
+   });
+
+   __block BOOL didInvokeOutputStreamClose = NO;
+   OCMStub([self.outputStream close]).andDo(^(NSInvocation *invocation) {
+       didInvokeOutputStreamClose = YES;
+   });
+
+   [self.thread cancelAndDisconnect:NO];
+   [self waitForExpectations:@[stopExpectation] timeout:1];
+
+   XCTAssertFalse(didInvokeSessionClose, @"The `close` method on `session` should not be invoked");
+   XCTAssertFalse(didInvokeDecoderInputStreamClose, @"The `close` method on `decoderInputStream` should not be invoked");
+   XCTAssertFalse(didInvokeEncoderOutputStreamClose, @"The `close` method on `encoderOutputStream` should not be invoked");
+   XCTAssertFalse(didInvokeOutputStreamClose, @"The `close` method on `outputStream` should not be invoked");
+}
+
+- (void)testCancelAndDisconnect_shouldSetIsCleaningUp {
     XCTestExpectation *stopExpectation = [self expectationWithDescription:@"AWSIoTStreamThread.onStop expectation"];
     self.thread.onStop = ^{
         [stopExpectation fulfill];
     };
 
-    __block BOOL didInvokeSessionClose = NO;
-    [OCMStub([self.session close]) andDo:^(NSInvocation *invocation) {
-        didInvokeSessionClose = YES;
-    }];
+    [self.thread cancelAndDisconnect:YES];
 
-    __block BOOL didInvokeDecoderInputStreamClose = NO;
-    [OCMStub([self.decoderInputStream close]) andDo:^(NSInvocation *invocation) {
-        didInvokeDecoderInputStreamClose = YES;
-    }];
+    __block BOOL isCleaningUp;
+    dispatch_sync(self.thread.cleanupQueue, ^{
+        isCleaningUp = self.thread.isCleaningUp;
+    });
 
-    __block BOOL didInvokeEncoderDecoderInputStreamClose = NO;
-    [OCMStub([self.encoderOutputStream close]) andDo:^(NSInvocation *invocation) {
-        didInvokeEncoderDecoderInputStreamClose = YES;
-    }];
-
-    __block BOOL didInvokeOutputStreamClose = NO;
-    [OCMStub([self.outputStream close]) andDo:^(NSInvocation *invocation) {
-        didInvokeOutputStreamClose = YES;
-    }];
-
-    [self.thread cancelAndDisconnect:NO];
+    XCTAssertTrue(isCleaningUp, @"isCleaningUp should be YES during cleanup");
     [self waitForExpectations:@[stopExpectation] timeout:1];
+}
 
-    XCTAssertFalse(didInvokeSessionClose);
-    XCTAssertFalse(didInvokeDecoderInputStreamClose);
-    XCTAssertFalse(didInvokeEncoderDecoderInputStreamClose);
-    XCTAssertFalse(didInvokeOutputStreamClose);
+- (void)testInvalidateTimer_shouldInvalidateAndSetTimerToNil {
+    [self.thread invalidateTimer];
+
+    __block BOOL isTimerInvalidated = NO;
+    OCMStub([self.thread.defaultRunLoopTimer invalidate]).andDo(^(NSInvocation *invocation) {
+        isTimerInvalidated = YES;
+    });
+
+    XCTAssertNil(self.thread.defaultRunLoopTimer, @"defaultRunLoopTimer should be nil after invalidation");
+    XCTAssertTrue(isTimerInvalidated, @"Timer invalidate method should have been called");
+}
+
+- (void)testRunLoop_shouldInvokeRunModeBeforeDate {
+    id mockRunLoop = OCMClassMock([NSRunLoop class]);
+    OCMStub([mockRunLoop runMode:NSDefaultRunLoopMode beforeDate:[OCMArg any]]);
+
+    // Replace the real run loop with the mock
+    self.thread.runLoopForStreamsThread = mockRunLoop;
+
+    // Let the thread run for a brief moment
+    XCTestExpectation *runLoopExpectation = [self expectationWithDescription:@"RunLoop expectation"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self.thread cancelAndDisconnect:YES];
+        [runLoopExpectation fulfill];
+    });
+
+    [self waitForExpectations:@[runLoopExpectation] timeout:1];
+
+    OCMVerify([mockRunLoop runMode:NSDefaultRunLoopMode beforeDate:[OCMArg any]]);
+    [mockRunLoop stopMocking];
+}
+
+- (void)testCancelAndDisconnect_shouldSynchronizeOnCleanupQueue {
+    XCTestExpectation *stopExpectation = [self expectationWithDescription:@"AWSIoTStreamThread.onStop expectation"];
+    self.thread.onStop = ^{
+        [stopExpectation fulfill];
+    };
+
+    [self.thread cancelAndDisconnect:YES];
+
+    // Validate synchronization
+    __block BOOL didSynchronize = NO;
+    dispatch_sync(self.thread.cleanupQueue, ^{
+        didSynchronize = YES;
+    });
+
+    XCTAssertTrue(didSynchronize, @"The cleanupQueue should synchronize the operations");
+    [self waitForExpectations:@[stopExpectation] timeout:1];
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Bug Fixes
 
 - **AWSIoT** 
-  - Fixing a race condition when invalidating/creating the reconnect timer (#5454)
-  - Fixing a potential race condition in the timer ring queue (#5461)
+  - Fixing race conditions during cleanup in `AWSIoTStreamThread` (#5477)
+  - Fixing a race condition when invalidating/creating the reconnect timer in `AWSIoTMQTTClient` (#5454)
+  - Fixing a potential race condition in the timer ring queue in `AWSMQTTSession` (#5461)
 
 ## 2.38.0
 


### PR DESCRIPTION
**Issue #, if available:**
- https://github.com/aws-amplify/aws-sdk-ios/issues/5452

**Description of changes:**

This PR works on top of https://github.com/aws-amplify/aws-sdk-ios/pull/5469 to address the issues that caused the unit tests to crash/fail.

The overall changes include:
- Adding a serial dispatch queue to synchronize the reading and writing of internal properties
- Fixing a retain cycle with the NSTimer
- Adding validations to prevent multiple starts or cleanups

*Check points:*

- [X] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
