### PR TITLE
chore: fix artifact versions for actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Download aratifacts
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0 # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0
         with:
           name: xcframework
           path: xcframeworks
@@ -159,7 +159,7 @@ jobs:
           role-session-name: "release-spm.${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
 
       - name: Download SPM checksum
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0 # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0
         with:
           name: spm-checksum
           path: /tmp/spm-checksum
@@ -194,7 +194,7 @@ jobs:
           persist-credentials: false
 
       - name: Download built xcframeworks
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0 # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0
         with:
           name: xcframework
           path: xcframeworks
@@ -446,7 +446,7 @@ jobs:
           persist-credentials: false
 
       - name: Download aratifacts
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0 # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # 4.1.0
         with:
           name: xcframework
           path: xcframeworks


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

> Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of actions/upload-artifact or actions/download-artifact. Customers should update workflows to begin using v4 of the artifact actions as soon as possible. ​

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
