### PR TITLE
fix: ensure thread-safe handling of streams in AWSIoT components

### DIFF
--- a/AWSIoT/Internal/AWSIoTStreamThread.m
+++ b/AWSIoT/Internal/AWSIoTStreamThread.m
@@ -150,25 +150,33 @@
             }
 
             // Make sure we handle the streams in a thread-safe way
-            if (self.outputStream) {
-                // Remove from runLoop first before closing
-                if (self.runLoopForStreamsThread) {
-                    [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread
-                                                 forMode:NSDefaultRunLoopMode];
+            @synchronized(self.outputStream) {
+                if (self.outputStream) {
+                    // Remove from runLoop first before closing
+                    if (self.runLoopForStreamsThread) {
+                        [self.outputStream removeFromRunLoop:self.runLoopForStreamsThread
+                                                    forMode:NSDefaultRunLoopMode];
+                    }
+                    self.outputStream.delegate = nil;
+                    [self.outputStream close];
+                    self.outputStream = nil;
                 }
-                self.outputStream.delegate = nil;
-                [self.outputStream close];
-                self.outputStream = nil;
             }
 
-            if (self.decoderInputStream) {
-                [self.decoderInputStream close];
-                self.decoderInputStream = nil;
+            // Make sure we handle the streams in a thread-safe way
+            @synchronized(self.decoderInputStream) {
+                if (self.decoderInputStream) {
+                    [self.decoderInputStream close];
+                    self.decoderInputStream = nil;
+                }
             }
 
-            if (self.encoderOutputStream) {
-                [self.encoderOutputStream close];
-                self.encoderOutputStream = nil;
+            // Make sure we handle the streams in a thread-safe way
+            @synchronized(self.encoderOutputStream) {
+                if (self.encoderOutputStream) {
+                    [self.encoderOutputStream close];
+                    self.encoderOutputStream = nil;
+                }
             }
         } else {
             AWSDDLogVerbose(@"Skipping disconnect for thread: [%@]", (NSThread *)self);

--- a/AWSIoT/Internal/MQTTSDK/AWSMQTTEncoder.m
+++ b/AWSIoT/Internal/MQTTSDK/AWSMQTTEncoder.m
@@ -44,10 +44,15 @@
 }
 
 - (void)close {
-    AWSDDLogDebug(@"closing encoder stream.");
-    [self.stream close];
-    [self.stream setDelegate:nil];
-    self.stream = nil;
+    // Make sure we handle the streams in a thread-safe way
+    @synchronized (self.stream) {
+        if (self.stream) { // We'd better double check that the stream is not nil
+            AWSDDLogDebug(@"closing encoder stream.");
+            [self.stream close];
+            [self.stream setDelegate:nil];
+            self.stream = nil;
+        }
+    }
 }
 
 //This is executed in the runLoop.


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Actually I already submitted a [PR](https://github.com/aws-amplify/aws-sdk-ios/pull/5482) several months ago, but it got declined because of the code change in it is not really able to resolve the issue, but you can get the issue details from that PR.

As for the code change in this PR, I already applied it in our release app for nearly a quarter by creating a pod patch, I can sure it's able to resolve the corresponding issue because we haven't observed the corresponding error report in both Sentry and Xcode crash statistics anymore.

*Check points:*

- [ ] Added new tests to cover change, if needed
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Updated CHANGELOG.md
- [ ] Documentation update for the change if required
- [ ] PR title conforms to conventional commit style

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
