### PR TITLE
AWSTranscribeStreamingItem  'confidence' attribute  #5553

### DIFF
--- a/AWSTranscribeStreaming/AWSTranscribeStreamingModel.h
+++ b/AWSTranscribeStreaming/AWSTranscribeStreamingModel.h
@@ -159,7 +159,7 @@ typedef NS_ENUM(NSInteger, AWSTranscribeStreamingMediaEncoding) {
  */
 @interface AWSTranscribeStreamingItem : AWSModel
 
-
+@property (nonatomic, strong) NSNumber * _Nullable confidence;
 /**
  <p>The word or punctuation that was recognized in the input audio.</p>
  */

--- a/AWSTranscribeStreaming/AWSTranscribeStreamingModel.m
+++ b/AWSTranscribeStreaming/AWSTranscribeStreamingModel.m
@@ -120,6 +120,7 @@ NSString *const AWSTranscribeStreamingErrorDomain = @"com.amazonaws.AWSTranscrib
              @"isPartial" : @"IsPartial",
              @"resultId" : @"ResultId",
              @"startTime" : @"StartTime",
+             @"confidence" : @"Confidence",
              };
 }
 


### PR DESCRIPTION
AWSTranscribeStreamingItem should contains 'confidence' attribute according docs #5553