### PR TITLE
fix(AWSLocation): Fixing clock skew retries

### DIFF
--- a/.github/workflows/integ-test.yml
+++ b/.github/workflows/integ-test.yml
@@ -47,6 +47,7 @@ jobs:
           - AWSKinesisVideoSignaling
           - AWSLambda
           - AWSLex
+          - AWSLocation
           - AWSPinpoint
           - AWSPolly
           - AWSRekognition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--Features for next release
+### Bug Fixes
+- **AWSLocation** 
+  - Fixing clock skew retries (#5491)
 
 ## 2.39.0
 


### PR DESCRIPTION
**Description of changes:**

This PR fixes the retry mechanism when dealing with clock skews in **AWSLocation**. The logic is actually implemented in the `AWSURLRequestRetryHandler`, but it depends on [both the error domain and code to be from `AWSService` itself](https://github.com/aws-amplify/aws-sdk-ios/blob/main/AWSCore/Serialization/AWSURLRequestRetryHandler.m#L37-L38).

Because the `AWSLocation` service defines its own error domain and codes, the conditions were never met and `isClockSkewError` always evaluated to `false`.

So I've just added some code to handle cases in which the error can be mapped to a "vanilla" `AWSService` error instead, which then makes the retry mechanism work.

**Note:** This is actually affecting every AWS service that defines its own set of errors and does not override the proper methods in `AWSURLRequestRetryHandler`. It should be fixed 

*Check points:*

- [ ] Added new tests to cover change, if needed
- [X] All unit tests pass
- [X] All integration tests pass
- [X] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [X] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
