### PR TITLE
feat(auth): remove support for token query param

### DIFF
--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClient.swift
@@ -33,7 +33,6 @@ final public class AWSMobileClient: _AWSMobileClient {
     internal var customRoleArnInternal: String? = nil
     
     internal var signInURIQueryParameters: [String: String]? = nil
-    internal var tokenURIQueryParameters: [String: String]? = nil
     internal var signOutURIQueryParameters: [String: String]? = nil
     internal var scopes: [String]? = nil
 
@@ -353,9 +352,6 @@ final public class AWSMobileClient: _AWSMobileClient {
         }
 
         let tokensURI = infoDictionary?["TokenURI"] as? String
-        if self.tokenURIQueryParameters == nil {
-            self.tokenURIQueryParameters = infoDictionary?["TokenURIQueryParameters"] as? [String: String]
-        }
 
         guard
             let clientId = clientId,
@@ -381,7 +377,6 @@ final public class AWSMobileClient: _AWSMobileClient {
             tokensUri: tokensURI,
             signInUriQueryParameters: self.signInURIQueryParameters,
             signOutUriQueryParameters: self.signOutURIQueryParameters,
-            tokenUriQueryParameters: self.tokenURIQueryParameters,
             userPoolServiceConfiguration: AWSMobileClient.serviceConfiguration?.userPoolServiceConfiguration,
             signInPrivateSession: false)
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+SignInUI.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/AWSMobileClientOperations/AWSMobileClient+SignInUI.swift
@@ -216,10 +216,7 @@ extension AWSMobileClient {
         }
 
         let tokensURI = infoDictionary?["TokenURI"] as? String
-        if self.tokenURIQueryParameters == nil {
-            self.tokenURIQueryParameters = infoDictionary?["TokenURIQueryParameters"] as? [String: String]
-        }
-
+        
         let identityProvider = hostedUIOptions.identityProvider
         let idpIdentifier = hostedUIOptions.idpIdentifier
 
@@ -232,10 +229,6 @@ extension AWSMobileClient {
 
         if hostedUIOptions.signInURIQueryParameters != nil {
             self.signInURIQueryParameters = hostedUIOptions.signInURIQueryParameters
-        }
-
-        if hostedUIOptions.tokenURIQueryParameters != nil {
-            self.tokenURIQueryParameters = hostedUIOptions.tokenURIQueryParameters
         }
 
         if hostedUIOptions.signOutURIQueryParameters != nil {
@@ -261,7 +254,6 @@ extension AWSMobileClient {
                                          tokensUri: tokensURI,
                                          signInUriQueryParameters: self.signInURIQueryParameters,
                                          signOutUriQueryParameters: self.signOutURIQueryParameters,
-                                         tokenUriQueryParameters: self.tokenURIQueryParameters,
                                          userPoolServiceConfiguration: AWSMobileClient.serviceConfiguration?.userPoolServiceConfiguration,
                                          signInPrivateSession: hostedUIOptions.signInPrivateSession)
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Helpers/AWSMobileClientConstants.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Helpers/AWSMobileClientConstants.swift
@@ -25,7 +25,6 @@ struct AWSMobileClientConstants {
     static let LoginsMapKey = "loginsMap"
     static let FederationProviderKey = "federationProvider"
     static let SignInURIQueryParametersKey = "signInURIQueryParameters"
-    static let TokenURIQueryParametersKey = "tokenURIQueryParameters"
     static let SignOutURIQueryParametersKey = "signOutURIQueryParameters"
     static let CustomRoleArnKey = "customRoleArn"
     static let FederationDisabledKey = "federationDisabled"

--- a/AWSAuthSDK/Sources/AWSMobileClient/Helpers/KeyChain/AWSMobileClient+Keychain.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Helpers/KeyChain/AWSMobileClient+Keychain.swift
@@ -37,13 +37,11 @@ extension AWSMobileClient {
 
     internal func saveOAuthURIQueryParametersInKeychain() {
         self.keychain.setData(JSONHelper.dataFromDictionary(self.signInURIQueryParameters), forKey: AWSMobileClientConstants.SignInURIQueryParametersKey)
-        self.keychain.setData(JSONHelper.dataFromDictionary(self.tokenURIQueryParameters), forKey: AWSMobileClientConstants.TokenURIQueryParametersKey)
         self.keychain.setData(JSONHelper.dataFromDictionary(self.signOutURIQueryParameters), forKey: AWSMobileClientConstants.SignOutURIQueryParametersKey)
     }
 
     internal func loadOAuthURIQueryParametersFromKeychain() {
         self.signInURIQueryParameters = JSONHelper.dictionaryFromData(self.keychain.data(forKey: AWSMobileClientConstants.SignInURIQueryParametersKey))
-        self.tokenURIQueryParameters = JSONHelper.dictionaryFromData(self.keychain.data(forKey: AWSMobileClientConstants.TokenURIQueryParametersKey))
         self.signOutURIQueryParameters = JSONHelper.dictionaryFromData(self.keychain.data(forKey: AWSMobileClientConstants.SignOutURIQueryParametersKey))
     }
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.h
@@ -31,7 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
                           tokensUri:(nullable NSString *) tokensUri
            signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
           signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
        userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration
                signInPrivateSession:(BOOL)signInPrivateSession;
 

--- a/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Internal/AWSCognitoAuth+Extensions.m
@@ -38,7 +38,6 @@
                                   tokensUri:(NSString *) tokensUri
                    signInUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-                    tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
                          isProviderExternal:(BOOL) isProviderExternal
                cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig
                        signInPrivateSession:(BOOL)isSignInPrivateSession;
@@ -60,7 +59,6 @@
                           tokensUri:(nullable NSString *) tokensUri
            signInUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
           signOutUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-            tokenUriQueryParameters:(nullable NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
        userPoolServiceConfiguration:(nullable AWSServiceConfiguration *)serviceConfiguration
                signInPrivateSession:(BOOL)signInPrivateSession {
     BOOL isProviderExternal = YES;
@@ -83,7 +81,6 @@
                                    tokensUri:tokensUri
                     signInUriQueryParameters:signInUriQueryParameters
                    signOutUriQueryParameters:signOutUriQueryParameters
-                     tokenUriQueryParameters:tokenUriQueryParameters
                           isProviderExternal:isProviderExternal
                 cognitoUserPoolServiceConfig:serviceConfiguration
                         signInPrivateSession:signInPrivateSession];

--- a/AWSAuthSDK/Sources/AWSMobileClient/Models/HostedUIOptions.swift
+++ b/AWSAuthSDK/Sources/AWSMobileClient/Models/HostedUIOptions.swift
@@ -29,7 +29,6 @@ public struct HostedUIOptions {
     let federationProviderName: String?
 
     let signInURIQueryParameters: [String: String]?
-    let tokenURIQueryParameters: [String: String]?
     let signOutURIQueryParameters: [String: String]?
 
     let signInPrivateSession: Bool
@@ -43,7 +42,6 @@ public struct HostedUIOptions {
     ///   - idpIdentifier: The IdentityProvider identifier if using multiple instances of same identity provider.
     ///   - federationProviderName: If federating with Cognito Identity and using a provider like Auth0 specify the provider name, e.g. <your_domain>.auth0.com.
     ///   - signInURIQueryParameters: The additional query parameters apart from standard OAuth w/ open id connect parameters for signInURI. If specified here, the signInURIQueryParameters specified in `awsconfiguration.json` would be over-ridden.
-    ///   - tokenURIQueryParameters: The additional query parameters apart from standard OAuth w/ open id connect parameters for tokenURI. If specified here, the tokenURIQueryParameters specified in `awsconfiguration.json` would be over-ridden.
     ///   - signOutURIQueryParameters: The additional query parameters apart from standard OAuth w/ open id connect parameters for signOutURI. If specified here, the signOutURIQueryParameters specified in `awsconfiguration.json` would be over-ridden.
     public init(disableFederation: Bool = false,
                 scopes: [String]? = nil,
@@ -51,7 +49,6 @@ public struct HostedUIOptions {
                 idpIdentifier: String? = nil,
                 federationProviderName: String? = nil,
                 signInURIQueryParameters: [String: String]? = nil,
-                tokenURIQueryParameters: [String: String]? = nil,
                 signOutURIQueryParameters: [String: String]? = nil,
                 signInPrivateSession: Bool = false) {
         self.disableFederation = disableFederation
@@ -69,7 +66,6 @@ public struct HostedUIOptions {
         self.idpIdentifier = idpIdentifier
         self.federationProviderName = federationProviderName
         self.signInURIQueryParameters = signInURIQueryParameters
-        self.tokenURIQueryParameters = tokenURIQueryParameters
         self.signOutURIQueryParameters = signOutURIQueryParameters
         self.signInPrivateSession = signInPrivateSession
     }

--- a/AWSCognitoAuth/AWSCognitoAuth.m
+++ b/AWSCognitoAuth/AWSCognitoAuth.m
@@ -1334,7 +1334,6 @@ withPresentingViewController:(UIViewController *)presentingViewController {
                                    tokensUri:[NSString stringWithFormat:@"%@/oauth2/token",webDomain]
                     signInUriQueryParameters:@{}
                    signOutUriQueryParameters:@{@"client_id": appClientId, @"logout_uri": signOutRedirectUri}
-                     tokenUriQueryParameters:@{}
                           isProviderExternal:NO];
 }
 
@@ -1353,7 +1352,6 @@ withPresentingViewController:(UIViewController *)presentingViewController {
                                   tokensUri:(NSString *) tokensUri
                    signInUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-                    tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
                          isProviderExternal:(BOOL) isProviderExternal {
 
     return [self initWithAppClientIdInternal:appClientId
@@ -1371,10 +1369,9 @@ withPresentingViewController:(UIViewController *)presentingViewController {
                                    tokensUri:tokensUri
                     signInUriQueryParameters:signInUriQueryParameters
                    signOutUriQueryParameters:signOutUriQueryParameters
-                     tokenUriQueryParameters:tokenUriQueryParameters
-                          isProviderExternal:isProviderExternal
-                cognitoUserPoolServiceConfig:nil
-                        signInPrivateSession:NO];
+                         isProviderExternal:isProviderExternal
+               cognitoUserPoolServiceConfig:nil
+                       signInPrivateSession:NO];
 }
 
 - (instancetype)initWithAppClientIdInternal:(NSString *) appClientId
@@ -1392,7 +1389,6 @@ withPresentingViewController:(UIViewController *)presentingViewController {
                                   tokensUri:(NSString *) tokensUri
                    signInUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signInUriQueryParameters
                   signOutUriQueryParameters:(NSDictionary<NSString *, NSString *> *) signOutUriQueryParameters
-                    tokenUriQueryParameters:(NSDictionary<NSString *, NSString *> *) tokenUriQueryParameters
                          isProviderExternal:(BOOL) isProviderExternal
                cognitoUserPoolServiceConfig:(nullable AWSServiceConfiguration *) serviceConfig
                        signInPrivateSession:(BOOL)isSignInPrivateSession {
@@ -1421,7 +1417,7 @@ withPresentingViewController:(UIViewController *)presentingViewController {
         _userPoolId = userPoolIdForEnablingASF;
         _isSFAuthenticationSessionEnabled = enableSFAuthSession;
         _signInUriQueryParameters = signInUriQueryParameters;
-        _tokensUriQueryParameters = tokenUriQueryParameters;
+        _tokensUriQueryParameters = @{};
         _isAuthProviderExternal = isProviderExternal;
         _userPoolConfig = serviceConfig;
         _isSignInPrivateSession = isSignInPrivateSession;
@@ -1448,7 +1444,6 @@ withPresentingViewController:(UIViewController *)presentingViewController {
                                                                                                       tokensUri:self.tokensUri
                                                                                        signInUriQueryParameters:self.signInUriQueryParameters
                                                                                       signOutUriQueryParameters:self.signOutUriQueryParameters
-                                                                                        tokenUriQueryParameters:self.tokensUriQueryParameters
                                                                                              isProviderExternal:self.isAuthProviderExternal
                                                                                    cognitoUserPoolServiceConfig:self.userPoolConfig
                                                                                            signInPrivateSession:self.isSignInPrivateSession];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removing support for `tokenQueryParam`.

As per OIDC / OAuth specification, token endpoint must not allow any query parameters. So, the SDK needs to be updated to not allow any query parameters for Token endpoint.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
