### PR TITLE
fix(auth): error handling around accessing credentials

### DIFF
--- a/AWSCore/Authentication/AWSCredentialsProvider.m
+++ b/AWSCore/Authentication/AWSCredentialsProvider.m
@@ -279,13 +279,23 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     @synchronized (self) {
         _internalCredentials = internalCredentials;
 
-        self.keychain[AWSCredentialsProviderKeychainAccessKeyId] = internalCredentials.accessKey;
-        self.keychain[AWSCredentialsProviderKeychainSecretAccessKey] = internalCredentials.secretKey;
-        self.keychain[AWSCredentialsProviderKeychainSessionToken] = internalCredentials.sessionKey;
-        if (internalCredentials.expiration) {
-            self.keychain[AWSCredentialsProviderKeychainExpiration] = [NSString stringWithFormat:@"%f", [internalCredentials.expiration timeIntervalSince1970]];
+        // Handle the case when internalCredentials is nil
+        if (internalCredentials) {
+            // Store credentials in keychain when credentials are not nil
+            self.keychain[AWSCredentialsProviderKeychainAccessKeyId] = internalCredentials.accessKey;
+            self.keychain[AWSCredentialsProviderKeychainSecretAccessKey] = internalCredentials.secretKey;
+            self.keychain[AWSCredentialsProviderKeychainSessionToken] = internalCredentials.sessionKey;
+            if (internalCredentials.expiration) {
+                self.keychain[AWSCredentialsProviderKeychainExpiration] = [NSString stringWithFormat:@"%f", [internalCredentials.expiration timeIntervalSince1970]];
+            } else {
+                self.keychain[AWSCredentialsProviderKeychainExpiration] = nil;
+            }
         } else {
-            self.keychain[AWSCredentialsProviderKeychainExpiration] = nil;
+            // Clear keychain entries when credentials are nil
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainAccessKeyId];
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainSecretAccessKey];
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainSessionToken];
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainExpiration];
         }
     }
 }
@@ -837,13 +847,23 @@ static NSString *const AWSCredentialsProviderKeychainIdentityId = @"identityId";
     @synchronized (self) {
         _internalCredentials = internalCredentials;
 
-        self.keychain[AWSCredentialsProviderKeychainAccessKeyId] = internalCredentials.accessKey;
-        self.keychain[AWSCredentialsProviderKeychainSecretAccessKey] = internalCredentials.secretKey;
-        self.keychain[AWSCredentialsProviderKeychainSessionToken] = internalCredentials.sessionKey;
-        if (internalCredentials.expiration) {
-            self.keychain[AWSCredentialsProviderKeychainExpiration] = [NSString stringWithFormat:@"%f", [internalCredentials.expiration timeIntervalSince1970]];
+        // Handle the case when internalCredentials is nil
+        if (internalCredentials) {
+            // Store credentials in keychain when credentials are not nil
+            self.keychain[AWSCredentialsProviderKeychainAccessKeyId] = internalCredentials.accessKey;
+            self.keychain[AWSCredentialsProviderKeychainSecretAccessKey] = internalCredentials.secretKey;
+            self.keychain[AWSCredentialsProviderKeychainSessionToken] = internalCredentials.sessionKey;
+            if (internalCredentials.expiration) {
+                self.keychain[AWSCredentialsProviderKeychainExpiration] = [NSString stringWithFormat:@"%f", [internalCredentials.expiration timeIntervalSince1970]];
+            } else {
+                self.keychain[AWSCredentialsProviderKeychainExpiration] = nil;
+            }
         } else {
-            self.keychain[AWSCredentialsProviderKeychainExpiration] = nil;
+            // Clear keychain entries when credentials are nil
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainAccessKeyId];
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainSecretAccessKey];
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainSessionToken];
+            [self.keychain removeItemForKey:AWSCredentialsProviderKeychainExpiration];
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

# Fix NSInvalidArgumentException in AWSCognitoCredentialsProvider during logout

## Description
This PR fixes a crash that occurs during logout when the AWS SDK attempts to clear credentials. The issue was an `NSInvalidArgumentException` thrown in `-[__NSPlaceholderDictionary initWithObjects:forKeys:count:]` when setting nil values in the keychain.

## Changes
- Modified `setInternalCredentials:` in `AWSCognitoCredentialsProvider` to properly handle nil credentials
- When credentials are nil, we now explicitly remove keychain entries instead of trying to set them to nil
- Maintains the same synchronization and security behavior as the original implementation

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
