### PR TITLE
AWSGoogleSignIn upgrade to GoogleSignIn 8.0.0

### DIFF
--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDConfiguration.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDConfiguration.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// This class represents the client configuration provided by the developer.
+@interface GIDConfiguration : NSObject <NSCopying, NSSecureCoding>
+
+/// The client ID of the app from the Google Cloud Console.
+@property(nonatomic, readonly) NSString *clientID;
+
+/// The client ID of the home server.  This will be returned as the `audience` property of the
+/// OpenID Connect ID token.  For more info on the ID token:
+/// https://developers.google.com/identity/sign-in/ios/backend-auth
+@property(nonatomic, readonly, nullable) NSString *serverClientID;
+
+/// The Google Apps domain to which users must belong to sign in.  To verify, check
+/// `GIDGoogleUser`'s `hostedDomain` property.
+@property(nonatomic, readonly, nullable) NSString *hostedDomain;
+
+/// The OpenID2 realm of the home server. This allows Google to include the user's OpenID
+/// Identifier in the OpenID Connect ID token.
+@property(nonatomic, readonly, nullable) NSString *openIDRealm;
+
+/// Unavailable.  Please use `initWithClientID:` or one of the other initializers below.
+/// :nodoc:
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Unavailable.  Please use `initWithClientID:` or one of the other initializers below.
+/// :nodoc:
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Initialize a `GIDConfiguration` object with a client ID.
+///
+/// @param clientID The client ID of the app.
+/// @return An initialized `GIDConfiguration` instance.
+- (instancetype)initWithClientID:(NSString *)clientID;
+
+/// Initialize a `GIDConfiguration` object with a client ID and server client ID.
+///
+/// @param clientID The client ID of the app.
+/// @param serverClientID The server's client ID.
+/// @return An initialized `GIDConfiguration` instance.
+- (instancetype)initWithClientID:(NSString *)clientID
+                  serverClientID:(nullable NSString *)serverClientID;
+
+/// Initialize a `GIDConfiguration` object by specifying all available properties.
+///
+/// @param clientID The client ID of the app.
+/// @param serverClientID The server's client ID.
+/// @param hostedDomain The Google Apps domain to be used.
+/// @param openIDRealm The OpenID realm to be used.
+/// @return An initialized `GIDConfiguration` instance.
+- (instancetype)initWithClientID:(NSString *)clientID
+                  serverClientID:(nullable NSString *)serverClientID
+                    hostedDomain:(nullable NSString *)hostedDomain
+                     openIDRealm:(nullable NSString *)openIDRealm NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDGoogleUser.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDGoogleUser.h
@@ -1,39 +1,114 @@
 /*
- * GIDGoogleUser.h
- * Google Sign-In iOS SDK
+ * Copyright 2022 Google LLC
  *
- * Copyright 2014 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Use of this SDK is subject to the Google APIs Terms of Service:
- * https://developers.google.com/terms/
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #import <Foundation/Foundation.h>
+#import <TargetConditionals.h>
 
-@class GIDAuthentication;
+#if __has_include(<UIKit/UIKit.h>)
+#import <UIKit/UIKit.h>
+#elif __has_include(<AppKit/AppKit.h>)
+#import <AppKit/AppKit.h>
+#endif
+
+
+@class GIDConfiguration;
+@class GIDSignInResult;
+@class GIDToken;
 @class GIDProfileData;
 
-/// This class represents a user account.
+NS_ASSUME_NONNULL_BEGIN
+
+/// This class represents a signed-in user.
 @interface GIDGoogleUser : NSObject <NSSecureCoding>
 
 /// The Google user ID.
-@property(nonatomic, readonly) NSString *userID;
+@property(nonatomic, readonly, nullable) NSString *userID;
 
-/// Representation of the Basic profile data. It is only available if
-/// `GIDSignIn.shouldFetchBasicProfile` is set and either `-[GIDSignIn signIn]` or
-/// `-[GIDSignIn restorePreviousSignIn]` has been completed successfully.
-@property(nonatomic, readonly) GIDProfileData *profile;
+/// The basic profile data for the user.
+@property(nonatomic, readonly, nullable) GIDProfileData *profile;
 
-/// The authentication object for the user.
-@property(nonatomic, readonly) GIDAuthentication *authentication;
+/// The OAuth2 scopes granted to the app in an array of `NSString`.
+@property(nonatomic, readonly, nullable) NSArray<NSString *> *grantedScopes;
 
-/// The API scopes granted to the app in an array of `NSString`.
-@property(nonatomic, readonly) NSArray *grantedScopes;
+/// The configuration that was used to sign in this user.
+@property(nonatomic, readonly) GIDConfiguration *configuration;
 
-/// For Google Apps hosted accounts, the domain of the user.
-@property(nonatomic, readonly) NSString *hostedDomain;
+/// The OAuth2 access token to access Google services.
+@property(nonatomic, readonly) GIDToken *accessToken;
 
-/// An OAuth2 authorization code for the home server.
-@property(nonatomic, readonly) NSString *serverAuthCode;
+/// The OAuth2 refresh token to exchange for new access tokens.
+@property(nonatomic, readonly) GIDToken *refreshToken;
+
+/// The OpenID Connect ID token that identifies the user.
+///
+/// Send this token to your server to authenticate the user there. For more information on this topic,
+/// see https://developers.google.com/identity/sign-in/ios/backend-auth.
+@property(nonatomic, readonly, nullable) GIDToken *idToken;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+/// The authorizer for use with `GTLRService`, `GTMSessionFetcher`, or `GTMHTTPFetcher`.
+// @property(nonatomic, readonly) id<GTMFetcherAuthorizationProtocol> fetcherAuthorizer;
+#pragma clang diagnostic pop
+
+/// Refresh the user's access and ID tokens if they have expired or are about to expire.
+///
+/// @param completion A completion block that takes a `GIDGoogleUser` or an error if the attempt to
+///     refresh tokens was unsuccessful.  The block will be called asynchronously on the main queue.
+- (void)refreshTokensIfNeededWithCompletion:(void (^)(GIDGoogleUser *_Nullable user,
+                                                      NSError *_Nullable error))completion;
+
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
+
+/// Starts an interactive consent flow on iOS to add new scopes to the user's `grantedScopes`.
+///
+/// The completion will be called at the end of this process.  If successful, a `GIDSignInResult`
+/// instance will be returned reflecting the new scopes and saved sign-in state will be updated.
+///
+/// @param scopes The scopes to ask the user to consent to.
+/// @param presentingViewController The view controller used to present `SFSafariViewController` on
+///     iOS 9 and 10 and to supply `presentationContextProvider` for `ASWebAuthenticationSession` on
+///     iOS 13+.
+/// @param completion The optional block that is called on completion.  This block will be called
+///     asynchronously on the main queue.
+- (void)addScopes:(NSArray<NSString *> *)scopes
+    presentingViewController:(UIViewController *)presentingViewController
+                  completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                                NSError *_Nullable error))completion
+    NS_EXTENSION_UNAVAILABLE("The add scopes flow is not supported in App Extensions.");
+
+#elif TARGET_OS_OSX
+
+/// Starts an interactive consent flow on macOS to add new scopes to the user's `grantedScopes`.
+///
+/// The completion will be called at the end of this process.  If successful, a `GIDSignInResult`
+/// instance will be returned reflecting the new scopes and saved sign-in state will be updated.
+///
+/// @param scopes An array of scopes to ask the user to consent to.
+/// @param presentingWindow The window used to supply `presentationContextProvider` for
+///     `ASWebAuthenticationSession`.
+/// @param completion The optional block that is called on completion.  This block will be called
+///     asynchronously on the main queue.
+- (void)addScopes:(NSArray<NSString *> *)scopes
+    presentingWindow:(NSWindow *)presentingWindow
+          completion:(nullable void (^)(GIDSignInResult *_Nullable signInResult,
+                                        NSError *_Nullable error))completion;
+
+#endif
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignInButton.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignInButton.h
@@ -1,14 +1,25 @@
 /*
- * GIDSignInButton.h
- * Google Sign-In iOS SDK
+ * Copyright 2021 Google LLC
  *
- * Copyright 2012 Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Use of this SDK is subject to the Google APIs Terms of Service:
- * https://developers.google.com/terms/
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+#import <TargetConditionals.h>
+
+#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
 
 #import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /// The layout styles supported by the `GIDSignInButton`.
 ///
@@ -31,11 +42,11 @@ typedef NS_ENUM(NSInteger, GIDSignInButtonColorScheme) {
 
 /// This class provides the "Sign in with Google" button.
 ///
-/// You can instantiate this class programmatically or from a NIB file. You
-/// should set up the `GIDSignIn` shared instance with your client ID and any
-/// additional scopes, implement the delegate methods for `GIDSignIn`, and add
-/// this button to your view hierarchy.
-@interface GIDSignInButton : UIControl
+/// You can instantiate this class programmatically or from a NIB file. You should connect this
+/// control to an `IBAction`, or something similar, that calls
+/// signInWithPresentingViewController:completion: on `GIDSignIn` and add it to your view
+/// hierarchy.
+@interface GIDSignInButton : UIControl <NSSecureCoding>
 
 /// The layout style for the sign-in button.
 /// Possible values:
@@ -51,3 +62,8 @@ typedef NS_ENUM(NSInteger, GIDSignInButtonColorScheme) {
 @property(nonatomic, assign) GIDSignInButtonColorScheme colorScheme;
 
 @end
+
+NS_ASSUME_NONNULL_END
+
+#endif
+

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignInResult.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDSignInResult.h
@@ -1,0 +1,41 @@
+/*
+* Copyright 2022 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import <Foundation/Foundation.h>
+
+@class GIDGoogleUser;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A helper object that contains the result of a successful signIn or addScopes flow.
+@interface GIDSignInResult : NSObject
+
+/// The updated `GIDGoogleUser` instance for the user who just completed the flow.
+@property(nonatomic, readonly) GIDGoogleUser *user;
+
+/// An OAuth2 authorization code for the home server.
+@property(nonatomic, readonly, nullable) NSString *serverAuthCode;
+
+/// Unsupported.
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Unsupported.
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GIDToken.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GIDToken.h
@@ -16,17 +16,31 @@
 
 #import <Foundation/Foundation.h>
 
-@class OIDAuthState;
-
 NS_ASSUME_NONNULL_BEGIN
 
-// Internal class for GIDGoogleUser NSCoding backward compatibility.
-@interface GIDAuthentication : NSObject <NSSecureCoding>
+/// This class represents an OAuth2 or OpenID Connect token.
+@interface GIDToken : NSObject <NSSecureCoding>
 
-@property(nonatomic) OIDAuthState* authState;
+/// The token string.
+@property(nonatomic, copy, readonly) NSString *tokenString;
 
-- (instancetype)initWithAuthState:(OIDAuthState *)authState;
+/// The estimated expiration date of the token.
+@property(nonatomic, readonly, nullable) NSDate *expirationDate;
+
+/// Check if current token is equal to another one.
+///
+/// @param otherToken Another token to compare.
+- (BOOL)isEqualToToken:(GIDToken *)otherToken;
+
+/// Unavailable.
+/// :nodoc:
++ (instancetype)new NS_UNAVAILABLE;
+
+/// Unavailable.
+/// :nodoc:
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/AWSAuthSDK/Dependencies/GoogleHeaders/GoogleSignIn.h
+++ b/AWSAuthSDK/Dependencies/GoogleHeaders/GoogleSignIn.h
@@ -12,5 +12,8 @@
 #import "GIDProfileData.h"
 #import "GIDSignIn.h"
 #import "GIDSignInButton.h"
+#import "GIDConfiguration.h"
+#import "GIDToken.h"
+#import "GIDSignInResult.h"
 
 #endif

--- a/AWSGoogleSignIn.podspec
+++ b/AWSGoogleSignIn.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
    s.requires_arc = true
    s.dependency 'AWSAuthCore', '2.40.1'
    s.dependency 'AWSCore', '2.40.1'
+   s.dependency 'GoogleSignIn', '8.0.0'
    s.source_files = 'AWSAuthSDK/Sources/AWSGoogleSignIn/*.{h,m}', 'AWSAuthSDK/Dependencies/GoogleHeaders/*.h'
    s.public_header_files = 'AWSAuthSDK/Sources/AWSGoogleSignIn/*.h'
    s.private_header_files = 'AWSAuthSDK/Dependencies/GoogleHeaders/*.h'


### PR DESCRIPTION
*Issue #, if available:* #4827

*Description of changes:* 
Upgrade AWSGoogleSignIn to use GoogleSignIn version 8.0.0 (was 5.x.x)


- GoogleSignIn no longer uses GIDSignInDelegate
- Copied in headers from GoogleSignIn as needed following the existing code pattern. 
- GoogleSignIn does not support setting scopes prior to authentication, scopes support removed (unnecessary)
- updated code as necessary and deleted unused legacy code
- Added s.dependency 'GoogleSignIn', '8.0.0' to podspec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
