### PR TITLE
fix: correctly cleaning up the websocket stream

### DIFF
--- a/AWSIoT/Internal/AWSIoTStreamThread.m
+++ b/AWSIoT/Internal/AWSIoTStreamThread.m
@@ -148,7 +148,12 @@
                 self.session = nil;
             }
 
-            if (self.outputStream) {
+             // Before cleaning up the output stream, we must apply stricter stream status checks to avoid possible cocurrent access issue, because the same stream object is possible to be shared in mutliple threads.
+            if (
+                self.outputStream && 
+                self.outputStream.delegate && 
+                (self.outputStream.streamStatus != NSStreamStatusNotOpen && self.outputStream.streamStatus != NSStreamStatusClosed)
+            ) {
                 self.outputStream.delegate = nil;
                 [self.outputStream close];
                 [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread

--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTEncoder.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTEncoder.m
@@ -44,10 +44,13 @@
 }
 
 - (void)close {
-    AWSDDLogDebug(@"closing encoder stream.");
-    [self.stream close];
-    [self.stream setDelegate:nil];
-    self.stream = nil;
+    // Before cleaning up the stream, we must apply stricter stream status checks to avoid possible cocurrent access issue, because the same stream object is possible to be shared in multiple threads.
+    if (self.stream && self.stream.delegate && (self.stream.streamStatus != NSStreamStatusNotOpen && self.stream.streamStatus != NSStreamStatusClosed)) {
+        AWSDDLogDebug(@"closing encoder stream.");
+        self.stream.delegate = nil;
+        [self.stream close];
+        self.stream = nil;
+    }
 }
 
 //This is executed in the runLoop.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
**The issue we're suffering from:**
Currently we found there're many crashes in our iOS app which are related to the `AWSIoT` lib when it's cleaning up the websocket streams, after dig into the relevant source code, I think the possible reason for those crashes is that the lib code doesn't put enough consideration for the situation where the created websocket stream is shared by mutiple threads, meanwhile, more than one thread have the method to perform the cleaning job for that websocket stream, and moreover, they don't check the stream status, that would cause the same websocket stream to be cleaned more than one time, then the app crash happens. The below screenshot shows some crash reports.
<img width="994" alt="image" src="https://github.com/user-attachments/assets/be283271-e538-4764-abdf-6cea6df540eb" />


**The changes implemented in this PR**
- Imposing stricter status check before cleaning the associated stream object, to ensure the stream will only be cleaned one time.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
